### PR TITLE
feat(audit): wave 14 Phase 4 — Dragon stability + systemd hardening

### DIFF
--- a/docs/WAVE-14-PROGRESS.md
+++ b/docs/WAVE-14-PROGRESS.md
@@ -40,12 +40,14 @@ Each of these removes friction that slows everything after it.
 ## Phase 4 — HIGH stability (firmware + server)
 
 - [ ] **W14-H06** `[TT]` unified suspended-task worker pattern (mode_switch / wifi / media_fetch / drawer_fetch)
-- [ ] **W14-H07** `[TT]` bump stacks: `sd_record_task` + `playback_task_fn` to 8 KB, `heap_watchdog_task` to 4 KB
+- [x] **W14-H07** `[TT]` bump stacks: `sd_record_task` + `playback_task_fn` to 8 KB, `heap_watchdog_task` to 4 KB · TinkerTab · verified: flashed, boots clean, 25 tasks live, wifi/dragon/voice connected, heap_min=21724236 stable, home screenshot clean
 - [ ] **W14-H08** `[TB]` `asyncio.to_thread` / `web.FileResponse` for 6 sync file-read sites
 - [ ] **W14-H09** `[TB]` MediaStore offload (`cleanup` + `store`) via `to_thread`; add default ClientTimeout
-- [ ] **W14-H10** `[TB]` `purge_old_messages` batching (`LIMIT N` + `asyncio.sleep(0)`); `executemany` for ingest
-- [ ] **W14-H11** `[TB]` `MemoryService` shared ClientSession lifecycle
-- [ ] **W14-H12** `[TB]` `MediaPipeline.close()` on shutdown (folded into H09)
+- [x] **W14-H10** `[TB]` `purge_old_messages` batching (`LIMIT N` + `asyncio.sleep(0)`); `executemany` for ingest · db.py batched at 500 rows/loop with yield; pytest green
+- [x] **W14-H11** `[TB]` `MemoryService` shared ClientSession lifecycle · memory.py._http_session + shutdown · live store+search+delete cycle green
+- [x] **W14-H12** `[TB]` `MediaPipeline.close()` on shutdown (folded into H09) · wired in server._on_shutdown
+- [x] **W14-H18** `[OPS]` `MemoryMax=4G MemoryHigh=3G` on voice service (bandaid); file the leak as separate issue · drop-in installed live: MemoryHigh=3221225472 MemoryMax=4294967296 TasksMax=512
+- [x] **W14-M09** `[TB]` `cancel() + await` `_periodic_purge` (wave 13 H3 pattern) · also folded memory_monitor cancel+await
 - [ ] **W14-H13** `[TB]` narrow ~17 residual `except Exception` in server/memory/media/tts
 - [ ] **W14-H14** `[OPS]` systemd hardening drop-ins for 6 units
 - [ ] **W14-H18** `[OPS]` `MemoryMax=4G MemoryHigh=3G` on voice service (bandaid); file the leak as separate issue

--- a/docs/WAVE-14-PROGRESS.md
+++ b/docs/WAVE-14-PROGRESS.md
@@ -41,7 +41,7 @@ Each of these removes friction that slows everything after it.
 
 - [ ] **W14-H06** `[TT]` unified suspended-task worker pattern (mode_switch / wifi / media_fetch / drawer_fetch)
 - [x] **W14-H07** `[TT]` bump stacks: `sd_record_task` + `playback_task_fn` to 8 KB, `heap_watchdog_task` to 4 KB · TinkerTab · verified: flashed, boots clean, 25 tasks live, wifi/dragon/voice connected, heap_min=21724236 stable, home screenshot clean
-- [ ] **W14-H08** `[TB]` `asyncio.to_thread` / `web.FileResponse` for 6 sync file-read sites
+- [x] **W14-H08** `[TB]` `asyncio.to_thread` / `web.FileResponse` for 6 sync file-read sites · api/synthesize.py (ota_check + ota_firmware), api/system.py (meminfo+loadavg), tools/system_tool.py (3 /proc reads), tts/piper_tts.py (voice config). Ruff ASYNC230 now 0. Live /api/v1/system + /api/ota/check + system_info tool all green.
 - [ ] **W14-H09** `[TB]` MediaStore offload (`cleanup` + `store`) via `to_thread`; add default ClientTimeout
 - [x] **W14-H10** `[TB]` `purge_old_messages` batching (`LIMIT N` + `asyncio.sleep(0)`); `executemany` for ingest · db.py batched at 500 rows/loop with yield; pytest green
 - [x] **W14-H11** `[TB]` `MemoryService` shared ClientSession lifecycle · memory.py._http_session + shutdown · live store+search+delete cycle green

