### PR TITLE
docs(audit): wave 14 Phase 5 TB — conn_mode / endpoint / widget_capability (H19/H21/H23)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,12 +73,7 @@ ssh radxa@192.168.1.91 "sudo systemctl restart tinkerclaw-voice"
   - `tinkerclaw-gateway.ngrok.dev` → 18789 (TinkerClaw)
 
 ## Three-Tier Voice Mode
-Tab5 sends `{"type":"config_update","voice_mode":0|1|2,"llm_model":"...","conn_mode":0|1|2}`. Dragon hot-swaps backends:
-
-**Connection mode (`conn_mode`):** Tab5 sends `conn_mode` in config_update to indicate its network path:
-- `0` = LAN direct (low latency, no proxy)
-- `1` = ngrok tunnel (higher latency, WS keepalive required)
-- `2` = mixed / unknown
+Tab5 sends `{"type":"config_update","voice_mode":0|1|2|3,"llm_model":"..."}`. Dragon hot-swaps backends:
 
 | Mode | voice_mode | STT | LLM | TTS |
 |------|-----------|-----|-----|-----|
@@ -185,7 +180,7 @@ The web dashboard is an 11-tab single-page application served by `dashboard.py` 
 | #16 | Session management infrastructure | DONE (sessions.py, db.py) |
 | #17 | Multi-turn conversation engine | DONE (conversation.py, messages.py) |
 | #18 | Unified voice + text input | DONE (server.py handles both voice and text) |
-| #21 | REST API framework | DONE (api/ package, 52 endpoints) |
+| #21 | REST API framework | DONE (api/ package, 47 endpoints — see header) |
 | #19 | Notes feature | DONE (notes/ module wired into server.py, API routes registered) |
 | — | Cloud mode (OpenRouter STT+TTS) | DONE (openrouter_stt.py, openrouter_tts.py, config_update WS command) |
 | — | Dictation mode + post-processing | DONE (dictation in pipeline.py, auto-generated title/summary) |
@@ -221,7 +216,9 @@ See `schema.sql` — 6 tables: devices, sessions, messages, notes, events, confi
 - Paginate through old sessions via REST API
 - Dashboard shows live conversation via WebSocket events
 
-## API-First Architecture (46 REST endpoints + 1 WebSocket)
+## API-First Architecture (47 REST endpoints + 1 WebSocket)
+
+_Counted from code: `for f in dragon_voice/api/*.py dragon_voice/notes/api.py; do grep -c 'app.router.add_' "$f"; done | paste -sd+ | bc` → 47. Drifted from "46" to "52" and back — see wave-14 H23._
 
 Dragon is an API-first server. Every capability is accessible via REST so any hardware client can use it.
 
@@ -324,7 +321,7 @@ dragon_voice/         — Voice pipeline package (port 3502)
   memory.py           — MemoryService: facts + documents + RAG with Ollama embeddings
   config.py           — Config dataclasses (incl. ToolsConfig, MemoryConfig)
   config.yaml         — Default configuration
-  api/                — Modular REST API package (52 endpoints)
+  api/                — Modular REST API package (47 endpoints, counted from code)
     __init__.py       — setup_all_routes() entry point
     utils.py          — Shared helpers (json_error, pagination)
     sessions.py       — Session CRUD + lifecycle routes

--- a/docs/WAVE-14-PROGRESS.md
+++ b/docs/WAVE-14-PROGRESS.md
@@ -54,11 +54,11 @@ Each of these removes friction that slows everything after it.
 
 ## Phase 5 — HIGH docs + protocol
 
-- [ ] **W14-H19** `[DOC]` reconcile `capabilities.widgets` / `widget_capability` / protocol.md §2.1 / §17.12
+- [x] **W14-H19** `[DOC]` reconcile `capabilities.widgets` / `widget_capability` / protocol.md §2.1 / §17.12 · §2.1 register now documents `capabilities.widgets` nested form; §17.12 rewritten as "wave-14 reconciliation note" pointing back; reference table updated
 - [ ] **W14-H20** `[DOC]` `clear_history` → `clear` in TinkerTab/CLAUDE.md
-- [ ] **W14-H21** `[DOC]` delete `conn_mode` paragraph from TinkerBox/CLAUDE.md
+- [x] **W14-H21** `[DOC]` delete `conn_mode` paragraph from TinkerBox/CLAUDE.md · removed from header + table row; voice_mode now includes 0|1|2|3
 - [ ] **W14-H22** `[DOC]` extend TinkerTab/CLAUDE.md NVS keys table with 11 missing entries
-- [ ] **W14-H23** `[DOC]` endpoint count: pick one number or generate from code
+- [x] **W14-H23** `[DOC]` endpoint count: pick one number or generate from code · canonical count is 47 REST endpoints; 3 stale callsites all updated with grep-from-code formula
 
 ## Phase 6 — MEDIUM
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -101,7 +101,18 @@ On reconnect, Tab5 sends the stored `session_id` in the `register` message to re
     "screen": true,
     "camera": true,
     "sd_card": true,
