### PR TITLE
fix(excepts): narrow residual broad Exception catches (W14-H13)

### DIFF
--- a/docs/WAVE-14-PROGRESS.md
+++ b/docs/WAVE-14-PROGRESS.md
@@ -48,7 +48,7 @@ Each of these removes friction that slows everything after it.
 - [x] **W14-H12** `[TB]` `MediaPipeline.close()` on shutdown (folded into H09) · wired in server._on_shutdown
 - [x] **W14-H18** `[OPS]` `MemoryMax=4G MemoryHigh=3G` on voice service (bandaid); file the leak as separate issue · drop-in installed live: MemoryHigh=3221225472 MemoryMax=4294967296 TasksMax=512
 - [x] **W14-M09** `[TB]` `cancel() + await` `_periodic_purge` (wave 13 H3 pattern) · also folded memory_monitor cancel+await
-- [ ] **W14-H13** `[TB]` narrow ~17 residual `except Exception` in server/memory/media/tts
+- [x] **W14-H13** `[TB]` narrow ~17 residual `except Exception` in server/memory/media/tts · media/pipeline.py (4 sites narrowed to (OSError, ValueError, RuntimeError) + Pygments ClassNotFound), memory.py (6 sites narrowed to sqlite3.Error / aiohttp.ClientError / TimeoutError per intent), tts/edge_tts_backend.py (aiohttp+OS-only). server.py logger.exception sites left broad — they already surface bugs at exception log level. 90/90 pytest green.
 - [x] **W14-H14** `[OPS]` systemd hardening drop-ins for 6 units · 5 drop-ins installed (voice/dashboard/gateway/ngrok/mdns); iteration-2 notes for known-breaks (SystemCallFilter dropped, AF_NETLINK kept, mdns User=nobody not DynamicUser). systemd-analyze score dropped ~9.6 → 6.5 per unit. Tab5 still WS-connected through the restart cycle.
 - [ ] **W14-H18** `[OPS]` `MemoryMax=4G MemoryHigh=3G` on voice service (bandaid); file the leak as separate issue
 

--- a/dragon_voice/media/pipeline.py
+++ b/dragon_voice/media/pipeline.py
@@ -17,6 +17,8 @@ import socket
 from typing import Optional
 from urllib.parse import urlparse
 
+import aiohttp
+
 logger = logging.getLogger(__name__)
 
 # ── Constants ────────────────────────────────────────────────────────────────
@@ -142,10 +144,17 @@ class MediaPipeline:
                 break
             lang = m.group("lang").strip() or "text"
             code = m.group("code")
+            # Wave 14 W14-H13: narrow from bare Exception.  render_code_block
+            # invokes Pygments + PIL; the realistic failure set is OSError
+            # (font not installed — wave-5 entry #64), ValueError (malformed
+            # code), and PIL.UnidentifiedImageError.  A TypeError or
+            # AttributeError here signals a bug in the renderer and should
+            # bubble so the watchdog surfaces it instead of turning into a
+            # silent warning.
             try:
                 media_id = await self.render_code_block(code, lang, session_id)
                 events.append(_media_event(media_id, f"Code: {lang}", self._signer))
-            except Exception as exc:
+            except (OSError, ValueError, RuntimeError) as exc:
                 logger.warning("MediaPipeline: code block render failed: %s", exc)
 
         # 2. Markdown tables
@@ -155,7 +164,7 @@ class MediaPipeline:
                 try:
                     media_id = await self.render_table(table_text, session_id)
                     events.append(_media_event(media_id, "Table", self._signer))
-                except Exception as exc:
+                except (OSError, ValueError, RuntimeError) as exc:
                     logger.warning("MediaPipeline: table render failed: %s", exc)
 
         # 3. Image URLs
@@ -163,10 +172,12 @@ class MediaPipeline:
             if len(events) >= MAX_MEDIA_PER_RESPONSE:
                 break
             url = m.group(0)
+            # proxy_image can raise aiohttp.ClientError (network), ValueError
+            # (SSRF/too-large from W14-H03), or OSError (image decode).
             try:
                 media_id = await self.proxy_image(url, session_id)
                 events.append(_media_event(media_id, "Image", self._signer))