--- a/docs/WAVE-14-PROGRESS.md
+++ b/docs/WAVE-14-PROGRESS.md
@@ -49,7 +49,7 @@ Each of these removes friction that slows everything after it.
 - [x] **W14-H18** `[OPS]` `MemoryMax=4G MemoryHigh=3G` on voice service (bandaid); file the leak as separate issue · drop-in installed live: MemoryHigh=3221225472 MemoryMax=4294967296 TasksMax=512
 - [x] **W14-M09** `[TB]` `cancel() + await` `_periodic_purge` (wave 13 H3 pattern) · also folded memory_monitor cancel+await
 - [ ] **W14-H13** `[TB]` narrow ~17 residual `except Exception` in server/memory/media/tts
-- [ ] **W14-H14** `[OPS]` systemd hardening drop-ins for 6 units
+- [x] **W14-H14** `[OPS]` systemd hardening drop-ins for 6 units · 5 drop-ins installed (voice/dashboard/gateway/ngrok/mdns); iteration-2 notes for known-breaks (SystemCallFilter dropped, AF_NETLINK kept, mdns User=nobody not DynamicUser). systemd-analyze score dropped ~9.6 → 6.5 per unit. Tab5 still WS-connected through the restart cycle.
 - [ ] **W14-H18** `[OPS]` `MemoryMax=4G MemoryHigh=3G` on voice service (bandaid); file the leak as separate issue
 
 ## Phase 5 — HIGH docs + protocol

--- a/dragon_voice/api/synthesize.py
+++ b/dragon_voice/api/synthesize.py
@@ -151,17 +151,24 @@ class SynthesizeRoutes:
 
     async def ota_check(self, request: web.Request) -> web.Response:
         """GET /api/ota/check?current=VERSION"""
+        import asyncio as _asyncio
         import os
         import re as _re
         current = request.query.get("current", "0.0.0")
 
-        if not os.path.exists(self.OTA_VERSION_FILE):
-            return web.json_response({"update": False, "current": current})
-
-        try:
-            with open(self.OTA_VERSION_FILE) as f:
-                info = json.load(f)
-        except Exception:
+        # Wave 14 W14-H08: offload the sync file stat + open to a thread
+        # so the event loop doesn't stall even if eMMC is slow.  The
+        # file is tiny (<1 KB) so the to_thread overhead is negligible.
+        def _load_version_file():
+            if not os.path.exists(self.OTA_VERSION_FILE):
+                return None
+            try:
+                with open(self.OTA_VERSION_FILE) as f:
+                    return json.load(f)
+            except Exception:
+                return None
+        info = await _asyncio.to_thread(_load_version_file)
+        if info is None:
             return web.json_response({"update": False, "current": current})
 
         available_ver = info.get("version", "0.0.0")
@@ -197,20 +204,22 @@ class SynthesizeRoutes:
         })
 
     async def ota_firmware(self, request: web.Request) -> web.StreamResponse:
-        """GET /api/ota/firmware.bin — stream firmware binary"""
+        """GET /api/ota/firmware.bin — stream firmware binary.
+
+        Wave 14 W14-H08: prior code stalled the event loop on every
+        8 KB `f.read()` chunk (eMMC page cycles ~15-100 ms on Radxa).
+        ``web.FileResponse`` hands the file to sendfile(2) on Linux —
+        kernel-level copy, zero event-loop blocking, and lower latency
+        for the firmware download Tab5 makes on every Settings tap.
+        """
         import os
         firmware_path = os.path.join(self.OTA_DIR, "tinkertab.bin")
         if not os.path.exists(firmware_path):
             return web.Response(text="No firmware available", status=404)
-
-        file_size = os.path.getsize(firmware_path)
-        resp = web.StreamResponse()
-        resp.content_type = "application/octet-stream"
-        resp.content_length = file_size
-        resp.headers["Content-Disposition"] = "attachment; filename=tinkertab.bin"
-        await resp.prepare(request)
-
-        with open(firmware_path, "rb") as f:
-            while chunk := f.read(8192):
-                await resp.write(chunk)
-        return resp
+        return web.FileResponse(
+            path=firmware_path,
+            headers={
+                "Content-Type": "application/octet-stream",
+                "Content-Disposition": "attachment; filename=tinkertab.bin",
+            },
+        )

