### PR TITLE
feat(audit): wave 13 Dragon security + quality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install runtime + test deps
+        run: |
+          python -m pip install --upgrade pip
+          # aiosqlite is used by dragon_voice.db but wasn't in requirements.txt.
+          pip install aiosqlite
+          pip install -r requirements.txt
+          # Test + lint tooling.
+          pip install ruff pytest pytest-asyncio
+
+      - name: Lint (ruff — real-bug gate)
+        run: |
+          # Wave 13 H9: start narrow.  The legacy tree has ~100 style
+          # findings we haven't triaged; failing CI on those would just
+          # block merges.  Gate on the codes that catch actual runtime bugs:
+          #   F821 undefined name        F811 redefinition of unused name
+          #   F722 syntax error           F823 local var referenced before assign
+          #   E999 syntax error           B006 mutable default argument
+          # Style/UP/I can be tightened in a follow-up wave.
+          ruff check --select F821,F722,F811,F823,B006 \
+            dragon_voice/ dashboard.py tests/
+
+      - name: Run unit + middleware tests
+        env:
+          DRAGON_API_TOKEN: ci-bearer-token
+          TINKERCLAW_TOKEN: ci-tc-token
+        run: |
+          # Dragon E2E suite requires a live server -- skip it in CI and only
+          # run the pure-unit + middleware tests that pass without I/O.
+          python -m pytest -v \
+            tests/test_auth_middleware.py \
+            tests/test_session_cas.py \
+            tests/test_media_store.py \
+            tests/test_media_pipeline.py \
+            tests/test_mcp_bridge.py

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -541,3 +541,46 @@ sequentially across the whole file (don't restart per section).
 - **Root Cause:** `devices.hardware_id` has a UNIQUE constraint. Empty string counts as a value. The register handler doesn't fill in a default if the client omits it.
 - **Fix:** Synthetic tests now send `hardware_id: "probe-hw-" + secrets.token_hex(6)` to dodge the constraint. Real Tab5s always send a MAC-derived ID so this doesn't hit in production.
 - **Prevention:** Either make `hardware_id` default to the `device_id` if empty in `_handle_register`, or drop the UNIQUE constraint (device_id is already the PK). For synthetic/integration tests, always generate unique hardware_ids.
+
+### 69. WiFi creds plaintext in public sdkconfig.defaults
+- **Date:** 2026-04-20 (wave 13 C1)
+- **Symptom:** Audit flagged real router SSID + password baked into `TinkerTab/sdkconfig.defaults` and pushed to the public GitHub repo. Password was a rotating-but-remembered secret.
+- **Root Cause:** `sdkconfig.defaults` is the expected place to define Kconfig-backed strings, and the ESP-IDF build bakes them into the firmware. Someone added placeholders, someone else filled them in with live values, and the file kept getting committed.
+- **Fix:** Replaced live values with `CHANGEME_SET_IN_SDKCONFIG_LOCAL` markers. Added `sdkconfig.local.example` (committed) and made `sdkconfig.local` (gitignored) the deployer's override. ESP-IDF merges `sdkconfig.local` on top of `.defaults` during reconfigure. CI plants a placeholder `sdkconfig.local` in-workflow so `idf.py build` still compiles.
+- **Prevention:** Any Kconfig string that carries an environment-specific value MUST default to an obviously-invalid placeholder. If the build fails loudly when run without overrides, nobody gets tempted to "just set it here real quick". The old password is in the git history forever — rotate it on the router.
+
+### 70. Dragon REST surface had no auth
+- **Date:** 2026-04-20 (wave 13 C2)
+- **Symptom:** `/api/v1/sessions`, `/api/v1/memory`, etc. were reachable from any host on the LAN (and via ngrok from anywhere) with zero credentials. Anyone could read conversation history or inject fake sessions.
+- **Root Cause:** No middleware gated the REST routes. The WS handshake authenticated at the `register` frame, but HTTP did not.
+- **Fix:** New `_auth_middleware` in `server.py` + `ServerConfig.api_token` field + `DRAGON_API_TOKEN` env override. All routes require `Authorization: Bearer <token>` except the `_AUTH_PUBLIC_PREFIXES` allowlist (`/health`, `/ws/voice` handshake, `/dashboard`, `/api/media/`). Constant-time comparison via `hmac.compare_digest`. Fail-closed with HTTP 503 when token is unconfigured. Regression tests in `tests/test_auth_middleware.py` (6 cases).
+- **Prevention:** Every new HTTP route handler must either land under an existing public prefix or add itself to the allowlist explicitly. The middleware's fail-closed behaviour (503 on unconfigured) makes "forgot to set the token" impossible to miss.
+
+### 71. TinkerClaw gateway token silently sent as blank
+- **Date:** 2026-04-20 (wave 13 H6/H7)
+- **Symptom:** Voice mode 3 (TinkerClaw) returned 401s on every request when the config tree was missing the gateway token, but the error path surfaced only a generic "LLM unavailable" to the user.
+- **Root Cause:** `TinkerClawBackend.__init__` copied `config.tinkerclaw_token` without validation. A blank string was a valid Python value that silently produced a broken `Authorization: Bearer ` header.
+- **Fix:** Constructor now raises `ValueError` with actionable message if token resolves to blank. `TINKERCLAW_TOKEN` env override lives in `config.load_config` (same pattern as `DRAGON_API_TOKEN`). `config.yaml` ships with the placeholder blank and a comment pointing at `/home/radxa/.env`.
+- **Prevention:** Never accept a blank credential as valid config at construction time. Validate at the boundary closest to the caller so the error message carries the most context. The pattern to copy: read → strip → raise-if-blank.
+
+### 72. pipeline.py silent swallow masked WS teardown errors
+- **Date:** 2026-04-20 (wave 13 H5)
+- **Symptom:** Clients disconnecting mid-turn produced cascading "Processing failed" log spam because the secondary `_on_event({"type":"error"...})` emit would raise a wholly different `ConnectionResetError`, get logged at `exception` level by the outer `logger.exception`, and mask the original pipeline fault.
+- **Root Cause:** Three `except Exception: pass` handlers in `pipeline.py` silently swallowed all exceptions — when the inner emit failed, the primary error was still logged, but the silent pass hid a signal we actually want.
+- **Fix:** Narrowed the three silent swallowers to `(ConnectionError, RuntimeError[, AttributeError])` and replaced `pass` with a `logger.debug(...)` that names the handler. The primary `logger.exception` paths keep `except Exception` because they surface the error for diagnosis.
+- **Prevention:** If a handler is silently swallowing, narrow the catch until the specific class makes sense. `except Exception: pass` is a smell — it means the author didn't know what can fail. The acceptable version is a narrow catch of expected failure modes plus at least a `logger.debug`.
+
+### 73. ClientSession on module-global bound to wrong event loop
+- **Date:** 2026-04-20 (wave 13 H4)
+- **Symptom:** Test harness that restarted the dashboard app between tests raised `RuntimeError: Session is closed` or "Timeout context manager should be used inside a task" depending on the test ordering. Production dashboard didn't show this — only the test rig did.
+- **Root Cause:** `_client: aiohttp.ClientSession | None = None` was a module global initialized in `on_startup`. On app teardown it was set to None, but the second app's `on_startup` created a new session bound to a *new* event loop — yet helpers accessing `_client` could still see a stale reference in flight.
+- **Fix:** Moved the session onto `app[CLIENT_KEY]` (aiohttp's `AppKey` API). Helpers now take the `app` explicitly (`_fetch_json(app, url)`). Lifecycle is app-scoped; each app owns its own session.
+- **Prevention:** Never hold an aiohttp session in a module global. Use `web.AppKey` + `app[key]`. This is the pattern aiohttp 3.9+ actively recommends.
+
+### 74. media_cleanup task not cancelled on shutdown
+- **Date:** 2026-04-20 (wave 13 H3)
+- **Symptom:** Graceful shutdown logged "Task was destroyed but it is pending" for `_media_cleanup_loop` when systemd sent SIGTERM during the 24h TTL sleep.
+- **Root Cause:** `_on_shutdown` cancelled `_memory_monitor_task` and `_purge_task` but missed `_media_cleanup_task` entirely. The loop sat in `asyncio.sleep(3600)` and the event loop closed out from under it.
+- **Fix:** Added cancel + await-with-suppressed-CancelledError for `_media_cleanup_task` in `_on_shutdown`, matching the sibling cleanup tasks.
+- **Prevention:** Every `asyncio.create_task(...)` that lives past the request must be tracked in a single `self._*_task` field AND cancelled in `_on_shutdown`. Grep for `create_task` before adding a new long-lived task.
+

--- a/dashboard.py
+++ b/dashboard.py
@@ -17,6 +17,8 @@ import asyncio
 import logging
 import time
 
+import os
+
 import aiohttp
 from aiohttp import web
 
@@ -28,31 +30,45 @@ PORT = 3500
 DRAGON_SERVER = "http://127.0.0.1:3501"
 VOICE_SERVER = "http://127.0.0.1:3502"
 
-_client: aiohttp.ClientSession | None = None
+# Wave 13 C2: voice server now enforces bearer-token auth on /api/v1/* and the
+# rest of the private REST surface. The dashboard proxies user clicks to those
+# routes, so it needs to inject the token. Reads DRAGON_API_TOKEN from the
+# same .env the voice server does; both services share the secret.
+DRAGON_API_TOKEN = os.environ.get("DRAGON_API_TOKEN", "").strip()
+
+
+def _auth_headers() -> dict:
+    return {"Authorization": f"Bearer {DRAGON_API_TOKEN}"} if DRAGON_API_TOKEN else {}
+
+# Wave 13 H4: ClientSession lives on the aiohttp Application, not as a module
+# global. That makes the dashboard safe to embed inside another app in tests
+# and keeps the session tied to the correct event loop (module-global sessions
+# can accidentally bind to the wrong loop when multiple tests run back-to-back).
+CLIENT_KEY = web.AppKey("client_session", aiohttp.ClientSession)
+
 _start_time = time.time()
 
 
 # ── Lifecycle ────────────────────────────────────────────────────────────
 
 async def on_startup(app: web.Application) -> None:
-    global _client
-    _client = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10))
+    app[CLIENT_KEY] = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10))
     log.info("Dashboard started on http://%s:%d", HOST, PORT)
 
 
 async def on_shutdown(app: web.Application) -> None:
-    global _client
-    if _client:
-        await _client.close()
-        _client = None
+    client = app.get(CLIENT_KEY)
+    if client is not None and not client.closed:
+        await client.close()
 
 
 # ── Internal helpers ─────────────────────────────────────────────────────
 
-async def _fetch_json(url: str) -> dict | None:
+async def _fetch_json(app: web.Application, url: str) -> dict | None:
     """Fetch JSON from an internal service, return None on failure."""
+    client = app[CLIENT_KEY]
     try:
-        async with _client.get(url) as resp:
+        async with client.get(url, headers=_auth_headers()) as resp:
             if resp.status == 200:
                 return await resp.json()
             return {"error": f"HTTP {resp.status}"}
@@ -77,7 +93,9 @@ async def _proxy_request(request: web.Request) -> web.Response:
         target_url += f"?{request.query_string}"
 
     method = request.method.upper()
-    headers = {}
+    # Wave 13 C2: inject bearer token so proxied dashboard calls clear the
+    # voice server's auth middleware. Browser-side JS doesn't know the token.
+    headers = dict(_auth_headers())
     body = None
 
     # Forward JSON body for POST/PUT/PATCH
@@ -94,8 +112,9 @@ async def _proxy_request(request: web.Request) -> web.Response:
             except Exception:
                 pass
 
