### PR TITLE
fix(stability+ops): wave 14 Phase 6 batch 2 — 5 audit items (H09/M07/M13/M17/L07)

### DIFF
--- a/dragon_voice/llm/tinkerclaw_llm.py
+++ b/dragon_voice/llm/tinkerclaw_llm.py
@@ -18,6 +18,14 @@ from dragon_voice.llm.base import LLMBackend
 
 logger = logging.getLogger(__name__)
 
+# Wave 14 W14-M07: per-line + total-stream caps for the TinkerClaw SSE
+# parser.  The gateway is trusted in theory, but a bug on the other
+# end (or a hostile proxy) could stream an unbounded SSE line or
+# infinite body that exhausts Dragon's memory budget.  We cap both.
+_SSE_MAX_LINE_BYTES = 256 * 1024          # 256 KiB — one SSE "data: ..." frame
+_SSE_MAX_STREAM_BYTES = 16 * 1024 * 1024  # 16 MiB — whole response total
+_SSE_MAX_TOKENS = 50_000                  # ~200 KB of text, generous
+
 
 class TinkerClawBackend(LLMBackend):
     """LLM backend that proxies to a local TinkerClaw agent gateway."""
@@ -137,10 +145,31 @@ class TinkerClawBackend(LLMBackend):
 
                 saw_done = False
                 token_count = 0
+                total_bytes = 0  # W14-M07: running total of SSE body bytes
                 consecutive_errors = 0  # P11: detect HTML error pages from proxy
 
-                async for line in resp.content:
-                    line = line.decode("utf-8", errors="replace").strip()
+                # W14-M07: use readline with explicit byte cap so one
+                # pathologically long SSE frame can't blow memory.
+                while True:
+                    raw = await resp.content.readline()
+                    if not raw:
+                        break
+                    if len(raw) > _SSE_MAX_LINE_BYTES:
+                        logger.error(
+                            "M07: SSE line exceeded %d bytes — aborting stream",
+                            _SSE_MAX_LINE_BYTES,
+                        )
+                        yield " ... (response aborted: oversized SSE frame)"
+                        return
+                    total_bytes += len(raw)
+                    if total_bytes > _SSE_MAX_STREAM_BYTES:
+                        logger.error(
+                            "M07: SSE stream exceeded %d bytes total — aborting",
+                            _SSE_MAX_STREAM_BYTES,
+                        )
+                        yield " ... (response aborted: stream too large)"
+                        return
+                    line = raw.decode("utf-8", errors="replace").strip()
                     if not line or not line.startswith("data: "):
                         continue
 
@@ -172,6 +201,13 @@ class TinkerClawBackend(LLMBackend):
                     token = delta.get("content", "")
                     if token:
                         token_count += 1
+                        if token_count > _SSE_MAX_TOKENS:
+                            logger.error(
+                                "M07: SSE token count exceeded %d — aborting",
+                                _SSE_MAX_TOKENS,
+                            )
+                            yield " ... (response aborted: too many tokens)"
+                            return
                         yield token
 
                 # A07: Truncation detection — stream ended without [DONE]

--- a/dragon_voice/media/store.py
+++ b/dragon_voice/media/store.py
@@ -4,6 +4,7 @@ Stores rendered images (and other binary blobs) with UUID-based IDs.
 Tab5 downloads them via HTTP GET /api/media/{id}.
 """
 
+import asyncio
 import os
 import time
 import uuid
@@ -60,12 +61,18 @@ class MediaStore:
         margin; HMAC signing on the URL (see server.py) is the real
         access control.
         """
-        self._media_dir.mkdir(parents=True, exist_ok=True)
-
+        # Wave 14 W14-H09: mkdir + write_bytes hit the disk and on the
+        # Dragon's eMMC the write of a multi-MB Pygments JPEG can easily
+        # block the event loop for 20–80 ms.  Offload so the LLM→media
+        # path doesn't stall live WebSocket traffic.
         media_id = f"{uuid.uuid4().hex}.{ext}"
         dest = self._media_dir / media_id
 
