### PR TITLE
refactor(server): extract 5 debug handlers to dragon_voice/handlers/debug.py (step 2 of #65)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,5 @@ jobs:
             tests/test_config_redact.py \
             tests/test_media_url_signer.py \
             tests/test_proxy_image_ssrf.py \
-            tests/test_security_headers.py
+            tests/test_security_headers.py \
+            tests/test_debug_handlers.py

--- a/dragon_voice/handlers/__init__.py
+++ b/dragon_voice/handlers/__init__.py
@@ -1,0 +1,12 @@
+"""HTTP request handlers extracted from :mod:`dragon_voice.server`.
+
+Each submodule owns a small, cohesive set of endpoints with one
+stakeholder (e.g. ``debug`` for dev/diagnostics, ``status`` for ops /
+product, ``config_api`` for product).  Handlers here are plain async
+callables — the URL routing + bearer-auth middleware wiring stays in
+``server.create_app``.
+"""
+
+from dragon_voice.handlers import debug
+
+__all__ = ["debug"]

--- a/dragon_voice/handlers/debug.py
+++ b/dragon_voice/handlers/debug.py
@@ -1,0 +1,279 @@
+"""Debug / diagnostic HTTP handlers.
+
+These endpoints exist for developer diagnostics (memory trace, widget
+emit test) and are gated by the usual bearer-token middleware.  They're
+extracted from :class:`dragon_voice.server.VoiceServer` so the main
+server module stays focused on request routing + lifecycle.
+
+Each handler is a plain async callable that takes ``request`` plus the
+deps it needs.  The four ``handle_widget_*`` handlers only need the
+surface manager, so they take it explicitly.  ``handle_debug_mem``
+reaches into many server attributes (lazily-attached baselines, uptime,
+active-connection count) so it takes the server as a single handle.
+When a debug endpoint's coupling to server state is narrow enough to
+express as a 1–2 arg signature, the handler should do that; when it's
+broad, ``server`` is acceptable.
+"""
+from __future__ import annotations
+
+import gc
+import logging
+import time
+from typing import Any
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+# ── W15-C01: tracemalloc-based mem-diff probe ───────────────────────────────
+
+async def handle_debug_mem(request: web.Request, *, server: Any) -> web.Response:
+    """GET /debug/mem — top-N allocation-growth snapshot since baseline.
+
+    Baseline is set lazily on first call; subsequent calls diff against
+    the stored baseline.  ``?reset=1`` replaces the baseline with the
+    current snapshot; ``?n=NN`` caps the result set (default 25);
+    ``?trim=1`` forces ``gc.collect()`` + ``malloc_trim(0)`` before the
+    snapshot so we can measure reclaimable vs genuinely-leaked bytes.
+
+    Requires ``DRAGON_TRACEMALLOC=1`` in the env — otherwise returns
+    503 with a hint.
+    """
+    import tracemalloc
+    import resource
+
+    if not tracemalloc.is_tracing():
+        return web.json_response(
+            {
+                "error": "tracemalloc_disabled",
+                "hint": "export DRAGON_TRACEMALLOC=1 and restart voice service",
+            },
+            status=503,
+        )
+
+    snap = tracemalloc.take_snapshot()
+    snap = snap.filter_traces(
+        (
+            tracemalloc.Filter(False, tracemalloc.__file__),
+            tracemalloc.Filter(False, "<frozen importlib._bootstrap>"),
+            tracemalloc.Filter(False, "<frozen importlib._bootstrap_external>"),
+        )
+    )
+    reset = request.query.get("reset", "0") == "1"
+    topn = int(request.query.get("n", "25"))
+
+    rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    rss_mb = rss_kb / 1024.0
+    out: dict = {
+        "rss_mb": round(rss_mb, 1),
+        "uptime_seconds": round(time.time() - server._start_time, 1),
+        "active_connections": len(server._active_connections),
+        "tracemalloc_peak_mb": round(tracemalloc.get_traced_memory()[1] / 1024 / 1024, 1),
+    }
+
+    if request.query.get("trim", "0") == "1":
+        before_rss = rss_mb
+        import ctypes
+        gc.collect()
+        try:
+            libc = ctypes.CDLL("libc.so.6")
+            libc.malloc_trim(0)
+        except (OSError, AttributeError) as e:
+            out["malloc_trim_error"] = str(e)
+        rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        rss_mb = rss_kb / 1024.0
+        out["rss_mb_after_trim"] = round(rss_mb, 1)
+        out["rss_reclaimed_mb"] = round(before_rss - rss_mb, 1)
+
+    baseline = getattr(server, "_mem_baseline", None)
+    if baseline is None or reset:
+        server._mem_baseline = snap
+        server._mem_baseline_rss_mb = rss_mb
+        out["note"] = "baseline set — call again after load to see diff"
+    else:
+        stats = snap.compare_to(baseline, "lineno")
+        out["rss_delta_mb"] = round(rss_mb - server._mem_baseline_rss_mb, 1)
+        out["top"] = [
+            {
+                "file": f"{s.traceback[0].filename.split('/')[-1]}:{s.traceback[0].lineno}",
+                "size_mb": round(s.size / 1024 / 1024, 3),
+                "size_diff_mb": round(s.size_diff / 1024 / 1024, 3),
+                "count": s.count,
+                "count_diff": s.count_diff,
+            }
+            for s in stats[:topn]
+        ]
+
+    # gc type-count diff — catches leaks tracemalloc misses (objects
+    # held in long-lived caches).
+    from collections import Counter
+    type_counts = Counter(type(o).__name__ for o in gc.get_objects())
+    base_counts = getattr(server, "_mem_type_counts", None)
+    if base_counts is None or reset:
+        server._mem_type_counts = type_counts
+        out["top_types"] = [
+            {"type": k, "count": v} for k, v in type_counts.most_common(25)
+        ]
+    else:
+        diff = {k: type_counts[k] - base_counts.get(k, 0) for k in type_counts}
+        growers = sorted(diff.items(), key=lambda kv: -kv[1])[:25]
+        out["top_type_growers"] = [
+            {"type": k, "delta": d, "now": type_counts[k]}
+            for k, d in growers if d > 0
+        ]
+    return web.json_response(out)
+
+
+# ── Audit widget emitters (B2 / B5 / B6 / K3) ───────────────────────────────
+#
+# Each takes the SurfaceManager directly so the coupling to
+# :class:`VoiceServer` is zero.  If ``surface_mgr`` is None (startup
+# hasn't finished wiring it) we return 503 so the dashboard shows a
+# clear "not ready" signal rather than a 500.
+
+def _iter_surface_sessions(surface_mgr) -> list[tuple[str, Any]]:
+    """Return a snapshot list of ``(session_id, state)`` pairs.
+
+    Small helper so the widget emitters all walk the same path and we
+    can stub it in tests without knowing SurfaceManager internals.
+    Returns a list (not a live iterator) so concurrent register /
+    unregister during emission doesn't mutate what we're iterating.
+    """
+    return list(surface_mgr._sessions.items())
+
+
+async def handle_debug_widget_chart(request: web.Request, *, surface_mgr) -> web.Response:
+    """POST /debug/widget_chart — audit B5 evidence.
+
+    Emits a chart widget on every registered Tab5Surface.
+    Body: ``{title, values, chart_max}``.
+    """
+    try:
+        data = await request.json()
+    except Exception:
+        data = {}
+    title = data.get("title", "Audit chart")
+    values = data.get("values", [3, 7, 12, 9, 15, 18, 22, 16, 11, 8, 14, 20])
+    chart_max = float(data.get("chart_max", 0))
+    if surface_mgr is None:
+        return web.json_response({"error": "surface_mgr not ready"}, status=503)
+    count = 0
+    for sid, state in _iter_surface_sessions(surface_mgr):
+        try:
+            await state.surface.chart(
+                title=title, values=values, chart_max=chart_max,
+                skill_id="audit", card_id="audit_chart_" + sid[:6],
+            )
+            count += 1
+        except Exception as e:
+            logger.warning("debug chart emit failed for %s: %s", sid, e)
+    return web.json_response({"emitted": count, "values": values})
+
+
+async def handle_debug_widget_prompt(request: web.Request, *, surface_mgr) -> web.Response:
+    """POST /debug/widget_prompt — audit B6/K3 evidence.
+
+    Emits a ``widget_prompt`` on every registered Tab5Surface AND
+    registers a handler so tap round-trips back to Dragon.
+    Body: ``{title, body, choices: [[text, event], ...]}``.
+    """
+    try:
+        data = await request.json()
+    except Exception:
+        data = {}
+    title = data.get("title", "Confirm?")
+    body = data.get("body", "")
+    choices_raw = data.get("choices", [["Yes", "audit_yes"], ["No", "audit_no"]])
+    choices = []
+    for c in choices_raw[:3]:
+        if isinstance(c, (list, tuple)) and len(c) >= 2:
+            choices.append((str(c[0]), str(c[1])))
+    if surface_mgr is None:
+        return web.json_response({"error": "surface_mgr not ready"}, status=503)
+    count = 0
+    for sid, state in _iter_surface_sessions(surface_mgr):
+        try:
+            card_id = f"audit_prompt_{sid[:6]}"
+
+            async def _handle(event: str, payload: dict, _sid=sid, _cid=card_id) -> None:
+                logger.info(
+                    "audit widget_prompt tapped: session=%s event=%s payload=%s",
+                    _sid, event, payload,
+                )
+                try:
+                    await state.surface.dismiss(_cid)
+                except Exception:
+                    pass
+                surface_mgr.unregister_action(_sid, _cid)
+
+            surface_mgr.register_action(sid, card_id, _handle)
+            await state.surface.prompt(
+                title=title, body=body, choices=choices,
+                skill_id="audit", card_id=card_id,
+            )
+            count += 1
+        except Exception as e:
+            logger.warning("debug prompt emit failed for %s: %s", sid, e)
+    return web.json_response({"emitted": count, "choices": choices})
+
+
+async def handle_debug_widget_card(request: web.Request, *, surface_mgr) -> web.Response:
+    """POST /debug/widget_card — audit B2 evidence.
+
+    Emits a ``widget_card`` on every registered Tab5Surface.  Cards go
+    to chat (not home).  Body: ``{title, body, tone}``.
+    """
+    try:
+        data = await request.json()
+    except Exception:
+        data = {}
+    title = data.get("title", "Workshop draft ready")
+    body = data.get("body", "Two edits queued from yesterday. Review before 10:30.")
+    tone = data.get("tone", "info")
+    if surface_mgr is None:
+        return web.json_response({"error": "surface_mgr not ready"}, status=503)
+    count = 0
+    for sid, state in _iter_surface_sessions(surface_mgr):
+        try:
+            await state.surface.card(
+                title=title, body=body, tone=tone,
+                skill_id="audit", card_id="audit_card_" + sid[:6],
+            )
+            count += 1
+        except Exception as e:
+            logger.warning("debug card emit failed for %s: %s", sid, e)
+    return web.json_response({"emitted": count})
+
+
+async def handle_debug_widget_media(request: web.Request, *, surface_mgr) -> web.Response:
+    """POST /debug/widget_media — audit B5 evidence.
+
+    Emits a ``widget_media`` pointing at a previously-uploaded image.
+    Body: ``{url, width, height, alt}``.
+    """
+    try:
+        data = await request.json()
+    except Exception:
+        data = {}
+    url = data.get("url", "")
+    # width + height are carried through to the payload default in the
+    # surface emitter; keep the parse so malformed input fails loud.
+    int(data.get("width", 480))
+    int(data.get("height", 300))
+    alt = data.get("alt", "Audit media")
+    if not url:
+        return web.json_response({"error": "url required"}, status=400)
+    if surface_mgr is None:
+        return web.json_response({"error": "surface_mgr not ready"}, status=503)
+    count = 0
+    for sid, state in _iter_surface_sessions(surface_mgr):
+        try:
+            await state.surface.media(
+                url=url, alt=alt, title="Audit media",
+                skill_id="audit", card_id="audit_media_" + sid[:6],
+            )
+            count += 1
+        except Exception as e:
+            logger.warning("debug media emit failed for %s: %s", sid, e)
+    return web.json_response({"emitted": count, "url": url})

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -32,6 +32,7 @@ from dragon_voice.config import (
 from dragon_voice.conversation import ConversationEngine
 from dragon_voice.db import Database
 from dragon_voice.messages import MessageStore
+from dragon_voice.handlers import debug as _handlers_debug
 from dragon_voice.middleware import (
     auth as _mw_auth,
     cors as _mw_cors,
@@ -751,220 +752,33 @@ class VoiceServer:
             }
         )
 
+    # Debug / diagnostic handlers — thin adapters over the functions in
+    # ``dragon_voice/handlers/debug.py``.  The URL routing + bearer-auth
+    # middleware wiring still lives in ``create_app``; only the handler
+    # bodies moved.
+
     async def _handle_debug_mem(self, request: web.Request) -> web.Response:
-        """W15-C01 mem-diff probe.
-
-        Returns the top-N allocation groups (ranked by growth since
-        baseline) from tracemalloc.  The baseline is taken on first
-        call; subsequent calls diff against the stored baseline.  The
-        ``?reset=1`` query flag replaces the baseline with the current
-        snapshot, so we can bisect leak growth windows.
-
-        Requires ``DRAGON_TRACEMALLOC=1`` in the env — otherwise the
-        endpoint returns 503 with a hint.
-        """
-        import tracemalloc
-        import resource
-        if not tracemalloc.is_tracing():
-            return web.json_response(
-                {
-                    "error": "tracemalloc_disabled",
-                    "hint": "export DRAGON_TRACEMALLOC=1 and restart voice service",
-                },
-                status=503,
-            )
-        snap = tracemalloc.take_snapshot()
-        # Filter out tracemalloc's own frames so the output isn't
-        # dominated by bookkeeping.
-        snap = snap.filter_traces(
-            (
-                tracemalloc.Filter(False, tracemalloc.__file__),
-                tracemalloc.Filter(False, "<frozen importlib._bootstrap>"),
-                tracemalloc.Filter(False, "<frozen importlib._bootstrap_external>"),
-            )
-        )
-        reset = request.query.get("reset", "0") == "1"
-        topn = int(request.query.get("n", "25"))
-        # Current RSS (kilobytes on Linux -> bytes).
-        rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-        rss_mb = rss_kb / 1024.0
-        out: dict = {
-            "rss_mb": round(rss_mb, 1),
-            "uptime_seconds": round(time.time() - self._start_time, 1),
-            "active_connections": len(self._active_connections),
-            "tracemalloc_peak_mb": round(tracemalloc.get_traced_memory()[1] / 1024 / 1024, 1),
-        }
-        # Optional ?trim=1 to force gc+malloc_trim before snapshot —
-        # tells us how much of RSS is reclaimable vs truly leaked.
-        if request.query.get("trim", "0") == "1":
-            before_rss = rss_mb
-            import ctypes
-            gc.collect()
-            try:
-                libc = ctypes.CDLL("libc.so.6")
-                libc.malloc_trim(0)
-            except (OSError, AttributeError) as e:
-                out["malloc_trim_error"] = str(e)
-            rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-            rss_mb = rss_kb / 1024.0
-            out["rss_mb_after_trim"] = round(rss_mb, 1)
-            out["rss_reclaimed_mb"] = round(before_rss - rss_mb, 1)
-
-        baseline = getattr(self, "_mem_baseline", None)
-        if baseline is None or reset:
-            self._mem_baseline = snap
-            self._mem_baseline_rss_mb = rss_mb
-            out["note"] = "baseline set — call again after load to see diff"
-        else:
-            stats = snap.compare_to(baseline, "lineno")
-            out["rss_delta_mb"] = round(rss_mb - self._mem_baseline_rss_mb, 1)
-            out["top"] = [
-                {
-                    "file": f"{s.traceback[0].filename.split('/')[-1]}:{s.traceback[0].lineno}",
-                    "size_mb": round(s.size / 1024 / 1024, 3),
-                    "size_diff_mb": round(s.size_diff / 1024 / 1024, 3),
-                    "count": s.count,
-                    "count_diff": s.count_diff,
-                }
-                for s in stats[:topn]
-            ]
-
-        # gc object counts by type — catches leaks tracemalloc misses
-        # (objects that grow in count, held in long-lived caches).
-        from collections import Counter
-        type_counts = Counter(type(o).__name__ for o in gc.get_objects())
-        # Persist a baseline so we can diff count growth too.
-        base_counts = getattr(self, "_mem_type_counts", None)
-        if base_counts is None or reset:
-            self._mem_type_counts = type_counts
-            out["top_types"] = [
-                {"type": k, "count": v}
-                for k, v in type_counts.most_common(25)
-            ]
-        else:
-            diff = {k: type_counts[k] - base_counts.get(k, 0) for k in type_counts}
-            growers = sorted(diff.items(), key=lambda kv: -kv[1])[:25]
-            out["top_type_growers"] = [
-                {"type": k, "delta": d, "now": type_counts[k]}
-                for k, d in growers if d > 0
-            ]
-        return web.json_response(out)
-
+        return await _handlers_debug.handle_debug_mem(request, server=self)
 
     async def _debug_widget_chart(self, request: web.Request) -> web.Response:
-        """POST /debug/widget_chart -- audit B5 evidence. Emits a chart
-        widget on every registered Tab5Surface. Body: {title, values, chart_max}."""
-        try:
-            data = await request.json()
-        except Exception:
-            data = {}
-        title = data.get("title", "Audit chart")
-        values = data.get("values", [3, 7, 12, 9, 15, 18, 22, 16, 11, 8, 14, 20])
-        chart_max = float(data.get("chart_max", 0))
-        if self._surface_mgr is None:
-            return web.json_response({"error": "surface_mgr not ready"}, status=503)
-        count = 0
-        for sid, state in list(self._surface_mgr._sessions.items()):
-            try:
-                await state.surface.chart(title=title, values=values, chart_max=chart_max,
-                                  skill_id="audit", card_id="audit_chart_" + sid[:6])
-                count += 1
-            except Exception as e:
-                logger.warning("debug chart emit failed for %s: %s", sid, e)
-        return web.json_response({"emitted": count, "values": values})
+        return await _handlers_debug.handle_debug_widget_chart(
+            request, surface_mgr=self._surface_mgr,
+        )
 
     async def _debug_widget_prompt(self, request: web.Request) -> web.Response:
-        """POST /debug/widget_prompt -- audit B6/K3 evidence.
-        Emits a widget_prompt on every registered Tab5Surface AND
-        registers a handler so tap round-trips back to Dragon.
-        Body: {title, body, choices: [[text, event], ...]}."""
-        try:
-            data = await request.json()
-        except Exception:
-            data = {}
-        title = data.get("title", "Confirm?")
-        body = data.get("body", "")
-        choices_raw = data.get("choices", [["Yes", "audit_yes"], ["No", "audit_no"]])
-        choices = []
-        for c in choices_raw[:3]:
-            if isinstance(c, (list, tuple)) and len(c) >= 2:
-                choices.append((str(c[0]), str(c[1])))
-        if self._surface_mgr is None:
-            return web.json_response({"error": "surface_mgr not ready"}, status=503)
-        count = 0
-        for sid, state in list(self._surface_mgr._sessions.items()):
-            try:
-                card_id = f"audit_prompt_{sid[:6]}"
-                async def _handle(event: str, payload: dict, _sid=sid, _cid=card_id) -> None:
-                    logger.info("audit widget_prompt tapped: session=%s event=%s payload=%s",
-                                _sid, event, payload)
-                    # Dismiss the card so the tap has an observable effect.
-                    try:
-                        await state.surface.dismiss(_cid)
-                    except Exception:
-                        pass
-                    self._surface_mgr.unregister_action(_sid, _cid)
-                self._surface_mgr.register_action(sid, card_id, _handle)
-                await state.surface.prompt(
-                    title=title, body=body, choices=choices,
-                    skill_id="audit", card_id=card_id,
-                )
-                count += 1
-            except Exception as e:
-                logger.warning("debug prompt emit failed for %s: %s", sid, e)
-        return web.json_response({"emitted": count, "choices": choices})
+        return await _handlers_debug.handle_debug_widget_prompt(
+            request, surface_mgr=self._surface_mgr,
+        )
 
     async def _debug_widget_card(self, request: web.Request) -> web.Response:
-        """POST /debug/widget_card -- audit B2 evidence.
-        Emits a widget_card on every registered Tab5Surface. Cards go
-        to chat (not home). Body: {title, body, tone}."""
-        try:
-            data = await request.json()
-        except Exception:
-            data = {}
-        title = data.get("title", "Workshop draft ready")
-        body = data.get("body", "Two edits queued from yesterday. Review before 10:30.")
-        tone = data.get("tone", "info")
-        if self._surface_mgr is None:
-            return web.json_response({"error": "surface_mgr not ready"}, status=503)
-        count = 0
-        for sid, state in list(self._surface_mgr._sessions.items()):
-            try:
-                await state.surface.card(title=title, body=body, tone=tone,
-                                          skill_id="audit",
-                                          card_id="audit_card_" + sid[:6])
-                count += 1
-            except Exception as e:
-                logger.warning("debug card emit failed for %s: %s", sid, e)
-        return web.json_response({"emitted": count})
+        return await _handlers_debug.handle_debug_widget_card(
+            request, surface_mgr=self._surface_mgr,
+        )
 
     async def _debug_widget_media(self, request: web.Request) -> web.Response:
-        """POST /debug/widget_media -- audit B5 evidence.
-        Emits widget_media pointing at a previously uploaded image.
-        Body: {url, width, height, alt}."""
-        try:
-            data = await request.json()
-        except Exception:
-            data = {}
-        url = data.get("url", "")
-        width = int(data.get("width", 480))
-        height = int(data.get("height", 300))
-        alt = data.get("alt", "Audit media")
-        if not url:
-            return web.json_response({"error": "url required"}, status=400)
-        if self._surface_mgr is None:
-            return web.json_response({"error": "surface_mgr not ready"}, status=503)
-        count = 0
-        for sid, state in list(self._surface_mgr._sessions.items()):
-            try:
-                await state.surface.media(url=url, alt=alt,
-                                          title="Audit media",
-                                          skill_id="audit",
-                                          card_id="audit_media_" + sid[:6])
-                count += 1
-            except Exception as e:
-                logger.warning("debug media emit failed for %s: %s", sid, e)
-        return web.json_response({"emitted": count, "url": url})
+        return await _handlers_debug.handle_debug_widget_media(
+            request, surface_mgr=self._surface_mgr,
+        )
 
 
 

--- a/tests/test_debug_handlers.py
+++ b/tests/test_debug_handlers.py
@@ -1,0 +1,164 @@
+"""Smoke tests for ``dragon_voice/handlers/debug.py``.
+
+These cover the thin wiring only — the "handler returns a sensible
+status when its dep isn't ready" paths.  The ``_iter_surface_sessions``
+iteration path is exercised via a minimal stub.
+
+Run:
+    python3 -m pytest -v tests/test_debug_handlers.py
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import unittest
+from unittest.mock import MagicMock
+
+from aiohttp import web
+
+from dragon_voice.handlers import debug as dbg
+
+
+class _ReqWithJson:
+    """Minimal async-json stub for the widget emitters.
+
+    aiohttp ``web.Request.json()`` is an awaitable; we only need the
+    parsed body + ``query`` dict, so build the smallest stand-in.
+    """
+
+    def __init__(self, body: dict | None = None, query: dict | None = None):
+        self._body = body or {}
+        self.query = query or {}
+
+    async def json(self):
+        return self._body
+
+
+class DebugMemHandlerTests(unittest.TestCase):
+    """``handle_debug_mem`` fails gracefully when tracemalloc is off."""
+
+    def test_returns_503_when_tracemalloc_disabled(self):
+        # Guard against the test accidentally importing with tracing
+        # already on from a prior test in the same process.
+        import tracemalloc
+        if tracemalloc.is_tracing():
+            tracemalloc.stop()
+
+        req = MagicMock()
+        req.query = {}
+        server = MagicMock()
+
+        async def go():
+            resp = await dbg.handle_debug_mem(req, server=server)
+            return resp
+
+        resp: web.Response = asyncio.run(go())
+        self.assertEqual(resp.status, 503)
+        payload = json.loads(resp.body)
+        self.assertEqual(payload["error"], "tracemalloc_disabled")
+
+
+class WidgetHandlerTests(unittest.TestCase):
+    """Each widget emitter returns 503 when surface_mgr is None and
+    400 where it validates inputs."""
+
+    def test_chart_returns_503_when_surface_mgr_missing(self):
+        req = _ReqWithJson()
+
+        async def go():
+            return await dbg.handle_debug_widget_chart(req, surface_mgr=None)
+
+        resp = asyncio.run(go())
+        self.assertEqual(resp.status, 503)
+        self.assertEqual(json.loads(resp.body)["error"], "surface_mgr not ready")
+
+    def test_prompt_returns_503_when_surface_mgr_missing(self):
+        req = _ReqWithJson()
+
+        async def go():
+            return await dbg.handle_debug_widget_prompt(req, surface_mgr=None)
+
+        resp = asyncio.run(go())
+        self.assertEqual(resp.status, 503)
+
+    def test_card_returns_503_when_surface_mgr_missing(self):
+        req = _ReqWithJson()
+
+        async def go():
+            return await dbg.handle_debug_widget_card(req, surface_mgr=None)
+
+        resp = asyncio.run(go())
+        self.assertEqual(resp.status, 503)
+
+    def test_media_requires_url(self):
+        # url is a required field — missing should 400 regardless of
+        # surface_mgr state.
+        req = _ReqWithJson(body={})
+
+        async def go():
+            return await dbg.handle_debug_widget_media(req, surface_mgr=None)
+
+        resp = asyncio.run(go())
+        self.assertEqual(resp.status, 400)
+        self.assertEqual(json.loads(resp.body)["error"], "url required")
+
+    def test_media_returns_503_when_surface_mgr_missing_but_url_present(self):
+        req = _ReqWithJson(body={"url": "http://example.com/a.jpg"})
+
+        async def go():
+            return await dbg.handle_debug_widget_media(req, surface_mgr=None)
+
+        resp = asyncio.run(go())
+        self.assertEqual(resp.status, 503)
+
+
+class WidgetChartEmitTests(unittest.TestCase):
+    """End-to-end smoke: chart emitter iterates the surface manager's
+    sessions and calls ``surface.chart`` once per session.
+
+    Uses a stub SurfaceManager that exposes ``_sessions`` the same way
+    the real one does so ``_iter_surface_sessions`` can walk it.
+    """
+
+    def test_emits_one_chart_per_session(self):
+        # Two fake sessions, each with a mock surface.
+        calls: list[tuple[str, str]] = []
+
+        class _Surface:
+            def __init__(self, name: str):
+                self.name = name
+
+            async def chart(self, *, title, values, chart_max, skill_id, card_id):
+                calls.append((self.name, card_id))
+
+        class _State:
+            def __init__(self, name: str):
+                self.surface = _Surface(name)
+
+        class _SurfaceMgr:
+            def __init__(self):
+                self._sessions = {
+                    "session_aaaaaaaa": _State("a"),
+                    "session_bbbbbbbb": _State("b"),
+                }
+
+        req = _ReqWithJson(body={"title": "t", "values": [1, 2, 3], "chart_max": 10})
+        mgr = _SurfaceMgr()
+
+        async def go():
+            return await dbg.handle_debug_widget_chart(req, surface_mgr=mgr)
+
+        resp = asyncio.run(go())
+        self.assertEqual(resp.status, 200)
+        payload = json.loads(resp.body)
+        self.assertEqual(payload["emitted"], 2)
+        self.assertEqual(payload["values"], [1, 2, 3])
+        # Each surface saw exactly one chart call, with a card_id that
+        # encodes the first 6 chars of its session id.
+        self.assertEqual(len(calls), 2)
+        self.assertIn(("a", "audit_chart_sessio"), calls)
+        self.assertIn(("b", "audit_chart_sessio"), calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Second of four planned PRs that decompose \`dragon_voice/server.py\`. This PR lifts the 5 debug/diagnostic handlers into \`dragon_voice/handlers/debug.py\` and adds a new smoke-test file to the CI named test set.

Closes step 2 of umbrella #65.

## What moved

| Was on \`VoiceServer\` | Now | Deps |
|---|---|---|
| \`_handle_debug_mem\` | \`handlers/debug.py → handle_debug_mem\` | \`server\` (reads ~5 attrs, lazy-sets 3 baselines) |
| \`_debug_widget_chart\` | \`handle_debug_widget_chart\` | \`surface_mgr\` |
| \`_debug_widget_prompt\` | \`handle_debug_widget_prompt\` | \`surface_mgr\` |
| \`_debug_widget_card\` | \`handle_debug_widget_card\` | \`surface_mgr\` |
| \`_debug_widget_media\` | \`handle_debug_widget_media\` | \`surface_mgr\` |

Design notes (see module docstring):
- \`handle_debug_mem\` takes \`server\` as a single handle because it touches many attributes and lazily sets baselines. A 7-arg signature + mutable state-dict would be worse for this diagnostic endpoint.
- Widget emitters take \`surface_mgr\` explicitly — zero coupling to \`VoiceServer\`.
- Shared helper \`_iter_surface_sessions\` returns a list snapshot (not a live iterator) so concurrent register/unregister during emission can't mutate what we're iterating.

The \`VoiceServer\` methods remain as 3-line adapters so the URL routing in \`create_app\` is unchanged.

## New tests (moved to CI)

\`tests/test_debug_handlers.py\` — **7 tests, 100% pass** :
- \`handle_debug_mem\` returns 503 when tracemalloc disabled (the common case in CI + dev)
- Each of the 4 widget emitters returns 503 when \`surface_mgr\` is None (startup not ready)
- \`handle_debug_widget_media\` returns 400 when \`url\` missing
- End-to-end: stub SurfaceManager with 2 sessions, chart emitter calls \`.chart()\` once per session, returns \`{emitted: 2}\`

Added to \`.github/workflows/ci.yml\` named test set per the Workflow rule.

## LOC impact

- \`dragon_voice/server.py\`: 2556 → **2370** (−186)
- \`dragon_voice/handlers/debug.py\`: +280 LOC
- \`dragon_voice/handlers/__init__.py\`: +12 LOC
- \`tests/test_debug_handlers.py\`: +151 LOC
- \`ci.yml\`: +1 LOC (new test file)

Cumulative from steps 1 + 2: \`server.py\` 2747 → 2370 (−377, 14% drop).

## Test plan

All run with \`DRAGON_API_TOKEN=ci-bearer-token\` + \`TINKERCLAW_TOKEN=ci-tc-token\`:
- [x] \`ruff --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006\` on \`dragon_voice/\` + \`tests/test_debug_handlers.py\` → **All checks passed**
- [x] \`tests/test_debug_handlers.py\` — **7/7 pass** (new)
- [x] Full CI-named unit-test set incl. new file → **104/104 pass**
- [x] \`from dragon_voice import server; from dragon_voice.handlers import debug\` — clean import

## Explicit non-goals

- **Not touching \`handle_debug_mem\` internals.** Same tracemalloc filters, same baseline lazy-init, same gc type-count diff.
- **Not refactoring the widget emitters.** Only extracted \`_iter_surface_sessions\` as a named helper — iteration logic is byte-identical.
- **Not migrating any existing tests.** The \`VoiceServer._debug_widget_*\` adapter methods still work.
- **Not renaming/moving any URL routes.** \`create_app\` routing is unchanged.

## References

- Umbrella: #65
- Workflow rules: [CLAUDE.md](CLAUDE.md#workflow) (updated in #64)
- Step 1: #66 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)