### PR TITLE
fix(voice): process-wide STT/TTS singletons stop RSS leak on pipeline restart

### DIFF
--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -15,8 +15,8 @@ from typing import Callable, Awaitable, Optional
 import numpy as np
 
 from dragon_voice.config import VoiceConfig
-from dragon_voice.stt import create_stt, STTBackend
-from dragon_voice.tts import create_tts, TTSBackend
+from dragon_voice.stt import get_stt_singleton, STTBackend
+from dragon_voice.tts import get_tts_singleton, TTSBackend
 from dragon_voice.llm import create_llm, LLMBackend
 
 logger = logging.getLogger(__name__)
@@ -113,19 +113,29 @@ class VoicePipeline:
         self._dictation_segments: list[str] = []
 
     async def initialize(self) -> None:
-        """Create and initialize all backends."""
+        """Attach to process-wide STT/TTS singletons; build pipeline-local LLM.
+
+        Fix 5 of #29: STT + TTS are expensive (~2.5 GB ONNX mmap each) and
+        were reloaded every time a pipeline was torn down + rebuilt by the
+        memory monitor or a mode-switch. The reload stacked mmap arenas
+        and leaked RSS. Now the first call loads the model process-wide;
+        subsequent calls with the same config reuse it; different config
+        evicts + loads the new one cleanly.
+
+        LLM backends remain pipeline-local because they're cheap (HTTP
+        clients) and each session may target a different model.
+        """
         logger.info("Initializing voice pipeline...")
 
-        self._stt = create_stt(self._config.stt)
-        self._tts = create_tts(self._config.tts)
-        self._llm = create_llm(self._config.llm)
+        # STT/TTS via singletons — no reload if already loaded for this cfg.
+        stt_task = asyncio.create_task(get_stt_singleton(self._config.stt))
+        tts_task = asyncio.create_task(get_tts_singleton(self._config.tts))
 
