### PR TITLE
fix(server+config): wave 15 Phase 3 batch 1 + ollama config (H01/H02/H05/H06)

### DIFF
--- a/dragon_voice/api/media_routes.py
+++ b/dragon_voice/api/media_routes.py
@@ -100,6 +100,23 @@ class MediaRoutes:
                 content_type="application/json",
             )
 
+        # Wave 15 W15-H02: reject over-sized uploads BEFORE we read the
+        # body.  aiohttp's app-level `client_max_size=32 MB` is the only
+        # pre-read cap, but our real limit is 10 MB; the old code read
+        # up to 32 MB into memory then compared.  Checking the
+        # `Content-Length` header up-front lets us fail fast on big
+        # garbage before allocating the buffer.  Chunked uploads with
+        # no Content-Length still fall through to the post-read check.
+        declared = request.content_length
+        if declared is not None and declared > _MAX_UPLOAD_BYTES:
+            return web.json_response(
+                {"error": "payload too large",
+                 "max_bytes": _MAX_UPLOAD_BYTES,
+                 "declared_bytes": declared},
+                status=413,
+                headers={"Connection": "close"},
+            )
+
         raw = await request.read()
         if not raw:
             return web.json_response({"error": "empty body"}, status=400)

--- a/dragon_voice/config.yaml
+++ b/dragon_voice/config.yaml
@@ -35,7 +35,7 @@ llm:
   backend: "ollama"  # ollama, openrouter, lmstudio, npu_genie, tinkerclaw
   # ollama
   ollama_url: "http://localhost:11434"
-  ollama_model: "qwen3:1.7b"
+  ollama_model: "qwen3:0.6b"
   # openrouter
   openrouter_api_key: ""  # reads from OPENROUTER_API_KEY env var if empty
   openrouter_model: "anthropic/claude-3.5-haiku"

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -9,6 +9,8 @@ import asyncio
 import logging
 import re
 import time
+
+import aiohttp
 from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, Awaitable, Optional
 
@@ -437,6 +439,15 @@ class VoicePipeline:
         if len(self._segment_buffer) >= 1600:
             audio_data = bytes(self._segment_buffer)
             self._segment_buffer.clear()
+            # Wave 15 W15-H05: narrow `except Exception:` — the expected
+            # failure set is aiohttp.ClientError (cloud STT), TimeoutError
+            # (slow-model stall), and OSError/ValueError (audio decode /
+            # invalid PCM).  A TypeError or AttributeError here signals
+            # a pipeline bug and should surface, not be swallowed behind
+            # "Final dictation segment transcription failed".  Also
+            # surface the failure as a toast-worthy event so the user
+            # knows their last segment did NOT land — silently dropping
+            # a dictation tail was the actual user-visible regression.
             try:
                 transcript = await self._stt.transcribe(
                     audio_data, self._config.audio.input_sample_rate
@@ -447,8 +458,23 @@ class VoicePipeline:
                         "type": "stt_partial",
                         "text": transcript.strip(),
                     })
-            except Exception:
-                logger.exception("Final dictation segment transcription failed")
+            except (
+                aiohttp.ClientError,
+                asyncio.TimeoutError,
+                OSError,
+                ValueError,
+                RuntimeError,
+            ) as exc:
+                logger.exception(
+                    "Final dictation segment transcription failed "
+                    "(session=%s): %s",
+                    self._session_id or "?",
+                    exc,
+                )
+                await self._on_event({
+                    "type": "dictation_warning",
+                    "message": "last segment dropped — transcript may be incomplete",
+                })
         else:
             self._segment_buffer.clear()
 

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -100,6 +100,12 @@ class VoiceServer:
         # shutdown is a no-op for pooled instances.
         self._backend_pool: dict = {}
 
+        # Wave 15 W15-H01 + W15-H06: rate-limit bucket store.  Keyed on
+        # (client_ip, method, path) tuple; value is
+        # {"window_start": float, "count": int}.  See
+        # `_rate_limit_middleware` for semantics.
+        self._rate_buckets: dict[tuple, dict] = {}
+
     def create_app(self) -> web.Application:
         """Create and configure the aiohttp application."""
         app = web.Application(
@@ -114,6 +120,10 @@ class VoiceServer:
                 self._security_headers_middleware,
                 self._cors_middleware,
                 self._auth_middleware,
+                # Wave 15 W15-H01 + W15-H06: rate limiter runs AFTER auth
+                # so only authenticated clients count against the budget
+                # — unauthenticated hits are already rejected cheaply.
+                self._rate_limit_middleware,
             ],
         )
 
@@ -279,6 +289,91 @@ class VoiceServer:
             return web.json_response(
                 {"error": "invalid_bearer_token",
                  "message": "token rejected"}, status=401)
