### PR TITLE
refactor(server): extract lifecycle (startup/shutdown/monitors/purge) (step 3 of #65)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,5 @@ jobs:
             tests/test_media_url_signer.py \
             tests/test_proxy_image_ssrf.py \
             tests/test_security_headers.py \
-            tests/test_debug_handlers.py
+            tests/test_debug_handlers.py \
+            tests/test_lifecycle_monitors.py

--- a/dragon_voice/lifecycle/__init__.py
+++ b/dragon_voice/lifecycle/__init__.py
@@ -1,0 +1,25 @@
+"""Server lifecycle helpers — boot, shutdown, and long-running monitors.
+
+Each submodule has one responsibility:
+
+* :mod:`monitors`  — ``get_rss_mb`` / ``get_cpu_temp`` helpers and the
+  ``memory_monitor_loop`` periodic task.
+* :mod:`purge`     — ``periodic_purge_loop`` (messages + events) and
+  ``media_cleanup_loop``.
+* :mod:`startup`   — ``run_startup(server, app)``: wires DB, session
+  manager, memory + tools, conversation engine, REST routes, notes
+  routes, MCP bridge, and starts the periodic tasks.
+* :mod:`shutdown`  — ``run_shutdown(server, app)``: cancels periodic
+  tasks, drains active pipelines, releases the backend pool, closes
+  shared HTTP sessions + foundation modules.
+
+Startup and shutdown take the ``VoiceServer`` instance as a single
+handle.  Their coupling to server state is wide (~20 attributes) —
+a 20-arg signature would be worse, not better.  Tests for individual
+startup steps should exercise the real module each step delegates to
+(the DB, the session manager, …), not this orchestration layer.
+"""
+
+from dragon_voice.lifecycle import monitors, purge, shutdown, startup
+
+__all__ = ["monitors", "purge", "shutdown", "startup"]

--- a/dragon_voice/lifecycle/monitors.py
+++ b/dragon_voice/lifecycle/monitors.py
@@ -1,0 +1,184 @@
+"""Resource monitoring helpers + the memory-monitor periodic task.
+
+* :func:`get_rss_mb` reads current process RSS from ``/proc/self/status``
+  (no ``psutil`` dependency).
+* :func:`get_cpu_temp` reads the hottest thermal zone under
+  ``/sys/class/thermal`` — primary probe used to detect thermal
+  throttling on Dragon Q6A (DQ03).
+* :func:`memory_monitor_loop` runs forever on an :mod:`asyncio` task,
+  sampling RSS + temperature + file-descriptor usage every 5 min.  On
+  an RSS breach it forces GC; if still above the crit threshold it
+  drains and re-inits the voice pipelines so leaked state is released
+  without restarting the whole process (A04).
+"""
+from __future__ import annotations
+
+import asyncio
+import gc
+import glob
+import logging
+import os
+import resource
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def get_rss_mb() -> float:
+    """Return current process RSS in MiB, or 0.0 if the read fails.
+
+    Reads ``/proc/self/status`` so we don't pull in ``psutil`` for a
+    single number.  Dragon exposes ``VmRSS`` in kilobytes; we convert.
+    """
+    try:
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith("VmRSS"):
+                    return int(line.split()[1]) / 1024.0  # kB -> MB
+    except Exception:
+        pass
+    return 0.0
+
+
+def get_cpu_temp() -> float:
+    """Return the hottest thermal-zone reading in °C, or 0.0 on failure.
+
+    Tries ``thermal_zone0`` first (fastest path, common on QCS6490),
+    then falls back to scanning every ``thermal_zone*/temp`` and
+    returning the max.  Failures on individual zones are swallowed;
+    if nothing reads, returns 0.0.
+    """
+    # Fast path — thermal_zone0 is usually the SoC sensor on Dragon.
+    try:
+        with open("/sys/class/thermal/thermal_zone0/temp") as f:
+            return int(f.read().strip()) / 1000.0
+    except Exception:
+        pass
+
+    max_temp = 0.0
+    for path in glob.glob("/sys/devices/virtual/thermal/thermal_zone*/temp"):
+        try:
+            with open(path) as f:
+                t = int(f.read().strip()) / 1000.0
+                if t > max_temp:
+                    max_temp = t
+        except Exception:
+            continue
+    return max_temp
+
+
+async def memory_monitor_loop(server: Any) -> None:
+    """Sample RSS + temp + FD usage every 5 min; react on breaches.
+
+    Thresholds come from ``server._mem_warn_mb`` / ``server._mem_crit_mb``.
+    On RSS warn: force :func:`gc.collect` + log.
+    On RSS crit after GC: drain + re-init pipelines so leaked state is
+    released without restarting the whole process (A04).
+
+    Also logs warnings if CPU ≥80°C (Gold cores throttle at ~80) or
+    ≥90°C (eMMC damage risk), and if FD usage ≥80%.
+    """
+    from dragon_voice.pipeline import VoicePipeline
+
+    while True:
+        await asyncio.sleep(300)  # 5 minutes
+        rss = get_rss_mb()
+        if rss <= 0:
+            continue
+
+        active = len(server._active_connections)
+        temp_c = get_cpu_temp()
+
+        # FD count monitoring (DQ08): detect file descriptor exhaustion
+        try:
+            fd_count = len(os.listdir(f"/proc/{os.getpid()}/fd"))
+            fd_limit = resource.getrlimit(resource.RLIMIT_NOFILE)[0]
+            fd_pct = (fd_count / fd_limit * 100) if fd_limit > 0 else 0
+        except Exception:
+            fd_count = fd_limit = 0
+            fd_pct = 0.0
+
+        logger.info(
+            "Memory monitor: RSS=%.0f MB, temp=%.1f°C, connections=%d, FDs=%d/%d (%.0f%%)",
+            rss, temp_c, active, fd_count, fd_limit, fd_pct,
+        )
+
+        # DQ03 thermal warnings — monitoring only, no throttling.
+        if temp_c >= 90:
+            logger.error(
+                "Memory monitor: CPU temp %.1f°C exceeds 90°C — "
+                "risk of eMMC degradation and component damage!",
+                temp_c,
+            )
+        elif temp_c >= 80:
+            logger.warning(
+                "Memory monitor: CPU temp %.1f°C exceeds 80°C — "
+                "Gold cores likely throttled from 2.7GHz",
+                temp_c,
+            )
+
+        if fd_pct >= 80:
+            logger.warning(
+                "Memory monitor: FD usage at %.0f%% (%d/%d) — risk of exhaustion!",
+                fd_pct, fd_count, fd_limit,
+            )
+
+        if rss > server._mem_warn_mb:
+            logger.warning(
+                "Memory monitor: RSS %.0f MB exceeds warning threshold (%d MB) — forcing GC",
+                rss, server._mem_warn_mb,
+            )
+            collected = gc.collect()
+            rss_after = get_rss_mb()
+            logger.warning(
+                "Memory monitor: GC collected %d objects, RSS now %.0f MB",
+                collected, rss_after,
+            )
+
+            if rss_after > server._mem_crit_mb:
+                logger.error(
+                    "Memory monitor: RSS %.0f MB exceeds critical threshold (%d MB) "
+                    "after GC — restarting all pipelines",
+                    rss_after, server._mem_crit_mb,
+                )
+                for ws_id, conn in list(server._active_connections.items()):
+                    pipeline = conn.get("pipeline")
+                    if pipeline:
+                        try:
+                            await pipeline.shutdown()
+                            conn["pipeline"] = None
+                            logger.info("Memory monitor: shut down pipeline for %s", ws_id)
+                        except Exception as e:
+                            logger.warning(
+                                "Memory monitor: pipeline shutdown failed for %s: %s",
+                                ws_id, e,
+                            )
+
+                gc.collect()
+                rss_final = get_rss_mb()
+                logger.warning("Memory monitor: post-restart RSS %.0f MB", rss_final)
+
+                # Re-initialize pipelines for registered connections.
+                for ws_id, conn in list(server._active_connections.items()):
+                    if conn.get("registered") and conn.get("pipeline") is None:
+                        cfg = conn.get("config", server._config)
+                        try:
+                            pipeline = VoicePipeline(
+                                cfg,
+                                conn.get("_on_audio"),
+                                conn.get("_on_event"),
+                                conversation_engine=server._conversation,
+                                session_id=conn.get("session_id", ""),
+                                media_pipeline=server._media_pipeline,
+                                backend_pool=server._backend_pool,
+                            )
+                            await pipeline.initialize()
+                            conn["pipeline"] = pipeline
+                            logger.info(
+                                "Memory monitor: re-initialized pipeline for %s", ws_id,
+                            )
+                        except Exception as e:
+                            logger.error(
+                                "Memory monitor: pipeline re-init failed for %s: %s",
+                                ws_id, e,
+                            )

--- a/dragon_voice/lifecycle/purge.py
+++ b/dragon_voice/lifecycle/purge.py
@@ -1,0 +1,44 @@
+"""Periodic retention/cleanup loops.
+
+* :func:`periodic_purge_loop` — every 24 h, delete messages + events
+  older than ``days``.  Used for message-retention policy (US-DQ14).
+* :func:`media_cleanup_loop`  — every hour, delete expired media
+  uploads from :class:`MediaStore`.
+
+Both loops are designed to be cheap no-ops when the underlying service
+isn't ready (shutdown races) and to swallow per-iteration exceptions so
+one failure doesn't kill the loop.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def periodic_purge_loop(server: Any, days: int) -> None:
+    """Run message/event purge every 24 h for ``days`` retention window."""
+    while True:
+        await asyncio.sleep(86400)  # 24 hours
+        if server._db is None:
+            break
+        try:
+            result = await server._db.purge_old_messages(days=days)
+            logger.info(
+                "Periodic purge: %d messages, %d events removed",
+                result["messages"], result["events"],
+            )
+        except Exception as e:
+            logger.warning("Periodic purge failed: %s", e)
+
+
+async def media_cleanup_loop(server: Any) -> None:
+    """Remove expired media uploads every hour."""
+    while True:
+        await asyncio.sleep(3600)
+        try:
+            await server._media_store.cleanup()
+        except Exception as e:
+            logger.warning("Media cleanup error: %s", e)

--- a/dragon_voice/lifecycle/shutdown.py
+++ b/dragon_voice/lifecycle/shutdown.py
@@ -1,0 +1,134 @@
+"""Server drain sequence — ``run_shutdown(server, app)``.
+
+Run in strict order so aiohttp can exit cleanly:
+
+1.  Cancel + await the three periodic tasks (memory monitor, purge,
+    media cleanup).  Await is critical — cancel-without-await left the
+    tasks attached long enough for aiohttp to close the loop first,
+    producing ``RuntimeError: Event loop is closed`` at systemctl
+    restart (W14-M09, W13-H3).
+2.  Shut down per-connection pipelines (gather, return_exceptions=True
+    so one failure doesn't block the rest).
+3.  Shut down the shared backend pool (W15-C01 — backends are only
+    torn down here; per-pipeline shutdowns are no-ops for pooled
+    backends).
+4.  Shut down the shared inference ``ThreadPoolExecutor`` so uvloop can
+    exit.
+5.  Close shared HTTP clients (proxy session for dashboard, media
+    pipeline's ClientSession — W14-H12).
+6.  Shut down notes, memory service (W14-H11), conversation, session
+    manager, DB — each guarded by a presence check.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+async def run_shutdown(server: Any, app: web.Application) -> None:
+    """Clean up all active sessions and foundation modules on shutdown."""
+    logger.info(
+        "Server shutting down — closing %d connections",
+        len(server._active_connections),
+    )
+
+    # Cancel periodic tasks.  Await after cancel so we don't leak the
+    # task across loop shutdown (W14-M09).
+    if server._memory_monitor_task and not server._memory_monitor_task.done():
+        server._memory_monitor_task.cancel()
+        try:
+            await server._memory_monitor_task
+        except (asyncio.CancelledError, Exception):
+            pass
+    if server._purge_task and not server._purge_task.done():
+        # periodic_purge_loop sleeps 86400 s in one shot; cancel-without-
+        # await left it attached long enough for aiohttp to close the
+        # loop first, producing "RuntimeError: Event loop is closed".
+        server._purge_task.cancel()
+        try:
+            await server._purge_task
+        except (asyncio.CancelledError, Exception):
+            pass
+    # Wave 13 H3: the media cleanup loop was being left running on
+    # shutdown because it wasn't touched here.  If it was mid-sleep when
+    # the loop closes, asyncio logs "Task was destroyed but it is
+    # pending" warnings and the 24 h TTL cleaner can orphan partial
+    # deletes.  Cancel + await.
+    if server._media_cleanup_task and not server._media_cleanup_task.done():
+        server._media_cleanup_task.cancel()
+        try:
+            await server._media_cleanup_task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    # Drain per-connection pipelines
+    tasks = []
+    for _ws_id, conn in list(server._active_connections.items()):
+        pipeline = conn.get("pipeline")
+        if pipeline:
+            tasks.append(pipeline.shutdown())
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+    server._active_connections.clear()
+
+    # W15-C01: now that no pipelines are holding references, shut down
+    # the shared backend pool.  Per-pipeline shutdowns above are no-ops
+    # for pooled backends (_pooled_* flag), so the pool is the single
+    # owner responsible for final teardown.
+    pool_tasks = []
+    for key, backend in list(server._backend_pool.items()):
+        logger.info("W15-C01: releasing pooled backend %s", key)
+        try:
+            pool_tasks.append(backend.shutdown())
+        except (AttributeError, RuntimeError) as e:
+            logger.warning("W15-C01: pool backend %s shutdown raised: %s", key, e)
+    if pool_tasks:
+        await asyncio.gather(*pool_tasks, return_exceptions=True)
+    server._backend_pool.clear()
+
+    # v4·D audit P0 fix: release the inference ThreadPoolExecutor so
+    # uvloop can exit cleanly.  Previously zombie threads lingered.
+    try:
+        from dragon_voice.pipeline import shutdown_inference_executor
+        shutdown_inference_executor(wait=False)
+        logger.info("Inference executor shut down")
+    except Exception:
+        logger.debug("inference executor shutdown failed", exc_info=True)
+
+    # Close shared proxy session (DQ08)
+    if server._proxy_session and not server._proxy_session.closed:
+        await server._proxy_session.close()
+
+    # Shut down foundation
+    if server._notes_svc:
+        await server._notes_svc.shutdown()
+    if server._media_pipeline:
+        # W14-H12: close the MediaPipeline's shared aiohttp
+        # ClientSession.  Prior behaviour left it dangling across
+        # systemctl restart, logging "Unclosed client session" and
+        # making the wave-13 FD counter noisy.
+        try:
+            await server._media_pipeline.close()
+        except Exception:
+            logger.debug("MediaPipeline shutdown failed", exc_info=True)
+    if server._memory_service:
+        logger.info("Shutting down memory service")
+        # W14-H11: close the shared Ollama HTTP session.
+        try:
+            await server._memory_service.shutdown()
+        except Exception:
+            logger.debug("MemoryService shutdown raised", exc_info=True)
+        server._memory_service = None
+    if server._conversation:
+        await server._conversation.shutdown()
+    if server._session_mgr:
+        await server._session_mgr.stop()
+    if server._db:
+        await server._db.close()
+
+    logger.info("Shutdown complete")

--- a/dragon_voice/lifecycle/startup.py
+++ b/dragon_voice/lifecycle/startup.py
@@ -1,0 +1,232 @@
+"""Server boot sequence — ``run_startup(server, app)``.
+
+Orchestrates the VoiceServer boot in a specific order:
+
+1.  Shared aiohttp ``ClientSession`` for the dashboard proxy (DQ08).
+2.  ``Database`` init + migrations.
+3.  ``SessionManager`` + ``MessageStore``.
+4.  ``MemoryService`` + ``ToolRegistry`` + core tools.  Each section is
+    wrapped in try/except so a missing optional dep (e.g. no memory
+    backend configured) logs a warning but doesn't block boot.
+5.  ``SurfaceManager`` + widget-emitting tools.
+6.  ``ConversationEngine`` (shared LLM backend for text/API input).
+7.  REST API routes + Notes API routes + MCP bridge.
+8.  Retention purge (initial) + periodic purge task.
+9.  Media cleanup + memory monitor periodic tasks.
+
+Takes ``server`` as a single handle because the sequence mutates ~20
+attributes on it.  A follow-up could introduce a ``StartupContext``
+dataclass if we ever need multiple boot profiles, but today this is
+one callsite that always wants to wire the same graph.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import aiohttp
+from aiohttp import web
+
+from dragon_voice.conversation import ConversationEngine
+from dragon_voice.db import Database
+from dragon_voice.lifecycle import monitors, purge
+from dragon_voice.messages import MessageStore
+from dragon_voice.sessions import SessionManager
+
+logger = logging.getLogger(__name__)
+
+
+async def run_startup(server: Any, app: web.Application) -> None:
+    """Initialize foundation modules on server start.
+
+    Mutates ``server`` in place — assigns the DB, session manager,
+    message store, memory service, tool registry, surface manager,
+    conversation engine, and the three background task handles
+    (``_purge_task``, ``_media_cleanup_task``, ``_memory_monitor_task``).
+    """
+    logger.info("Initializing foundation modules...")
+
+    # Shared client session for dashboard proxy (DQ08)
+    server._proxy_session = aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(total=30)
+    )
+
+    # Database
+    server._db = Database()
+    await server._db.initialize()
+
+    # Session manager (with background cleanup)
+    server._session_mgr = SessionManager(server._db)
+    await server._session_mgr.start()
+
+    # Message store
+    server._message_store = MessageStore(server._db)
+
+    # Memory service (agentic: facts + documents + RAG) + core tools
+    server._memory_service = None
+    server._tool_registry = None
+    try:
+        from dragon_voice.memory import MemoryService
+        from dragon_voice.tools import ToolRegistry
+        from dragon_voice.tools.web_search import WebSearchTool
+        from dragon_voice.tools.datetime_tool import DateTimeTool
+
+        server._memory_service = MemoryService(
+            server._db,
+            ollama_url=server._config.llm.ollama_url,
+        )
+        await server._memory_service.initialize()
+
+        server._tool_registry = ToolRegistry()
+        server._tool_registry.register(WebSearchTool(
+            searxng_url=getattr(server._config.tools, "searxng_url", "")
+        ))
+        server._tool_registry.register(DateTimeTool())
+
+        # Memory tools need memory_service
+        from dragon_voice.tools.memory_tools import (
+            ForgetFactTool, RecallFactsTool, StoreFactTool,
+        )
+        server._tool_registry.register(StoreFactTool(server._memory_service))
+        server._tool_registry.register(RecallFactsTool(server._memory_service))
+        # v4·D Gauntlet G9: two-step confirm-gated forget_fact tool.
+        server._tool_registry.register(ForgetFactTool(server._memory_service))
+
+        # Tier 1 tools.  Audit D8/K7 dedup (2026-04-20): TimerTool is
+        # no longer registered here — TimesenseTool (registered below
+        # after SurfaceManager init) covers "set a timer" AND emits
+        # widget_live progress.  Keeping both caused the LLM to pick
+        # TimerTool on short phrases, making the widget reference flow
+        # unreachable.  TimerTool class file is retained for REST-only
+        # callers; it's just not wired into the agentic loop.
+        from dragon_voice.tools.calculator_tool import CalculatorTool
+        from dragon_voice.tools.stock_ticker_tool import StockTickerTool
+        from dragon_voice.tools.system_tool import SystemInfoTool
+        from dragon_voice.tools.unit_converter_tool import UnitConverterTool
+        from dragon_voice.tools.weather_tool import WeatherTool
+
+        server._tool_registry.register(WeatherTool())
+        server._tool_registry.register(CalculatorTool())
+        server._tool_registry.register(UnitConverterTool())
+        server._tool_registry.register(SystemInfoTool())
+        server._tool_registry.register(StockTickerTool())
+
+        logger.info(
+            "Agentic modules initialized (tools: %d, memory: ok)",
+            len(server._tool_registry.list_tools()),
+        )
+    except Exception as e:
+        logger.warning("Agentic modules not available: %s", e)
+
+    # v4·D Phase 4g stability fix (audit P0 #1): SurfaceManager so Tab5
+    # widget_action events have somewhere to land.
+    from dragon_voice.surfaces import SurfaceManager
+    server._surface_mgr = SurfaceManager()
+    logger.info("SurfaceManager initialized")
+
+    # Register widget-emitting tools AFTER surface_mgr exists.
+    if server._tool_registry is not None:
+        try:
+            from dragon_voice.tools.timesense_tool import TimesenseTool
+            server._tool_registry.register(TimesenseTool(server._surface_mgr))
+            logger.info("TimesenseTool registered (widget emitter)")
+            # Wave 12 skill SDK reference — declarative
+            # ``surface.prompt(on_action=handler)`` style.
+            from dragon_voice.tools.quick_poll_tool import QuickPollTool
+            server._tool_registry.register(QuickPollTool(server._surface_mgr))
+            logger.info("QuickPollTool registered (declarative widget skill)")
+        except Exception as e:
+            logger.warning("TimesenseTool registration failed: %s", e)
+
+    # Conversation engine (shared LLM backend for text/API input)
+    server._conversation = ConversationEngine(
+        server._db, server._message_store, server._config.llm,
+        tool_registry=server._tool_registry,
+        memory_service=server._memory_service,
+    )
+    await server._conversation.initialize()
+
+    # REST API routes (modular package)
+    from dragon_voice.api import setup_all_routes
+    setup_all_routes(
+        app,
+        db=server._db,
+        session_mgr=server._session_mgr,
+        message_store=server._message_store,
+        conversation=server._conversation,
+        voice_config=server._config,
+        start_time=server._start_time,
+        get_active_connections=lambda: len(server._active_connections),
+        tool_registry=server._tool_registry,
+        memory_service=server._memory_service,
+        media_store=server._media_store,
+        media_url_signer=server._media_url_signer,
+    )
+
+    # Notes API routes
+    try:
+        from dragon_voice.notes.api import setup_routes as setup_notes_routes
+        from dragon_voice.notes.db import NotesDB
+        from dragon_voice.notes.service import NotesService
+
+        notes_db = NotesDB()
+        # Wave 14 W14-C05: NotesDB.initialize is async now.  NotesService
+        # awaits it internally, so we don't call it here.
+        notes_svc = NotesService(server._config, notes_db)
+        await notes_svc.initialize()
+        server._notes_svc = notes_svc
+        setup_notes_routes(app, notes_svc)
+        logger.info("Notes API routes registered")
+
+        # Register NoteTool now that NotesService is available.
+        if server._tool_registry and server._notes_svc:
+            from dragon_voice.tools.note_tool import NoteTool
+            server._tool_registry.register(NoteTool(server._notes_svc))
+            logger.info("Note tool registered (notes service available)")
+    except Exception as e:
+        logger.warning("Notes API not available: %s", e)
+
+    # MCP servers (from config)
+    try:
+        from dragon_voice.mcp.bridge import bridge_mcp_server
+        mcp_servers = getattr(server._config, "mcp_servers", [])
+        for mcp in mcp_servers:
+            count = await bridge_mcp_server(
+                server._tool_registry,
+                name=mcp.get("name", "mcp"),
+                url=mcp.get("url"),
+                token=mcp.get("token"),
+            )
+            logger.info("MCP %s: %d tools bridged", mcp.get("name"), count)
+    except Exception as e:
+        logger.warning("MCP bridge not available: %s", e)
+
+    # Run initial message purge + schedule periodic (US-DQ14)
+    retention_days = server._config.database.message_retention_days
+    if retention_days > 0:
+        try:
+            result = await server._db.purge_old_messages(days=retention_days)
+            logger.info(
+                "Startup purge complete: %d messages, %d events removed (retention=%d days)",
+                result["messages"], result["events"], retention_days,
+            )
+        except Exception as e:
+            logger.warning("Startup purge failed: %s", e)
+
+        server._purge_task = asyncio.create_task(
+            purge.periodic_purge_loop(server, retention_days)
+        )
+
+    # Media cleanup (hourly, removes expired uploads)
+    server._media_cleanup_task = asyncio.create_task(purge.media_cleanup_loop(server))
+
+    # Start periodic memory monitor (A04)
+    server._memory_monitor_task = asyncio.create_task(monitors.memory_monitor_loop(server))
+    rss = monitors.get_rss_mb()
+    logger.info(
+        "Memory monitor started (RSS=%.0f MB, warn=%d MB, crit=%d MB)",
+        rss, server._mem_warn_mb, server._mem_crit_mb,
+    )
+
+    logger.info("Foundation modules initialized")

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -10,18 +10,15 @@ refs #16, #17, #18
 
 import asyncio
 import copy
-import gc
 import json
 import logging
 import os
-import resource
 import time
 from typing import Optional
 
 import aiohttp
 from aiohttp import web, WSMsgType
 
-from dragon_voice.api import setup_all_routes
 from dragon_voice.media.store import MediaStore
 from dragon_voice.media.pipeline import MediaPipeline
 from dragon_voice.config import (
@@ -33,6 +30,12 @@ from dragon_voice.conversation import ConversationEngine
 from dragon_voice.db import Database
 from dragon_voice.messages import MessageStore
 from dragon_voice.handlers import debug as _handlers_debug
+from dragon_voice.lifecycle import (
+    monitors as _lc_monitors,
+    purge as _lc_purge,
+    shutdown as _lc_shutdown,
+    startup as _lc_startup,
+)
 from dragon_voice.middleware import (
     auth as _mw_auth,
     cors as _mw_cors,
@@ -231,477 +234,35 @@ class VoiceServer:
             )
 
     # --------------------------------------------------------------- Lifecycle
+    #
+    # Thin adapters over dragon_voice/lifecycle/.  The orchestration
+    # logic (~470 LOC) moved to startup.py, shutdown.py, monitors.py,
+    # purge.py so server.py stays focused on request routing + the
+    # class definition.  These methods preserve the aiohttp on_startup
+    # / on_shutdown signatures expected by ``create_app``.
 
     async def _on_startup(self, app: web.Application) -> None:
-        """Initialize foundation modules on server start."""
-        logger.info("Initializing foundation modules...")
-
-        # Shared client session for dashboard proxy (DQ08)
-        self._proxy_session = aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=30)
-        )
-
-        # Database
-        self._db = Database()
-        await self._db.initialize()
-
-        # Session manager (with background cleanup)
-        self._session_mgr = SessionManager(self._db)
-        await self._session_mgr.start()
-
-        # Message store
-        self._message_store = MessageStore(self._db)
-
-        # Memory service (agentic: facts + documents + RAG)
-        self._memory_service = None
-        self._tool_registry = None
-        try:
-            from dragon_voice.memory import MemoryService
-            from dragon_voice.tools import ToolRegistry
-            from dragon_voice.tools.web_search import WebSearchTool
-            from dragon_voice.tools.datetime_tool import DateTimeTool
-
-            self._memory_service = MemoryService(
-                self._db,
-                ollama_url=self._config.llm.ollama_url,
-            )
-            await self._memory_service.initialize()
-
-            self._tool_registry = ToolRegistry()
-            self._tool_registry.register(WebSearchTool(
-                searxng_url=getattr(self._config.tools, "searxng_url", "")
-            ))
-            self._tool_registry.register(DateTimeTool())
-
-            # Memory tools need memory_service
-            from dragon_voice.tools.memory_tools import (
-                StoreFactTool, RecallFactsTool, ForgetFactTool,
-            )
-            self._tool_registry.register(StoreFactTool(self._memory_service))
-            self._tool_registry.register(RecallFactsTool(self._memory_service))
-            # v4·D Gauntlet G9: two-step confirm-gated forget_fact tool.
-            self._tool_registry.register(ForgetFactTool(self._memory_service))
-
-            # Tier 1 tools.
-            # Audit D8/K7 dedup (wave 7, 2026-04-20): TimerTool is no
-            # longer registered. TimesenseTool (registered below, after
-            # SurfaceManager init) covers the "set a timer" use case
-            # AND emits widget_live progress.  Keeping both caused the
-            # LLM to pick TimerTool on short phrases ("timer 5 min"),
-            # leaving the whole widget-platform reference flow unreachable
-            # from voice.  TimerTool class file is retained for REST-only
-            # use cases; it's just not wired into the agentic loop.
-            from dragon_voice.tools.weather_tool import WeatherTool
-            from dragon_voice.tools.calculator_tool import CalculatorTool
-            from dragon_voice.tools.unit_converter_tool import UnitConverterTool
-            from dragon_voice.tools.note_tool import NoteTool
-            from dragon_voice.tools.system_tool import SystemInfoTool
-            from dragon_voice.tools.stock_ticker_tool import StockTickerTool
-
-            self._tool_registry.register(WeatherTool())
-            self._tool_registry.register(CalculatorTool())
-            self._tool_registry.register(UnitConverterTool())
-            self._tool_registry.register(SystemInfoTool())
-            self._tool_registry.register(StockTickerTool())
-
-            logger.info("Agentic modules initialized (tools: %d, memory: ok)",
-                        len(self._tool_registry.list_tools()))
-        except Exception as e:
-            logger.warning("Agentic modules not available: %s", e)
-
-        # v4·D Phase 4g stability fix (audit P0 #1): instantiate the
-        # SurfaceManager so Tab5 widget_action events have somewhere to
-        # land.  Previously server.py imported nothing from surfaces/,
-        # and every Tab5 widget tap logged "Unknown command" and died.
-        from dragon_voice.surfaces import SurfaceManager
-        self._surface_mgr = SurfaceManager()
-        logger.info("SurfaceManager initialized")
-        # Audit P0 #1 (2026-04-20): register TimesenseTool - the reference
-        # widget-emitting skill.  Must be registered AFTER surface_mgr init
-        # (it takes the surface manager as constructor arg).  TimerTool and
-        # TimesenseTool have distinct names (timer vs timesense_timer) so
-        # both coexist; LLM picks based on description.
-        if self._tool_registry is not None:
-            try:
-                from dragon_voice.tools.timesense_tool import TimesenseTool
-                self._tool_registry.register(TimesenseTool(self._surface_mgr))
-                logger.info("TimesenseTool registered (widget emitter)")
-                # Wave 12 skill SDK: QuickPollTool is the reference
-                # for docs/SKILL_AUTHORING.md — declarative
-                # surface.prompt(on_action=handler), no imperative
-                # register_action bookkeeping.  ~80 LOC total, a
-                # minimal viable widget skill.
-                from dragon_voice.tools.quick_poll_tool import QuickPollTool
-                self._tool_registry.register(QuickPollTool(self._surface_mgr))
-                logger.info("QuickPollTool registered (declarative widget skill)")
-            except Exception as e:
-                logger.warning("TimesenseTool registration failed: %s", e)
-
-
-        # Conversation engine (shared LLM backend for text/API input)
-        self._conversation = ConversationEngine(
-            self._db, self._message_store, self._config.llm,
-            tool_registry=self._tool_registry,
-            memory_service=self._memory_service,
-        )
-        await self._conversation.initialize()
-
-        # REST API routes (modular package)
-        setup_all_routes(
-            app,
-            db=self._db,
-            session_mgr=self._session_mgr,
-            message_store=self._message_store,
-            conversation=self._conversation,
-            voice_config=self._config,
-            start_time=self._start_time,
-            get_active_connections=lambda: len(self._active_connections),
-            tool_registry=self._tool_registry,
-            memory_service=self._memory_service,
-            media_store=self._media_store,
-            media_url_signer=self._media_url_signer,
-        )
-
-        # Notes API routes
-        try:
-            from dragon_voice.notes.db import NotesDB
-            from dragon_voice.notes.service import NotesService
-            from dragon_voice.notes.api import setup_routes as setup_notes_routes
-
-            notes_db = NotesDB()
-            # Wave 14 W14-C05: NotesDB.initialize is async now. The prior
-            # direct call here was un-awaited, producing a stray coroutine
-            # and an intermittent None-connection race. NotesService.initialize
-            # already calls await self._db.initialize(), so this line is gone.
-            notes_svc = NotesService(self._config, notes_db)
-            await notes_svc.initialize()
-            self._notes_svc = notes_svc  # Store for shutdown
-            setup_notes_routes(app, notes_svc)
-            logger.info("Notes API routes registered")
-
-            # Register note tool now that NotesService is available
-            if self._tool_registry and self._notes_svc:
-                from dragon_voice.tools.note_tool import NoteTool
-                self._tool_registry.register(NoteTool(self._notes_svc))
-                logger.info("Note tool registered (notes service available)")
-        except Exception as e:
-            logger.warning("Notes API not available: %s", e)
-
-        # MCP servers (from config)
-        try:
-            from dragon_voice.mcp.bridge import bridge_mcp_server
-            mcp_servers = getattr(self._config, 'mcp_servers', [])
-            for mcp in mcp_servers:
-                count = await bridge_mcp_server(
-                    self._tool_registry,
-                    name=mcp.get('name', 'mcp'),
-                    url=mcp.get('url'),
-                    token=mcp.get('token'),
-                )
-                logger.info("MCP %s: %d tools bridged", mcp.get('name'), count)
-        except Exception as e:
-            logger.warning("MCP bridge not available: %s", e)
-
-        # Run initial message purge and schedule periodic purge (US-DQ14)
-        retention_days = self._config.database.message_retention_days
-        if retention_days > 0:
-            try:
-                result = await self._db.purge_old_messages(days=retention_days)
-                logger.info(
-                    "Startup purge complete: %d messages, %d events removed (retention=%d days)",
-                    result["messages"], result["events"], retention_days,
-                )
-            except Exception as e:
-                logger.warning("Startup purge failed: %s", e)
-
-            self._purge_task = asyncio.create_task(
-                self._periodic_purge(retention_days)
-            )
-
-        # Media cleanup (hourly, removes expired uploads)
-        self._media_cleanup_task = asyncio.create_task(self._media_cleanup_loop())
-
-        # Start periodic memory monitor (A04)
-        self._memory_monitor_task = asyncio.create_task(self._memory_monitor())
-        rss = self._get_rss_mb()
-        logger.info("Memory monitor started (RSS=%.0f MB, warn=%d MB, crit=%d MB)",
-                     rss, self._mem_warn_mb, self._mem_crit_mb)
-
-        logger.info("Foundation modules initialized")
+        await _lc_startup.run_startup(self, app)
 
     async def _periodic_purge(self, days: int) -> None:
-        """Run message/event purge every 24 hours."""
-        while True:
-            await asyncio.sleep(86400)  # 24 hours
-            if self._db is None:
-                break
-            try:
-                result = await self._db.purge_old_messages(days=days)
-                logger.info(
-                    "Periodic purge: %d messages, %d events removed",
-                    result["messages"], result["events"],
-                )
-            except Exception as e:
-                logger.warning("Periodic purge failed: %s", e)
+        await _lc_purge.periodic_purge_loop(self, days)
 
     async def _media_cleanup_loop(self):
-        """Remove expired media uploads every hour."""
-        while True:
-            await asyncio.sleep(3600)
-            try:
-                await self._media_store.cleanup()
-            except Exception as e:
-                logger.warning("Media cleanup error: %s", e)
+        await _lc_purge.media_cleanup_loop(self)
 
     @staticmethod
     def _get_rss_mb() -> float:
-        """Read current process RSS from /proc/self/status (no psutil dependency)."""
-        try:
-            with open("/proc/self/status") as f:
-                for line in f:
-                    if line.startswith("VmRSS"):
-                        return int(line.split()[1]) / 1024.0  # kB -> MB
-        except Exception:
-            pass
-        return 0.0
+        return _lc_monitors.get_rss_mb()
 
     @staticmethod
     def _get_cpu_temp() -> float:
-        """Read CPU temperature from thermal zone sysfs (DQ03).
-
-        Tries thermal_zone0 first (common on QCS6490), then scans all
-        thermal zones for the highest reading.  Returns 0.0 on failure.
-        """
-        # Try thermal_zone0 first (fastest path)
-        try:
-            with open('/sys/class/thermal/thermal_zone0/temp') as f:
-                temp_mc = int(f.read().strip())
-                return temp_mc / 1000.0
-        except Exception:
-            pass
-
-        # Fallback: scan all thermal zones, return the highest
-        import glob
-        max_temp = 0.0
-        for path in glob.glob('/sys/devices/virtual/thermal/thermal_zone*/temp'):
-            try:
-                with open(path) as f:
-                    temp_mc = int(f.read().strip())
-                    t = temp_mc / 1000.0
-                    if t > max_temp:
-                        max_temp = t
-            except Exception:
-                continue
-        return max_temp
+        return _lc_monitors.get_cpu_temp()
 
     async def _memory_monitor(self) -> None:
-        """Periodic memory check every 5 minutes (A04).
-
-        - Log RSS and CPU temperature at INFO level
-        - If RSS > warn threshold: force gc.collect() and log WARNING
-        - If RSS > critical threshold after GC: gracefully restart all pipelines
-        - DQ03: Log CPU temperature warnings at 80°C and errors at 90°C
-        """
-        while True:
-            await asyncio.sleep(300)  # 5 minutes
-            rss = self._get_rss_mb()
-            if rss <= 0:
-                continue
-
-            active = len(self._active_connections)
-
-            # CPU temperature monitoring (DQ03): detect thermal throttling
-            temp_c = self._get_cpu_temp()
-
-            # FD count monitoring (DQ08): detect file descriptor exhaustion
-            try:
-                fd_count = len(os.listdir(f'/proc/{os.getpid()}/fd'))
-                fd_limit = resource.getrlimit(resource.RLIMIT_NOFILE)[0]
-                fd_pct = (fd_count / fd_limit * 100) if fd_limit > 0 else 0
-            except Exception:
-                fd_count = fd_limit = 0
-                fd_pct = 0.0
-
-            logger.info(
-                "Memory monitor: RSS=%.0f MB, temp=%.1f°C, connections=%d, FDs=%d/%d (%.0f%%)",
-                rss, temp_c, active, fd_count, fd_limit, fd_pct,
-            )
-
-            # DQ03: Thermal warnings — monitoring only, no throttling
-            if temp_c >= 90:
-                logger.error(
-                    "Memory monitor: CPU temp %.1f°C exceeds 90°C — "
-                    "risk of eMMC degradation and component damage!",
-                    temp_c,
-                )
-            elif temp_c >= 80:
-                logger.warning(
-                    "Memory monitor: CPU temp %.1f°C exceeds 80°C — "
-                    "Gold cores likely throttled from 2.7GHz",
-                    temp_c,
-                )
-
-            if fd_pct >= 80:
-                logger.warning(
-                    "Memory monitor: FD usage at %.0f%% (%d/%d) — risk of exhaustion!",
-                    fd_pct, fd_count, fd_limit,
-                )
-
-            if rss > self._mem_warn_mb:
-                logger.warning(
-                    "Memory monitor: RSS %.0f MB exceeds warning threshold (%d MB) — forcing GC",
-                    rss, self._mem_warn_mb,
-                )
-                collected = gc.collect()
-                rss_after = self._get_rss_mb()
-                logger.warning(
-                    "Memory monitor: GC collected %d objects, RSS now %.0f MB",
-                    collected, rss_after,
-                )
-
-                if rss_after > self._mem_crit_mb:
-                    logger.error(
-                        "Memory monitor: RSS %.0f MB exceeds critical threshold (%d MB) "
-                        "after GC — restarting all pipelines",
-                        rss_after, self._mem_crit_mb,
-                    )
-                    # Gracefully restart every active pipeline
-                    for ws_id, conn in list(self._active_connections.items()):
-                        pipeline = conn.get("pipeline")
-                        if pipeline:
-                            try:
-                                await pipeline.shutdown()
-                                conn["pipeline"] = None
-                                logger.info("Memory monitor: shut down pipeline for %s", ws_id)
-                            except Exception as e:
-                                logger.warning("Memory monitor: pipeline shutdown failed for %s: %s", ws_id, e)
-
-                    # Force another GC after pipeline shutdown
-                    gc.collect()
-                    rss_final = self._get_rss_mb()
-                    logger.warning("Memory monitor: post-restart RSS %.0f MB", rss_final)
-
-                    # Re-initialize pipelines for registered connections
-                    for ws_id, conn in list(self._active_connections.items()):
-                        if conn.get("registered") and conn.get("pipeline") is None:
-                            cfg = conn.get("config", self._config)
-                            try:
-                                pipeline = VoicePipeline(
-                                    cfg,
-                                    conn.get("_on_audio"),
-                                    conn.get("_on_event"),
-                                    conversation_engine=self._conversation,
-                                    session_id=conn.get("session_id", ""),
-                                    media_pipeline=self._media_pipeline,
-                                    backend_pool=self._backend_pool,
-                                )
-                                await pipeline.initialize()
-                                conn["pipeline"] = pipeline
-                                logger.info("Memory monitor: re-initialized pipeline for %s", ws_id)
-                            except Exception as e:
-                                logger.error("Memory monitor: pipeline re-init failed for %s: %s", ws_id, e)
+        await _lc_monitors.memory_monitor_loop(self)
 
     async def _on_shutdown(self, app: web.Application) -> None:
-        """Clean up all active sessions and foundation modules on server shutdown."""
-        logger.info("Server shutting down — closing %d connections", len(self._active_connections))
-
-        # Cancel periodic tasks
-        if self._memory_monitor_task and not self._memory_monitor_task.done():
-            self._memory_monitor_task.cancel()
-            # Wave 14 W14-M09 pattern: await so we don't leak the task
-            # across loop shutdown (produces the same "Task was
-            # destroyed but it is pending" warning wave-13 H3 fixed).
-            try:
-                await self._memory_monitor_task
-            except (asyncio.CancelledError, Exception):
-                pass
-        if self._purge_task and not self._purge_task.done():
-            self._purge_task.cancel()
-            # Wave 14 W14-M09: _periodic_purge sleeps 86400 s in one
-            # shot; cancel-without-await left it attached long enough
-            # for aiohttp to close the loop first, producing
-            # "RuntimeError: Event loop is closed" at systemctl restart.
-            try:
-                await self._purge_task
-            except (asyncio.CancelledError, Exception):
-                pass
-        # Wave 13 H3: the media cleanup loop was being left running on shutdown
-        # because it isn't touched here. If it was mid-sleep when the event loop
-        # closes, asyncio logs "Task was destroyed but it is pending" warnings
-        # and the 24h TTL cleaner can orphan partial deletes. Cancel + await.
-        if self._media_cleanup_task and not self._media_cleanup_task.done():
-            self._media_cleanup_task.cancel()
-            try:
-                await self._media_cleanup_task
-            except (asyncio.CancelledError, Exception):
-                pass
-
-        # Shut down pipelines
-        tasks = []
-        for _ws_id, conn in list(self._active_connections.items()):
-            pipeline = conn.get("pipeline")
-            if pipeline:
-                tasks.append(pipeline.shutdown())
-        if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
-        self._active_connections.clear()
-
-        # Wave 15 W15-C01: now that no pipelines are holding references,
-        # shut down the shared backend pool.  Per-pipeline shutdowns
-        # above are no-ops for pooled backends (_pooled_* flag), so the
-        # pool is the single owner responsible for final teardown.
-        pool_tasks = []
-        for key, backend in list(self._backend_pool.items()):
-            logger.info("W15-C01: releasing pooled backend %s", key)
-            try:
-                pool_tasks.append(backend.shutdown())
-            except (AttributeError, RuntimeError) as e:
-                logger.warning("W15-C01: pool backend %s shutdown raised: %s", key, e)
-        if pool_tasks:
-            await asyncio.gather(*pool_tasks, return_exceptions=True)
-        self._backend_pool.clear()
-
-        # v4·D audit P0 fix: release the inference ThreadPoolExecutor so
-        # uvloop can exit cleanly.  Previously zombie threads lingered.
-        try:
-            from dragon_voice.pipeline import shutdown_inference_executor
-            shutdown_inference_executor(wait=False)
-            logger.info("Inference executor shut down")
-        except Exception:
-            logger.debug("inference executor shutdown failed", exc_info=True)
-
-        # Close shared proxy session (DQ08)
-        if self._proxy_session and not self._proxy_session.closed:
-            await self._proxy_session.close()
-
-        # Shut down foundation
-        if self._notes_svc:
-            await self._notes_svc.shutdown()
-        if self._media_pipeline:
-            # Wave 14 W14-H12: close the MediaPipeline's shared aiohttp
-            # ClientSession.  Prior behaviour left it dangling across
-            # systemctl restart, logging "Unclosed client session" and
-            # making the wave-13 FD counter noisy.
-            try:
-                await self._media_pipeline.close()
-            except Exception:
-                logger.debug("MediaPipeline shutdown failed", exc_info=True)
-        if self._memory_service:
-            logger.info("Shutting down memory service")
-            # Wave 14 W14-H11: close the shared Ollama HTTP session.
-            try:
-                await self._memory_service.shutdown()
-            except Exception:
-                logger.debug("MemoryService shutdown raised", exc_info=True)
-            self._memory_service = None
-        if self._conversation:
-            await self._conversation.shutdown()
-        if self._session_mgr:
-            await self._session_mgr.stop()
-        if self._db:
-            await self._db.close()
-
-        logger.info("Shutdown complete")
+        await _lc_shutdown.run_shutdown(self, app)
 
     # ------------------------------------------------------------------ HTTP
 

--- a/tests/test_lifecycle_monitors.py
+++ b/tests/test_lifecycle_monitors.py
@@ -1,0 +1,120 @@
+"""Smoke tests for ``dragon_voice/lifecycle/monitors.py``.
+
+Coverage:
+ - ``get_rss_mb`` returns a non-negative float (on Linux it should
+   produce a real reading; on systems where ``/proc/self/status`` is
+   unreadable it returns 0.0).
+ - ``get_cpu_temp`` returns a non-negative float (same no-crash
+   contract — 0.0 when no thermal zone is readable).
+ - ``memory_monitor_loop`` logs + respects the warn / crit thresholds.
+   We run a single iteration with patched ``asyncio.sleep`` so we
+   don't wait 5 min.
+
+Run:
+    python3 -m pytest -v tests/test_lifecycle_monitors.py
+"""
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from dragon_voice.lifecycle import monitors
+
+
+class HelperFunctionTests(unittest.TestCase):
+    def test_get_rss_mb_returns_non_negative_float(self):
+        rss = monitors.get_rss_mb()
+        self.assertIsInstance(rss, float)
+        self.assertGreaterEqual(rss, 0.0)
+
+    def test_get_cpu_temp_returns_non_negative_float(self):
+        # Dragon Q6A reports a reading; CI runners typically do too.
+        # Either way, the contract is "non-negative float, no crash".
+        temp = monitors.get_cpu_temp()
+        self.assertIsInstance(temp, float)
+        self.assertGreaterEqual(temp, 0.0)
+
+    def test_get_rss_mb_survives_missing_proc(self):
+        # When /proc/self/status is unavailable, returns 0.0 (not
+        # raises).  Exercise the except branch.
+        with patch("builtins.open", side_effect=OSError("no /proc")):
+            self.assertEqual(monitors.get_rss_mb(), 0.0)
+
+
+class MemoryMonitorLoopTests(unittest.TestCase):
+    """Single-iteration tests for the 5-min loop.
+
+    We patch ``asyncio.sleep`` to raise after one tick so the loop
+    exits cleanly without waiting 300 s.  Thresholds are driven by
+    patched ``get_rss_mb`` / ``get_cpu_temp`` + a tiny stub ``server``.
+    """
+
+    def _make_server(self, warn=2048, crit=3072):
+        s = MagicMock()
+        s._mem_warn_mb = warn
+        s._mem_crit_mb = crit
+        s._active_connections = {}
+        s._config = MagicMock()
+        s._conversation = MagicMock()
+        s._media_pipeline = MagicMock()
+        s._backend_pool = {}
+        return s
+
+    def _fake_sleep_pass_once(self):
+        """Return an ``asyncio.sleep`` stub that passes once, then raises CancelledError.
+
+        This lets the first loop iteration run its body in full, then
+        exits cleanly when the loop comes around to the next sleep.
+        """
+        call_count = {"n": 0}
+
+        async def fake_sleep(_):
+            call_count["n"] += 1
+            if call_count["n"] >= 2:
+                raise asyncio.CancelledError()
+            # first call returns normally — loop body runs once.
+
+        return fake_sleep, call_count
+
+    def test_loop_runs_one_iteration_below_warn(self):
+        """Below-warn path: one iteration runs, no GC, loop exits on the 2nd sleep."""
+        server = self._make_server()
+        fake_sleep, call_count = self._fake_sleep_pass_once()
+
+        async def go():
+            with patch.object(monitors.asyncio, "sleep", AsyncMock(side_effect=fake_sleep)), \
+                 patch.object(monitors, "get_rss_mb", return_value=1024.0), \
+                 patch.object(monitors, "get_cpu_temp", return_value=50.0), \
+                 patch.object(monitors.gc, "collect") as mock_gc:
+                with self.assertRaises(asyncio.CancelledError):
+                    await monitors.memory_monitor_loop(server)
+                mock_gc.assert_not_called()
+
+        asyncio.run(go())
+        # Two sleeps: one at the start of iteration 1 (which passed),
+        # one at the start of iteration 2 (which cancelled).
+        self.assertEqual(call_count["n"], 2)
+
+    def test_loop_forces_gc_when_rss_over_warn(self):
+        """Above-warn, below-crit path: GC is called, no pipeline drain."""
+        server = self._make_server(warn=1000, crit=10000)
+        fake_sleep, _ = self._fake_sleep_pass_once()
+        # First RSS read is above warn; second (post-GC) is still high
+        # but below crit, so no pipeline drain runs.
+        rss_values = iter([2000.0, 1500.0])
+
+        async def go():
+            with patch.object(monitors.asyncio, "sleep", AsyncMock(side_effect=fake_sleep)), \
+                 patch.object(monitors, "get_rss_mb", side_effect=lambda: next(rss_values, 1500.0)), \
+                 patch.object(monitors, "get_cpu_temp", return_value=50.0), \
+                 patch.object(monitors.gc, "collect", return_value=42) as mock_gc:
+                with self.assertRaises(asyncio.CancelledError):
+                    await monitors.memory_monitor_loop(server)
+                mock_gc.assert_called_once()
+
+        asyncio.run(go())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Third of four PRs that decompose \`dragon_voice/server.py\`. **Highest-risk extraction** — boot + shutdown are ordering-sensitive and touch ~20 instance attributes. Moved with minimal structural change per the "extract before decompose" Workflow rule.

Closes step 3 of umbrella #65.

## What moved

| Was on \`VoiceServer\` | Now | Deps |
|---|---|---|
| \`_on_startup\` (~200 LOC) | \`lifecycle/startup.py → run_startup(server, app)\` | \`server\` (writes ~20 attrs) |
| \`_on_shutdown\` (~100 LOC) | \`lifecycle/shutdown.py → run_shutdown(server, app)\` | \`server\` (reads + tears down ~20 attrs) |
| \`_periodic_purge\` | \`lifecycle/purge.py → periodic_purge_loop(server, days)\` | \`server._db\` |
| \`_media_cleanup_loop\` | \`lifecycle/purge.py → media_cleanup_loop(server)\` | \`server._media_store\` |
| \`_get_rss_mb\` (static) | \`lifecycle/monitors.py → get_rss_mb()\` | none — pure sysfs |
| \`_get_cpu_temp\` (static) | \`lifecycle/monitors.py → get_cpu_temp()\` | none — pure sysfs |
| \`_memory_monitor\` | \`lifecycle/monitors.py → memory_monitor_loop(server)\` | \`server\` (reads warn/crit thresholds, active connections, drains pipelines on crit) |

Startup/shutdown take \`server\` as a single handle because their coupling is wide (~20 attrs on each side). A 20-arg signature would be worse. Monitors + purge take \`server\` only where they need it; the two helpers (\`get_rss_mb\`, \`get_cpu_temp\`) take no args — pure sysfs reads.

\`server.py\` now has 7 thin adapter methods (one per extracted function) so aiohttp \`on_startup\`/\`on_shutdown\` signatures + external call sites are unchanged.

## Now-unused imports removed from \`server.py\`

- \`setup_all_routes\` → moved to \`startup.py\`
- \`gc\` → only used in \`memory_monitor\`
- \`resource\` → only used in \`memory_monitor\`

## New tests (in CI)

\`tests/test_lifecycle_monitors.py\` — **5 tests, 100% pass**:

- \`get_rss_mb\` returns non-negative float
- \`get_cpu_temp\` returns non-negative float
- \`get_rss_mb\` survives unreadable \`/proc\` (no crash)
- \`memory_monitor_loop\`: below-warn path, one iteration runs, no GC, loop exits on 2nd sleep cancel
- \`memory_monitor_loop\`: above-warn/below-crit path, GC fires once, no pipeline drain

Uses a two-tick \`asyncio.sleep\` stub so the body of the loop actually runs (the first failed version of this test only exercised the sleep — caught it locally, fixed before commit).

Added to \`.github/workflows/ci.yml\` named test set per the Workflow rule.

## LOC impact

- \`dragon_voice/server.py\`: 2370 → **1931** (**−439** this step)
- **Cumulative from original 2747: −816 (30% drop)**
- \`dragon_voice/lifecycle/\`: +619 LOC (logic + docstrings)
- \`tests/test_lifecycle_monitors.py\`: +120 LOC
- \`ci.yml\`: +1 LOC

## Test plan

All run with \`DRAGON_API_TOKEN=ci-bearer-token\` + \`TINKERCLAW_TOKEN=ci-tc-token\`:

- [x] \`ruff --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006\` on \`dragon_voice/\` + \`tests/test_lifecycle_monitors.py\` → **All checks passed**
- [x] \`tests/test_lifecycle_monitors.py\` — **5/5 pass** (new)
- [x] Full CI-named unit-test set incl. new file → **109/109 pass**
- [x] \`from dragon_voice import server; from dragon_voice.lifecycle import monitors, purge, startup, shutdown\` — clean import

## Explicit non-goals

- **Not restructuring the startup sequence.** Identical order, identical try/except boundaries, identical log messages.
- **Not restructuring shutdown.** \`W14-M09\` cancel+await pattern preserved, \`W14-H12\` media pipeline close preserved, \`W14-H11\` memory service close preserved, v4·D inference executor shutdown preserved.
- **Not adding a \`StartupContext\` / \`ShutdownContext\` dataclass.** One callsite per lifecycle hook — the \`server\` handle is simpler.
- **Not writing an end-to-end startup integration test.** Real startup needs a real DB, memory backend, etc. — those already live in \`tests/test_api_e2e.py\` and \`tests/test_e2e_dragon.py\` (local-only, not CI).

## References

- Umbrella: #65
- Workflow rules: [CLAUDE.md](CLAUDE.md#workflow) (updated in #64)
- Steps 1-2: #66 (merged), #67 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)