--- a/dragon_voice/api/system.py
+++ b/dragon_voice/api/system.py
@@ -31,12 +31,34 @@ class SystemRoutes:
         uptime_s = time.time() - self._start_time
         active = self._get_active_connections()
 
-        # Memory from /proc/meminfo (no external dependency)
+        # Memory from /proc/meminfo (no external dependency).
+        # Wave 14 W14-H08: /proc reads are usually instant but get slow
+        # under load (cgroup accounting on Radxa).  Offload to a thread
+        # so system polls from the dashboard don't jitter the event loop.
+        import asyncio as _asyncio
+
+        def _read_meminfo():
+            try:
+                with open("/proc/meminfo") as f:
+                    return f.read()
+            except Exception:
+                return ""
+
+        def _read_loadavg():
+            try:
+                with open("/proc/loadavg") as f:
+                    return f.read()
+            except Exception:
+                return ""
+
+        meminfo_raw = await _asyncio.to_thread(_read_meminfo)
+        loadavg_raw = await _asyncio.to_thread(_read_loadavg)
+
         mem = {"total_mb": 0, "used_mb": 0, "available_mb": 0, "percent": 0}
-        try:
-            with open("/proc/meminfo") as f:
+        if meminfo_raw:
+            try:
                 info = {}
-                for line in f:
+                for line in meminfo_raw.splitlines():
                     parts = line.split()
                     if len(parts) >= 2:
                         info[parts[0].rstrip(":")] = int(parts[1])
@@ -46,18 +68,17 @@ class SystemRoutes:
                 mem["available_mb"] = round(available / 1024)
                 mem["used_mb"] = mem["total_mb"] - mem["available_mb"]
                 mem["percent"] = round((1 - available / total) * 100, 1) if total else 0
-        except Exception:
-            pass
+            except Exception:
+                pass
 
-        # CPU from /proc/stat (simple instant snapshot)
         cpu_percent = 0
-        try:
-            with open("/proc/loadavg") as f:
-                load_1m = float(f.read().split()[0])
+        if loadavg_raw:
+            try:
+                load_1m = float(loadavg_raw.split()[0])
                 cpu_count = os.cpu_count() or 1
                 cpu_percent = round(load_1m / cpu_count * 100, 1)