+    client = request.app[CLIENT_KEY]
     try:
-        async with _client.request(
+        async with client.request(
             method, target_url, data=body, headers=headers,
             timeout=aiohttp.ClientTimeout(total=120),
         ) as resp:
@@ -131,8 +150,9 @@ async def _proxy_request(request: web.Request) -> web.Response:
 
 async def handle_status(request: web.Request) -> web.Response:
     """Aggregate health from both services."""
-    dragon_task = asyncio.create_task(_fetch_json(f"{DRAGON_SERVER}/health"))
-    voice_task = asyncio.create_task(_fetch_json(f"{VOICE_SERVER}/health"))
+    app = request.app
+    dragon_task = asyncio.create_task(_fetch_json(app, f"{DRAGON_SERVER}/health"))
+    voice_task = asyncio.create_task(_fetch_json(app, f"{VOICE_SERVER}/health"))
     dragon, voice = await asyncio.gather(dragon_task, voice_task)
     return web.json_response({
         "dashboard_uptime": int(time.time() - _start_time),
@@ -143,7 +163,7 @@ async def handle_status(request: web.Request) -> web.Response:
 
 async def handle_get_voice_config(request: web.Request) -> web.Response:
     """Proxy GET /api/config from voice server."""
-    result = await _fetch_json(f"{VOICE_SERVER}/api/config")
+    result = await _fetch_json(request.app, f"{VOICE_SERVER}/api/config")
     if result is None:
         return web.json_response({"error": "Voice server unreachable"}, status=502)
     return web.json_response(result)
@@ -155,8 +175,9 @@ async def handle_set_voice_config(request: web.Request) -> web.Response:
         body = await request.json()
     except Exception:
         return web.json_response({"error": "Invalid JSON"}, status=400)
+    client = request.app[CLIENT_KEY]
     try:
-        async with _client.post(f"{VOICE_SERVER}/api/config", json=body) as resp:
+        async with client.post(f"{VOICE_SERVER}/api/config", json=body, headers=_auth_headers()) as resp:
             data = await resp.json()
             return web.json_response(data, status=resp.status)
     except Exception as exc:

--- a/dragon_voice/config.py
+++ b/dragon_voice/config.py
@@ -50,6 +50,10 @@ MAX_TOKENS_CLOUD = 512   # Cloud LLM can handle more
 class ServerConfig:
     host: str = "0.0.0.0"
     port: int = 3502
+    # Wave 13 C2: Bearer token protecting all REST routes except the public
+    # prefixes declared in server.py (_AUTH_PUBLIC_PREFIXES). Blank in the
+    # committed config — populated from DRAGON_API_TOKEN at load time.
+    api_token: str = ""
 
 
 @dataclass
@@ -283,6 +287,20 @@ def load_config(path: Optional[str] = None) -> VoiceConfig:
         memory=_dict_to_dataclass(MemoryConfig, raw["memory"]),
         database=_dict_to_dataclass(DatabaseConfig, raw["database"]),
     )
+
+    # Wave 13 C2: DRAGON_API_TOKEN env var sets the REST bearer token without
+    # requiring the DRAGON_VOICE_SERVER_API_TOKEN naming (shorter, lines up with
+    # how Tab5 and deploy scripts refer to it). Explicit env wins over yaml.
+    _dragon_api_token = os.environ.get("DRAGON_API_TOKEN", "").strip()
+    if _dragon_api_token:
+        config.server.api_token = _dragon_api_token
+
+    # Wave 13 H7: same pattern for the TinkerClaw gateway token. Used to live
+    # in config.yaml in the committed tree, which is a leak vector — now the
+    # yaml keeps a blank placeholder and real deploys inject via env/.env.
+    _tc_token = os.environ.get("TINKERCLAW_TOKEN", "").strip()
+    if _tc_token:
+        config.llm.tinkerclaw_token = _tc_token
 
     # Remember original local LLM backend for fallback from cloud mode
     if not config.llm.local_backend:

--- a/dragon_voice/config.yaml
+++ b/dragon_voice/config.yaml
@@ -1,6 +1,10 @@
 server:
   host: "0.0.0.0"
   port: 3502
+  # Wave 13 C2: REST bearer token. Leave blank here — real value comes from
+  # DRAGON_API_TOKEN env (see /home/radxa/.env on Dragon). Middleware fails
+  # closed (503) on private routes if this is empty.
+  api_token: ""
 
 stt:
   backend: "moonshine"  # moonshine, whisper_cpp, vosk
@@ -42,7 +46,11 @@ llm:
 
   # TinkerClaw agent gateway (optional sidecar)
   tinkerclaw_url: "http://localhost:18789"
-  tinkerclaw_token: ""  # set to match gateway auth token
+  # Wave 13 H7: tinkerclaw_token MUST stay blank here. Inject via the
+  # TINKERCLAW_TOKEN env var (see /home/radxa/.env loaded by systemd
+  # EnvironmentFile=). TinkerClawBackend raises at construction if the
+  # token resolves to blank, so a misconfigured gateway no-ops loudly.
+  tinkerclaw_token: ""
   tinkerclaw_model: "minimax/MiniMax-M2.5"
 
   system_prompt: "You are Tinker, a helpful AI assistant. Reply in 1-2 sentences maximum. Be concise. Never simulate user responses. Never generate text after your answer. Stop immediately after answering."

--- a/dragon_voice/llm/tinkerclaw_llm.py
+++ b/dragon_voice/llm/tinkerclaw_llm.py
@@ -25,7 +25,17 @@ class TinkerClawBackend(LLMBackend):
     def __init__(self, config: LLMConfig) -> None:
         self._config = config
         self._url = (config.tinkerclaw_url or "http://localhost:18789").rstrip("/")
-        self._token = config.tinkerclaw_token
+        self._token = (config.tinkerclaw_token or "").strip()
+        # Wave 13 H6: fail fast at construction rather than silently sending
+        # unauthenticated requests that the gateway will reject with 401 on
+        # every single turn. The misconfigured case used to look like a
+        # "model is dumb" bug from the user's perspective.
+        if not self._token:
+            raise ValueError(
+                "tinkerclaw_token is blank — set TINKERCLAW_TOKEN in env "
+                "or llm.tinkerclaw_token in config.yaml. Gateway (port "
+                "18789) rejects every request without a bearer token."
+            )
         # Audit J12/J20/K13 (wave 7): align the empty-config fallback with
         # dragon_voice.config.LLMConfig.tinkerclaw_model default
         # ("minimax/MiniMax-M2.5") and with the TinkerTab audit expectation.

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -260,8 +260,11 @@ class VoicePipeline:
                 if self._tts_started:
                     await self._on_event({"type": "tts_end", "tts_ms": 0})
                     self._tts_started = False
-            except Exception:
-                pass
+            except (ConnectionError, RuntimeError) as e:
+                # Wave 13 H5: narrow from `except Exception` — WS is the only
+                # thing `_on_event` can fail on, and it's expected to fail
+                # when the client already disconnected during timeout.
+                logger.debug("timeout-recovery emit skipped (client gone): %s", e)
 
     async def cancel(self) -> None:
         """Cancel ongoing processing and clean up in-flight TTS subprocesses."""
@@ -716,8 +719,10 @@ class VoicePipeline:
                 await self._on_event(
                     {"type": "error", "message": "Processing failed — see server logs"}
                 )
-            except Exception:
-                pass
+            except (ConnectionError, RuntimeError) as _e:
+                # Wave 13 H5: the WS is already torn down — don't mask the
+                # original exception with a secondary send failure.
+                logger.debug("pipeline-error notice not delivered: %s", _e)
         finally:
             total_ms = (time.monotonic() - pipeline_start) * 1000
             logger.info("Pipeline total: %.0fms", total_ms)
@@ -738,8 +743,11 @@ class VoicePipeline:
                         "type": "api_usage",
                         **cost_data,
                     })
