### PR TITLE
fix(pipeline+server): fallback text when LLM yields empty response (W15-H09)

### DIFF
--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -741,6 +741,29 @@ class VoicePipeline:
             if sentence_buffer.strip() and not self._cancelled:
                 await self._synthesize_and_send(sentence_buffer.strip())
 
+            # Wave 15 W15-H09: empty-response guard.  If the LLM stream
+            # finished without producing any text (common failure mode:
+            # model attempts a tool call, the tool errors out, model
+            # halts without formulating a user-facing answer — seen
+            # today with MiniMax-M2.5 on TinkerClaw when BRAVE_API_KEY
+            # is missing), the user was left staring at "thinking" until
+            # Tab5 timed out and dropped to READY with no audio.  Emit a
+            # fallback sentence so the user ALWAYS hears something.
+            # Skip the fallback if we were cancelled — that's a user
+            # action (stop button, new session) and silence is correct.
+            if not full_response.strip() and not self._cancelled:
+                fallback = (
+                    "Sorry, I couldn't generate a response for that. "
+                    "Please try rephrasing, or try again in a moment."
+                )
+                logger.warning(
+                    "W15-H09: LLM stream produced zero text tokens — "
+                    "emitting fallback response to avoid silent drop"
+                )
+                await self._on_event({"type": "llm", "text": fallback})
+                await self._synthesize_and_send(fallback)
+                full_response = fallback
+
             llm_ms = (time.monotonic() - t0) * 1000
             logger.info("LLM (%.0fms): %s", llm_ms, full_response[:80])
             await self._on_event({"type": "llm_done", "llm_ms": round(llm_ms)})

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -2263,6 +2263,27 @@ class VoiceServer:
                 keepalive_task.cancel()
 
             response_text = "".join(full_response)
+
+            # Wave 15 W15-H09: same empty-response guard as the voice
+            # pipeline.  When MiniMax / the TinkerClaw agent halts after
+            # a failed tool call without formulating a user-facing reply
+            # (e.g. brave_search returns missing_brave_api_key), we'd
+            # otherwise send llm_done with text="" and Tab5 silently
+            # drops the chat bubble.  Emit a fallback so the user always
+            # sees something in the chat view.
+            if not response_text.strip():
+                fallback = (
+                    "Sorry, I couldn't generate a response for that. "
+                    "Please try rephrasing, or try again in a moment."
+                )
+                logger.warning(
+                    "W15-H09: TinkerClaw text path produced zero tokens — "
+                    "emitting fallback response"
+                )
+                if not ws.closed:
+                    await ws.send_json({"type": "llm", "text": fallback})
+                response_text = fallback
+
             logger.info("TinkerClaw text response (%d chars): %s",
                         len(response_text), response_text[:80])
             if not ws.closed:


### PR DESCRIPTION
## Summary

User report: *"I tapped the orb, spoke, it said thinking, then I didn't hear anything and it went back to the speak/record screen."*

Root cause traced on-device:

- STT fine → \"Tell me about the news in Iran today.\"
- Mode 3 (TinkerClaw) → MiniMax-M2.5 invokes \`web_search\` tool
- OpenClaw \`brave-search\` provider → \`missing_brave_api_key\` (no \`BRAVE_API_KEY\` env in gateway config — [openclaw/extensions/brave/src/brave-web-search-provider.ts:406](https://github.com/... )).
- MiniMax halts with **zero text tokens**. Pipeline logs \`LLM (10163ms):\` blank.
- Tab5 receives \`llm_done\` with no preceding \`llm\` text event, transitions THINKING → READY, **no TTS** — silent drop.

## Fix

Two parallel paths, same guard:

1. [dragon_voice/pipeline.py](dragon_voice/pipeline.py) — voice turn (modes 0/1/2 + 3 voice): if \`full_response\` is empty and the turn wasn't cancelled, emit fallback via \`llm\` event + synthesize through TTS.
2. [dragon_voice/server.py](dragon_voice/server.py) — \`_handle_text\` TinkerClaw bypass (mode 3 text input): same guard before \`llm_done\`.

Skip the fallback on cancelled turns — that's a deliberate user action (stop/new session) and silence is correct.

## Test plan

- [x] Deployed to Dragon (\`scp\` + \`sudo systemctl restart tinkerclaw-voice\`), \`/health\` OK
- [ ] Tab5 side: force an empty-response condition in mode 3 and confirm fallback sentence reaches the chat + plays via TTS
- [ ] Chat keyboard back-and-forth (pending follow-up test)

Refs wave-15 audit (W15-H09). Pairs with TinkerTab W15-H07/H08 Wi-Fi fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)