-        except Exception:
-            pass
+            except Exception:
+                pass
 
         result = {
             "uptime_s": round(uptime_s, 1),

--- a/dragon_voice/db.py
+++ b/dragon_voice/db.py
@@ -6,6 +6,7 @@ Schema is applied from schema.sql on first run.
 refs #16
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -496,11 +497,21 @@ class Database:
         row = await cursor.fetchone()
         return dict(row) if row else None
 
-    async def purge_old_messages(self, days: int = 30) -> dict[str, int]:
+    async def purge_old_messages(
+        self, days: int = 30, batch_size: int = 500
+    ) -> dict[str, int]:
         """Purge messages and orphaned events older than `days`.
 
         Skips messages belonging to active or paused sessions to avoid
         deleting context from sessions still in use.
+
+        Wave 14 W14-H10: previously a single ``DELETE ... WHERE NOT IN
+        (SELECT ...)`` ran on the shared aiosqlite connection — on a
+        large tail it serialized every other coroutine behind 2-3 s of
+        purge. Now the delete runs in ``batch_size``-row chunks with
+        ``await asyncio.sleep(0)`` between batches, yielding the event
+        loop so WS keepalives and receipt emits can progress even on a
+        huge purge.
 
         Returns dict with counts: {"messages": N, "events": M}.
         """
@@ -511,34 +522,57 @@ class Database:
         cutoff = time.time() - (days * 86400)
 
         # Delete old messages, but only from ended sessions (or sessions
-        # with no matching row, i.e. orphaned messages)
-        cursor = await self.conn.execute(
-            """
-            DELETE FROM messages
-            WHERE created_at < ?
-              AND session_id NOT IN (
-                  SELECT id FROM sessions WHERE status IN ('active', 'paused')
-              )
-            """,
-            (cutoff,),
-        )
-        msg_count = cursor.rowcount
-        await self.conn.commit()
+        # with no matching row, i.e. orphaned messages).
+        # Wave 14 W14-H10: batch via LIMIT + asyncio.sleep(0) yield so
+        # the purge does NOT hold the aiosqlite background thread
+        # exclusively for the full delete.
+        msg_count = 0
+        while True:
+            cursor = await self.conn.execute(
+                """
+                DELETE FROM messages
+                WHERE rowid IN (
+                    SELECT rowid FROM messages
+                    WHERE created_at < ?
+                      AND session_id NOT IN (
+                          SELECT id FROM sessions WHERE status IN ('active', 'paused')
+                      )
+                    LIMIT ?
+                )
+                """,
+                (cutoff, batch_size),
+            )
+            deleted = cursor.rowcount
+            await self.conn.commit()
+            msg_count += deleted
+            if deleted < batch_size:
+                break
+            await asyncio.sleep(0)  # yield the loop between batches
 
-        # Delete orphaned events older than the cutoff
-        cursor = await self.conn.execute(
-            """
-            DELETE FROM events
-            WHERE created_at < ?
-              AND (session_id IS NULL
-                   OR session_id NOT IN (
-                       SELECT id FROM sessions WHERE status IN ('active', 'paused')
-                   ))
-            """,
-            (cutoff,),
-        )
-        evt_count = cursor.rowcount
-        await self.conn.commit()
+        # Delete orphaned events older than the cutoff — same batching.
+        evt_count = 0
+        while True:
+            cursor = await self.conn.execute(
+                """
+                DELETE FROM events
+                WHERE rowid IN (
+                    SELECT rowid FROM events
+                    WHERE created_at < ?
+                      AND (session_id IS NULL
+                           OR session_id NOT IN (
+                               SELECT id FROM sessions WHERE status IN ('active', 'paused')
+                           ))
+                    LIMIT ?
+                )
+                """,
+                (cutoff, batch_size),
+            )
+            deleted = cursor.rowcount
+            await self.conn.commit()
+            evt_count += deleted
+            if deleted < batch_size:
+                break
+            await asyncio.sleep(0)
 
         # PASSIVE checkpoint after bulk deletes — moves WAL pages back into
         # the main DB file without blocking readers. Reduces WAL file growth

--- a/dragon_voice/memory.py
+++ b/dragon_voice/memory.py
@@ -41,9 +41,23 @@ class MemoryService:
         # Falls back to Python-loop cosine when unavailable.
         self._use_vec: bool = False
         self._vec_created: bool = False
+        # Wave 14 W14-H11: shared aiohttp ClientSession for Ollama embed
+        # calls. Previously _get_embedding opened a fresh session + TCP
+        # per call — 200 TCP open/close cycles during a 200-chunk
+        # document ingest, and FD churn visible in the server.py DQ08
+        # FD counter.  Lazy-initialized in initialize(); closed in a new
+        # shutdown().
+        self._http_session: Optional[aiohttp.ClientSession] = None
 
     async def initialize(self) -> None:
         """Create memory tables if they don't exist."""
+        # Wave 14 W14-H11: open the shared Ollama HTTP session here.
+        # Default 30 s total, 5 s sock_connect.  Retried lazily in
+        # _get_embedding if someone closed it mid-run.
+        if self._http_session is None or self._http_session.closed:
+            self._http_session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=30, sock_connect=5),
+            )
         # Try to load sqlite-vec for fast ANN search. Python-loop cosine
         # fallback kicks in if this fails. aiosqlite exposes
         # enable_load_extension + load_extension as coroutines that run on
@@ -139,24 +153,30 @@ class MemoryService:
     # ── Embeddings ──
 
     async def _get_embedding(self, text: str) -> Optional[bytes]:
-        """Get embedding vector from Ollama. Returns packed floats as bytes."""
+        """Get embedding vector from Ollama. Returns packed floats as bytes.
+
+        Wave 14 W14-H11: reuses a shared ClientSession instead of opening
+        one per call. Lazy-recreates if someone closed it.
+        """
+        if self._http_session is None or self._http_session.closed:
+            self._http_session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=30, sock_connect=5),
+            )
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    f"{self._ollama_url}/api/embed",
-                    json={"model": self._embed_model, "input": text, "keep_alive": "30s"},
-                    timeout=aiohttp.ClientTimeout(total=30),
-                ) as resp:
-                    if resp.status != 200:
-                        logger.warning("Embedding request failed: %d", resp.status)
-                        return None
-                    data = await resp.json()
-                    embeddings = data.get("embeddings", [])
-                    if not embeddings:
-                        return None
-                    vec = embeddings[0]
-                    self._embed_dim = len(vec)
-                    return struct.pack(f"{len(vec)}f", *vec)
+            async with self._http_session.post(
+                f"{self._ollama_url}/api/embed",
+                json={"model": self._embed_model, "input": text, "keep_alive": "30s"},
+            ) as resp:
+                if resp.status != 200:
+                    logger.warning("Embedding request failed: %d", resp.status)
+                    return None
+                data = await resp.json()
+                embeddings = data.get("embeddings", [])
+                if not embeddings:
+                    return None
+                vec = embeddings[0]
+                self._embed_dim = len(vec)
+                return struct.pack(f"{len(vec)}f", *vec)
         except Exception as e:
             logger.warning("Embedding failed (Ollama may not be running): %s", e)
             return None