-        # Initialize in parallel
-        await asyncio.gather(
-            self._stt.initialize(),
-            self._tts.initialize(),
-            self._llm.initialize(),
-        )
+        # LLM is pipeline-local; cheap to (re)build.
+        self._llm = create_llm(self._config.llm)
+        await asyncio.gather(stt_task, tts_task, self._llm.initialize())
+        self._stt = stt_task.result()
+        self._tts = tts_task.result()
 
         logger.info(
             "Pipeline ready — STT=%s, TTS=%s, LLM=%s",
@@ -434,14 +444,15 @@ class VoicePipeline:
             except (Exception, asyncio.TimeoutError) as stt_err:
                 if self._config.stt.backend == "openrouter":
                     logger.error("Cloud STT failed: %s — falling back to local", stt_err)
-                    from dragon_voice.stt import create_stt
+                    # Use the singleton so we share the already-loaded Moonshine
+                    # model with any other session in local mode. No reload.
+                    from dragon_voice.stt import get_stt_singleton
                     from dragon_voice.config import STTConfig
-                    fallback = create_stt(STTConfig(backend="moonshine"))
-                    await fallback.initialize()
+                    fallback = await get_stt_singleton(STTConfig(backend="moonshine"))
                     transcript = await fallback.transcribe(
                         audio_data, self._config.audio.input_sample_rate
                     )
-                    await fallback.shutdown()
+                    # Do NOT shutdown — singleton stays loaded for next call.
                     # Notify Tab5: auto-disable cloud mode
                     await self._on_event({
                         "type": "config_update",
@@ -642,12 +653,11 @@ class VoicePipeline:
             except (Exception, asyncio.TimeoutError) as tts_err:
                 if self._config.tts.backend == "openrouter":
                     logger.error("Cloud TTS failed: %s — falling back to local", tts_err)
-                    from dragon_voice.tts import create_tts
+                    from dragon_voice.tts import get_tts_singleton
                     from dragon_voice.config import TTSConfig
-                    fallback = create_tts(TTSConfig(backend="piper"))
-                    await fallback.initialize()
+                    fallback = await get_tts_singleton(TTSConfig(backend="piper"))
                     audio_bytes = await fallback.synthesize(text)
-                    await fallback.shutdown()
+                    # Do NOT shutdown — singleton stays loaded for next call.
                     await self._on_event({
                         "type": "config_update",
                         "error": "Cloud TTS unavailable, reverted to local",
@@ -745,26 +755,26 @@ class VoicePipeline:
 
             tasks = []
 
+            # Fix 5 of #29: STT/TTS backend swap goes through the singleton
+            # layer. get_stt_singleton/get_tts_singleton evicts the prior
+            # singleton cleanly (releases its mmap arena via fix 6's
+            # del + gc.collect) and loads the new one. No pipeline-local
+            # shutdown call — that would be a no-op now anyway.
+
             # Check if STT backend changed
             if (
                 config.stt.backend != old_config.stt.backend
                 or config.stt.model != old_config.stt.model
             ):
                 logger.info("Swapping STT: %s -> %s", old_config.stt.backend, config.stt.backend)
-                if self._stt:
-                    await self._stt.shutdown()
-                self._stt = create_stt(config.stt)
-                tasks.append(self._stt.initialize())
+                tasks.append(get_stt_singleton(config.stt))
 
             # Check if TTS backend changed
             if config.tts.backend != old_config.tts.backend:
                 logger.info("Swapping TTS: %s -> %s", old_config.tts.backend, config.tts.backend)
-                if self._tts:
-                    await self._tts.shutdown()
-                self._tts = create_tts(config.tts)
-                tasks.append(self._tts.initialize())
+                tasks.append(get_tts_singleton(config.tts))
 
-            # Check if LLM backend changed
+            # LLM remains pipeline-local — no singleton layer.
             if (
                 config.llm.backend != old_config.llm.backend
                 or config.llm.ollama_model != old_config.llm.ollama_model
@@ -776,7 +786,15 @@ class VoicePipeline:
                 tasks.append(self._llm.initialize())
 
             if tasks:
-                await asyncio.gather(*tasks)
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+                # If STT/TTS tasks returned backends, latch them. Any exceptions
+                # get raised here so the swap fails loudly rather than silently.
+                for r in results:
+                    if isinstance(r, Exception):
+                        raise r
+                # Re-query singletons for current refs (cheap — already cached).
+                self._stt = await get_stt_singleton(config.stt)
+                self._tts = await get_tts_singleton(config.tts)
                 logger.info("Backend swap complete")
         finally:
             # US-P01: Re-enable audio ingestion after swap completes (or fails)
@@ -803,15 +821,26 @@ class VoicePipeline:
         return self._processing
 
     async def shutdown(self) -> None:
-        """Shut down all backends."""
+        """Tear down this pipeline — but NOT the shared STT/TTS singletons.
+
+        Fix 5 of #29: STT and TTS are process-wide singletons (see
+        dragon_voice/stt/__init__.py + dragon_voice/tts/__init__.py).
+        Shutting them down here would defeat the whole point — the next
+        pipeline would have to reload the ~2.5 GB Moonshine arena, which
+        was the source of the RSS leak. Only shut down the pipeline-local
+        LLM (which is cheap — HTTP client) and drop our refs.
+
+        The singletons are released exactly once, at process shutdown,
+        by server.py calling shutdown_stt_singleton + shutdown_tts_singleton.
+        """
         await self.cancel()
-        tasks = []
-        if self._stt:
-            tasks.append(self._stt.shutdown())
-        if self._tts:
-            tasks.append(self._tts.shutdown())
         if self._llm:
-            tasks.append(self._llm.shutdown())
-        if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
-        logger.info("Voice pipeline shut down")
+            try:
+                await self._llm.shutdown()
+            except Exception:
+                logger.exception("LLM shutdown raised")
+        # Drop refs but don't shut down — singletons keep the model alive.
+        self._stt = None
+        self._tts = None
+        self._llm = None
+        logger.info("Voice pipeline shut down (STT/TTS singletons preserved)")

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -528,7 +528,7 @@ class VoiceServer:
         if self._purge_task and not self._purge_task.done():
             self._purge_task.cancel()
 
-        # Shut down pipelines
+        # Shut down pipelines (does NOT release STT/TTS singletons — see fix 5 of #29)
         tasks = []
         for ws_id, conn in list(self._active_connections.items()):
             pipeline = conn.get("pipeline")
@@ -537,6 +537,17 @@ class VoiceServer:
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
         self._active_connections.clear()
+
+        # Release process-wide STT + TTS singletons explicitly on final exit.
+        # During the server's lifetime the singletons stay loaded across
+        # every pipeline rebuild; only here do we let the ONNX mmaps free.
+        try:
+            from dragon_voice.stt import shutdown_stt_singleton
+            from dragon_voice.tts import shutdown_tts_singleton
+            await shutdown_stt_singleton()
+            await shutdown_tts_singleton()
+        except Exception:
+            logger.exception("Singleton shutdown raised — continuing exit")
 
         # Close shared proxy session (DQ08)
         if self._proxy_session and not self._proxy_session.closed:

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -59,9 +59,17 @@ class VoiceServer:
         self._purge_task: Optional[asyncio.Task] = None
         self._memory_monitor_task: Optional[asyncio.Task] = None
 
-        # Memory thresholds (MB) — Dragon has 8GB total, Ollama ~1.5GB, TinkerClaw ~300MB
-        self._mem_warn_mb = 2048   # Force GC above this
-        self._mem_crit_mb = 3072   # Restart pipeline above this (after GC)
+        # Memory thresholds (MB). Dragon has 8 GB total. Steady-state RSS
+        # includes Moonshine ONNX (~2.5 GB mmap) + Piper (~300 MB) + Ollama
+        # (~1.5 GB) + TinkerClaw (~300 MB). The old 3072 MB critical threshold
+        # fired on legitimate steady state, triggering a pipeline restart
+        # that REloaded Moonshine/Piper without releasing the prior mmap
+        # (onnxruntime arenas survive pipeline.shutdown + gc.collect until
+        # the singleton refactor in fix 5 of #29 lands). Result: RSS climbed
+        # 60 -> 1444 -> 2085 -> 3054 -> 3657 MB in 25 min of normal use.
+        # Raise ceilings so the monitor only fires on an actual runaway.
+        self._mem_warn_mb = 3072   # Force GC above this
+        self._mem_crit_mb = 4096   # Restart pipeline above this (after GC)
 
         # Backend names for status page
         self._stt_name = config.stt.backend

--- a/dragon_voice/stt/__init__.py
+++ b/dragon_voice/stt/__init__.py
@@ -1,7 +1,28 @@
-"""STT backend factory."""
+"""STT backend factory — with process-level singletons.
+
+Models (Moonshine ONNX ~2.5 GB mmap, Whisper.cpp ~500 MB) are expensive
+to load and their C-extension mmap arenas don't release cleanly on GC.
+Pre-fix-5 every VoicePipeline.initialize() rebuilt + re-initialized
+backends, stacking arena copies and driving the RSS leak tracked in
+#29 (60 MB → 3.6 GB in 25 min of normal use).
+
+Fix: cache initialized backends by config fingerprint. A VoicePipeline
+switching from mode A to mode B shuts down the old singleton explicitly
+(fix 6 of #29 releases the mmap via del + gc.collect) before loading
+the new one. Within a mode, every pipeline restart shares the same
+already-loaded backend — no reload.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
 
 from dragon_voice.config import STTConfig
 from dragon_voice.stt.base import STTBackend
+
+logger = logging.getLogger(__name__)
 
 _BACKENDS = {
     "whisper_cpp": "dragon_voice.stt.whisper_cpp.WhisperCppBackend",
@@ -10,20 +31,20 @@ _BACKENDS = {
     "openrouter": "dragon_voice.stt.openrouter_stt.OpenRouterSTTBackend",
 }
 
+# ── Process-wide singleton cache ──────────────────────────────────
+# Exactly ONE STT instance per (backend, model) key. Switching modes
+# evicts the prior singleton so its mmap releases.
+_singleton: Optional[STTBackend] = None
+_singleton_key: Optional[tuple[str, str]] = None
+_singleton_lock = asyncio.Lock()
 
-def create_stt(config: STTConfig) -> STTBackend:
-    """Create an STT backend instance from configuration.
 
-    Args:
-        config: STT section of the voice config.
+def _key_for(config: STTConfig) -> tuple[str, str]:
+    return (config.backend.lower(), getattr(config, "model", "") or "")
 
-    Returns:
-        An uninitialized STTBackend — caller must await .initialize().
 
-    Raises:
-        ValueError: If the requested backend name is unknown.
-        ImportError: If the required package for the backend is not installed.
-    """
+def _build(config: STTConfig) -> STTBackend:
+    """Resolve the backend class and instantiate (uninitialized)."""
     backend_name = config.backend.lower()
     if backend_name not in _BACKENDS:
         available = ", ".join(sorted(_BACKENDS.keys()))
@@ -47,4 +68,73 @@ def create_stt(config: STTConfig) -> STTBackend:
     return cls(config)
 
 
-__all__ = ["create_stt", "STTBackend"]
+async def get_stt_singleton(config: STTConfig) -> STTBackend:
+    """Return an initialized STT singleton for the given config.
+
+    First call for a given (backend, model) key loads + initializes
+    the model. Subsequent calls with the same key return the cached
+    instance. A different key shuts down the prior singleton first.
+
+    Concurrency: guarded by _singleton_lock so two pipeline starts
+    can't race to load the model twice.
+    """
+    global _singleton, _singleton_key
+
+    key = _key_for(config)
+
+    async with _singleton_lock:
+        if _singleton is not None and _singleton_key == key:
+            # Fast path — same config, return cached already-initialized
+            return _singleton
+
+        # Evict previous singleton if any — pair with fix 6's gc.collect
+        if _singleton is not None:
+            logger.info(
+                "STT singleton: evicting %s for %s", _singleton_key, key
+            )
+            try:
+                await _singleton.shutdown()
+            except Exception:
+                logger.exception("STT singleton eviction shutdown raised")
+            _singleton = None
+            _singleton_key = None
+
+        # Build + initialize new
+        inst = _build(config)
+        await inst.initialize()
+        _singleton = inst
+        _singleton_key = key
+        logger.info("STT singleton: loaded %s", key)
+        return _singleton
+
+
+async def shutdown_stt_singleton() -> None:
+    """Release the STT singleton. Called on process shutdown only."""
+    global _singleton, _singleton_key
+    async with _singleton_lock:
+        if _singleton is not None:
+            try:
+                await _singleton.shutdown()
+            except Exception:
+                logger.exception("STT singleton final shutdown raised")
+            _singleton = None
+            _singleton_key = None
+
+
+def create_stt(config: STTConfig) -> STTBackend:
+    """DEPRECATED — prefer get_stt_singleton.
+
+    Kept so any legacy caller that builds an STT outside the pipeline
+    keeps working. Does NOT use the singleton cache (builds a fresh
+    instance every call), so memory pressure returns if called at
+    scale. VoicePipeline switched to get_stt_singleton in fix 5 of #29.
+    """
+    return _build(config)
+
+
+__all__ = [
+    "create_stt",
+    "get_stt_singleton",
+    "shutdown_stt_singleton",
+    "STTBackend",
+]

--- a/dragon_voice/stt/moonshine_stt.py
+++ b/dragon_voice/stt/moonshine_stt.py
@@ -122,10 +122,26 @@ class MoonshineBackend(STTBackend):
         return text
 
     async def shutdown(self) -> None:
+        """Release the Transcriber + its onnxruntime InferenceSession.
+
+        The Transcriber wraps onnxruntime sessions that mmap the ~2.5 GB
+        model file. Simply dropping the reference isn't enough — the
+        onnxruntime C extension holds its own arenas that only release
+        when the Python wrapper is GC'd. We del + gc.collect explicitly
+        so a pipeline restart doesn't stack two copies of the arena
+        (which was the visible RSS leak in #29 pre-singleton).
+
+        Harmless no-op when called before initialize or twice. """
         if self._transcriber is not None:
-            self._transcriber.close()
+            try:
+                self._transcriber.close()
+            except Exception:
+                logger.exception("Moonshine transcriber.close() raised — proceeding to del")
             self._transcriber = None
-        logger.info("Moonshine backend shut down")
+        self._model_arch = None
+        import gc
+        gc.collect()
+        logger.info("Moonshine backend shut down (transcriber released, gc run)")
 
     @property
     def name(self) -> str:

--- a/dragon_voice/tts/__init__.py
+++ b/dragon_voice/tts/__init__.py
@@ -1,7 +1,19 @@
-"""TTS backend factory."""
+"""TTS backend factory — with process-level singletons.
+
+See dragon_voice/stt/__init__.py for the rationale — same pattern
+applies to Piper (~300 MB onnxruntime arena) and Kokoro (larger).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
 
 from dragon_voice.config import TTSConfig
 from dragon_voice.tts.base import TTSBackend
+
+logger = logging.getLogger(__name__)
 
 _BACKENDS = {
     "piper": "dragon_voice.tts.piper_tts.PiperBackend",
@@ -10,20 +22,22 @@ _BACKENDS = {
     "openrouter": "dragon_voice.tts.openrouter_tts.OpenRouterTTSBackend",
 }
 
+_singleton: Optional[TTSBackend] = None
+_singleton_key: Optional[tuple[str, str]] = None
+_singleton_lock = asyncio.Lock()
 
-def create_tts(config: TTSConfig) -> TTSBackend:
-    """Create a TTS backend instance from configuration.
 
-    Args:
-        config: TTS section of the voice config.
+def _key_for(config: TTSConfig) -> tuple[str, str]:
+    # Piper uses piper_model (voice file). Others use backend name as model.
+    model = (
+        getattr(config, "piper_model", None)
+        or getattr(config, "model", None)
+        or ""
+    )
+    return (config.backend.lower(), model)
 
-    Returns:
-        An uninitialized TTSBackend — caller must await .initialize().
 
-    Raises:
-        ValueError: If the requested backend name is unknown.
-        ImportError: If the required package for the backend is not installed.
-    """
+def _build(config: TTSConfig) -> TTSBackend:
     backend_name = config.backend.lower()
     if backend_name not in _BACKENDS:
         available = ", ".join(sorted(_BACKENDS.keys()))
@@ -47,4 +61,56 @@ def create_tts(config: TTSConfig) -> TTSBackend:
     return cls(config)
 
 
-__all__ = ["create_tts", "TTSBackend"]
+async def get_tts_singleton(config: TTSConfig) -> TTSBackend:
+    """Return an initialized TTS singleton for the given config."""
+    global _singleton, _singleton_key
+
+    key = _key_for(config)
+
+    async with _singleton_lock:
+        if _singleton is not None and _singleton_key == key:
+            return _singleton
+
+        if _singleton is not None:
+            logger.info(
+                "TTS singleton: evicting %s for %s", _singleton_key, key
+            )
+            try:
+                await _singleton.shutdown()
+            except Exception:
+                logger.exception("TTS singleton eviction shutdown raised")
+            _singleton = None
+            _singleton_key = None
+
+        inst = _build(config)
+        await inst.initialize()
+        _singleton = inst
+        _singleton_key = key
+        logger.info("TTS singleton: loaded %s", key)
+        return _singleton
+
+
+async def shutdown_tts_singleton() -> None:
+    """Release the TTS singleton. Called on process shutdown only."""
+    global _singleton, _singleton_key
+    async with _singleton_lock:
+        if _singleton is not None:
+            try:
+                await _singleton.shutdown()
+            except Exception:
+                logger.exception("TTS singleton final shutdown raised")
+            _singleton = None
+            _singleton_key = None
+
+
+def create_tts(config: TTSConfig) -> TTSBackend:
+    """DEPRECATED — prefer get_tts_singleton. Kept for legacy callers."""
+    return _build(config)
+
+
+__all__ = [
+    "create_tts",
+    "get_tts_singleton",
+    "shutdown_tts_singleton",
+    "TTSBackend",
+]

--- a/dragon_voice/tts/piper_tts.py
+++ b/dragon_voice/tts/piper_tts.py
@@ -247,9 +247,28 @@ class PiperBackend(TTSBackend):
             logger.info("Killed %d in-flight Piper processes", killed)
 
     async def shutdown(self) -> None:
+        """Release the Piper voice model + any in-flight subprocesses.
+
+        When using the piper-tts Python package the _voice object wraps
+        an onnxruntime.InferenceSession with a mmap-backed model arena
+        (~300 MB). Dropping the reference isn't enough — the C extension
+        keeps the arena alive until Python GC runs, so a pipeline restart
+        would stack two copies of the model before the first was freed.
+        del + gc.collect lets the runtime actually release the mmap. """
         self.kill_active_procs()
-        self._voice = None
-        logger.info("Piper TTS shut down")
+        if self._voice is not None:
+            try:
+                # Best-effort: piper-tts Python wrapper doesn't define
+                # close(), but some onnxruntime sessions offer __del__.
+                del self._voice
+            except Exception:
+                logger.exception("Piper voice del raised — proceeding")
+            self._voice = None
+        self._binary_path = None
+        self._model_path = None
+        import gc
+        gc.collect()
+        logger.info("Piper TTS shut down (voice released, gc run)")
 
     @property
     def sample_rate(self) -> int:


### PR DESCRIPTION
## Summary
Closes #29. Stops the voice server RSS leak (60 MB → 3.6 GB in 25 min) that was forcing constant pipeline restarts, which in turn caused Tab5 WS flap → SDIO saturation → Tab5 HTTP debug server starvation (companion [TinkerTab #75](https://github.com/lorcan35/TinkerTab/pull/75)).

## Three atomic fixes

| # | Commit | What |
|---|---|---|
| 7 | f5ac262 | Raise RSS thresholds 2048 warn / 3072 crit → 3072 / 4096 — old crit fired on legitimate Moonshine steady-state |
| 6 | 1206f9b | Explicit \`del self._session; gc.collect()\` in \`moonshine_stt.shutdown()\` + \`piper_tts.shutdown()\` — onnxruntime C-extension mmap arenas don't release on GC without this |
| 5 | **0ab646d** | **Process-wide STT + TTS singletons.** \`get_stt_singleton(config)\` / \`get_tts_singleton(config)\` keyed by \`(backend, model)\`. Pipeline restart no longer reloads models — it attaches to the already-loaded singleton. |

## Architecture change — macro-level

**Before:**
\`\`\`
Every pipeline.initialize() → create_stt(cfg) → new MoonshineBackend → mmap ~2.5 GB
Every pipeline.shutdown()   → stt.shutdown() → C-ext mmap ≠ released
Memory-monitor forced-restart → another pipeline + another mmap stacked → RSS up
\`\`\`

**After:**
\`\`\`
pipeline.initialize() → get_stt_singleton(cfg):
  if singleton matches config → return cached (0 load time, 0 extra RSS)
  else → evict old singleton (fix 6's gc releases mmap) + load new
pipeline.shutdown() → drops refs, does NOT touch singleton
Memory-monitor forced-restart → pipeline rebuilt on top of SAME singleton
Only process exit frees the mmap (via shutdown_stt_singleton in server._on_shutdown)
\`\`\`

## Files touched
- \`dragon_voice/stt/__init__.py\` — added \`get_stt_singleton\`, \`shutdown_stt_singleton\`, kept \`create_stt\` as deprecated shim
- \`dragon_voice/tts/__init__.py\` — same pattern
- \`dragon_voice/stt/moonshine_stt.py\` — explicit release + gc in shutdown
- \`dragon_voice/tts/piper_tts.py\` — same
- \`dragon_voice/pipeline.py\` — migrated 4 call sites (initialize + 2 fallbacks + backend swap) to singletons
- \`dragon_voice/server.py\` — new thresholds, process-exit singleton release

## Test plan
- [x] All syntax + import checks pass
- [x] Deploy to live Dragon at 192.168.70.242 — clean restart, RSS 61 MB cold start
- [x] New thresholds visible in log: \`Memory monitor started (RSS=61 MB, warn=3072 MB, crit=4096 MB)\`
- [ ] 1 h soak test with Tab5 voice turns across local/hybrid/cloud — RSS must plateau <= 2.5 GB, no forced-restart entries
- [ ] Mode-swap stress: alternate local↔cloud 20×, verify singleton eviction fires cleanly + RSS doesn't grow