-        dest.write_bytes(data)
+        def _write_sync() -> None:
+            self._media_dir.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(data)
+
+        await asyncio.to_thread(_write_sync)
         logger.debug(
             "MediaStore.store: %s (%d bytes) session=%s",
             media_id,
@@ -96,7 +103,16 @@ class MediaStore:
         1. Delete every file whose mtime is older than *max_age_hours*.
         2. If total size still exceeds *max_total_mb*, delete the oldest
            remaining files until the store is within budget.
+
+        Wave 14 W14-H09: the whole sweep iterates the media dir, stats
+        every entry, and unlinks — synchronous disk I/O that can stall
+        for hundreds of ms on a full store.  Run the entire pass in a
+        worker thread so the hourly cleanup task can't freeze the WS
+        event loop.
         """
+        await asyncio.to_thread(self._cleanup_sync)
+
+    def _cleanup_sync(self) -> None:
         if not self._media_dir.exists():
             return
 

--- a/dragon_voice/tts/piper_tts.py
+++ b/dragon_voice/tts/piper_tts.py
@@ -62,8 +62,13 @@ class PiperBackend(TTSBackend):
         try:
             import piper
 
-            model_path = self._ensure_model(model_name, data_dir)
             loop = asyncio.get_running_loop()
+            # Wave 14 W14-M13: blocking wget happens inside _ensure_model
+            # when the voice isn't cached yet. Offload so cold-boot doesn't
+            # stall the event loop for up to 2×120 s.
+            model_path = await loop.run_in_executor(
+                inference_executor, self._ensure_model, model_name, data_dir,
+            )
 
             def _load():
                 voice = piper.PiperVoice.load(str(model_path))
@@ -100,7 +105,10 @@ class PiperBackend(TTSBackend):
 
         self._use_binary = True
         self._binary_path = binary
-        self._model_path = self._ensure_model(model_name, data_dir)
+        loop = asyncio.get_running_loop()
+        self._model_path = await loop.run_in_executor(
+            inference_executor, self._ensure_model, model_name, data_dir,
+        )
         logger.info("Piper will use binary at %s", binary)
 
     @staticmethod

--- a/scripts/deploy-firmware.sh
+++ b/scripts/deploy-firmware.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# deploy-firmware.sh — atomic TinkerTab OTA publisher.
+#
+# Wave 14 W14-L07: the old workflow was two separate scp commands —
+# one for tinkertab.bin and one for version.json — which left the
+# /api/ota/check endpoint exposing a torn state window where the
+# reported sha256 didn't match the binary on disk (either old-sha
+# with new-bin, or new-sha with old-bin, depending on which scp
+# landed first).  A Tab5 polling OTA mid-deploy could reboot into
+# a bricked image.
+#
+# This script fixes that:
+#   1. scp the new bin to .new (staging slot)
+#   2. compute sha256 locally, build the new version.json
+#   3. scp version.json to .new on Dragon
+#   4. ssh once: mv tinkertab.bin.new -> tinkertab.bin, then
+#      mv version.json.new -> version.json.  Both renames are on
+#      the same ext4 filesystem so each individual rename is
+#      atomic; by moving the bin BEFORE the version.json, any
+#      Tab5 checking mid-sequence sees the old version pointing
+#      at the old (still-present) sha, or the new version
+#      pointing at the new bin — never a mismatch.
+#
+# Usage: scripts/deploy-firmware.sh <path/to/tinkertab.bin> <version-string>
+#
+# Example:
+#   scripts/deploy-firmware.sh build/tinkertab.bin 0.12.0-wave14
+
+set -euo pipefail
+
+BIN="${1:-}"
+VERSION="${2:-}"
+
+if [[ -z "$BIN" || -z "$VERSION" ]]; then
+    echo "usage: $0 <tinkertab.bin> <version>" >&2
+    exit 2
+fi
+if [[ ! -f "$BIN" ]]; then
+    echo "error: firmware binary not found: $BIN" >&2
+    exit 2
+fi
+
+DRAGON="${DRAGON:-radxa@192.168.1.91}"
+OTA_DIR="${OTA_DIR:-/home/radxa/ota}"
+
+SHA=$(sha256sum "$BIN" | awk '{print $1}')
+SIZE=$(stat -c%s "$BIN")
+echo "[deploy-firmware] bin=$BIN size=$SIZE sha256=$SHA version=$VERSION" >&2
+
+# Use Dragon's public hostname for firmware_url.  Dragon's synth
+# endpoint serves the binary from /api/ota/firmware.bin, so the URL
+# does not need to change per release — keep it stable.
+URL="http://${DRAGON##*@}:3502/api/ota/firmware.bin"
+
+VERSION_JSON=$(printf '{"version":"%s","sha256":"%s","size":%d,"url":"%s"}' \
+    "$VERSION" "$SHA" "$SIZE" "$URL")
+
+TMP_JSON=$(mktemp --suffix=.json)
+trap 'rm -f "$TMP_JSON"' EXIT
+printf '%s\n' "$VERSION_JSON" > "$TMP_JSON"
+
+echo "[deploy-firmware] staging bin -> $OTA_DIR/tinkertab.bin.new" >&2
+scp -q "$BIN"      "$DRAGON:$OTA_DIR/tinkertab.bin.new"
+
+echo "[deploy-firmware] staging version -> $OTA_DIR/version.json.new" >&2
+scp -q "$TMP_JSON" "$DRAGON:$OTA_DIR/version.json.new"
+
+echo "[deploy-firmware] atomic promote" >&2
+# Promote bin first, then json.  If promote fails mid-way, the old
+# bin+json pair stays intact (worst case a stale .new file, cleaned
+# up below).
+ssh "$DRAGON" "set -e
+    cd '$OTA_DIR'
+    mv -f tinkertab.bin.new tinkertab.bin
+    mv -f version.json.new version.json
+    # Drop any stray stale stagings from earlier aborted runs.
+    rm -f tinkertab.bin.new version.json.new
+    echo '[remote] published:' \"\$(cat version.json)\"
+"
+
+echo "[deploy-firmware] probing /api/ota/check" >&2
+# A client polling with current=0.0.0 should get an update=true
+# response that matches the sha we just computed.  The endpoint
+# requires a bearer token (W14-C04); read from $DRAGON_API_TOKEN
+# or fall back to parsing Dragon's systemd env.
+if [[ -z "${DRAGON_API_TOKEN:-}" ]]; then
+    DRAGON_API_TOKEN=$(ssh "$DRAGON" \
+        "grep -oP '^DRAGON_API_TOKEN=\\K.+' /home/radxa/.env 2>/dev/null" \
+        || true)
+fi
+if [[ -n "$DRAGON_API_TOKEN" ]]; then
+    CHECK=$(curl -sS -H "Authorization: Bearer $DRAGON_API_TOKEN" \
+        "http://${DRAGON##*@}:3502/api/ota/check?current=0.0.0" || true)
+    echo "[deploy-firmware] /api/ota/check -> $CHECK" >&2
+    if ! grep -q "\"$SHA\"" <<<"$CHECK"; then
+        echo "[deploy-firmware] WARNING: server sha does not match local sha — manual check recommended" >&2
+        exit 1
+    fi
+else
+    echo "[deploy-firmware] no DRAGON_API_TOKEN available, skipping /check probe" >&2
+fi
+
+echo "[deploy-firmware] OK version=$VERSION sha=$SHA" >&2


### PR DESCRIPTION
## Summary

Closes W14-H09, W14-M07, W14-M13, W14-M17, W14-L07. Brings the wave-14 closed-item tally to 54/63.

| ID | Fix |
|---|---|
| H09 | `MediaStore.store()` + `cleanup()` now offloaded via `asyncio.to_thread` |
| M07 | TinkerClaw SSE parser: per-line 256 KiB / stream 16 MiB / 50K tokens caps |
| M13 | `PiperBackend._ensure_model` wget now runs in `inference_executor` |
| M17 | Killed `tinkeraimcp.ngrok.dev` tunnel (exposed SearXNG), added `basic_auth` to dashboard + gateway tunnels |
| L07 | New `scripts/deploy-firmware.sh` atomically publishes OTA (stage→rename, bin before version.json) |

## Live verification

- **M17 ngrok probe**: tinkeraimcp → 404, dashboard/gateway unauth → 401, authed → 200, voice still open for bearer.
- **L07 deploy probe**: ran end-to-end against Dragon twice; `/api/ota/check` returned sha matching the uploaded bin both times.
- **Tests**: 121/121 pytest green locally.

## Test plan
- [x] pytest ignore=tests/audit — 121 passed
- [x] ruff narrow-gate still clean (no new broad Exception)
- [x] ngrok restart on Dragon verified all four auth states
- [x] Firmware publish round-trips a test version tag then restores real version