@@ -412,3 +432,20 @@ class MemoryService:
             lines.append(f"- [From {c['document_title']}]: {c['content'][:200]}")
         lines.append("[END MEMORY CONTEXT]")
         return "\n".join(lines)
+
+
+    async def shutdown(self) -> None:
+        """Close the shared HTTP session.
+
+        Wave 14 W14-H11: the prior path opened a fresh ClientSession
+        per `_get_embedding` call. Now we keep one, which means someone
+        has to close it on service shutdown. VoiceServer._on_shutdown
+        calls this before DB.close() so the session outlives the final
+        recall. Idempotent.
+        """
+        if self._http_session is not None and not self._http_session.closed:
+            try:
+                await self._http_session.close()
+            except Exception:
+                logger.debug("MemoryService HTTP session close raised", exc_info=True)
+        self._http_session = None

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -631,8 +631,23 @@ class VoiceServer:
         # Cancel periodic tasks
         if self._memory_monitor_task and not self._memory_monitor_task.done():
             self._memory_monitor_task.cancel()
+            # Wave 14 W14-M09 pattern: await so we don't leak the task
+            # across loop shutdown (produces the same "Task was
+            # destroyed but it is pending" warning wave-13 H3 fixed).
+            try:
+                await self._memory_monitor_task
+            except (asyncio.CancelledError, Exception):
+                pass
         if self._purge_task and not self._purge_task.done():
             self._purge_task.cancel()
+            # Wave 14 W14-M09: _periodic_purge sleeps 86400 s in one
+            # shot; cancel-without-await left it attached long enough
+            # for aiohttp to close the loop first, producing
+            # "RuntimeError: Event loop is closed" at systemctl restart.
+            try:
+                await self._purge_task
+            except (asyncio.CancelledError, Exception):
+                pass
         # Wave 13 H3: the media cleanup loop was being left running on shutdown
         # because it isn't touched here. If it was mid-sleep when the event loop
         # closes, asyncio logs "Task was destroyed but it is pending" warnings
@@ -670,9 +685,22 @@ class VoiceServer:
         # Shut down foundation
         if self._notes_svc:
             await self._notes_svc.shutdown()
+        if self._media_pipeline:
+            # Wave 14 W14-H12: close the MediaPipeline's shared aiohttp
+            # ClientSession.  Prior behaviour left it dangling across
+            # systemctl restart, logging "Unclosed client session" and
+            # making the wave-13 FD counter noisy.
+            try:
+                await self._media_pipeline.close()
+            except Exception:
+                logger.debug("MediaPipeline shutdown failed", exc_info=True)
         if self._memory_service:
             logger.info("Shutting down memory service")
-            # MemoryService doesn't have explicit shutdown but clear reference
+            # Wave 14 W14-H11: close the shared Ollama HTTP session.
+            try:
+                await self._memory_service.shutdown()
+            except Exception:
+                logger.debug("MemoryService shutdown raised", exc_info=True)
             self._memory_service = None
         if self._conversation:
             await self._conversation.shutdown()

--- a/dragon_voice/tools/system_tool.py
+++ b/dragon_voice/tools/system_tool.py
@@ -1,5 +1,6 @@
 """System info tool: report Dragon server status."""
 
+import asyncio
 import logging
 import os
 import time
@@ -12,13 +13,20 @@ logger = logging.getLogger(__name__)
 _import_time = time.time()
 
 
-def _read_proc_file(path: str) -> str:
-    """Read a /proc file, return empty string on failure."""
+def _sync_read_proc_file(path: str) -> str:
+    """Sync helper; call from inside asyncio.to_thread only."""
     try:
         with open(path, "r") as f:
             return f.read()
     except (OSError, PermissionError):
         return ""
+
+
+async def _read_proc_file(path: str) -> str:
+    """Wave 14 W14-H08: async wrapper — /proc reads offloaded to a
+    thread so a slow read (cgroup accounting under load) doesn't
+    stall the tool-execution path + the WS it's called from."""
+    return await asyncio.to_thread(_sync_read_proc_file, path)
 
 
 class SystemInfoTool(Tool):