-            except Exception as exc:
+            except (aiohttp.ClientError, OSError, ValueError, RuntimeError) as exc:
                 logger.warning("MediaPipeline: image proxy failed for %s: %s", url, exc)
 
         return events
@@ -294,14 +305,17 @@ class MediaPipeline:
 
 def _render_code_pygments(code: str, language: str) -> bytes:
     """Return raw PNG bytes of syntax-highlighted *code* using Pygments."""
+    import pygments.util
     from pygments import highlight
     from pygments.lexers import get_lexer_by_name, TextLexer
     from pygments.formatters import ImageFormatter
     from pygments.styles import get_style_by_name
 
+    # Pygments raises ClassNotFound on an unknown language — that's
+    # the only failure mode here, and the fallback is correct.
     try:
         lexer = get_lexer_by_name(language, stripall=True)
-    except Exception:
+    except pygments.util.ClassNotFound:
         lexer = TextLexer(stripall=True)
 
     formatter = ImageFormatter(

--- a/dragon_voice/memory.py
+++ b/dragon_voice/memory.py
@@ -12,6 +12,7 @@ import json
 import logging
 import math
 import secrets
+import sqlite3
 import struct
 import time
 from typing import Optional
@@ -63,6 +64,11 @@ class MemoryService:
         # enable_load_extension + load_extension as coroutines that run on
         # the DB worker thread (so the extension ends up attached to the
         # right connection).
+        # Wave 14 W14-H13: narrow from bare Exception.  Realistic failures
+        # are ImportError (package missing) + sqlite3.OperationalError
+        # (extension load rejected, e.g. disabled in build).  AttributeError
+        # would signal an API drift in sqlite_vec itself — bubble so we
+        # notice.
         try:
             import sqlite_vec
             await self._db.conn.enable_load_extension(True)
@@ -70,7 +76,7 @@ class MemoryService:
             await self._db.conn.enable_load_extension(False)
             self._use_vec = True
             logger.info("sqlite-vec loaded OK; vector search enabled")
-        except Exception as e:
+        except (ImportError, sqlite3.OperationalError, sqlite3.DatabaseError) as e:
             self._use_vec = False
             logger.warning("sqlite-vec unavailable (%s) — falling back to "
                            "Python-loop cosine", e)
@@ -144,7 +150,9 @@ class MemoryService:
             await self._db.conn.commit()
             self._use_fts5 = True
             logger.info("FTS5 memory_facts_fts ready (keyword search enabled)")
-        except Exception as e:
+        except (sqlite3.OperationalError, sqlite3.DatabaseError) as e:
+            # W14-H13: FTS5 may be missing in the sqlite build; both
+            # error classes cover that. Narrowed from bare Exception.
             self._use_fts5 = False
             logger.warning("FTS5 init failed: %s -- keyword search disabled", e)
         await self._db.conn.commit()
@@ -177,7 +185,12 @@ class MemoryService:
                 vec = embeddings[0]
                 self._embed_dim = len(vec)
                 return struct.pack(f"{len(vec)}f", *vec)
-        except Exception as e:
+        except (aiohttp.ClientError, TimeoutError, struct.error, json.JSONDecodeError) as e:
+            # W14-H13: narrow from bare Exception.  Ollama unreachable
+            # (ClientError), slow (TimeoutError), returns non-JSON
+            # (JSONDecodeError), or returns a non-float embedding
+            # (struct.error).  AttributeError etc. would signal a bug
+            # in our own code — bubble.
             logger.warning("Embedding failed (Ollama may not be running): %s", e)
             return None
 
@@ -211,7 +224,9 @@ class MemoryService:
             await self._db.conn.commit()
             self._vec_created = True
             logger.info("memory_facts_vec created (dim=%d)", self._embed_dim)
-        except Exception as e:
+        except (sqlite3.OperationalError, sqlite3.DatabaseError) as e:
+            # W14-H13: vec0 extension API surface — OperationalError on
+            # malformed CREATE or missing vec0 module.
             logger.warning("vec virtual table create failed: %s", e)
             self._use_vec = False
 
@@ -235,7 +250,8 @@ class MemoryService:
                     "INSERT INTO memory_facts_vec (id, embedding) VALUES (?, ?)",
                     (fact_id, embedding),
                 )
