### PR TITLE
feat(tools): stock_ticker — live US quote via Stooq CSV (closes #60)

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -585,16 +585,9 @@ sequentially across the whole file (don't restart per section).
 - **Prevention:** Every `asyncio.create_task(...)` that lives past the request must be tracked in a single `self._*_task` field AND cancelled in `_on_shutdown`. Grep for `create_task` before adding a new long-lived task.
 
 
-### 75. TinkerClaw SSE timeout killed long agent work mid-execution
-- **Date:** 2026-04-23 (#58)
-- **Symptom:** Long TC-mode turns that involved agent work (skill authoring, git clone, multi-step planning, exec chains) returned "Response timed out, please try again." on Tab5 even though the gateway was still actively modifying files on Dragon. Gateway logs showed the agent continuing to write config files, restart the bundle, and emit text — 30+ seconds *after* Dragon had already sent the timeout message.
-- **Root Cause:** `TinkerClawLLM._session` was created with `ClientTimeout(total=180, sock_read=90)`. MiniMax-M2.5 can go 2+ minutes between SSE chunks while it's tool-calling. The 90s sock_read limit was an over-conservative guess that predated long-running agent workloads.
-- **Fix:** Bumped `total=180 → 600` and `sock_read=90 → 600` in `dragon_voice/llm/tinkerclaw_llm.py:68`. Also bumped aiohttp `WebSocketResponse.receive_timeout=120 → 600` in `server.py:1368` so Tab5 WS survives long TC turns without heartbeat-triggered disconnect.
-- **Prevention:** Timeouts that guard against network failure should be multiples of the expected workload, not bound to it. When adding a new backend, look up its typical long-tail response time and add 3× headroom.
-
-### 76. ConversationEngine stuck on initial backend's compact tool prompt after mode swap
-- **Date:** 2026-04-23 (#58)
-- **Symptom:** In cloud mode (voice_mode=2) the LLM only "saw" the top-5 compact tool list (web_search, datetime, remember, recall, calculator), even after 9+ other tools were registered (weather, stock_ticker, timesense_timer, quick_poll, note, system_info, unit_converter, forget_fact, convert). Asking "list every tool you have" returned those same 5. Asking it to use e.g. stock_ticker explicitly prompted it to say "I don't have that tool."
-- **Root Cause:** `ConversationEngine._augment_context_with_tools` picks compact-vs-full format via `self._llm_config.backend in ("ollama", "npu_genie", "lmstudio")`. The `config_update` handler in `server.py` swapped `self._conversation._llm` (the backend instance) but *not* `self._conversation._llm_config` (the config object the is-local check reads). So after any swap from the default `ollama` config, `_llm_config.backend` was permanently stuck on `"ollama"` — the is-local check returned True forever, forcing compact format.
-- **Fix:** The config_update handler now updates `self._conversation._llm_config = conn_config.llm` alongside the `_llm` swap (`server.py:1824`). Swap-log line now includes the new backend name so regressions are visible.
-- **Prevention:** When a class holds both a live object and its config, any hot-swap of the live object must also swap its config — or the config should be derived-on-read rather than cached. Grep for `_llm_config` usage any time `_llm` is reassigned.
+### 77. Yahoo Finance 429s Dragon's static IP — Stooq CSV is the usable free quote feed
+- **Date:** 2026-04-23 (#60)
+- **Symptom:** `stock_ticker` tool's first implementation used Yahoo Finance chart API (`query1.finance.yahoo.com/v8/finance/chart/{symbol}`). Second call onwards returned HTTP 429 "Too Many Requests" from Dragon's IP — even with a spoofed desktop User-Agent. Yahoo blocks datacenter IPs aggressively.
+- **Root Cause:** Yahoo's chart API is rate-limited by IP, not by key or UA. Dragon's static ngrok-adjacent IP gets flagged quickly.
+- **Fix:** Made Stooq CSV the primary source (`https://stooq.com/q/l/?s={sym}.us&f=sd2t2ohlcv&h&e=csv`, no auth, stable on Dragon), Yahoo Finance the fallback for when Stooq is unreachable. Tool returns the source name in its dict so debug logs show which fed the answer.
+- **Prevention:** For any free public API that might rate-limit, design with two sources — primary + fallback — from the first commit. Log the source in the result so regressions are visible from a single turn.

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -486,11 +486,13 @@ class VoiceServer:
             from dragon_voice.tools.unit_converter_tool import UnitConverterTool
             from dragon_voice.tools.note_tool import NoteTool
             from dragon_voice.tools.system_tool import SystemInfoTool
+            from dragon_voice.tools.stock_ticker_tool import StockTickerTool
 
             self._tool_registry.register(WeatherTool())
             self._tool_registry.register(CalculatorTool())
             self._tool_registry.register(UnitConverterTool())
             self._tool_registry.register(SystemInfoTool())
+            self._tool_registry.register(StockTickerTool())
 
             logger.info("Agentic modules initialized (tools: %d, memory: ok)",
                         len(self._tool_registry.list_tools()))

--- a/dragon_voice/tools/stock_ticker_tool.py
+++ b/dragon_voice/tools/stock_ticker_tool.py
@@ -1,0 +1,151 @@
+"""
+StockTickerTool — real-time stock/ETF quote.
+
+Designed by TinkerClaw (Gemini 3 Flash Preview) on 2026-04-22 during
+the "max-capabilities" long session, then installed on Dragon by the
+user (Emile) and exercised end-to-end.
+
+Uses Stooq CSV (no auth, usually reachable) as primary, Yahoo Finance
+chart API as fallback. Yahoo frequently 429s Dragon's static IP — Stooq
+has been stable.
+"""
+
+import csv
+import io
+import logging
+
+import aiohttp
+
+from dragon_voice.tools.base import Tool
+
+logger = logging.getLogger(__name__)
+
+STOOQ = "https://stooq.com/q/l/?s={symbol}.us&f=sd2t2ohlcv&h&e=csv"
+YAHOO = "https://query1.finance.yahoo.com/v8/finance/chart/{symbol}"
+UA = (
+    "Mozilla/5.0 (X11; Linux aarch64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/120.0.0.0 Safari/537.36"
+)
+
+
+class StockTickerTool(Tool):
+    """Fetch the current price + daily change for a US ticker."""
+
+    @property
+    def name(self) -> str:
+        return "stock_ticker"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Get the current price and daily change for a US stock or ETF ticker "
+            "(e.g. AAPL, TSLA, SPY, MSFT). Returns price, open, high, low, percent change."
+        )
+
+    @property
+    def parameters_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "symbol": {
+                    "type": "string",
+                    "description": "US ticker symbol, e.g. AAPL, MSFT, TSLA, SPY",
+                },
+                "currency": {
+                    "type": "string",
+                    "description": "ISO currency code, defaults to USD",
+                    "default": "USD",
+                },
+            },
+            "required": ["symbol"],
+        }
+
+    async def execute(self, args: dict) -> dict:
+        symbol = (args.get("symbol") or "").upper().strip()
+        currency = (args.get("currency") or "USD").upper().strip()
+        if not symbol or not symbol.replace(".", "").replace("-", "").isalnum():
+            return {"error": "invalid symbol", "symbol": symbol}
+
+        timeout = aiohttp.ClientTimeout(total=6)
+        headers = {"User-Agent": UA, "Accept": "*/*"}
+
+        # Primary: Stooq CSV (no rate limiting on Dragon's IP)
+        try:
+            url = STOOQ.format(symbol=symbol.lower())
+            async with aiohttp.ClientSession(timeout=timeout, headers=headers) as s:
+                async with s.get(url) as r:
+                    if r.status == 200:
+                        row = self._parse_stooq(await r.text())
+                        if row:
+                            price = row["close"]
+                            prev = row["open"]
+                            change = price - prev
+                            pct = (change / prev * 100.0) if prev else 0.0
+                            arrow = "↑" if change > 0 else ("↓" if change < 0 else "→")
+                            summary = (
+                                f"{symbol} {arrow} {price:.2f} {currency} "
+                                f"({change:+.2f}, {pct:+.2f}% vs open)"
+                            )
+                            logger.info("stock_ticker stooq: %s", summary)
+                            return {
+                                "symbol": symbol,
+                                "source": "stooq",
+                                "price": round(price, 4),
+                                "open": round(row["open"], 4),
+                                "high": round(row["high"], 4),
+                                "low": round(row["low"], 4),
+                                "volume": row["volume"],
+                                "as_of": f"{row['date']} {row['time']}",
+                                "currency": currency,
+                                "change": round(change, 4),
+                                "change_pct": round(pct, 4),
+                                "summary": summary,
+                            }
+        except Exception as e:
+            logger.warning("stooq fetch failed for %s: %s", symbol, e)
+
+        # Fallback: Yahoo Finance
+        try:
+            async with aiohttp.ClientSession(timeout=timeout, headers=headers) as s:
+                async with s.get(YAHOO.format(symbol=symbol)) as r:
+                    if r.status != 200:
+                        return {"error": f"both sources unreachable (yahoo http {r.status})", "symbol": symbol}
+                    payload = await r.json()
+            meta = payload["chart"]["result"][0]["meta"]
+            price = float(meta.get("regularMarketPrice") or 0.0)
+            prev = float(meta.get("chartPreviousClose") or meta.get("previousClose") or 0.0)
+            change = price - prev if prev else 0.0
+            pct = (change / prev * 100.0) if prev else 0.0
+            arrow = "↑" if change > 0 else ("↓" if change < 0 else "→")
+            return {
+                "symbol": symbol,
+                "source": "yahoo",
+                "price": round(price, 4),
+                "currency": meta.get("currency", currency),
+                "change": round(change, 4),
+                "change_pct": round(pct, 4),
+                "exchange": meta.get("exchangeName", ""),
+                "summary": f"{symbol} {arrow} {price:.2f} ({change:+.2f}, {pct:+.2f}%)",
+            }
+        except Exception as e:
+            logger.exception("yahoo fallback failed for %s", symbol)
+            return {"error": f"fetch failed: {e}", "symbol": symbol}
+
+    @staticmethod
+    def _parse_stooq(text: str):
+        reader = csv.DictReader(io.StringIO(text))
+        for row in reader:
+            try:
+                return {
+                    "date": row["Date"],
+                    "time": row["Time"],
+                    "open": float(row["Open"]),
+                    "high": float(row["High"]),
+                    "low": float(row["Low"]),
+                    "close": float(row["Close"]),
+                    "volume": int(row["Volume"]),
+                }
+            except (KeyError, ValueError):
+                return None
+        return None


### PR DESCRIPTION
## Summary
Adds \`stock_ticker\` to the agentic ToolRegistry.  Agent invokes via \`<tool>stock_ticker</tool><args>{\"symbol\":\"AAPL\"}</args>\` and gets back price + daily change + OHLC.

Data sources:
- **Primary:** Stooq CSV (no auth, stable on Dragon's static IP).
- **Fallback:** Yahoo Finance chart API (regularly 429s datacenter IPs — only a backstop).

## Backstory
**TinkerClaw designed this tool itself** during a 'max out capabilities' Tab5 user test on 2026-04-22.  When prompted for 'pure-Python + public APIs, no new Tab5 firmware', Gemini 3 Flash Preview proposed the \`symbol/currency → price/change\` spec in the exact \`NAME | PURPOSE | ARGS | RETURNS\` format asked for.  We installed the spec live and the same agent called the tool end-to-end 4× in follow-up turns.

Session transcript (including Dragon tool-call audit trail): TinkerTab \`.superpowers/brainstorm/ui-overhaul-v4/longsession-2026-04-22-skill-install/REPORT.md\`.  LEARNINGS.md #77 for the Yahoo 429 story and primary/fallback pattern.

## Test plan
- [x] \`python3 -m py_compile\` clean on both files.
- [x] Live Dragon restart — \`Tool registered: stock_ticker\` appears; total tool count 10.
- [x] Agent turn \"Use stock_ticker to get AAPL price\" — Dragon logs \`Tool call detected: stock_ticker({'symbol': 'AAPL'})\` + \`stock_ticker stooq: AAPL ↑ 272.39 USD (+4.56, +1.70% vs open)\` + 694 ms execute time.
- [x] Multi-symbol turn (\"TSLA and SPY\") — two back-to-back tool calls succeed.
- [x] Portfolio-value turn (\"40 AAPL + 12 TSLA\") — chained with calculator, returned \$15,549.42.
- [ ] Yahoo fallback path — untested in this PR (Stooq hasn't gone down).  Manual test idea: firewall Stooq temporarily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)