### PR TITLE
refactor(server): extract 4 middleware to dragon_voice/middleware/ (step 1 of #65)

### DIFF
--- a/dragon_voice/middleware/__init__.py
+++ b/dragon_voice/middleware/__init__.py
@@ -1,0 +1,18 @@
+"""aiohttp middleware for the Dragon voice server.
+
+Each submodule exposes a stateless ``handle_*`` coroutine with the
+aiohttp middleware signature ``(request, handler, **deps) -> response``.
+The deps that aren't request-scoped (config values, rate-limit bucket
+dict, …) are passed in by the caller so each middleware can be tested
+without instantiating the full :class:`VoiceServer`.
+
+The ``VoiceServer._*_middleware`` methods remain thin adapters that bind
+instance state to these ``handle_*`` functions — so existing test
+imports (``srv_mod.VoiceServer._auth_middleware``) keep working.  When
+the tests migrate to call the ``handle_*`` functions directly, those
+adapter methods can be deleted in a follow-up.
+"""
+
+from dragon_voice.middleware import auth, cors, rate_limit, security_headers
+
+__all__ = ["auth", "cors", "rate_limit", "security_headers"]

--- a/dragon_voice/middleware/auth.py
+++ b/dragon_voice/middleware/auth.py
@@ -1,0 +1,81 @@
+"""Bearer-token auth middleware (Wave 13 C2).
+
+Enforces ``Authorization: Bearer <token>`` on every privileged route.
+The expected token is passed in by the caller (read from
+``config.server.api_token`` / ``DRAGON_API_TOKEN``) so rotation is
+a config change, not a code change.
+
+Public paths are allowlisted:
+  - ``/health`` — liveness probe for ops
+  - ``/ws/voice`` — the upgrade request itself is allowed through so
+    ``_handle_ws_voice`` can enforce auth *before* ``ws.prepare()``; do
+    NOT remove this or CORS will bounce the upgrade (W14-C04).
+  - ``/dashboard`` — proxied to ``localhost:3500`` and separately gated.
+  - ``/api/media/`` — media fetches use an HMAC-signed query-string
+    signature instead of the bearer (W14-H04) so Tab5 can pull images
+    without presenting the token.
+"""
+from __future__ import annotations
+
+import hmac
+
+from aiohttp import web
+
+PUBLIC_PREFIXES: tuple[str, ...] = (
+    "/health",
+    "/ws/voice",
+    "/dashboard",
+    "/api/media/",
+)
+
+
+async def handle_auth(
+    request: web.Request,
+    handler,
+    *,
+    expected_token: str,
+):
+    """Apply bearer-token auth to a single request.
+
+    Returns either the wrapped handler's response, or a short-circuit
+    ``web.Response`` for the 401 / 503 cases.  Uses a constant-time
+    comparison to avoid timing oracles on credential rejection.
+    """
+    path = request.path or "/"
+
+    # OPTIONS is answered by the CORS middleware upstream.
+    if request.method == "OPTIONS":
+        return await handler(request)
+
+    # Allowlist the public prefixes.
+    if any(path == p or path.startswith(p) for p in PUBLIC_PREFIXES):
+        return await handler(request)
+
+    expected = (expected_token or "").strip()
+    if not expected:
+        # Fail closed: token not configured but a private path was hit.
+        # Deployer must set DRAGON_API_TOKEN or api_token in config.yaml.
+        return web.json_response(
+            {
+                "error": "dragon_api_token_not_configured",
+                "message": "Set DRAGON_API_TOKEN in env or api_token in config.yaml",
+            },
+            status=503,
+        )
+
+    auth = request.headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        return web.json_response(
+            {
+                "error": "missing_bearer_token",
+                "message": "Authorization: Bearer <token> required",
+            },
+            status=401,
+        )
+    supplied = auth[7:].strip()
+    if not hmac.compare_digest(supplied, expected):
+        return web.json_response(
+            {"error": "invalid_bearer_token", "message": "token rejected"},
+            status=401,
+        )
+    return await handler(request)

--- a/dragon_voice/middleware/cors.py
+++ b/dragon_voice/middleware/cors.py
@@ -1,0 +1,60 @@
+"""CORS middleware (SEC12).
+
+Adds ``Access-Control-Allow-Origin`` headers to responses whose ``Origin``
+matches the allowlist, and answers preflight ``OPTIONS`` requests.
+Cross-origin requests from unlisted origins are left unanswered at the
+CORS layer — the browser blocks the response.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+from aiohttp import web
+
+# Default allowlist, matching the origins the repo's auth/deploy path
+# expects: the dashboard (localhost + Tab5's LAN address) and the public
+# ngrok tunnel.  Callers may pass their own set if a deployment needs a
+# different list.
+DEFAULT_ALLOWED_ORIGINS: frozenset[str] = frozenset({
+    "http://localhost:3500",
+    "http://127.0.0.1:3500",
+    "http://192.168.1.90:8080",
+    "https://tinkerclaw-dashboard.ngrok.dev",
+})
+
+
+async def handle_cors(
+    request: web.Request,
+    handler,
+    *,
+    allowed_origins: Iterable[str] = DEFAULT_ALLOWED_ORIGINS,
+):
+    """Apply CORS rules to a single request.
+
+    Returns either the wrapped handler's response (with an
+    ``Access-Control-Allow-Origin`` header if the origin is allowed) or
+    a short-circuit ``web.Response`` for preflight / rejected-origin
+    cases.
+    """
+    origin = request.headers.get("Origin", "")
+    allowed = frozenset(allowed_origins)
+
+    # If origin is not in the allowlist, skip CORS headers entirely
+    # (browser will block the cross-origin request).
+    if origin not in allowed:
+        if request.method == "OPTIONS":
+            return web.Response(status=403)
+        return await handler(request)
+
+    # Preflight OPTIONS for an allowed origin — answer directly.
+    if request.method == "OPTIONS":
+        return web.Response(headers={
+            "Access-Control-Allow-Origin": origin,
+            "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+            "Access-Control-Allow-Headers": "Content-Type, X-Sample-Rate, Accept, Authorization",
+            "Access-Control-Max-Age": "3600",
+        })
+
+    response = await handler(request)
+    response.headers["Access-Control-Allow-Origin"] = origin
+    return response

--- a/dragon_voice/middleware/rate_limit.py
+++ b/dragon_voice/middleware/rate_limit.py
@@ -1,0 +1,110 @@
+"""Per-IP + per-path rate-limit middleware (Wave 15 W15-H01, W15-H06).
+
+Throttles a small set of state-changing or stream-amplifying endpoints
+on a fixed window keyed on (client_ip, method, path).  In-memory only
+— if the process restarts, counters reset.  That's fine for this threat
+model (single-tenant deployment, goal is to stop loop-bugs + obvious
+DoS, not to enforce commercial quotas).
+
+The bucket dict is supplied by the caller so state lives on the
+:class:`VoiceServer` instance and survives across middleware invocations
+without any module-level globals.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Iterable
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+# (method, path_prefix, max_requests, window_seconds).  Keep the list
+# short; the matcher walks it per request.  Endpoints not listed here
+# are unthrottled.
+DEFAULT_RATE_LIMIT_RULES: tuple[tuple[str, str, int, int], ...] = (
+    ("DELETE", "/api/v1/devices/",          20, 60),
+    ("DELETE", "/api/v1/sessions/",         20, 60),
+    ("DELETE", "/api/v1/messages",          20, 60),
+    ("DELETE", "/api/v1/memory/",           30, 60),
+    ("DELETE", "/api/v1/documents/",        10, 60),
+    ("DELETE", "/api/v1/config/",           20, 60),
+    ("POST",   "/api/v1/sessions/",         30, 60),  # /end, /pause, /resume
+    # W15-H06: SSE reconnect amplification — a broken client can re-open
+    # the chat stream 30 times/sec on tab-flap.  Cap at 20/min per IP +
+    # session to give legit retries room but stop the storm.
+    ("POST",   "/api/v1/sessions/",         20, 60),  # covers /chat too
+    ("POST",   "/api/media/upload",         30, 60),  # 10 MB upload × spam DoS
+)
+
+# Above this count we GC entries whose window started more than
+# ``_GC_STALE_SECONDS`` ago.  Each bucket is ~200 B so 4096 ≈ 800 KB —
+# worth reclaiming before it drifts.
+_GC_TRIGGER_ENTRIES = 4096
+_GC_STALE_SECONDS = 600
+
+
+async def handle_rate_limit(
+    request: web.Request,
+    handler,
+    *,
+    buckets: dict,
+    rules: Iterable[tuple[str, str, int, int]] = DEFAULT_RATE_LIMIT_RULES,
+):
+    """Apply rate-limit rules to a single request.
+
+    ``buckets`` is mutated in place — caller should pass the same dict
+    across all requests so windows are shared.  Returns either the
+    wrapped handler's response or a 429 with ``Retry-After`` set.
+    """
+    path = request.path
+    method = request.method
+
+    # Walk the rule table and keep the tightest (smallest cap) match.
+    matched: tuple[int, int] | None = None
+    for m, p, cap, win in rules:
+        if method == m and path.startswith(p):
+            if matched is None or cap < matched[0]:
+                matched = (cap, win)
+    if matched is None:
+        return await handler(request)
+
+    # Peername behind ngrok/proxy is the proxy IP, which is fine for
+    # single-tenant threat model.
+    peer = request.transport.get_extra_info("peername") if request.transport else None
+    client = peer[0] if peer else "unknown"
+    cap, win = matched
+    key = (client, method, path)
+
+    now = time.monotonic()
+    bucket = buckets.get(key)
+    if bucket is None or now - bucket["window_start"] >= win:
+        buckets[key] = {"window_start": now, "count": 1}
+    else:
+        bucket["count"] += 1
+        if bucket["count"] > cap:
+            retry_after = int(win - (now - bucket["window_start"])) + 1
+            logger.warning(
+                "rate-limit: %s %s from %s (%d/%d in %ds)",
+                method, path, client, bucket["count"], cap, win,
+            )
+            return web.json_response(
+                {
+                    "error": "rate_limited",
+                    "message": f"limit {cap} requests per {win} s for this path",
+                    "retry_after_seconds": retry_after,
+                },
+                status=429,
+                headers={"Retry-After": str(retry_after)},
+            )
+
+    # Cheap periodic GC so the dict doesn't grow unbounded over long
+    # uptimes.  The caller's dict is mutated in place.
+    if len(buckets) > _GC_TRIGGER_ENTRIES:
+        cutoff = now - _GC_STALE_SECONDS
+        stale = [k for k, v in buckets.items() if v["window_start"] <= cutoff]
+        for k in stale:
+            buckets.pop(k, None)
+
+    return await handler(request)

