### PR TITLE
fix(tinkerclaw): TC timeout bumps + swap _llm_config on mode change (closes #58)

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -584,3 +584,17 @@ sequentially across the whole file (don't restart per section).
 - **Fix:** Added cancel + await-with-suppressed-CancelledError for `_media_cleanup_task` in `_on_shutdown`, matching the sibling cleanup tasks.
 - **Prevention:** Every `asyncio.create_task(...)` that lives past the request must be tracked in a single `self._*_task` field AND cancelled in `_on_shutdown`. Grep for `create_task` before adding a new long-lived task.
 
+
+### 75. TinkerClaw SSE timeout killed long agent work mid-execution
+- **Date:** 2026-04-23 (#58)
+- **Symptom:** Long TC-mode turns that involved agent work (skill authoring, git clone, multi-step planning, exec chains) returned "Response timed out, please try again." on Tab5 even though the gateway was still actively modifying files on Dragon. Gateway logs showed the agent continuing to write config files, restart the bundle, and emit text — 30+ seconds *after* Dragon had already sent the timeout message.
+- **Root Cause:** `TinkerClawLLM._session` was created with `ClientTimeout(total=180, sock_read=90)`. MiniMax-M2.5 can go 2+ minutes between SSE chunks while it's tool-calling. The 90s sock_read limit was an over-conservative guess that predated long-running agent workloads.
+- **Fix:** Bumped `total=180 → 600` and `sock_read=90 → 600` in `dragon_voice/llm/tinkerclaw_llm.py:68`. Also bumped aiohttp `WebSocketResponse.receive_timeout=120 → 600` in `server.py:1368` so Tab5 WS survives long TC turns without heartbeat-triggered disconnect.
+- **Prevention:** Timeouts that guard against network failure should be multiples of the expected workload, not bound to it. When adding a new backend, look up its typical long-tail response time and add 3× headroom.
+
+### 76. ConversationEngine stuck on initial backend's compact tool prompt after mode swap
+- **Date:** 2026-04-23 (#58)
+- **Symptom:** In cloud mode (voice_mode=2) the LLM only "saw" the top-5 compact tool list (web_search, datetime, remember, recall, calculator), even after 9+ other tools were registered (weather, stock_ticker, timesense_timer, quick_poll, note, system_info, unit_converter, forget_fact, convert). Asking "list every tool you have" returned those same 5. Asking it to use e.g. stock_ticker explicitly prompted it to say "I don't have that tool."
+- **Root Cause:** `ConversationEngine._augment_context_with_tools` picks compact-vs-full format via `self._llm_config.backend in ("ollama", "npu_genie", "lmstudio")`. The `config_update` handler in `server.py` swapped `self._conversation._llm` (the backend instance) but *not* `self._conversation._llm_config` (the config object the is-local check reads). So after any swap from the default `ollama` config, `_llm_config.backend` was permanently stuck on `"ollama"` — the is-local check returned True forever, forcing compact format.
+- **Fix:** The config_update handler now updates `self._conversation._llm_config = conn_config.llm` alongside the `_llm` swap (`server.py:1824`). Swap-log line now includes the new backend name so regressions are visible.
+- **Prevention:** When a class holds both a live object and its config, any hot-swap of the live object must also swap its config — or the config should be derived-on-read rather than cached. Grep for `_llm_config` usage any time `_llm` is reassigned.

--- a/dragon_voice/llm/tinkerclaw_llm.py
+++ b/dragon_voice/llm/tinkerclaw_llm.py
@@ -61,11 +61,14 @@ class TinkerClawBackend(LLMBackend):
             headers["Authorization"] = f"Bearer {self._token}"
 
         self._session = aiohttp.ClientSession(
-            # P05: sock_read raised from 30s to 90s. TinkerClaw tool execution
-            # (web_search, memory recall, etc.) can take 10-30s with no SSE
-            # data flowing. The total=180s covers the full agent run including
-            # multiple tool rounds.
-            timeout=aiohttp.ClientTimeout(total=180, sock_read=90),
+            # 2026-04-23 (#58): bumped total 180→600 and sock_read 90→600.
+            # Previous 90 s budget killed TC agents mid-work — any skill that
+            # authored a file, cloned a repo, or did multi-step planning
+            # routinely exceeded 90 s of silent streaming.  User saw
+            # "Response timed out, please try again." on Tab5 while the
+            # agent was actively modifying files on Dragon.  10 min covers
+            # real TC agent workloads with headroom.
+            timeout=aiohttp.ClientTimeout(total=600, sock_read=600),
             headers=headers,
         )
 

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -1363,7 +1363,13 @@ class VoiceServer:
         ws = web.WebSocketResponse(
             max_msg_size=10 * 1024 * 1024,
             heartbeat=60.0,
-            receive_timeout=120.0,
+            # 2026-04-23 (#58): 120 → 600 s.  Previously Tab5 WS got dropped
+            # mid-turn when TC was running a long agent task — heartbeat
+            # PING goes out every 60 s but if the TC response hasn't started
+            # streaming within 120 s (normal for MiniMax-M2.5 + tools), the
+            # aiohttp server-side receive_timeout would yank the connection
+            # and Tab5 would see the flap as "Dragon unreachable".
+            receive_timeout=600.0,
             autoping=True,
         )
         await ws.prepare(request)
@@ -1816,8 +1822,17 @@ class VoiceServer:
                                         if old_llm is not None and old_llm not in self._backend_pool.values():
                                             await old_llm.shutdown()
                                         self._conversation._llm = new_llm
-                                        logger.info("ConversationEngine LLM swapped to %s%s",
-                                                    new_llm.name, " (pooled)" if pooled else "")
+                                        # 2026-04-23 (#58): also swap _llm_config so the
+                                        # compact-vs-full tool prompt logic in
+                                        # ConversationEngine._augment_context_with_tools
+                                        # picks the right format for the active backend.
+                                        # Without this, cloud-mode agents stayed on the
+                                        # top-5 compact tool list and never saw weather,
+                                        # stock_ticker, timesense_timer, quick_poll, note,
+                                        # system_info, or unit_converter.
+                                        self._conversation._llm_config = conn_config.llm
+                                        logger.info("ConversationEngine LLM swapped to %s%s (backend=%s)",
+                                                    new_llm.name, " (pooled)" if pooled else "", conn_config.llm.backend)
                                     except Exception as e:
                                         logger.exception("ConversationEngine LLM swap failed: %s", e)
 


### PR DESCRIPTION
## Summary
Two distinct TC-mode fixes surfaced during a long-session Tab5 test:

1. **TinkerClawLLM SSE timeouts bumped** (`ClientTimeout total 180→600, sock_read 90→600`).  MiniMax-M2.5 can go 2+ min between SSE chunks while tool-calling; the old 90 s budget aborted real workloads (skill authoring, multi-step planning, exec chains) while the gateway was still actively writing files.  Also bumped server `WebSocketResponse.receive_timeout 120→600` so Tab5 WS survives long TC turns without a heartbeat-triggered disconnect.
2. **ConversationEngine `_llm_config` now swaps with `_llm`** on `config_update`.  Previously the handler swapped `_llm` (the live backend) but not `_llm_config` (the cached config that `_augment_context_with_tools` reads for is-local detection).  So cloud-mode LLM was stuck on the top-5 compact tool list forever — newly-registered tools were invisible to the model.  Now they swap together; the swap log line reports the new backend name.

LEARNINGS.md entries [#75](LEARNINGS.md) (timeouts) and [#76](LEARNINGS.md) (`_llm_config` swap).

## Verification (live Dragon)
- Cloud-mode `list every tool name` returned **all 14** registered tools (was 5).
- TC-mode `tab_pulse` skill-authoring turn completed end-to-end in 61 s (was 91 s → timeout).
- Evidence: TinkerTab repo `.superpowers/brainstorm/ui-overhaul-v4/tc-skill-2026-04-22/REPORT.md`.

## Test plan
- [x] `python3 -m py_compile dragon_voice/llm/tinkerclaw_llm.py dragon_voice/server.py`
- [x] Live Dragon restart — `systemctl is-active tinkerclaw-voice` = active.
- [x] Tab5 issues `config_update` for voice_mode=2 — log line `ConversationEngine LLM swapped to OpenRouter (google/gemini-3-flash-preview) (backend=openrouter)` appears (previously didn't show backend).
- [x] Cloud-mode tool list turn — 14 tools returned (was 5).
- [x] TC-mode 60+ s agent turn — completes without timing out.
- [ ] Regression: short cloud-mode turns still fast (should still be ≤ 20 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)