### PR TITLE
feat: mode-per-session fields (voice_mode + llm_model)

### DIFF
--- a/dragon_voice/api/sessions.py
+++ b/dragon_voice/api/sessions.py
@@ -44,15 +44,33 @@ class SessionRoutes:
         return paginated_response(sessions, limit, offset)
 
     async def create_session(self, request: web.Request) -> web.Response:
-        """POST /api/v1/sessions"""
+        """POST /api/v1/sessions
+
+        Chat v4·C (refs #27): accepts optional ``voice_mode`` (0-3) and
+        ``llm_model`` (str, max 128 chars) so each session carries its
+        own mode fingerprint.
+        """
         body, err = await parse_json_body(request)
         if err:
             return err
+
+        voice_mode = body.get("voice_mode", 0)
+        try:
+            voice_mode = int(voice_mode)
+        except (TypeError, ValueError):
+            return json_error("voice_mode must be an integer 0-3")
+        if not 0 <= voice_mode <= 3:
+            return json_error("voice_mode must be 0-3")
+
+        llm_model = str(body.get("llm_model", ""))[:128]
+
         session = await self._session_mgr.create_session(
             device_id=body.get("device_id"),
             session_type=body.get("type", "conversation"),
             system_prompt=body.get("system_prompt", ""),
             config=body.get("config"),
+            voice_mode=voice_mode,
+            llm_model=llm_model,
         )
         return web.json_response(session, status=201)
 
@@ -96,7 +114,12 @@ class SessionRoutes:
         return web.json_response({"status": "paused", "session_id": session_id})
 
     async def update_session(self, request: web.Request) -> web.Response:
-        """PATCH /api/v1/sessions/{session_id} — update title/system_prompt/metadata/config"""
+        """PATCH /api/v1/sessions/{session_id} — update session mode/meta.
+
+        Chat v4·C (refs #27): accepts ``voice_mode`` (0-3) and
+        ``llm_model`` (str, max 128 chars) alongside the existing
+        title/system_prompt/metadata/config patch fields.
+        """
         session_id = request.match_info["session_id"]
         session = await self._session_mgr.get_session(session_id)
         if not session:
@@ -106,10 +129,27 @@ class SessionRoutes:
         if err:
             return err
 
-        allowed = {"title", "system_prompt", "metadata", "config"}
+        allowed = {"title", "system_prompt", "metadata", "config",
+                   "voice_mode", "llm_model"}
         updates = {k: v for k, v in body.items() if k in allowed}
         if not updates:
-            return json_error("No valid fields to update (allowed: title, system_prompt, metadata, config)")
+            return json_error(
+                "No valid fields to update "
+                "(allowed: title, system_prompt, metadata, config, "
+                "voice_mode, llm_model)"
+            )
+
+        if "voice_mode" in updates:
+            try:
+                vm = int(updates["voice_mode"])
+            except (TypeError, ValueError):
+                return json_error("voice_mode must be an integer 0-3")
+            if not 0 <= vm <= 3:
+                return json_error("voice_mode must be 0-3")
+            updates["voice_mode"] = vm
+
+        if "llm_model" in updates:
+            updates["llm_model"] = str(updates["llm_model"])[:128]
 
         await self._db.update_session(session_id, **updates)
         updated = await self._session_mgr.get_session(session_id)

--- a/dragon_voice/db.py
+++ b/dragon_voice/db.py
@@ -275,6 +275,14 @@ class Database:
 
     # ── Sessions ───────────────────────────────────────────────────────
 
+    # Explicit column list for sessions SELECTs. Never use `SELECT *` so
+    # schema drift (e.g. new columns added via migration on an older DB
+    # build) surfaces as a query-time error instead of a silent mismatch.
+    _SESSION_COLUMNS = (
+        "id, device_id, type, status, title, system_prompt, config, metadata, "
+        "message_count, voice_mode, llm_model, created_at, last_active_at, ended_at"
+    )
+
     async def create_session(
         self,
         session_id: str,
@@ -282,24 +290,37 @@ class Database:
         session_type: str = "conversation",
         system_prompt: str = "",
         config: Optional[dict] = None,
+        voice_mode: int = 0,
+        llm_model: str = "",
     ) -> dict:
-        """Create a new session. Returns the session row as dict."""
+        """Create a new session. Returns the session row as dict.
+
+        ``voice_mode`` (0-3) and ``llm_model`` persist the active chat v4·C
+        mode onto the session row so the conversation-drawer can show its
+        fingerprint and the pipeline can restore it on resume.
+        """
         now = time.time()
         await self.conn.execute(
             """
             INSERT INTO sessions (id, device_id, type, status, system_prompt, config,
+                                  voice_mode, llm_model,
                                   created_at, last_active_at)
-            VALUES (?, ?, ?, 'active', ?, ?, ?, ?)
+            VALUES (?, ?, ?, 'active', ?, ?, ?, ?, ?, ?)
             """,
             (session_id, device_id, session_type, system_prompt,
-             json.dumps(config or {}), now, now),
+             json.dumps(config or {}),
+             int(voice_mode), str(llm_model or ""),
+             now, now),
         )
         await self.conn.commit()
         return await self.get_session(session_id)
 
     async def get_session(self, session_id: str) -> Optional[dict]:
         """Fetch a session by ID."""
-        cursor = await self.conn.execute("SELECT * FROM sessions WHERE id = ?", (session_id,))
+        cursor = await self.conn.execute(
+            f"SELECT {self._SESSION_COLUMNS} FROM sessions WHERE id = ?",
+            (session_id,),
+        )
         row = await cursor.fetchone()
         return dict(row) if row else None
 
@@ -322,7 +343,10 @@ class Database:
             params.append(status)
 
         where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
-        query = f"SELECT * FROM sessions {where} ORDER BY last_active_at DESC LIMIT ? OFFSET ?"
+        query = (
+            f"SELECT {self._SESSION_COLUMNS} FROM sessions {where} "
+            f"ORDER BY last_active_at DESC LIMIT ? OFFSET ?"
+        )
         params.extend([limit, offset])
 
         cursor = await self.conn.execute(query, params)
@@ -363,8 +387,13 @@ class Database:
         await self.conn.commit()
 
     async def update_session(self, session_id: str, **kwargs) -> None:
-        """Update session fields. Allowed: title, system_prompt, metadata, config."""
-        allowed = {"title", "system_prompt", "metadata", "config"}
+        """Update session fields.
+
+        Allowed: ``title``, ``system_prompt``, ``metadata``, ``config``,
+        ``voice_mode``, ``llm_model``.
+        """
+        allowed = {"title", "system_prompt", "metadata", "config",
+                   "voice_mode", "llm_model"}
         updates = {k: v for k, v in kwargs.items() if k in allowed}
         if not updates:
             return
@@ -372,8 +401,15 @@ class Database:
         sets = []
         params = []
         for k, v in updates.items():
+            if k in ("metadata", "config"):
+                params.append(json.dumps(v))
+            elif k == "voice_mode":
+                params.append(int(v))
+            elif k == "llm_model":
+                params.append(str(v or ""))
+            else:
+                params.append(v)
             sets.append(f"{k} = ?")
-            params.append(json.dumps(v) if k in ("metadata", "config") else v)
         sets.append("last_active_at = ?")
         params.append(now)
         params.append(session_id)