--- a/dragon_voice/middleware/security_headers.py
+++ b/dragon_voice/middleware/security_headers.py
@@ -1,0 +1,49 @@
+"""Defensive response-header middleware (W14-M06).
+
+Stamps the standard ``X-Content-Type-Options`` / ``X-Frame-Options`` /
+``Referrer-Policy`` / ``Content-Security-Policy`` headers onto every
+response.  Amplifies the dashboard XSS sweep (W14-H02) — CSP blocks
+payloads that slip through the ``escHtml`` gate — and blocks framing +
+MIME sniffing for free.
+
+The CSP allows Google Fonts because the dashboard inlines fonts from
+there; all other sources stay same-origin.  If the dashboard ever moves
+its stylesheet out-of-line the ``'unsafe-inline'`` source can be
+tightened.
+"""
+from __future__ import annotations
+
+from aiohttp import web
+
+SECURITY_HEADERS: dict[str, str] = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "no-referrer",
+    "Content-Security-Policy": (
+        "default-src 'self'; "
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+        "font-src 'self' https://fonts.gstatic.com; "
+        "img-src 'self' data:; "
+        "connect-src 'self'; "
+        "frame-ancestors 'none'; "
+        "base-uri 'self'"
+    ),
+}
+
+
+async def handle_security_headers(request: web.Request, handler):
+    """Run the handler and stamp the defensive headers onto the response.
+
+    WebSocket upgrade responses and streaming responses that don't
+    expose ``.headers`` in this phase are skipped silently — setting
+    CSP on a WS upgrade confuses some clients.
+    """
+    response = await handler(request)
+    try:
+        for k, v in SECURITY_HEADERS.items():
+            if k not in response.headers:
+                response.headers[k] = v
+    except (AttributeError, TypeError):
+        # WS / streaming responses without a headers mapping at this phase.
+        pass
+    return response

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -16,7 +16,7 @@ import logging
 import os
 import resource
 import time