@@ -43,7 +51,7 @@ class SystemInfoTool(Tool):
         result = {}
 
         # Memory from /proc/meminfo
-        meminfo = _read_proc_file("/proc/meminfo")
+        meminfo = await _read_proc_file("/proc/meminfo")
         if meminfo:
             mem = {}
             for line in meminfo.splitlines():
@@ -64,7 +72,7 @@ class SystemInfoTool(Tool):
                 result["ram_percent"] = round(used_kb / total_kb * 100, 1)
 
         # CPU load from /proc/loadavg
-        loadavg = _read_proc_file("/proc/loadavg")
+        loadavg = await _read_proc_file("/proc/loadavg")
         if loadavg:
             parts = loadavg.split()
             if len(parts) >= 3:
@@ -80,7 +88,7 @@ class SystemInfoTool(Tool):
                 pass
 
         # Uptime from /proc/uptime
-        uptime_str = _read_proc_file("/proc/uptime")
+        uptime_str = await _read_proc_file("/proc/uptime")
         if uptime_str:
             try:
                 uptime_secs = float(uptime_str.split()[0])

--- a/dragon_voice/tts/piper_tts.py
+++ b/dragon_voice/tts/piper_tts.py
@@ -71,12 +71,18 @@ class PiperBackend(TTSBackend):
 
             self._voice = await loop.run_in_executor(inference_executor, _load)
             self._model_path = model_path
-            # Piper voices declare their sample rate in config
+            # Piper voices declare their sample rate in config.
+            # Wave 14 W14-H08: offload the small config read to a thread
+            # so model-swap doesn't stall the event loop on a slow eMMC.
             config_path = model_path.with_suffix(model_path.suffix + ".json")
             if config_path.exists():
+                import asyncio as _asyncio
                 import json
-                with open(config_path) as f:
-                    voice_cfg = json.load(f)
+
+                def _load_cfg(p):
+                    with open(p) as f:
+                        return json.load(f)
+                voice_cfg = await _asyncio.to_thread(_load_cfg, config_path)
                 self._sample_rate = voice_cfg.get("audio", {}).get("sample_rate", 22050)
             logger.info("Piper loaded via Python package (rate=%d)", self._sample_rate)
             return

--- a/systemd/tinkerclaw-dashboard.service.d/hardening.conf
+++ b/systemd/tinkerclaw-dashboard.service.d/hardening.conf
@@ -1,0 +1,22 @@
+[Service]
+# Wave 14 W14-H14 — dashboard process hardening.
+# Dashboard only proxies HTTP to the voice + dragon services and
+# serves its own SPA; it needs nothing from the filesystem beyond
+# /home/radxa (read) to pick up the SPA on restart.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+# Dashboard doesn't write to disk; no ReadWritePaths needed.
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictNamespaces=true
+LockPersonality=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+# Wave 14 W14-H14: SystemCallFilter removed — aiohttp + uvloop
+# violate `~@resources` (thread scheduling). See voice.service
+# hardening.conf comment.
+MemoryDenyWriteExecute=true
+MemoryMax=512M
+TasksMax=128

--- a/systemd/tinkerclaw-gateway.service.d/hardening.conf
+++ b/systemd/tinkerclaw-gateway.service.d/hardening.conf
@@ -1,0 +1,24 @@
+[Service]
+# Wave 14 W14-H14 — TinkerClaw gateway (port 18789) hardening.
+# Gateway runs the agent runner; it legitimately writes to
+# ~/.tinkerclaw/ (delivery queue + skill cache).  Network only for
+# the localhost listener + LLM egress.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/home/radxa/.tinkerclaw /home/radxa/.cache
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictNamespaces=true
+LockPersonality=true
+# Wave 14 W14-H14 iteration 2: added AF_NETLINK because
+# Node.js os.networkInterfaces() → libuv uv_interface_addresses()
+# → getifaddrs() needs NETLINK on Linux (EAFNOSUPPORT / errno 97
+# without it). Gateway starts up calling pickPrimaryLanIPv4 for
+# self-presence, so this is load-bearing at boot.
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+# Wave 14 W14-H14: SystemCallFilter removed — Node.js/v8 runtime
+# violates `~@resources`. See voice.service drop-in.
+MemoryDenyWriteExecute=false

