### PR TITLE
feat(auth): /ws/voice upgrade now requires bearer (W14-C04 server half)

### DIFF
--- a/docs/WAVE-14-PROGRESS.md
+++ b/docs/WAVE-14-PROGRESS.md
@@ -22,10 +22,10 @@ Each of these removes friction that slows everything after it.
 
 ## Phase 2 — CRITICALs
 
-- [ ] **W14-C01** `[TT]` `touch_ws.c:294-297` — copy string literal to stack buffer before `esp_transport_ws_send_raw`
-- [ ] **W14-C02** `[TT]` `ota.c:90-91` — NULL-guard after second `esp_http_client_init`
-- [ ] **W14-C03** `[TT]` `ui_notes.c:1066-1067` — NULL-guard on transcription-queue HTTP init
-- [ ] **W14-C04** `[TB+TT]` authenticate `/ws/voice` register frame (bearer OR signed HMAC)
+- [x] **W14-C01** `[TT]` `touch_ws.c:294-297` — copy string literal to stack buffer before `esp_transport_ws_send_raw` · verified: flashed, 20-tap stress, heap_min 21724696 stable, home screenshot renders clean
+- [x] **W14-C02** `[TT]` `ota.c:90-91` — NULL-guard after second `esp_http_client_init` · verified: `/ota/check` exercised, Tab5 alive post-call
+- [x] **W14-C03** `[TT]` `ui_notes.c:1066-1067` — NULL-guard on transcription-queue HTTP init · verified: transcribe queue task alive (4 notes pending), selftest wifi/voice_ws/sd_card all pass
+- [x] **W14-C04** `[TB+TT]` authenticate `/ws/voice` register frame (bearer OR signed HMAC) · TB server.py `_handle_ws_voice` + TT sdkconfig/Kconfig/voice.c · verified: Dragon rejects no-bearer with HTTP 401, Tab5 flashed with matching token in sdkconfig.local reconnects inside 8 s, `active_connections=1` on Dragon, session resumed cleanly
 - [ ] **W14-C05** `[TB]` port `NotesDB` to `aiosqlite` (or uniform `asyncio.to_thread`)
 - [x] **W14-C06** `[TB]` store + cancel 3 fire-and-forget `asyncio.create_task` sites · same commit as M16 · verified: NotesService._spawn_bg + conn_state["bg_tasks"] both wired; cancelled in shutdown/_handle_disconnect
 

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -154,9 +154,14 @@ class VoiceServer:
     # (health, WS handshake is separately gated via the `register` frame).
     _AUTH_PUBLIC_PREFIXES = (
         "/health",              # liveness probe
-        "/ws/voice",            # WS handshake; auth is at `register` time
+        # Wave 14 W14-C04: /ws/voice is allow-listed here (because the
+        # bearer comes from the upgrade header, not the request path),
+        # but _handle_ws_voice itself performs the Authorization check
+        # before ws.prepare().  Do NOT remove /ws/voice from this list or
+        # the CORS middleware will bounce the upgrade.
+        "/ws/voice",            # auth enforced inside _handle_ws_voice
         "/dashboard",           # proxied to localhost:3500 (separately gated)
-        "/api/media/",          # rendered media fetch — authenticated by ID obscurity
+        "/api/media/",          # rendered media fetch — W14-H04 will fix this
     )
 
     @web.middleware
@@ -984,6 +989,36 @@ class VoiceServer:
                     config_update, error, event
             - Binary: PCM int16 audio at config.tts_sample_rate
         """
+        # Wave 14 W14-C04: authenticate the WS upgrade request.  Prior to
+        # this, /ws/voice was publicly reachable and the `register` frame
+        # only required a non-empty device_id — so any attacker with the
+        # ngrok URL could impersonate any Tab5, hijack sessions, and burn
+        # OpenRouter/TinkerClaw budget.
+        #
+        # Contract:
+        #   - If server.api_token is configured: client MUST present
+        #       `Authorization: Bearer <token>` on the upgrade request,
+        #       matched with hmac.compare_digest.  Mismatch → 401.
+        #   - If server.api_token is blank (unprovisioned/dev): allow the
+        #       handshake but log-warn so the operator knows they're
+        #       running unauthenticated.  This matches the pattern of
+        #       letting first-run bootstraps work without breaking Tab5
+        #       flashes mid-upgrade.
+        expected_token = (getattr(self._config.server, "api_token", "") or "").strip()
+        if expected_token:
+            auth_header = request.headers.get("Authorization", "")
+            supplied = auth_header[7:].strip() if auth_header.startswith("Bearer ") else ""
+            import hmac as _hmac
+            if not supplied or not _hmac.compare_digest(supplied, expected_token):
+                logger.warning(
+                    "WS /ws/voice: rejecting unauthenticated upgrade from %s (header_present=%s)",
+                    request.remote, bool(auth_header))
+                return web.Response(text="Unauthorized", status=401)
+        else:
+            logger.warning(
+                "WS /ws/voice: server.api_token not configured — allowing "
+                "unauthenticated WS. Set DRAGON_API_TOKEN to enforce.")
+
         # Reject if at connection limit
         if len(self._active_connections) >= self._max_connections:
             logger.warning("Connection limit reached (%d), rejecting", self._max_connections)


### PR DESCRIPTION
## Summary

Closes W14-C04 on the Dragon side. Pairs with TinkerTab PR #87.

Before this, `/ws/voice` was in `_AUTH_PUBLIC_PREFIXES` and the `register` frame only required a non-empty `device_id`. Wave 14 audit flagged as CRITICAL: any attacker with the ngrok URL could impersonate any Tab5, replay resume-tail conversations, enqueue tool calls, and burn the operator's OpenRouter / TinkerClaw budget.

### Change

`dragon_voice/server.py:_handle_ws_voice` now validates `Authorization: Bearer <token>` against `self._config.server.api_token` via `hmac.compare_digest` BEFORE `ws.prepare()`.

- `api_token` configured + missing/wrong bearer → HTTP 401 with logged remote + `header_present` flag.
- `api_token` configured + correct bearer → register flow unchanged.
- `api_token` unconfigured → log-warn and allow (matches wave-13 C2 fail-open-during-bootstrap).

## Test plan

Verified live on 192.168.1.91:
- [x] Deployed via `scripts/deploy.sh`, auth probe 401/200 clean
- [x] Pre-flash Tab5 (no bearer) → HTTP 401, journal: `WS /ws/voice: rejecting unauthenticated upgrade from 192.168.1.90 (header_present=False)`
- [x] `aiohttp.ws_connect` no-auth probe → `WSServerHandshakeError 401`
- [x] Flashed Tab5 with matching token → `active_connections=1`, session resumed in ~8s
- [x] Local `pytest` 52/52 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)