-            except Exception:
-                pass  # Cost tracking is best-effort
+            except (ConnectionError, RuntimeError, AttributeError) as _e:
+                # Wave 13 H5: cost tracking must never take down the pipeline.
+                # Narrow from `Exception` to the handful of runtime errors we
+                # actually expect (WS torn down, backend without total_calls).
+                logger.debug("cost tracking emit skipped: %s", _e)
 
     async def speak_system(self, text: str) -> None:
         """Speak a short system message (not stored in conversation history).

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -87,7 +87,7 @@ class VoiceServer:
         """Create and configure the aiohttp application."""
         app = web.Application(
             client_max_size=32 * 1024 * 1024,  # 32MB for audio uploads
-            middlewares=[self._cors_middleware],
+            middlewares=[self._cors_middleware, self._auth_middleware],
         )
 
         # HTTP routes (legacy)
@@ -138,12 +138,60 @@ class VoiceServer:
             return web.Response(headers={
                 "Access-Control-Allow-Origin": origin,
                 "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
-                "Access-Control-Allow-Headers": "Content-Type, X-Sample-Rate, Accept",
+                "Access-Control-Allow-Headers": "Content-Type, X-Sample-Rate, Accept, Authorization",
                 "Access-Control-Max-Age": "3600",
             })
         response = await handler(request)
         response.headers["Access-Control-Allow-Origin"] = origin
         return response
+
+    # ----------------------------------------------------------------- Auth
+    #
+    # Wave 13 C2 security: bearer-token auth on every privileged route.
+    # Matches the scheme docs/protocol.md calls out for Tab5 debug server;
+    # the token is read from config.yaml (reads DRAGON_API_TOKEN env)
+    # and can be rotated without code changes.  Public paths are allowlisted
+    # (health, WS handshake is separately gated via the `register` frame).
+    _AUTH_PUBLIC_PREFIXES = (
+        "/health",              # liveness probe
+        "/ws/voice",            # WS handshake; auth is at `register` time
+        "/dashboard",           # proxied to localhost:3500 (separately gated)
+        "/api/media/",          # rendered media fetch — authenticated by ID obscurity
+    )
+
+    @web.middleware
+    async def _auth_middleware(self, request: web.Request, handler):
+        path = request.path or "/"
+        # Never gate OPTIONS (CORS middleware already answered it).
+        if request.method == "OPTIONS":
+            return await handler(request)
+        if any(path == p or path.startswith(p) for p in self._AUTH_PUBLIC_PREFIXES):
+            return await handler(request)
+        # Resolve the expected token once from config (hot-reload-safe).
+        expected = (getattr(self._config.server, "api_token", "") or "").strip()
+        if not expected:
+            # Token not configured — fail closed on private paths to avoid
+            # accidentally exposing everything when a deployer forgets.
+            # During local-dev bootstrap, set `api_token: ""` in config.yaml
+            # explicitly to an empty-string marker + allowlist the paths.
+            return web.json_response(
+                {"error": "dragon_api_token_not_configured",
+                 "message": "Set DRAGON_API_TOKEN in env or api_token in config.yaml"},
+                status=503)
+        auth = request.headers.get("Authorization", "")
+        if not auth.startswith("Bearer "):
+            return web.json_response(
+                {"error": "missing_bearer_token",
+                 "message": "Authorization: Bearer <token> required"},
+                status=401)
+        supplied = auth[7:].strip()
+        # Constant-time compare to avoid timing-oracle credential leaks.
+        import hmac
+        if not hmac.compare_digest(supplied, expected):
+            return web.json_response(
+                {"error": "invalid_bearer_token",
+                 "message": "token rejected"}, status=401)
+        return await handler(request)
 
     # --------------------------------------------------------------- Dashboard proxy
 
@@ -562,6 +610,16 @@ class VoiceServer:
             self._memory_monitor_task.cancel()
         if self._purge_task and not self._purge_task.done():
             self._purge_task.cancel()
+        # Wave 13 H3: the media cleanup loop was being left running on shutdown
+        # because it isn't touched here. If it was mid-sleep when the event loop
+        # closes, asyncio logs "Task was destroyed but it is pending" warnings
+        # and the 24h TTL cleaner can orphan partial deletes. Cancel + await.
+        if self._media_cleanup_task and not self._media_cleanup_task.done():
+            self._media_cleanup_task.cancel()
+            try:
+                await self._media_cleanup_task
+            except (asyncio.CancelledError, Exception):
+                pass
 
         # Shut down pipelines
         tasks = []
@@ -2102,8 +2160,13 @@ class VoiceServer:
                 })
             return
 
-        with open(image_path, "rb") as f:
-            image_b64 = base64.b64encode(f.read()).decode()
+        # Wave 13 H2: image may be up to ~8 MB (camera JPEG) -- reading on the
+        # event loop thread stalls every other WS connection. Offload the
+        # blocking read + base64 to the default executor.
+        def _read_and_encode(path: str) -> str:
+            with open(path, "rb") as f:
+                return base64.b64encode(f.read()).decode()
+        image_b64 = await asyncio.to_thread(_read_and_encode, image_path)
 
         messages = [{
             "role": "user",

--- a/dragon_voice/surfaces/base.py
+++ b/dragon_voice/surfaces/base.py
@@ -28,6 +28,13 @@ from typing import Any, Awaitable, Callable, Optional, Tuple
 
 log = logging.getLogger("tab5.surface")
 
+# Wave 13 H9 (ruff F821 fix): the `prompt(..., on_action=...)` signature
+# referenced `ActionHandler` but the import lived only in manager.py, so a
+# runtime-evaluated annotation (outside `from __future__ import annotations`
+# semantics at class-define time) would have NameError'd.  Define the alias
+# locally so the base module is self-contained.
+ActionHandler = Callable[[str, dict], Awaitable[Any]]
+
 # Type for the ws-send callable the surface uses. aiohttp WebSocketResponse.send_json
 # is async and raises on closed sockets; caller handles that.
 SendJson = Callable[[dict], Awaitable[Any]]

--- a/dragon_voice/surfaces/manager.py
+++ b/dragon_voice/surfaces/manager.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass, field
-from typing import Optional
 from typing import Any, Awaitable, Callable, Dict, Optional
 
 from .base import Tab5Surface, SendJson

--- a/tests/audit/test_stress_40.py
+++ b/tests/audit/test_stress_40.py
@@ -34,6 +34,12 @@ OUT = Path("/tmp/stress40")
 OUT.mkdir(exist_ok=True, parents=True)
 
 HEADERS = {"Authorization": f"Bearer {TOKEN}"}
+# Wave 13 C2: Dragon /debug/* and /api/v1/* now require a bearer token.
+# DRAGON_HEADERS gets threaded through every Dragon POST below.
+DRAGON_API_TOKEN = os.environ.get("DRAGON_API_TOKEN", "").strip()
+DRAGON_HEADERS = (
+    {"Authorization": f"Bearer {DRAGON_API_TOKEN}"} if DRAGON_API_TOKEN else {}
+)
 
 trace: list[dict] = []
 failures: list[str] = []
@@ -327,7 +333,7 @@ async def main():
                             data=json.dumps({"title": "Stress probe card",
                                              "body": "tap-free evidence", "tone": "info"}).encode())
         # Actually hit Dragon directly not Tab5 — tab5_post prepends TAB5
-        async with s.post(f"{DRAGON}/debug/widget_card",
+        async with s.post(f"{DRAGON}/debug/widget_card", headers=DRAGON_HEADERS,
                           data=json.dumps({"title": "Stress probe card",
                                             "body": f"t+{step_idx}", "tone": "info"}).encode()) as r2:
             dd = await r2.json()
@@ -348,7 +354,7 @@ async def main():
         step("Dragon emits widget_prompt")
         dp = {"emitted": 0}
         for attempt in range(2):
-            async with s.post(f"{DRAGON}/debug/widget_prompt",
+            async with s.post(f"{DRAGON}/debug/widget_prompt", headers=DRAGON_HEADERS,
                               data=json.dumps({"title": "Stress poll?",
                                                 "body": "Either works",
                                                 "choices": [["Yes", "ev.y"], ["No", "ev.n"]]}).encode()) as r2:
@@ -368,7 +374,7 @@ async def main():
 
         # 26. Emit widget_media (home live slot decoded)
         step("Dragon emits widget_media")
-        async with s.post(f"{DRAGON}/debug/widget_media",
+        async with s.post(f"{DRAGON}/debug/widget_media", headers=DRAGON_HEADERS,
                           data=json.dumps({
                               "url": "http://192.168.1.91:3502/api/media/wave7_b5.jpg",
                               "width": 480, "height": 80,
@@ -454,7 +460,7 @@ async def main():
         step("flood 5 widget_cards in 10s")
         emits = []
         for i in range(5):
-            async with s.post(f"{DRAGON}/debug/widget_card",
+            async with s.post(f"{DRAGON}/debug/widget_card", headers=DRAGON_HEADERS,
                               data=json.dumps({"title": f"Flood {i+1}",
                                                 "body": "flood", "tone": "info"}).encode()) as r2:
                 emits.append((await r2.json()).get("emitted", 0))

--- a/tests/audit/test_user_stories.py
+++ b/tests/audit/test_user_stories.py
@@ -27,6 +27,13 @@ DRAGON_WS = os.environ.get("DRAGON_URL", "ws://192.168.1.91:3502/ws/voice")
 DRAGON_HTTP = os.environ.get("DRAGON_HTTP", "http://192.168.1.91:3502")
 TAB5_URL = os.environ.get("TAB5_URL", "http://192.168.1.90:8080")
 TOKEN = os.environ.get("TAB5_TOKEN", "05eed3b13bf62d92cfd8ac424438b9f2")
+# Wave 13 C2: all Dragon private REST routes now require a bearer token.
+# Existing stories hitting /api/v1/memory etc. were getting 401; pass the
+# token via DRAGON_API_TOKEN env for every aiohttp session here.
+DRAGON_API_TOKEN = os.environ.get("DRAGON_API_TOKEN", "").strip()
+DRAGON_AUTH_HEADERS = (
+    {"Authorization": f"Bearer {DRAGON_API_TOKEN}"} if DRAGON_API_TOKEN else {}
+)
 
 results: list[tuple[str, bool, str]] = []
 
@@ -80,7 +87,7 @@ async def _collect(ws, until: str = "tts_end", timeout: int = 30):
 async def story_d6_code_block():
     """User asks for a Python snippet in Cloud. Dragon renders JPEG, Tab5
     gets media event AFTER text_update clears the raw markdown bubble."""
-    async with aiohttp.ClientSession() as s:
+    async with aiohttp.ClientSession(headers=DRAGON_AUTH_HEADERS) as s:
         async with s.ws_connect(DRAGON_WS) as ws:
             await _register(ws)
             await ws.send_json({"type": "text",
@@ -98,7 +105,7 @@ async def story_d6_code_block():
 
 # ── Story 2: Cloud tool call — no XML leak, tool events fire ──────────────
 async def story_d5_cloud_tool_call():
-    async with aiohttp.ClientSession() as s:
+    async with aiohttp.ClientSession(headers=DRAGON_AUTH_HEADERS) as s:
         async with s.ws_connect(DRAGON_WS) as ws:
             await _register(ws)
             await ws.send_json({"type": "text",
@@ -112,7 +119,7 @@ async def story_d5_cloud_tool_call():
 
 # ── Story 3: Mode swap mid-session survives (cloud -> local -> cloud) ─────
 async def story_mode_swap_midsession():
-    async with aiohttp.ClientSession() as s:
+    async with aiohttp.ClientSession(headers=DRAGON_AUTH_HEADERS) as s:
         async with s.ws_connect(DRAGON_WS) as ws:
             await _register(ws, voice_mode=2)
             # Drain the register/initial config_update echo backlog so the
@@ -157,7 +164,7 @@ async def story_mode_swap_midsession():
 
 # ── Story 4: Memory store then semantic recall round-trip ─────────────────
 async def story_memory_semantic_recall():
-    async with aiohttp.ClientSession() as s:
+    async with aiohttp.ClientSession(headers=DRAGON_AUTH_HEADERS) as s:
         # Store a fact
         fact_id: Optional[str] = None
         async with s.post(f"{DRAGON_HTTP}/api/v1/memory",
@@ -183,7 +190,7 @@ async def story_memory_semantic_recall():
 async def story_widget_prompt_no_handler_dismiss():
     """Emit a widget_prompt with NO handler registered, tap a choice,
     expect a widget_dismiss back (wave 8 default-dismiss guard)."""
-    async with aiohttp.ClientSession() as s:
+    async with aiohttp.ClientSession(headers=DRAGON_AUTH_HEADERS) as s:
         async with s.ws_connect(DRAGON_WS) as ws:
             await _register(ws, voice_mode=2)
             # Manually emit a widget_prompt via debug endpoint to ensure a
@@ -214,7 +221,7 @@ async def story_widget_prompt_no_handler_dismiss():
 
 # ── Story 6: sqlite-vec hybrid search result includes score ──────────────
 async def story_sqlite_vec_ranking():
-    async with aiohttp.ClientSession() as s:
+    async with aiohttp.ClientSession(headers=DRAGON_AUTH_HEADERS) as s:
         async with s.post(f"{DRAGON_HTTP}/api/v1/memory/search",
                           json={"query": "what do I drink in the morning"}) as r:
             d = await r.json()
@@ -229,7 +236,7 @@ async def story_sqlite_vec_ranking():
 async def story_session_resume_replay():
     """Connect, chat, disconnect, reconnect with same session_id, assert
     session_messages event fires with recent history."""
-    async with aiohttp.ClientSession() as s:
+    async with aiohttp.ClientSession(headers=DRAGON_AUTH_HEADERS) as s:
         # First session
         did = "resume-" + secrets.token_hex(4)
         hw = "hw-" + secrets.token_hex(6)
@@ -278,7 +285,7 @@ async def story_session_resume_replay():
 
 # ── Story 8: TC receipt model stamp is honest (not bare "tinkerclaw") ─────
 async def story_tc_receipt_model_honest():
-    async with aiohttp.ClientSession() as s:
+    async with aiohttp.ClientSession(headers=DRAGON_AUTH_HEADERS) as s:
         async with s.ws_connect(DRAGON_WS) as ws:
             await _register(ws, voice_mode=3)
             await ws.send_json({"type": "text", "content": "pick one word"})

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -1,0 +1,132 @@
+"""Wave 13 C2: regression test for the REST bearer-token middleware.
+
+Covers:
+  1. Public prefixes (`/health`, `/ws/voice`, `/dashboard`, `/api/media/`)
+     are reachable without any Authorization header.
+  2. Private routes with no token       -> 401 missing_bearer_token
+  3. Private routes with a wrong token  -> 401 invalid_bearer_token
+  4. Private routes with the right one  -> 200 OK + handler runs
+  5. OPTIONS preflight always passes    -> 200 (CORS answers first)
+  6. Fail-closed: when api_token is blank -> 503 dragon_api_token_not_configured
+     (this is the critical "deployer forgot to set DRAGON_API_TOKEN" case)
+
+Run:
+    python3 -m pytest tests/test_auth_middleware.py -v
+    # or:
+    python3 tests/test_auth_middleware.py
+"""
+
+import asyncio
+import os
+import unittest
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from dragon_voice.config import load_config
+from dragon_voice import server as srv_mod
+
+
+class _StubServer(srv_mod.VoiceServer):
+    """Subclass that bypasses the heavy VoiceServer constructor."""
+    def __init__(self, config):
+        self._config = config
+
+
+def _build_app(stub: _StubServer) -> web.Application:
+    async def _ok(request):
+        return web.json_response({"ok": True})
+
+    @web.middleware
+    async def _mw(request, handler):
+        return await stub._auth_middleware(request, handler)
+
+    app = web.Application(middlewares=[_mw])
+    for path in ("/health", "/ws/voice", "/dashboard", "/api/media/abc", "/api/v1/sessions"):
+        app.router.add_get(path, _ok)
+    app.router.add_options("/api/v1/sessions", _ok)
+    return app
+
+
+class AuthMiddlewareTests(unittest.TestCase):
+    def setUp(self):
+        os.environ["DRAGON_API_TOKEN"] = "wave13-c2-test-token"
+        self.cfg = load_config()
+        self.assertEqual(self.cfg.server.api_token, "wave13-c2-test-token")
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_public_prefixes_no_auth(self):
+        stub = _StubServer(self.cfg)
+        app = _build_app(stub)
+
+        async def go():
+            async with TestServer(app) as server, TestClient(server) as client:
+                for path in ("/health", "/ws/voice", "/dashboard", "/api/media/abc"):
+                    r = await client.get(path)
+                    self.assertEqual(r.status, 200, f"{path} expected 200, got {r.status}")
+        self._run(go())
+
+    def test_private_route_missing_token(self):
+        stub = _StubServer(self.cfg)
+        app = _build_app(stub)
+
+        async def go():
+            async with TestServer(app) as server, TestClient(server) as client:
+                r = await client.get("/api/v1/sessions")
+                self.assertEqual(r.status, 401)
+                body = await r.json()
+                self.assertEqual(body["error"], "missing_bearer_token")
+        self._run(go())
+
+    def test_private_route_wrong_token(self):
+        stub = _StubServer(self.cfg)
+        app = _build_app(stub)
+
+        async def go():
+            async with TestServer(app) as server, TestClient(server) as client:
+                r = await client.get("/api/v1/sessions", headers={"Authorization": "Bearer wrong"})
+                self.assertEqual(r.status, 401)
+                body = await r.json()
+                self.assertEqual(body["error"], "invalid_bearer_token")
+        self._run(go())
+
+    def test_private_route_right_token(self):
+        stub = _StubServer(self.cfg)
+        app = _build_app(stub)
+
+        async def go():
+            async with TestServer(app) as server, TestClient(server) as client:
+                r = await client.get(
+                    "/api/v1/sessions",
+                    headers={"Authorization": "Bearer wave13-c2-test-token"})
+                self.assertEqual(r.status, 200)
+        self._run(go())
+
+    def test_options_preflight(self):
+        stub = _StubServer(self.cfg)
+        app = _build_app(stub)
+
+        async def go():
+            async with TestServer(app) as server, TestClient(server) as client:
+                r = await client.options("/api/v1/sessions")
+                self.assertEqual(r.status, 200)
+        self._run(go())
+
+    def test_fail_closed_when_token_unconfigured(self):
+        self.cfg.server.api_token = ""
+        stub = _StubServer(self.cfg)
+        app = _build_app(stub)
+
+        async def go():
+            async with TestServer(app) as server, TestClient(server) as client:
+                r = await client.get("/api/v1/sessions", headers={"Authorization": "Bearer any"})
+                self.assertEqual(r.status, 503)
+                body = await r.json()
+                self.assertEqual(body["error"], "dragon_api_token_not_configured")
+        self._run(go())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_media_pipeline.py
+++ b/tests/test_media_pipeline.py
@@ -22,7 +22,6 @@ from dragon_voice.media.pipeline import (
     MAX_MEDIA_PER_RESPONSE,
     MediaPipeline,
     _extract_table,
-    _og_meta,
     _parse_table,
     _render_code_plain,
     _render_table_pillow,
@@ -297,27 +296,9 @@ def test_extract_table_stops_at_non_pipe_line():
     assert "| A | B |" in result
 
 
-# ── _og_meta ─────────────────────────────────────────────────────────────────
-
-
-def test_og_meta_property_before_content():
-    html = '<meta property="og:title" content="My Title">'
-    assert _og_meta(html, "og:title") == "My Title"
-
-
-def test_og_meta_content_before_property():
-    html = '<meta content="My Title" property="og:title">'
-    assert _og_meta(html, "og:title") == "My Title"
-
-
-def test_og_meta_not_found():
-    html = '<meta property="og:description" content="desc">'
-    assert _og_meta(html, "og:title") is None
-
-
-def test_og_meta_twitter_card():
-    html = '<meta name="twitter:title" content="Tweet Title">'
-    assert _og_meta(html, "twitter:title") == "Tweet Title"
+# Wave 5 (audit H12) removed _og_meta + fetch_link_preview from
+# dragon_voice/media/pipeline.py as dead code (never called from the live
+# path). The four tests that exercised that helper are deleted here to match.
 
 
 # ── render_code_block (unit, no I/O) ────────────────────────────────────────


### PR DESCRIPTION
## Summary

Wave 13 closes the CRITICAL + HIGH-tier Dragon-side items from the cross-stack audit:

**Security (C-tier)**
- C2 bearer-token middleware for `/api/v1/*` + private REST routes via `server.api_token` / `DRAGON_API_TOKEN` env; allowlist covers `/health`, `/ws/voice`, `/dashboard`, `/api/media/`; fail-closed 503 when unconfigured.
- C6 `LEARNINGS.md` entries 69–74 for the wave.

**Quality (H-tier)**
- H2 `asyncio.to_thread` for blocking `f.read()` in `_handle_user_media`
- H3 `_media_cleanup_task` cancelled on shutdown
- H4 dashboard `ClientSession` moved to `app[AppKey]` from module global
- H5 narrowed 3 silent `except Exception: pass` to `(ConnectionError, RuntimeError[, AttributeError])` + `logger.debug`
- H6 `TinkerClawBackend` raises `ValueError` at construction on blank token
- H7 `TINKERCLAW_TOKEN` env override + yaml placeholder locked down
- H9 new CI: ruff narrow-gate (F821/F722/F811/F823/B006) + pytest for auth_middleware + session_cas + media + mcp (52 tests green locally)

**Collateral fixes from ruff gate**
- `dragon_voice/surfaces/base.py`: local `ActionHandler` alias (F821)
- `dragon_voice/surfaces/manager.py`: dedup `Optional` import (F811)

## Test plan

Verified live on Dragon 192.168.1.91:
- [x] `/health` reachable without auth
- [x] `/api/v1/sessions` → 401 missing / 401 wrong / 200 right token
- [x] Dashboard `/api/proxy/api/v1/sessions` → 200 (token auto-injected)
- [x] `tests/audit/test_d5_d6_ws.py` — D5 tool strip + D6 media order both pass
- [x] `tests/audit/test_user_stories.py` — 12/13 (tc_receipt timeout pre-existing TC gateway latency, unrelated)
- [x] `tests/audit/test_stress_40.py` — 42/45 (3 post-reboot screenshot artifacts, same envelope as prior wave-12 43/45 baseline)
- [x] `tests/test_auth_middleware.py` — 6/6 new regression cases

## Deployment notes

After merge, ensure `DRAGON_API_TOKEN` is set in `/home/radxa/.env` before restarting `tinkerclaw-voice` + `tinkerclaw-dashboard`. Dashboard systemd drop-in at `/etc/systemd/system/tinkerclaw-dashboard.service.d/env.conf` already installed so it reads `.env` on restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)