--- a/systemd/tinkerclaw-mdns.service.d/hardening.conf
+++ b/systemd/tinkerclaw-mdns.service.d/hardening.conf
@@ -1,0 +1,24 @@
+[Service]
+# Wave 14 W14-H14 + W14-L08 — mDNS avahi-publish hardening.
+#
+# Iteration 2 (2026-04-21): DROPPED `DynamicUser=true`.  avahi-publish-
+# service talks to avahi-daemon over the SYSTEM D-Bus socket
+# (/run/dbus/system_bus_socket).  With DynamicUser systemd gave the
+# throwaway uid no policy entry in /etc/dbus-1/system.d/, producing
+# "Failed to create client object: An unexpected D-Bus error occurred"
+# on every restart.  Instead, pin to a stable unprivileged user
+# (`nobody`) that already has the generic avahi-client D-Bus ACL.
+User=nobody
+Group=nogroup
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictNamespaces=true
+LockPersonality=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+MemoryMax=64M
+TasksMax=16

--- a/systemd/tinkerclaw-ngrok.service.d/hardening.conf
+++ b/systemd/tinkerclaw-ngrok.service.d/hardening.conf
@@ -1,0 +1,24 @@
+[Service]
+# Wave 14 W14-H14 — ngrok tunnel process hardening.
+# ngrok self-updates and caches under ~/.config/ngrok and ~/.ngrok2.
+# Keep those writable, lock everything else down.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+# Wave 14 W14-H14 iteration 2: ReadWritePaths entries must exist at
+# service activation or systemd fails to set up the mount namespace
+# (status=226/NAMESPACE).  Only reference paths that are guaranteed to
+# exist — .ngrok2 gets created on first run, .cache is provisioned by
+# the user.  Dropped .cache/ngrok (unused by ngrok 3.x anyway).
+ReadWritePaths=/home/radxa/.config/ngrok /home/radxa/.ngrok2
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictNamespaces=true
+LockPersonality=true
+# ngrok (Go) also uses netlink for local interface enumeration at start.
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+# SystemCallFilter removed — Go runtime violates `~@resources`.
+MemoryMax=512M
+TasksMax=128

--- a/systemd/tinkerclaw-voice.service.d/hardening.conf
+++ b/systemd/tinkerclaw-voice.service.d/hardening.conf
@@ -1,0 +1,52 @@
+[Service]
+# Wave 14 W14-H14 — process hardening for the voice server.
+#
+# The audit flagged that every wave-14 security fix assumes the
+# underlying process isn't already popped.  Without these directives,
+# any RCE in an aiohttp handler would run as the `radxa` uid with full
+# read/write to $HOME (SSH keys, ngrok authtoken, OpenRouter key in
+# .env, the whole tinkerclaw DB), full syscall surface, and the ability
+# to spawn setuid helpers.
+#
+# Verified per directive vs systemd-analyze security before flipping.
+# MemoryMax / MemoryHigh live in memory-cap.conf (W14-H18).
+
+# No privilege escalation — eliminates suid helpers as a post-exploit
+# primitive.
+NoNewPrivileges=true
+
+# Private /tmp — stops the process from reading another service's temp
+# files (piper scratch space, etc.).
+PrivateTmp=true
+
+# Wave 14 W14-H14 iteration 2: DROPPED SystemCallFilter entirely.
+# First attempt used `@system-service + ~@privileged ~@resources` which
+# killed the voice process with SIGSYS (status=31/SYS) inside 5 s —
+# numpy / piper-onnxruntime / aiohttp hit at least one syscall in the
+# denied set (likely sched_setaffinity or prctl for thread naming,
+# which @resources blocks).  The remaining directives are still very
+# strong defense in depth; seccomp is best added back once we identify
+# the minimal missing set via `journalctl -k | grep SECCOMP`.
+
+# Read-only rootfs except for the explicit writeable paths below.
+# Voice service touches tinkerclaw (db), media (rendered images),
+# dragon_voice (code cache pyc), ota (firmware blobs), .cache (piper
+# model downloads).
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/home/radxa/dragon_voice /home/radxa/media /home/radxa/tinkerclaw /home/radxa/ota /home/radxa/.cache /home/radxa/backups
+
+# Block namespacing + kernel fiddling.
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictNamespaces=true
+LockPersonality=true
+
+# Network stays available (SDIO-over-WiFi needs netlink; keep that).
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+
+# Do NOT flip MemoryDenyWriteExecute=true — Piper's onnxruntime uses
+# JIT in SimpleInterpreter and asserts on a RWX reject.  Revisit when
+# we either disable onnxruntime JIT or move TTS off this process.
+MemoryDenyWriteExecute=false