@@ -386,8 +422,8 @@ class Database:
         """Find active/paused sessions inactive beyond the timeout."""
         cutoff = time.time() - timeout_seconds
         cursor = await self.conn.execute(
-            """
-            SELECT * FROM sessions
+            f"""
+            SELECT {self._SESSION_COLUMNS} FROM sessions
             WHERE status IN ('active', 'paused') AND last_active_at < ?
             ORDER BY last_active_at ASC
             """,

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -1072,14 +1072,33 @@ class VoiceServer:
                                 continue
 
                             # Update session system prompt in DB for conversation engine
+                            # Chat v4·C (refs #27): also persist voice_mode + llm_model
+                            # onto the session row so the drawer surfaces the active
+                            # mode fingerprint and pipeline-resume picks the right
+                            # backends without a fresh config_update from the client.
                             sid = conn_state.get("session_id")
                             if sid and self._db:
+                                # Resolve the best "active model" string to persist,
+                                # matching the client-visible payload below.
+                                if voice_mode == 2:
+                                    active_model_db = conn_config.llm.openrouter_model or ""
+                                elif llm_be == "tinkerclaw":
+                                    active_model_db = conn_config.llm.tinkerclaw_model or ""
+                                elif llm_be == "ollama":
+                                    active_model_db = conn_config.llm.ollama_model or ""
+                                else:
+                                    active_model_db = str(llm_model or "")
                                 try:
                                     await self._db.update_session(
-                                        sid, system_prompt=conn_config.llm.system_prompt
+                                        sid,
+                                        system_prompt=conn_config.llm.system_prompt,
+                                        voice_mode=int(voice_mode),
+                                        llm_model=active_model_db[:128],
                                     )
                                 except Exception:
-                                    logger.warning("Failed to update session system_prompt")
+                                    logger.warning(
+                                        "Failed to update session system_prompt / mode"
+                                    )
 
                             # Apply config
                             conn_config.stt.backend = stt_be

--- a/dragon_voice/sessions.py
+++ b/dragon_voice/sessions.py
@@ -97,8 +97,14 @@ class SessionManager:
         session_type: str = "conversation",
         system_prompt: str = "",
         config: Optional[dict] = None,
+        voice_mode: int = 0,
+        llm_model: str = "",
     ) -> dict:
-        """Create a new session and log the event."""
+        """Create a new session and log the event.
+
+        ``voice_mode`` (0-3) and ``llm_model`` persist the chat v4·C
+        mode fingerprint onto the session row (refs #27).
+        """
         session_id = _generate_session_id()
         session = await self._db.create_session(
             session_id=session_id,
@@ -106,15 +112,38 @@ class SessionManager:
             session_type=session_type,
             system_prompt=system_prompt,
             config=config,
+            voice_mode=voice_mode,
+            llm_model=llm_model,
         )
         await self._db.add_event(
             "session.created",
             session_id=session_id,
             device_id=device_id,
-            data={"type": session_type},
+            data={
+                "type": session_type,
+                "voice_mode": int(voice_mode),
+                "llm_model": str(llm_model or ""),
+            },
         )
-        logger.info("Session created: %s (device=%s, type=%s)", session_id, device_id, session_type)
+        logger.info(
+            "Session created: %s (device=%s, type=%s, voice_mode=%d, llm_model=%s)",
+            session_id, device_id, session_type, int(voice_mode), llm_model,
+        )
         return session
+
+    async def update_session(self, session_id: str, **kwargs) -> Optional[dict]:
+        """Update session fields and return the refreshed row.
+
+        Passes through to :meth:`Database.update_session`; allowed fields
+        are ``title``, ``system_prompt``, ``metadata``, ``config``,
+        ``voice_mode``, ``llm_model``. Returns ``None`` if the session
+        does not exist.
+        """
+        session = await self._db.get_session(session_id)
+        if not session:
+            return None
+        await self._db.update_session(session_id, **kwargs)
+        return await self._db.get_session(session_id)
 
     async def get_session(self, session_id: str) -> Optional[dict]:
         """Fetch a session by ID."""
@@ -197,6 +226,8 @@ class SessionManager:
         session_type: str = "conversation",
         system_prompt: str = "",
         config: Optional[dict] = None,
+        voice_mode: int = 0,
+        llm_model: str = "",
     ) -> tuple[dict, bool]:
         """Get an existing session or create a new one.
 
@@ -217,6 +248,8 @@ class SessionManager:
             session_type=session_type,
             system_prompt=system_prompt,
             config=config,
+            voice_mode=voice_mode,
+            llm_model=llm_model,
         )
         return session, False
 

--- a/migrations/006_session_mode_fields.sql
+++ b/migrations/006_session_mode_fields.sql
@@ -1,0 +1,12 @@
+-- 006_session_mode_fields.sql — Chat v4·C mode-per-session (refs #27)
+--
+-- Adds explicit voice_mode + llm_model columns to the sessions table so
+-- each conversation carries its own mode fingerprint. Lossless for
+-- existing rows (defaults to Local mode, empty model → session inherits
+-- the device's active mode at runtime).
+--
+-- Both fields are also surfaceable via sessions.config JSON, but explicit
+-- columns let the REST drawer query sort/filter fast without JSON parsing.
+
+ALTER TABLE sessions ADD COLUMN voice_mode INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sessions ADD COLUMN llm_model  TEXT    NOT NULL DEFAULT '';

--- a/schema.sql
+++ b/schema.sql
@@ -51,6 +51,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     config        TEXT NOT NULL DEFAULT '{}',     -- JSON: session-level config (llm model, temperature, etc.)
     metadata      TEXT NOT NULL DEFAULT '{}',     -- JSON: arbitrary session data (skill context, tags, etc.)
     message_count INTEGER NOT NULL DEFAULT 0,    -- denormalized for fast listing
+    voice_mode    INTEGER NOT NULL DEFAULT 0,    -- 0=local, 1=hybrid, 2=cloud, 3=tinkerclaw (chat v4·C mode-per-session)
+    llm_model     TEXT NOT NULL DEFAULT '',     -- LLM model for this session (e.g. "anthropic/claude-3.5-haiku")
     created_at    REAL NOT NULL,
     last_active_at REAL NOT NULL,
     ended_at      REAL,                          -- NULL until ended

--- a/tests/test_api_e2e.py
+++ b/tests/test_api_e2e.py
@@ -292,6 +292,61 @@ async def tier2_multi_step(t: TestRunner):
 
         await t.post(f"/api/v1/sessions/{sid}/end")
 
+    # MS9: Chat v4·C — create session with voice_mode + llm_model (refs #27)
+    async def ms9_create_session_with_mode():
+        s, body = await t.post("/api/v1/sessions", {
+            "type": "conversation",
+            "voice_mode": 2,
+            "llm_model": "anthropic/claude-3.5-haiku",
+        })
+        assert s == 201, f"Create: {s} {body}"
+        sid = body["id"]
+        assert body["voice_mode"] == 2, f"voice_mode missing: {body}"
+        assert body["llm_model"] == "anthropic/claude-3.5-haiku", f"llm_model missing: {body}"
+
+        # Round-trip via GET by id
+        s, body = await t.get(f"/api/v1/sessions/{sid}")
+        assert s == 200
+        assert body["voice_mode"] == 2
+        assert body["llm_model"] == "anthropic/claude-3.5-haiku"
+
+        # List surfaces it too
+        s, body = await t.get("/api/v1/sessions?limit=50")
+        assert s == 200
+        match = next((x for x in body["items"] if x["id"] == sid), None)
+        assert match is not None, "session not in list"
+        assert match["voice_mode"] == 2
+        assert match["llm_model"] == "anthropic/claude-3.5-haiku"
+
+        await t.post(f"/api/v1/sessions/{sid}/end")
+
+    # MS10: Chat v4·C — PATCH session voice_mode + llm_model (refs #27)
+    async def ms10_patch_session_mode():
+        s, body = await t.post("/api/v1/sessions", {"type": "conversation"})
+        sid = body["id"]
+        assert body["voice_mode"] == 0
+        assert body["llm_model"] == ""
+
+        # PATCH to cloud mode
+        s, body = await t.patch(f"/api/v1/sessions/{sid}", {
+            "voice_mode": 2,
+            "llm_model": "openai/gpt-4o-mini",
+        })
+        assert s == 200, f"PATCH: {s} {body}"
+        assert body["voice_mode"] == 2
+        assert body["llm_model"] == "openai/gpt-4o-mini"
+
+        # Verify persisted
+        s, body = await t.get(f"/api/v1/sessions/{sid}")
+        assert body["voice_mode"] == 2
+        assert body["llm_model"] == "openai/gpt-4o-mini"
+
+        # Reject out-of-range voice_mode
+        s, body = await t.patch(f"/api/v1/sessions/{sid}", {"voice_mode": 9})
+        assert s == 400, f"expected 400 for voice_mode=9, got {s}"
+
+        await t.post(f"/api/v1/sessions/{sid}/end")
+
     # MS4: Memory store → search → delete
     async def ms4_memory_crud():
         # Store
@@ -392,6 +447,8 @@ async def tier2_multi_step(t: TestRunner):
         ("MS6: Config set→get→delete", ms6_config_crud),
         ("MS7: Device name update→restore", ms7_device_update),
         ("MS8: Message purge on session", ms8_message_purge),
+        ("MS9: Session voice_mode + llm_model on create (#27)", ms9_create_session_with_mode),
+        ("MS10: Session voice_mode + llm_model PATCH (#27)", ms10_patch_session_mode),
     ]:
         await t.run_test(name, fn)
 

--- a/tests/test_foundation.py
+++ b/tests/test_foundation.py
@@ -146,6 +146,46 @@ async def test_session_create(db, session_mgr):
     assert session["device_id"] == "dev-001"
     assert session["type"] == "conversation"
     assert len(session["id"]) == 12  # 6 bytes = 12 hex chars
+    # Default mode fingerprint (refs #27)
+    assert session["voice_mode"] == 0
+    assert session["llm_model"] == ""
+
+
+@pytest.mark.asyncio
+async def test_session_mode_fields_roundtrip(db, session_mgr):
+    """Chat v4·C: voice_mode + llm_model round-trip through create→get→update (refs #27)."""
+    await db.upsert_device("dev-mode", "02:02:02:02:02:02")
+
+    # Create with non-default mode fingerprint
+    created = await session_mgr.create_session(
+        device_id="dev-mode",
+        voice_mode=2,
+        llm_model="anthropic/claude-3.5-haiku",
+    )
+    assert created["voice_mode"] == 2
+    assert created["llm_model"] == "anthropic/claude-3.5-haiku"
+
+    # Fetch back and confirm persistence (no SELECT * — explicit projection)
+    loaded = await session_mgr.get_session(created["id"])
+    assert loaded is not None
+    assert loaded["voice_mode"] == 2
+    assert loaded["llm_model"] == "anthropic/claude-3.5-haiku"
+
+    # List path returns the columns too
+    listed = await session_mgr.list_sessions(device_id="dev-mode")
+    assert len(listed) == 1
+    assert listed[0]["voice_mode"] == 2
+    assert listed[0]["llm_model"] == "anthropic/claude-3.5-haiku"
+
+    # Update path — flip to mode 3 + new model
+    updated = await session_mgr.update_session(
+        created["id"],
+        voice_mode=3,
+        llm_model="tinkerclaw/agent",
+    )
+    assert updated is not None
+    assert updated["voice_mode"] == 3
+    assert updated["llm_model"] == "tinkerclaw/agent"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #27.

## Summary
Chat v4·C adds two explicit columns to the `sessions` table so each
conversation carries its own mode fingerprint instead of relying on the
global device mode at replay time:

- `voice_mode INTEGER NOT NULL DEFAULT 0` (0=local, 1=hybrid, 2=cloud, 3=tinkerclaw)
- `llm_model TEXT NOT NULL DEFAULT ''` (e.g. `anthropic/claude-3.5-haiku`)

Both fields are round-tripped through the schema, migration, dataclass-style
row dicts, REST API, and the WS `config_update` handler — so the drawer,
the pipeline, and any external consumer all see the same truth.

## Changes
- `schema.sql` + `migrations/006_session_mode_fields.sql` — schema + idempotent ALTER.
- `dragon_voice/db.py` — explicit `_SESSION_COLUMNS` projection (no more `SELECT *`), `create_session` / `update_session` accept the new fields.
- `dragon_voice/sessions.py` — `SessionManager.create_session` + new `update_session` wrapper accept + persist the mode fingerprint; `get_or_create_session` forwards too.
- `dragon_voice/api/sessions.py` — POST validates `voice_mode` is in `0..3` and truncates `llm_model` to 128 chars; PATCH accepts both as optional updates; GET + list surface them automatically.
- `dragon_voice/server.py` — `config_update` WS handler writes `voice_mode` + resolved `llm_model` onto the active session row (matches the payload already ACKed to Tab5).
- `tests/test_foundation.py` — `test_session_mode_fields_roundtrip` covers create → get → list → update.
- `tests/test_api_e2e.py` — MS9 (create with mode) + MS10 (PATCH flip + validation rejection).

## Test plan
- [x] `pytest tests/test_foundation.py -q` — 21/21 pass
- [x] Migration applied on Dragon (`/home/radxa/tinkerclaw/tinkerclaw.db`) via Python `ALTER TABLE` path (no sqlite3 CLI on Dragon).
- [x] `tinkerclaw-voice.service` restarted cleanly; startup logs clean.
- [x] `GET /api/v1/sessions?limit=1` includes `voice_mode` + `llm_model` on a pre-existing row (defaults to 0 / '').
- [x] `POST /api/v1/sessions {voice_mode: 2, llm_model: "anthropic/claude-3.5-haiku"}` → 201 with mode persisted.
- [x] `PATCH /api/v1/sessions/{id} {voice_mode: 3, llm_model: "tinkerclaw/agent"}` → 200 with updated row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)