-    "touch": true
+    "touch": true,
+    "widgets": {
+      "types": ["live","card","list","chart","media","prompt"],
+      "list_max_items": 5,
+      "chart_max_points": 12,
+      "prompt_max_choices": 3,
+      "screen_w": 720,
+      "screen_h": 1280,
+      "media_max_w": 660,
+      "media_max_h": 440,
+      "action_rate_per_sec": 4
+    }
   }
 }
 ```
@@ -116,6 +127,7 @@ On reconnect, Tab5 sends the stored `session_id` in the `register` message to re
 | `platform` | string | yes | Device type identifier (e.g. `"esp32p4-tab5"`). |
 | `session_id` | string or null | no | Previous session ID to resume, or `null` for new session. |
 | `capabilities` | object | yes | Declares device hardware capabilities. |
+| `capabilities.widgets` | object | no | Wave-14 W14-H19: widget capability descriptor. Tab5 advertises widget-renderer limits here instead of as a separate `widget_capability` frame (see below). `types` is the set of widget kinds the renderer supports; the `*_max_*` / `screen_*` numbers let skills downgrade gracefully (e.g. a 20-point chart truncates to 12). |
 
 **When sent:** Immediately after WebSocket connection is established, before any other frames.
 
@@ -1347,7 +1359,7 @@ clients that don't recognize a `widget_*` type simply ignore it.
 | Dragon → Tab5 | `widget_prompt` | Ask one question with typed input |
 | Dragon → Tab5 | `widget_dismiss` | Dismiss any non-live widget by card_id |
 | Tab5 → Dragon | `widget_action` | User tapped action or answered prompt |
-| Tab5 → Dragon | `widget_capability` | Advertise supported widgets / icons (optional) |
+| Tab5 → Dragon | `register.capabilities.widgets` | Widget renderer limits — nested inline in §2.1 `register`, **not** a standalone frame (W14-H19). |
 
 ### 17.2 Live widget — `widget_live`
 
@@ -1536,26 +1548,20 @@ With payload (from prompt answer or list selection):
 Dragon's `widget_action_router` dispatches to the owning skill's
 `on_action(event, payload)` handler. Errors → `widget_card` with `tone=alert`.
 
-### 17.12 Capability advertisement — `widget_capability` (Tab5 → Dragon)
+### 17.12 Capability advertisement — inline in `register` frame
 
-Optional. Extends the existing `register` frame. Sent at registration or on
-firmware upgrade.
+**Wave 14 W14-H19 reconciliation:** this section previously described a
+standalone `{"type":"widget_capability",...}` frame sent separately from
+`register`. That frame was **never implemented**. In reality Tab5 nests
+widget capabilities inside the `register` frame's `capabilities.widgets`
+sub-object (see §2.1). Dragon's register handler reads
+`capabilities.widgets.types` + the `*_max_*` fields and caches them on
+the session; the `SurfaceManager` downgrade path uses those values.
 
-```json
-{
-  "type": "widget_capability",
-  "widgets": ["live", "card", "list", "media", "prompt"],
-  "icons": ["clock","briefcase","laundry","coffee","book","car","pot",
-            "person","droplet","check","alert","sun","moon","cloud",
-            "calendar","star"],
-  "render_mode": "client",
-  "screen": {"w": 720, "h": 1280, "fmt": "rgb565", "touch": true},
-  "input": {"mic": true, "keyboard": true, "imu": true, "camera": true}
-}
-```
-
-Brain stores this per session. Missing = assume full capability (Tab5
-default). Used by `SurfaceManager` to downgrade before emission.
+If you're looking for the shape, see §2.1 — it is canonical. The
+icon list + separate `render_mode` fields from the old spec are not
+plumbed; Dragon assumes `render_mode: "client"` and does not restrict
+icons server-side (unknown icons render blank on Tab5 per §17.13).
 
 ### 17.13 Error handling
 
@@ -1592,5 +1598,5 @@ widget_card is its superset (adds action).
 | `widget_prompt` | D→T | `skill_id`, `card_id`, `question`, `input`, `on_answer` | v1 |
 | `widget_dismiss` | D→T | `card_id` | v1 |
 | `widget_action` | T→D | `card_id`, `event` | v1 |
-| `widget_capability` | T→D | `widgets`, `render_mode` | v1 |
+| (capability) | inline in `register` | `capabilities.widgets.{types, *_max_*, screen_*}` | v1, see §2.1 |
 


### PR DESCRIPTION
## Summary

Doc-only reconciliation for TinkerBox side. Each finding had a CLAUDE.md or protocol.md claim that didn't match what the code actually did — a future engineer chasing a phantom field was the failure mode.

### W14-H19 — widget_capability reconciliation

protocol.md §2.1 `register` now documents `capabilities.widgets` (nested object with `types[]`, `*_max_*`, `screen_*`, `action_rate_per_sec`) — which is what Tab5 has always sent. §17.12 was a phantom standalone-frame spec; rewritten as a reconciliation note pointing to §2.1. Reference table row updated.

### W14-H21 — conn_mode deleted

TinkerBox/CLAUDE.md claimed Tab5 sent `conn_mode` in config_update (with inverted semantics relative to the Tab5-internal `conn_m` NVS key). Neither side implemented it. Paragraph + schema reference deleted.

### W14-H23 — endpoint count truthed

Three stale numbers (46 / 52 / 52) replaced with the grep-counted 47 + the formula that produces it (`grep -c 'app.router.add_' dragon_voice/api/*.py dragon_voice/notes/api.py | paste -sd+ | bc`).

## Test plan

- [x] grep confirms widget_capability references only now point to §2.1
- [x] grep confirms conn_mode is 0 remaining in CLAUDE.md
- [x] Endpoint grep formula returns 47, matches all 3 CLAUDE.md sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)