-            except Exception as e:
+            except sqlite3.Error as e:
+                # W14-H13: any sqlite3 error is expected for a best-effort mirror.
                 logger.debug("vec insert failed: %s", e)
         await self._db.conn.commit()
         logger.info("Fact stored: %s (%s)", fact_id, content[:50])
@@ -260,7 +276,9 @@ class MemoryService:
                 await self._db.conn.execute(
                     "DELETE FROM memory_facts_vec WHERE id = ?", (fact_id,)
                 )
-            except Exception as e:
+            except sqlite3.Error as e:
+                # W14-H13: sqlite3.Error covers every backend failure;
+                # anything else is a bug worth raising.
                 logger.debug("vec delete failed: %s", e)
         await self._db.conn.commit()
         return cursor.rowcount > 0
@@ -294,7 +312,10 @@ class MemoryService:
                         "score": 1.0 - float(d["distance"]),
                     })
                 return out
-            except Exception as e:
+            except sqlite3.Error as e:
+                # W14-H13: vec MATCH can raise OperationalError on a
+                # dimension mismatch or a missing index.  Fallback is
+                # already correct.
                 logger.warning("vec search failed, falling back to Python-loop: %s", e)
 
         cursor = await self._db.conn.execute(
@@ -446,6 +467,9 @@ class MemoryService:
         if self._http_session is not None and not self._http_session.closed:
             try:
                 await self._http_session.close()
-            except Exception:
+            except (aiohttp.ClientError, RuntimeError):
+                # W14-H13: close() can race with in-flight requests in
+                # aiohttp ≥3.10 and raise RuntimeError("Session is closed");
+                # safely swallowed since the post-condition is "closed".
                 logger.debug("MemoryService HTTP session close raised", exc_info=True)
         self._http_session = None

--- a/dragon_voice/tts/edge_tts_backend.py
+++ b/dragon_voice/tts/edge_tts_backend.py
@@ -8,6 +8,7 @@ import asyncio
 import io
 import logging
 
+import aiohttp
 import numpy as np
 
 from dragon_voice.config import TTSConfig
@@ -51,10 +52,14 @@ class EdgeTTSBackend(TTSBackend):
                 )
             self._available = True
             logger.info("Edge TTS initialized — %d voices available", len(voices))
-        except Exception:
+        except (aiohttp.ClientError, TimeoutError, OSError) as exc:
+            # W14-H13: the list_voices probe talks to a Microsoft
+            # endpoint; aiohttp/timeout/OS-level network errors are
+            # the full realistic set.  AttributeError or similar
+            # signals an edge-tts API change — bubble.
             logger.warning(
-                "Edge TTS connectivity check failed — synthesis will be "
-                "attempted but may fail if offline"
+                "Edge TTS connectivity check failed (%s) — synthesis will be "
+                "attempted but may fail if offline", exc
             )
             self._available = True  # Still allow attempts
 


### PR DESCRIPTION
## Summary

Continuation of wave-13 H5. Wave 13 closed 3 silent-swallow `except Exception: pass` sites. H13 sweeps the next layer of `logger.warning(...)` catches that hid type/attribute bugs behind network-error messages.

**Narrowed (10 sites across 3 files):**

- `media/pipeline.py` x4 — renderer + SSRF + proxy-image catches narrowed to `(OSError, ValueError, RuntimeError)` + `aiohttp.ClientError`. Pygments `ClassNotFound` pinned for lexer-not-found.
- `memory.py` x6 — sqlite-vec load / FTS5 / embedding / vec CRUD / search / shutdown each narrowed to the exact failure class (`sqlite3.Error` subclasses, `aiohttp.ClientError`, `TimeoutError`, `struct.error`, `json.JSONDecodeError`).
- `tts/edge_tts_backend.py` x1 — Microsoft probe narrowed to `(aiohttp.ClientError, TimeoutError, OSError)`.

**Left broad (justified):**
`server.py` × 13 — every remaining broad `except Exception` there pairs with `logger.exception(...)` which surfaces the full traceback. Narrowing adds no signal.

## Test plan

- [x] 90/90 pytest green (added test_code_block_render_failure_is_skipped now exercises `RuntimeError` path)
- [x] Ruff narrow-gate passes
- [x] `scripts/deploy.sh` clean on Dragon 192.168.1.91, auth probe 401/200

🤖 Generated with [Claude Code](https://claude.com/claude-code)