-from typing import ClassVar, Optional
+from typing import Optional
 
 import aiohttp
 from aiohttp import web, WSMsgType
@@ -32,6 +32,12 @@ from dragon_voice.config import (
 from dragon_voice.conversation import ConversationEngine
 from dragon_voice.db import Database
 from dragon_voice.messages import MessageStore
+from dragon_voice.middleware import (
+    auth as _mw_auth,
+    cors as _mw_cors,
+    rate_limit as _mw_rate_limit,
+    security_headers as _mw_security_headers,
+)
 from dragon_voice.pipeline import VoicePipeline
 from dragon_voice.sessions import SessionManager
 
@@ -155,226 +161,29 @@ class VoiceServer:
         self._app = app
         return app
 
-    # Allowed CORS origins — only these can make cross-origin API calls
-    # Wave 14 W14-M14: frozenset at class scope (ruff RUF012) — no
-    # accidental mutation across instances.
-    _CORS_ALLOWED_ORIGINS: ClassVar[frozenset[str]] = frozenset({
-        "http://localhost:3500",
-        "http://127.0.0.1:3500",
-        "http://192.168.1.90:8080",
-        "https://tinkerclaw-dashboard.ngrok.dev",
-    })
+    # Middleware — thin adapters over the stateless handlers in
+    # ``dragon_voice/middleware/``.  Each adapter binds instance state
+    # (config, rate-limit buckets) and forwards to the shared handler.
+    # See dragon_voice/middleware/__init__.py for the migration plan.
 
     @web.middleware
     async def _cors_middleware(self, request: web.Request, handler):
-        """Add CORS headers to API responses for allowed origins only (SEC12)."""
-        origin = request.headers.get("Origin", "")
-
-        # If origin is not in the allowlist, skip CORS headers entirely
-        # (browser will block the cross-origin request)
-        if origin not in self._CORS_ALLOWED_ORIGINS:
-            if request.method == "OPTIONS":
-                return web.Response(status=403)
-            return await handler(request)
-
-        # Handle preflight OPTIONS requests for allowed origins
-        if request.method == "OPTIONS":
-            return web.Response(headers={
-                "Access-Control-Allow-Origin": origin,
-                "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
-                "Access-Control-Allow-Headers": "Content-Type, X-Sample-Rate, Accept, Authorization",
-                "Access-Control-Max-Age": "3600",
-            })
-        response = await handler(request)
-        response.headers["Access-Control-Allow-Origin"] = origin
-        return response
-
-    # ----------------------------------------------------------------- Security headers
-    #
-    # Wave 14 W14-M06: stamp the standard defensive headers on every
-    # response. Amplifies the W14-H02 dashboard XSS sweep (CSP blocks
-    # the payload even if a new innerHTML site slips through the
-    # escHtml gate) and blocks framing + MIME sniffing for free.
-    # /dashboard SPA uses Google Fonts so the CSP allows that origin
-    # specifically; all other sources stay same-origin.
-    _SECURITY_HEADERS = {
-        "X-Content-Type-Options": "nosniff",
-        "X-Frame-Options": "DENY",
-        "Referrer-Policy": "no-referrer",
-        # CSP — intentionally strict.  style-src allows 'unsafe-inline'
-        # because the dashboard inlines its whole stylesheet.  If we
-        # ever extract the CSS to a separate file, tighten this.
-        "Content-Security-Policy": (
-            "default-src 'self'; "
-            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
-            "font-src 'self' https://fonts.gstatic.com; "
-            "img-src 'self' data:; "
-            "connect-src 'self'; "
-            "frame-ancestors 'none'; "
-            "base-uri 'self'"
-        ),
-    }
+        return await _mw_cors.handle_cors(request, handler)
 
     @web.middleware
     async def _security_headers_middleware(self, request: web.Request, handler):
-        response = await handler(request)
-        # Only stamp on Response objects — WS upgrade responses are
-        # not subject to CSP and setting these headers on them confuses
-        # some clients. aiohttp WebSocketResponse doesn't expose
-        # .headers until prepare(); the middleware path doesn't touch
-        # it in that case.
-        try:
-            for k, v in self._SECURITY_HEADERS.items():
-                if k not in response.headers:
-                    response.headers[k] = v
-        except (AttributeError, TypeError):
-            # WS responses or streaming responses that don't expose
-            # headers in this phase — skip silently.
-            pass
-        return response
-
-    # ----------------------------------------------------------------- Auth
-    #
-    # Wave 13 C2 security: bearer-token auth on every privileged route.
-    # Matches the scheme docs/protocol.md calls out for Tab5 debug server;
-    # the token is read from config.yaml (reads DRAGON_API_TOKEN env)
-    # and can be rotated without code changes.  Public paths are allowlisted
-    # (health, WS handshake is separately gated via the `register` frame).
-    _AUTH_PUBLIC_PREFIXES = (
-        "/health",              # liveness probe
-        # Wave 14 W14-C04: /ws/voice is allow-listed here (because the
-        # bearer comes from the upgrade header, not the request path),
-        # but _handle_ws_voice itself performs the Authorization check
-        # before ws.prepare().  Do NOT remove /ws/voice from this list or
-        # the CORS middleware will bounce the upgrade.
-        "/ws/voice",            # auth enforced inside _handle_ws_voice
-        "/dashboard",           # proxied to localhost:3500 (separately gated)
-        # Wave 14 W14-H04: /api/media/* remains in the public allowlist
-        # (so Tab5 doesn't need to present the bearer on image fetches),
-        # but the handler itself now requires an HMAC signature in the
-        # query string when server.api_token is configured.  The URLs
-        # emitted in WS media events carry that signature automatically.
-        "/api/media/",
-    )
+        return await _mw_security_headers.handle_security_headers(request, handler)
 
     @web.middleware
     async def _auth_middleware(self, request: web.Request, handler):
-        path = request.path or "/"
-        # Never gate OPTIONS (CORS middleware already answered it).
-        if request.method == "OPTIONS":
-            return await handler(request)
-        if any(path == p or path.startswith(p) for p in self._AUTH_PUBLIC_PREFIXES):
-            return await handler(request)
-        # Resolve the expected token once from config (hot-reload-safe).
         expected = (getattr(self._config.server, "api_token", "") or "").strip()
-        if not expected:
-            # Token not configured — fail closed on private paths to avoid
-            # accidentally exposing everything when a deployer forgets.
-            # During local-dev bootstrap, set `api_token: ""` in config.yaml
-            # explicitly to an empty-string marker + allowlist the paths.
-            return web.json_response(
-                {"error": "dragon_api_token_not_configured",
-                 "message": "Set DRAGON_API_TOKEN in env or api_token in config.yaml"},
-                status=503)
-        auth = request.headers.get("Authorization", "")
-        if not auth.startswith("Bearer "):
-            return web.json_response(
-                {"error": "missing_bearer_token",
-                 "message": "Authorization: Bearer <token> required"},
-                status=401)
-        supplied = auth[7:].strip()
-        # Constant-time compare to avoid timing-oracle credential leaks.
-        import hmac
-        if not hmac.compare_digest(supplied, expected):
-            return web.json_response(
-                {"error": "invalid_bearer_token",
-                 "message": "token rejected"}, status=401)
-        return await handler(request)
-
-    # --------------------------------------------------------------- Rate limit
-
-    # Wave 15 W15-H01 + W15-H06: throttle per-IP + per-path on a small
-    # fixed window.  Keyed on client-IP + method + path so a DELETE to
-    # /api/v1/devices/foo burns budget independently from a POST to
-    # /api/v1/sessions/bar/chat.  State-changing + SSE-streaming
-    # endpoints get tight limits; read-only endpoints are
-    # unthrottled.  In-memory only — if the process restarts the
-    # counters reset, which is fine for this threat model (single-
-    # tenant deployment, we just want to stop loop-bugs and obvious
-    # DoS).
-    _RATE_LIMIT_RULES: ClassVar[tuple[tuple[str, str, int, int], ...]] = (
-        # (method_prefix, path_prefix, max_requests, window_seconds)
-        ("DELETE", "/api/v1/devices/",          20, 60),
-        ("DELETE", "/api/v1/sessions/",         20, 60),
-        ("DELETE", "/api/v1/messages",          20, 60),
-        ("DELETE", "/api/v1/memory/",           30, 60),
-        ("DELETE", "/api/v1/documents/",        10, 60),
-        ("DELETE", "/api/v1/config/",           20, 60),
-        ("POST",   "/api/v1/sessions/",         30, 60),  # /end, /pause, /resume
-        # W15-H06: SSE reconnect amplification — a broken client can
-        # re-open the chat stream 30 times/sec on tab-flap.  Cap at
-        # 20/min per IP + session to give the client room for legit
-        # retries but stop the storm.
-        ("POST",   "/api/v1/sessions/",         20, 60),  # covers /chat too
-        # Upload path — protect against the 10 MB upload × spam DoS
-        ("POST",   "/api/media/upload",         30, 60),
-    )
+        return await _mw_auth.handle_auth(request, handler, expected_token=expected)
 
     @web.middleware
     async def _rate_limit_middleware(self, request: web.Request, handler):
-        # Fast path: only even consider paths that match at least one rule.
-        path = request.path
-        method = request.method
-        # `match_prefix` just walks the rule table — tiny list so this
-        # is cheap even at 1000 req/sec.
-        matched = None
-        for m, p, cap, win in self._RATE_LIMIT_RULES:
-            if method == m and path.startswith(p):
-                # Keep the TIGHTEST matching rule (smallest cap).
-                if matched is None or cap < matched[0]:
-                    matched = (cap, win)
-        if matched is None:
-            return await handler(request)
-
-        # Use peername as the client key; behind ngrok/proxy it's the
-        # proxy IP which is fine for single-tenant threat model.
-        peer = request.transport.get_extra_info("peername") if request.transport else None
-        client = peer[0] if peer else "unknown"
-        cap, win = matched
-        key = (client, method, path)
-
-        now = time.monotonic()
-        bucket = self._rate_buckets.get(key)
-        if bucket is None or now - bucket["window_start"] >= win:
-            self._rate_buckets[key] = {"window_start": now, "count": 1}
-        else:
-            bucket["count"] += 1
-            if bucket["count"] > cap:
-                retry_after = int(win - (now - bucket["window_start"])) + 1
-                logger.warning(
-                    "rate-limit: %s %s from %s (%d/%d in %ds)",
-                    method, path, client, bucket["count"], cap, win,
-                )
-                return web.json_response(
-                    {
-                        "error": "rate_limited",
-                        "message": f"limit {cap} requests per {win} s for this path",
-                        "retry_after_seconds": retry_after,
-                    },
-                    status=429,
-                    headers={"Retry-After": str(retry_after)},
-                )
-
-        # Periodic cheap GC so the dict doesn't grow unbounded over
-        # long uptimes (each entry is ~200 B; 10 000 entries = 2 MB).
-        if len(self._rate_buckets) > 4096:
-            cutoff = now - 600  # anything untouched 10 min gets dropped
-            self._rate_buckets = {
-                k: v for k, v in self._rate_buckets.items()
-                if v["window_start"] > cutoff
-            }
-
-        return await handler(request)
+        return await _mw_rate_limit.handle_rate_limit(
+            request, handler, buckets=self._rate_buckets
+        )
 
     # --------------------------------------------------------------- Dashboard proxy
 


### PR DESCRIPTION
## Summary

First of four planned PRs that decompose \`dragon_voice/server.py\` (2,747 LOC, one god-class). This PR lifts CORS / security-headers / auth / rate-limit middleware out of \`VoiceServer\` into a dedicated \`dragon_voice/middleware/\` package. **Code moves with behavior unchanged** — no restructuring of the middleware internals, per the [CLAUDE.md "extract before decompose" rule](CLAUDE.md#workflow).

Closes step 1 of umbrella #65 (does not close the umbrella itself — 3 more steps to go: debug handlers, lifecycle, status/config).

## What moved

| Was on \`VoiceServer\` | Now at | LOC |
|---|---|---|
| \`_CORS_ALLOWED_ORIGINS\` + \`_cors_middleware\` | \`dragon_voice/middleware/cors.py\` → \`handle_cors\` + \`DEFAULT_ALLOWED_ORIGINS\` | 60 |
| \`_SECURITY_HEADERS\` + \`_security_headers_middleware\` | \`dragon_voice/middleware/security_headers.py\` → \`handle_security_headers\` + \`SECURITY_HEADERS\` | 49 |
| \`_AUTH_PUBLIC_PREFIXES\` + \`_auth_middleware\` | \`dragon_voice/middleware/auth.py\` → \`handle_auth\` + \`PUBLIC_PREFIXES\` | 81 |
| \`_RATE_LIMIT_RULES\` + \`_rate_limit_middleware\` | \`dragon_voice/middleware/rate_limit.py\` → \`handle_rate_limit\` + \`DEFAULT_RATE_LIMIT_RULES\` | 110 |

Each extracted module exposes a **stateless** \`handle_*\` coroutine with the aiohttp middleware signature plus explicit deps (expected token, bucket dict, allowed origins). The \`VoiceServer._*_middleware\` methods remain as 3-5 line adapters that bind instance state and forward to the shared handlers.

## Why the adapter methods stay

Existing middleware tests call \`stub._auth_middleware(request, handler)\` via a stub subclass (\`_StubServer(VoiceServer)\`). Keeping the adapters preserves that interface **zero tests need changes in this PR**. A follow-up PR can migrate tests to call \`handle_auth(...)\` directly and then delete the adapter stubs.

## Line-count impact

- \`dragon_voice/server.py\`: 2747 → 2556 (**−191 LOC**)
- \`dragon_voice/middleware/\`: +318 LOC (logic + module docstrings + \`__init__\`)
- Net growth is the package overhead — worth it for testability + locality + single-reason-to-change.

## One intentional tweak

\`_RATE_LIMIT_RULES\` GC: the original code rebound \`self._rate_buckets\` to a new dict when size crossed 4096; the extracted code mutates the caller's dict in place (via \`pop\`) so the reference stays valid. Net effect is identical: stale entries are dropped, same \`window_start\` predicate for "stale". Called out here for review.

## Test plan

All run locally with the CI env (\`DRAGON_API_TOKEN=ci-bearer-token\`, \`TINKERCLAW_TOKEN=ci-tc-token\`):

- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006\` on \`dragon_voice/server.py\` + \`dragon_voice/middleware/\` → **All checks passed**
- [x] \`tests/test_auth_middleware.py\` — **6/6 pass** (existing)
- [x] \`tests/test_security_headers.py\` — **3/3 pass** (existing)
- [x] \`tests/test_rate_limit.py\` — **4/4 pass** (existing)
- [x] Full CI-named unit-test set — **93/93 pass**
- [x] \`python3 -c "from dragon_voice import server; from dragon_voice.middleware import auth, cors, rate_limit, security_headers"\` — clean import

## Explicit non-goals

- **Not touching any other server.py code.** Status handlers, debug handlers, lifecycle, and the WS voice handler all stay put. Those are steps 2-4.
- **Not migrating tests to call \`handle_*\` directly.** That's a follow-up once this has burned in.
- **Not introducing DI frameworks, factory classes, or abstract base classes.** Stateless functions + explicit deps are enough.
- **Not renaming anything in the test files, in \`docs/\`, or in cross-component imports.**

## References

- Umbrella: #65
- Workflow rules followed: [CLAUDE.md](CLAUDE.md#workflow) (expanded in #64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)