--- a/systemd/tinkerclaw-voice.service.d/memory-cap.conf
+++ b/systemd/tinkerclaw-voice.service.d/memory-cap.conf
@@ -1,0 +1,24 @@
+[Service]
+# Wave 14 W14-H18 — hard memory cap on the voice service.
+#
+# Symptom the audit caught: voice service RSS climbs to 5.5 GB over a
+# few hours because each Ollama/Piper/OpenRouter reload retains model
+# state even after pipeline.shutdown(). The in-process memory monitor
+# notices, logs, and restarts all pipelines — but post-restart RSS
+# stays at 5.1 GB because the monitor can't actually reclaim the
+# retained memory. Eventually the process hits ENOMEM and systemd OOM-
+# kills it (status=9/KILL) mid-request.
+#
+# This drop-in caps the process at 4 GB hard, 3 GB soft. Hitting
+# MemoryHigh causes the kernel to aggressively reclaim page cache;
+# hitting MemoryMax triggers a clean oneshot restart via the
+# on-failure restart policy already in the unit. That matches the
+# in-process monitor's intent but uses kernel-level enforcement
+# instead of trusting the leaking code path to release memory.
+#
+# The underlying leak (tracked as follow-up: piper-onnx / openrouter-
+# ssl retention) is NOT fixed by this drop-in; this is the band-aid
+# so OOM doesn't take out a user mid-turn.
+MemoryMax=4G
+MemoryHigh=3G
+TasksMax=512


### PR DESCRIPTION
## Summary

Big Phase 4 bundle — Dragon-side stability fixes + systemd hardening drop-ins. Closes 8 wave-14 items plus folds in 2 extras.

### Stability / async hygiene

| ID | What |
|----|------|
| **W14-H08** | 6 sync file-read sites moved to `asyncio.to_thread` / `web.FileResponse`. Ruff `ASYNC230` count dropped from 6 → 0. |
| **W14-H10** | `purge_old_messages` batched at 500 rows/loop with `await asyncio.sleep(0)`. No longer holds the aiosqlite worker thread exclusively. |
| **W14-H11** | `MemoryService` uses a shared `aiohttp.ClientSession` + new `shutdown()`. No more 200 TCP/TLS cycles per document ingest. |
| **W14-H12** | `MediaPipeline.close()` wired into `_on_shutdown`. No more "Unclosed client session" on `systemctl restart`. |
| **W14-M09** | `_periodic_purge` + `_memory_monitor_task` now `cancel()`+`await` on shutdown (matches wave-13 H3 pattern). |

### Operational

| ID | What |
|----|------|
| **W14-H18** | `systemd/tinkerclaw-voice.service.d/memory-cap.conf`: MemoryMax=4G, MemoryHigh=3G, TasksMax=512. Bandaid until the onnxruntime retention leak is root-caused. |
| **W14-H14 + W14-L08** | Five hardening drop-ins (voice/dashboard/gateway/ngrok/mdns). `systemd-analyze security` score drops 9.6 → 6.5 per service (6.7 for mdns). |

## Test plan

Verified live on Dragon 192.168.1.91 (three successive `scripts/deploy.sh` runs, rollback snapshots `.20260421-160351` / `.161131` retained):

- [x] `pytest` (9 files, 90/90) green at each commit
- [x] Ruff `F821,F722,F811,F823,B006,B904,E722,B007,RUF006` clean
- [x] `GET /api/v1/system` → ram=11558 MB, cpu=10.9%, uptime=17.2 s (H08)
- [x] `GET /api/ota/check?current=0.1.0` → version.json served async (H08)
- [x] `POST /api/v1/tools/system_info/execute` → ram_total_mb=11558, cpu_cores=8 (H08)
- [x] MemoryService round-trip: `POST /api/v1/memory` 201 → `POST /api/v1/memory/search` 3 results → `DELETE` 200 (H11)
- [x] `systemctl show tinkerclaw-voice`: `MemoryHigh=3221225472 MemoryMax=4294967296 TasksMax=512` (H18)
- [x] All 5 services `systemctl is-active = "active"` post-hardening (H14)
- [x] `/health active_connections=1` throughout — Tab5 bearer auth survived every deploy cycle

## Deployment notes

The hardening drop-ins reference `/home/radxa/.config/ngrok` and `/home/radxa/.ngrok2` — ensure both exist on any new Dragon before first boot (`mkdir -p`). Already created on the current deployment.

`SystemCallFilter` was intentionally left out of every drop-in — details in each file's header comment. Follow-up: identify minimal filter via `journalctl -k | grep SECCOMP` during normal operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)