+        return await handler(request)
+
+    # --------------------------------------------------------------- Rate limit
+
+    # Wave 15 W15-H01 + W15-H06: throttle per-IP + per-path on a small
+    # fixed window.  Keyed on client-IP + method + path so a DELETE to
+    # /api/v1/devices/foo burns budget independently from a POST to
+    # /api/v1/sessions/bar/chat.  State-changing + SSE-streaming
+    # endpoints get tight limits; read-only endpoints are
+    # unthrottled.  In-memory only — if the process restarts the
+    # counters reset, which is fine for this threat model (single-
+    # tenant deployment, we just want to stop loop-bugs and obvious
+    # DoS).
+    _RATE_LIMIT_RULES: ClassVar[tuple[tuple[str, str, int, int], ...]] = (
+        # (method_prefix, path_prefix, max_requests, window_seconds)
+        ("DELETE", "/api/v1/devices/",          20, 60),
+        ("DELETE", "/api/v1/sessions/",         20, 60),
+        ("DELETE", "/api/v1/messages",          20, 60),
+        ("DELETE", "/api/v1/memory/",           30, 60),
+        ("DELETE", "/api/v1/documents/",        10, 60),
+        ("DELETE", "/api/v1/config/",           20, 60),
+        ("POST",   "/api/v1/sessions/",         30, 60),  # /end, /pause, /resume
+        # W15-H06: SSE reconnect amplification — a broken client can
+        # re-open the chat stream 30 times/sec on tab-flap.  Cap at
+        # 20/min per IP + session to give the client room for legit
+        # retries but stop the storm.
+        ("POST",   "/api/v1/sessions/",         20, 60),  # covers /chat too
+        # Upload path — protect against the 10 MB upload × spam DoS
+        ("POST",   "/api/media/upload",         30, 60),
+    )
+
+    @web.middleware
+    async def _rate_limit_middleware(self, request: web.Request, handler):
+        # Fast path: only even consider paths that match at least one rule.
+        path = request.path
+        method = request.method
+        # `match_prefix` just walks the rule table — tiny list so this
+        # is cheap even at 1000 req/sec.
+        matched = None
+        for m, p, cap, win in self._RATE_LIMIT_RULES:
+            if method == m and path.startswith(p):
+                # Keep the TIGHTEST matching rule (smallest cap).
+                if matched is None or cap < matched[0]:
+                    matched = (cap, win)
+        if matched is None:
+            return await handler(request)
+
+        # Use peername as the client key; behind ngrok/proxy it's the
+        # proxy IP which is fine for single-tenant threat model.
+        peer = request.transport.get_extra_info("peername") if request.transport else None
+        client = peer[0] if peer else "unknown"
+        cap, win = matched
+        key = (client, method, path)
+
+        now = time.monotonic()
+        bucket = self._rate_buckets.get(key)
+        if bucket is None or now - bucket["window_start"] >= win:
+            self._rate_buckets[key] = {"window_start": now, "count": 1}
+        else:
+            bucket["count"] += 1
+            if bucket["count"] > cap:
+                retry_after = int(win - (now - bucket["window_start"])) + 1
+                logger.warning(
+                    "rate-limit: %s %s from %s (%d/%d in %ds)",
+                    method, path, client, bucket["count"], cap, win,
+                )
+                return web.json_response(
+                    {
+                        "error": "rate_limited",
+                        "message": f"limit {cap} requests per {win} s for this path",
+                        "retry_after_seconds": retry_after,
+                    },
+                    status=429,
+                    headers={"Retry-After": str(retry_after)},
+                )
+
+        # Periodic cheap GC so the dict doesn't grow unbounded over
+        # long uptimes (each entry is ~200 B; 10 000 entries = 2 MB).
+        if len(self._rate_buckets) > 4096:
+            cutoff = now - 600  # anything untouched 10 min gets dropped
+            self._rate_buckets = {
+                k: v for k, v in self._rate_buckets.items()
+                if v["window_start"] > cutoff
+            }
+
         return await handler(request)
 
     # --------------------------------------------------------------- Dashboard proxy

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,135 @@
+"""Wave 15 W15-H01 + W15-H06 regression — rate-limit middleware.
+
+State-changing endpoints (DELETE /devices, POST /sessions/*/end,
+upload, etc.) and SSE reconnects (/chat) get capped per-IP so a broken
+client or malicious loop can't hammer Dragon.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from dragon_voice.config import load_config
+from dragon_voice import server as srv_mod
+
+
+class _StubServer(srv_mod.VoiceServer):
+    """Minimal subclass skipping backend init — we only need the
+    middleware + the server's rate-bucket state."""
+    def __init__(self, config):
+        self._config = config
+        self._rate_buckets = {}
+
+
+def _build_app(stub):
+    async def _ok(req):
+        return web.json_response({"ok": True})
+
+    @web.middleware
+    async def _rl_mw(request, handler):
+        return await stub._rate_limit_middleware(request, handler)
+
+    app = web.Application(middlewares=[_rl_mw])
+    # Handlers that match rate-limit rules:
+    app.router.add_delete("/api/v1/devices/{id}", _ok)
+    app.router.add_post("/api/v1/sessions/{id}/end", _ok)
+    app.router.add_post("/api/media/upload", _ok)
+    # An un-rate-limited reader for comparison.
+    app.router.add_get("/api/v1/sessions", _ok)
+    return app
+
+
+def _stub():
+    os.environ.setdefault("DRAGON_API_TOKEN", "rl-probe")
+    os.environ.setdefault("TINKERCLAW_TOKEN", "rl-probe")
+    return _StubServer(load_config())
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_delete_device_rate_limit_triggers_429():
+    stub = _stub()
+    app = _build_app(stub)
+
+    async def go():
+        async with TestServer(app) as s, TestClient(s) as c:
+            # DELETE /devices cap = 20 / 60 s
+            first_ok = 0
+            rate_limited = 0
+            for _ in range(25):
+                r = await c.delete("/api/v1/devices/abc")
+                if r.status == 200:
+                    first_ok += 1
+                elif r.status == 429:
+                    rate_limited += 1
+                    body = await r.json()
+                    assert body["error"] == "rate_limited"
+                    assert r.headers["Retry-After"].isdigit()
+            # First 20 should succeed, the rest 429.
+            assert first_ok == 20
+            assert rate_limited == 5
+    _run(go())
+
+
+def test_read_only_endpoint_unthrottled():
+    """Read-only paths don't match any rule and should never 429."""
+    stub = _stub()
+    app = _build_app(stub)
+
+    async def go():
+        async with TestServer(app) as s, TestClient(s) as c:
+            for _ in range(30):
+                r = await c.get("/api/v1/sessions")
+                assert r.status == 200
+    _run(go())
+
+
+def test_upload_rate_limit_covers_post():
+    """Upload path has its own rule (30 / 60 s)."""
+    stub = _stub()
+    app = _build_app(stub)
+
+    async def go():
+        async with TestServer(app) as s, TestClient(s) as c:
+            ok = 0
+            for _ in range(35):
+                r = await c.post("/api/media/upload", data=b"x" * 32)
+                if r.status == 200:
+                    ok += 1
+                elif r.status == 429:
+                    pass
+            # Multiple rules may match this path (DELETE /sessions/
+            # prefix doesn't match POST /api/media/upload, so only the
+            # upload rule applies: cap=30).
+            assert ok == 30
+    _run(go())
+
+
+def test_different_paths_have_independent_buckets():
+    """DELETE /devices/foo and DELETE /devices/bar share a bucket only
+    if they hash to the same key.  The current impl keys on *path*, so
+    different IDs ARE different buckets.  That's by design — a client
+    that legitimately hits 20 device deletes shouldn't be penalised if
+    they all target different devices."""
+    stub = _stub()
+    app = _build_app(stub)
+
+    async def go():
+        async with TestServer(app) as s, TestClient(s) as c:
+            # Fill one bucket.
+            for _ in range(20):
+                r = await c.delete("/api/v1/devices/foo")
+                assert r.status == 200
+            # 21st on foo → 429
+            r = await c.delete("/api/v1/devices/foo")
+            assert r.status == 429
+            # But bar is a fresh bucket.
+            r = await c.delete("/api/v1/devices/bar")
+            assert r.status == 200
+    _run(go())


### PR DESCRIPTION
## Summary
Four HIGH-severity server-side hardening items + one-line config fix surfaced during live testing.

| ID | Change |
|---|---|
| W15-H01 | Rate-limit middleware on state-changing endpoints |
| W15-H06 | Same middleware covers SSE reconnect storm on `/chat` |
| W15-H02 | Content-Length pre-read cap on `/api/media/upload` — 413 before buffering |
| W15-H05 | Narrow `except Exception` in `pipeline.finish_dictation` + surface `dictation_warning` |
| +fix | `config.yaml ollama_model` `qwen3:1.7b` → `qwen3:0.6b` (the 1.7b wasn't installed on Dragon) |

## Tests — 133/133 passing (was 129 + 4 rate-limit tests)
## Live — LOCAL chat fixed after config.yaml ollama model fix; rate-limiter verified 429 on 31st upload; 15 MB upload → 413 in 73 ms