### PR TITLE
refactor(server): extract status + config_api handlers (step 4 of #65, closes #65)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,6 @@ jobs:
             tests/test_proxy_image_ssrf.py \
             tests/test_security_headers.py \
             tests/test_debug_handlers.py \
-            tests/test_lifecycle_monitors.py
+            tests/test_lifecycle_monitors.py \
+            tests/test_status_handlers.py \
+            tests/test_config_api_handlers.py

--- a/dragon_voice/handlers/__init__.py
+++ b/dragon_voice/handlers/__init__.py
@@ -7,6 +7,6 @@ callables — the URL routing + bearer-auth middleware wiring stays in
 ``server.create_app``.
 """
 
-from dragon_voice.handlers import debug
+from dragon_voice.handlers import config_api, debug, status
 
-__all__ = ["debug"]
+__all__ = ["config_api", "debug", "status"]

--- a/dragon_voice/handlers/config_api.py
+++ b/dragon_voice/handlers/config_api.py
@@ -1,0 +1,118 @@
+"""Config get/set HTTP handlers.
+
+* :func:`handle_get_config` — ``GET /config`` — dumps the current
+  :class:`VoiceConfig` with secrets redacted (via
+  :func:`dragon_voice.config.config_to_dict`).
+* :func:`handle_set_config` — ``POST /config`` — hot-reloads the
+  config file, applies a partial override from the request body,
+  validates, then swaps backends on every active voice pipeline.
+
+Backend swaps acquire each connection's ``conn_lock`` first (A06) to
+prevent races with a concurrent WS ``config_update`` from the same
+device.  Two concurrent ``swap_backends`` calls would interleave
+shutdown/init of the same backend instance, producing use-after-free
+errors on the shared Ollama / OpenRouter session objects.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from aiohttp import web
+
+from dragon_voice.config import config_to_dict, load_config
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_get_config(request: web.Request, *, server: Any) -> web.Response:
+    """``GET /config`` — redacted config dump."""
+    return web.json_response(config_to_dict(server._config, redact_secrets=True))
+
+
+async def handle_set_config(request: web.Request, *, server: Any) -> web.Response:
+    """``POST /config`` — partial hot-reload + backend swap on pipelines.
+
+    Request body: JSON with ``stt``/``tts``/``llm``/``audio`` sections.
+    Each section is a partial dict — only listed fields are overridden.
+    The reload starts from the on-disk config (so a missing field in
+    the body reverts to its file value, not its previous in-memory
+    value).
+    """
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    logger.info("Config update requested: %s", list(body.keys()))
+
+    try:
+        # Reload full config from file first, then apply overrides.
+        new_config = load_config()
+
+        for section in ("stt", "tts", "llm", "audio"):
+            overrides = body.get(section)
+            if not overrides:
+                continue
+            target = getattr(new_config, section, None)
+            if target is None:
+                continue
+            for k, v in overrides.items():
+                if hasattr(target, k):
+                    setattr(target, k, v)
+
+        # Validate before applying.
+        validation_errors = new_config.validate()
+        if validation_errors:
+            return web.json_response(
+                {"error": "Config validation failed", "details": validation_errors},
+                status=400,
+            )
+
+        server._config = new_config
+
+        # Update displayed backend names for /status + /health.
+        server._stt_name = new_config.stt.backend
+        server._tts_name = new_config.tts.backend
+        server._llm_name = new_config.llm.backend
+
+        # A06: Swap backends on all active pipelines.  Acquire each
+        # connection's conn_lock first to prevent races with a
+        # concurrent WS config_update on the same connection — two
+        # swap_backends() calls would interleave shutdown/init of the
+        # backend, causing use-after-free errors.
+        swap_errors = []
+        for ws_id, conn in list(server._active_connections.items()):
+            pipeline = conn.get("pipeline")
+            if pipeline:
+                lock = conn.get("conn_lock")
+                logger.info("Swapping backends for connection %s", ws_id)
+                try:
+                    if lock:
+                        async with lock:
+                            await pipeline.swap_backends(new_config)
+                    else:
+                        await pipeline.swap_backends(new_config)
+                except Exception as e:
+                    logger.warning("Backend swap failed for %s: %s", ws_id, e)
+                    swap_errors.append(str(e))
+
+        pipelines_with_swap = sum(
+            1 for c in server._active_connections.values() if c.get("pipeline")
+        )
+        return web.json_response(
+            {
+                "status": "ok",
+                "message": f"Config updated, {pipelines_with_swap} pipelines reloaded",
+                "backends": {
+                    "stt": new_config.stt.backend,
+                    "tts": new_config.tts.backend,
+                    "llm": new_config.llm.backend,
+                },
+            }
+        )
+
+    except Exception as e:
+        logger.exception("Config update failed")
+        return web.json_response({"error": str(e)}, status=500)

--- a/dragon_voice/handlers/status.py
+++ b/dragon_voice/handlers/status.py
@@ -1,0 +1,74 @@
+"""Status + health HTTP handlers.
+
+* :func:`handle_status` — ``GET /status`` — small HTML page showing
+  backend names, uptime, active connections, session count.  Intended
+  for a quick human-readable peek; the real operator UI is the
+  dashboard at port 3500.
+* :func:`handle_health` — ``GET /health`` — JSON liveness probe.
+  Public (no bearer required; see the auth middleware allowlist in
+  ``dragon_voice/middleware/auth.py``).
+
+Both take ``server`` as a single handle — the values they read
+(uptime baseline, backend names, active-connection count, session
+count) are cheap attribute reads and live on the same instance.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from aiohttp import web
+
+
+async def handle_status(request: web.Request, *, server: Any) -> web.Response:
+    """``GET /status`` — small HTML status page."""
+    uptime = time.time() - server._start_time
+    hours = int(uptime // 3600)
+    minutes = int((uptime % 3600) // 60)
+    seconds = int(uptime % 60)
+
+    html = f"""<!DOCTYPE html>
+<html>
+<head><title>Dragon Voice Server</title>
+<style>
+  body {{ font-family: monospace; background: #1a1a2e; color: #e0e0e0; padding: 2em; }}
+  h1 {{ color: #ff6b35; }}
+  .info {{ background: #16213e; padding: 1em; border-radius: 8px; margin: 1em 0; }}
+  .label {{ color: #0f3460; font-weight: bold; }}
+  span.val {{ color: #53d769; }}
+</style>
+</head>
+<body>
+  <h1>Dragon Voice Server</h1>
+  <div class="info">
+    <p>STT Backend: <span class="val">{server._stt_name}</span></p>
+    <p>TTS Backend: <span class="val">{server._tts_name}</span></p>
+    <p>LLM Backend: <span class="val">{server._llm_name}</span></p>
+    <p>Uptime: <span class="val">{hours}h {minutes}m {seconds}s</span></p>
+    <p>Active Connections: <span class="val">{len(server._active_connections)}</span></p>
+    <p>Total Sessions: <span class="val">{server._session_count}</span></p>
+  </div>
+</body>
+</html>"""
+    return web.Response(text=html, content_type="text/html")
+
+
+async def handle_health(request: web.Request, *, server: Any) -> web.Response:
+    """``GET /health`` — JSON liveness probe.
+
+    Public endpoint; used by ops + ngrok healthcheck + the
+    dashboard's status tile.  Returns uptime in seconds, active
+    connection count, and the three backend names.
+    """
+    return web.json_response(
+        {
+            "status": "ok",
+            "uptime_seconds": round(time.time() - server._start_time, 1),
+            "active_connections": len(server._active_connections),
+            "backends": {
+                "stt": server._stt_name,
+                "tts": server._tts_name,
+                "llm": server._llm_name,
+            },
+        }
+    )

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -22,14 +22,18 @@ from aiohttp import web, WSMsgType
 from dragon_voice.media.store import MediaStore
 from dragon_voice.media.pipeline import MediaPipeline
 from dragon_voice.config import (
-    VoiceConfig, config_to_dict, load_config,
+    VoiceConfig,
     SYSTEM_PROMPT_LOCAL, SYSTEM_PROMPT_HYBRID, SYSTEM_PROMPT_CLOUD,
     MAX_TOKENS_LOCAL, MAX_TOKENS_HYBRID, MAX_TOKENS_CLOUD,
 )
 from dragon_voice.conversation import ConversationEngine
 from dragon_voice.db import Database
 from dragon_voice.messages import MessageStore
-from dragon_voice.handlers import debug as _handlers_debug
+from dragon_voice.handlers import (
+    config_api as _handlers_config_api,
+    debug as _handlers_debug,
+    status as _handlers_status,
+)
 from dragon_voice.lifecycle import (
     monitors as _lc_monitors,
     purge as _lc_purge,
@@ -266,52 +270,13 @@ class VoiceServer:
 
     # ------------------------------------------------------------------ HTTP
 
-    async def _handle_status(self, request: web.Request) -> web.Response:
-        """Status page with backend info and uptime."""
-        uptime = time.time() - self._start_time
-        hours = int(uptime // 3600)
-        minutes = int((uptime % 3600) // 60)
-        seconds = int(uptime % 60)
+    # Status + health — thin adapters over dragon_voice/handlers/status.py.
 
-        html = f"""<!DOCTYPE html>
-<html>
-<head><title>Dragon Voice Server</title>
-<style>
-  body {{ font-family: monospace; background: #1a1a2e; color: #e0e0e0; padding: 2em; }}
-  h1 {{ color: #ff6b35; }}
-  .info {{ background: #16213e; padding: 1em; border-radius: 8px; margin: 1em 0; }}
-  .label {{ color: #0f3460; font-weight: bold; }}
-  span.val {{ color: #53d769; }}
-</style>
-</head>
-<body>
-  <h1>Dragon Voice Server</h1>
-  <div class="info">
-    <p>STT Backend: <span class="val">{self._stt_name}</span></p>
-    <p>TTS Backend: <span class="val">{self._tts_name}</span></p>
-    <p>LLM Backend: <span class="val">{self._llm_name}</span></p>
-    <p>Uptime: <span class="val">{hours}h {minutes}m {seconds}s</span></p>
-    <p>Active Connections: <span class="val">{len(self._active_connections)}</span></p>
-    <p>Total Sessions: <span class="val">{self._session_count}</span></p>
-  </div>
-</body>
-</html>"""
-        return web.Response(text=html, content_type="text/html")
+    async def _handle_status(self, request: web.Request) -> web.Response:
+        return await _handlers_status.handle_status(request, server=self)
 
     async def _handle_health(self, request: web.Request) -> web.Response:
-        """Health check endpoint returning JSON."""
-        return web.json_response(
-            {
-                "status": "ok",
-                "uptime_seconds": round(time.time() - self._start_time, 1),
-                "active_connections": len(self._active_connections),
-                "backends": {
-                    "stt": self._stt_name,
-                    "tts": self._tts_name,
-                    "llm": self._llm_name,
-                },
-            }
-        )
+        return await _handlers_status.handle_health(request, server=self)
 
     # Debug / diagnostic handlers — thin adapters over the functions in
     # ``dragon_voice/handlers/debug.py``.  The URL routing + bearer-auth
@@ -344,106 +309,13 @@ class VoiceServer:
 
 
 
+    # Config get/set — thin adapters over dragon_voice/handlers/config_api.py.
+
     async def _handle_get_config(self, request: web.Request) -> web.Response:
-        """Return current config with secrets redacted."""
-        return web.json_response(
-            config_to_dict(self._config, redact_secrets=True)
-        )
+        return await _handlers_config_api.handle_get_config(request, server=self)
 
     async def _handle_set_config(self, request: web.Request) -> web.Response:
-        """Hot-reload configuration.
-
-        Accepts a partial config JSON — only provided sections are updated.
-        Swaps backends on active sessions if needed.
-        """
-        try:
-            body = await request.json()
-        except json.JSONDecodeError:
-            return web.json_response(
-                {"error": "Invalid JSON"}, status=400
-            )
-
-        logger.info("Config update requested: %s", list(body.keys()))
-
-        try:
-            # Reload full config from file first, then apply overrides
-            new_config = load_config()
-
-            # Apply overrides from the request body
-            if "stt" in body:
-                for k, v in body["stt"].items():
-                    if hasattr(new_config.stt, k):
-                        setattr(new_config.stt, k, v)
-            if "tts" in body:
-                for k, v in body["tts"].items():
-                    if hasattr(new_config.tts, k):
-                        setattr(new_config.tts, k, v)
-            if "llm" in body:
-                for k, v in body["llm"].items():
-                    if hasattr(new_config.llm, k):
-                        setattr(new_config.llm, k, v)
-            if "audio" in body:
-                for k, v in body["audio"].items():
-                    if hasattr(new_config.audio, k):
-                        setattr(new_config.audio, k, v)
-
-            # Validate before applying
-            validation_errors = new_config.validate()
-            if validation_errors:
-                return web.json_response(
-                    {"error": "Config validation failed", "details": validation_errors},
-                    status=400,
-                )
-
-            old_config = self._config
-            self._config = new_config
-
-            # Update displayed backend names
-            self._stt_name = new_config.stt.backend
-            self._tts_name = new_config.tts.backend
-            self._llm_name = new_config.llm.backend
-
-            # Swap backends on all active pipelines.
-            # A06: Acquire each connection's conn_lock before swapping to
-            # prevent races with WS config_update on the same connection.
-            # Two concurrent swap_backends() calls would interleave
-            # shutdown/init of backends, causing use-after-free errors.
-            swap_errors = []
-            for ws_id, conn in list(self._active_connections.items()):
-                pipeline = conn.get("pipeline")
-                if pipeline:
-                    lock = conn.get("conn_lock")
-                    logger.info("Swapping backends for connection %s", ws_id)
-                    try:
-                        if lock:
-                            async with lock:
-                                await pipeline.swap_backends(new_config)
-                        else:
-                            await pipeline.swap_backends(new_config)
-                    except Exception as e:
-                        logger.warning("Backend swap failed for %s: %s", ws_id, e)
-                        swap_errors.append(str(e))
-
-            pipelines_with_swap = sum(
-                1 for c in self._active_connections.values() if c.get("pipeline")
-            )
-            return web.json_response(
-                {
-                    "status": "ok",
-                    "message": f"Config updated, {pipelines_with_swap} pipelines reloaded",
-                    "backends": {
-                        "stt": new_config.stt.backend,
-                        "tts": new_config.tts.backend,
-                        "llm": new_config.llm.backend,
-                    },
-                }
-            )
-
-        except Exception as e:
-            logger.exception("Config update failed")
-            return web.json_response(
-                {"error": str(e)}, status=500
-            )
+        return await _handlers_config_api.handle_set_config(request, server=self)
 
     # --------------------------------------------------------------- WebSocket
 

--- a/tests/test_config_api_handlers.py
+++ b/tests/test_config_api_handlers.py
@@ -1,0 +1,142 @@
+"""Smoke tests for ``dragon_voice/handlers/config_api.py``.
+
+Covers the three branches of ``handle_set_config``:
+  - invalid JSON -> 400
+  - validation failure -> 400 with "details"
+  - happy path -> 200, backend names updated, pipelines swap_backends called
+
+``handle_get_config`` is a thin wrapper over ``config_to_dict`` and is
+covered indirectly by the existing ``test_config_redact.py`` which
+targets that helper.
+
+Run:
+    python3 -m pytest -v tests/test_config_api_handlers.py
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aiohttp import web
+
+from dragon_voice.handlers import config_api as cfg_mod
+
+
+class _ReqWithJson:
+    """Minimal stub for ``web.Request`` — just an async ``json()``.
+
+    Raising from ``json()`` simulates an invalid-JSON body.
+    """
+
+    def __init__(self, body=None, raise_exc: Exception | None = None):
+        self._body = body
+        self._raise = raise_exc
+
+    async def json(self):
+        if self._raise is not None:
+            raise self._raise
+        return self._body
+
+
+def _make_stub_backends(stt="stt_a", tts="tts_a", llm="llm_a"):
+    """Build the nested-attr shape ``load_config`` returns."""
+    cfg = MagicMock()
+    cfg.stt.backend = stt
+    cfg.tts.backend = tts
+    cfg.llm.backend = llm
+    cfg.validate.return_value = []
+    return cfg
+
+
+class SetConfigHandlerTests(unittest.TestCase):
+    def test_invalid_json_returns_400(self):
+        req = _ReqWithJson(raise_exc=json.JSONDecodeError("bad", "x", 0))
+        server = MagicMock()
+
+        async def go():
+            return await cfg_mod.handle_set_config(req, server=server)
+
+        resp: web.Response = asyncio.run(go())
+        self.assertEqual(resp.status, 400)
+        payload = json.loads(resp.body)
+        self.assertEqual(payload["error"], "Invalid JSON")
+
+    def test_validation_failure_returns_400_with_details(self):
+        cfg = _make_stub_backends()
+        cfg.validate.return_value = ["stt.backend unknown"]
+        server = MagicMock()
+        server._active_connections = {}
+
+        req = _ReqWithJson(body={"stt": {"backend": "nonsense"}})
+
+        async def go():
+            with patch.object(cfg_mod, "load_config", return_value=cfg):
+                return await cfg_mod.handle_set_config(req, server=server)
+
+        resp = asyncio.run(go())
+        self.assertEqual(resp.status, 400)
+        payload = json.loads(resp.body)
+        self.assertEqual(payload["error"], "Config validation failed")
+        self.assertEqual(payload["details"], ["stt.backend unknown"])
+        # Server config should NOT have been swapped in.
+        self.assertNotEqual(server._config, cfg)
+
+    def test_happy_path_swaps_pipeline_backends(self):
+        cfg = _make_stub_backends(stt="new_stt", tts="new_tts", llm="new_llm")
+        # Two connections, one with a pipeline (swap_backends expected),
+        # one without (skipped).
+        pipeline = MagicMock()
+        pipeline.swap_backends = AsyncMock()
+        server = MagicMock()
+        server._config = MagicMock()
+        server._active_connections = {
+            "ws_with_pipeline": {"pipeline": pipeline, "conn_lock": None},
+            "ws_without_pipeline": {"pipeline": None},
+        }
+
+        req = _ReqWithJson(body={"llm": {"backend": "new_llm"}})
+
+        async def go():
+            with patch.object(cfg_mod, "load_config", return_value=cfg):
+                return await cfg_mod.handle_set_config(req, server=server)
+
+        resp = asyncio.run(go())
+        self.assertEqual(resp.status, 200)
+        payload = json.loads(resp.body)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["backends"],
+                         {"stt": "new_stt", "tts": "new_tts", "llm": "new_llm"})
+
+        # Server state should now reflect new backend names.
+        self.assertEqual(server._stt_name, "new_stt")
+        self.assertEqual(server._tts_name, "new_tts")
+        self.assertEqual(server._llm_name, "new_llm")
+        self.assertIs(server._config, cfg)
+
+        # swap_backends called exactly once on the pipeline-holding conn.
+        pipeline.swap_backends.assert_awaited_once_with(cfg)
+
+
+class GetConfigHandlerTests(unittest.TestCase):
+    def test_returns_redacted_config(self):
+        server = MagicMock()
+        server._config = MagicMock()
+        req = MagicMock()
+
+        async def go():
+            with patch.object(cfg_mod, "config_to_dict",
+                              return_value={"stt": {"backend": "x"}}) as mock_dump:
+                resp = await cfg_mod.handle_get_config(req, server=server)
+                mock_dump.assert_called_once_with(server._config, redact_secrets=True)
+                return resp
+
+        resp: web.Response = asyncio.run(go())
+        self.assertEqual(resp.status, 200)
+        payload = json.loads(resp.body)
+        self.assertEqual(payload, {"stt": {"backend": "x"}})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_status_handlers.py
+++ b/tests/test_status_handlers.py
@@ -1,0 +1,83 @@
+"""Smoke tests for ``dragon_voice/handlers/status.py``.
+
+Exercises the thin wiring — ``/status`` returns an HTML page with the
+current backend names; ``/health`` returns JSON with a stable shape.
+
+Run:
+    python3 -m pytest -v tests/test_status_handlers.py
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import unittest
+from unittest.mock import MagicMock
+
+from aiohttp import web
+
+from dragon_voice.handlers import status as status_mod
+
+
+def _make_server(*, start_time=1000.0, stt="moonshine", tts="piper", llm="qwen",
+                 active=0, sessions=42) -> MagicMock:
+    s = MagicMock()
+    s._start_time = start_time
+    s._stt_name = stt
+    s._tts_name = tts
+    s._llm_name = llm
+    s._active_connections = {f"conn{i}": {} for i in range(active)}
+    s._session_count = sessions
+    return s
+
+
+class StatusHandlerTests(unittest.TestCase):
+    def test_status_returns_html_200(self):
+        server = _make_server(stt="moonshine", tts="piper", llm="qwen3:0.6b")
+        req = MagicMock()
+
+        async def go():
+            return await status_mod.handle_status(req, server=server)
+
+        resp: web.Response = asyncio.run(go())
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.content_type, "text/html")
+        body = resp.text
+        self.assertIn("moonshine", body)
+        self.assertIn("piper", body)
+        self.assertIn("qwen3:0.6b", body)
+
+    def test_status_shows_active_connection_count(self):
+        server = _make_server(active=3)
+        req = MagicMock()
+
+        async def go():
+            return await status_mod.handle_status(req, server=server)
+
+        resp = asyncio.run(go())
+        self.assertIn("Active Connections", resp.text)
+        # The count literal "3" should appear between the val span tags.
+        self.assertIn('class="val">3<', resp.text)
+
+
+class HealthHandlerTests(unittest.TestCase):
+    def test_health_returns_json_with_expected_shape(self):
+        server = _make_server(start_time=0.0, stt="stt_x", tts="tts_y", llm="llm_z", active=5)
+        req = MagicMock()
+
+        async def go():
+            return await status_mod.handle_health(req, server=server)
+
+        resp: web.Response = asyncio.run(go())
+        self.assertEqual(resp.status, 200)
+        payload = json.loads(resp.body)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["active_connections"], 5)
+        self.assertEqual(payload["backends"], {"stt": "stt_x", "tts": "tts_y", "llm": "llm_z"})
+        # uptime_seconds should be a non-negative number (we set
+        # start_time=0 so it's the epoch-relative time).
+        self.assertIsInstance(payload["uptime_seconds"], float)
+        self.assertGreater(payload["uptime_seconds"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fourth and **final** PR of the \`server.py\` decomposition plan. Moves the 4 small top-level handlers out of \`VoiceServer\` into dedicated modules, updates the CI named test set, and **closes umbrella #65**.

## What moved

| Was on \`VoiceServer\` | Now | Deps |
|---|---|---|
| \`_handle_status\` | \`handlers/status.py → handle_status\` | \`server\` |
| \`_handle_health\` | \`handlers/status.py → handle_health\` | \`server\` |
| \`_handle_get_config\` | \`handlers/config_api.py → handle_get_config\` | \`server\` |
| \`_handle_set_config\` | \`handlers/config_api.py → handle_set_config\` | \`server\` |

Both modules take \`server\` as a single handle — same pattern as \`handlers/debug.py\` and the lifecycle extractions. The \`config_api\` module owns the \`config_to_dict\` + \`load_config\` imports that used to live on \`server.py\`.

One small readability tidy inside \`handle_set_config\`: the original did 4 copy-pasted if-blocks, one per section (stt/tts/llm/audio). Replaced with a single loop over those section names. Behavior identical; 20 lines became 10.

## Imports dropped from server.py (now unused)

- \`config_to_dict\`, \`load_config\` — used only in the 2 config handlers, which now own them.

## New tests (in CI)

\`tests/test_status_handlers.py\` — **3 tests**:
- \`/status\` returns HTML 200 with all three backend names inlined
- \`/status\` shows the active-connection count
- \`/health\` returns JSON with the expected shape + non-zero uptime

\`tests/test_config_api_handlers.py\` — **4 tests**:
- \`set_config\`: invalid JSON body → 400
- \`set_config\`: validation failure → 400 with details, \`server._config\` **not** swapped in
- \`set_config\`: happy path → 200, server state updated, pipeline \`swap_backends()\` awaited once on the pipeline-holding connection, skipped on the one without
- \`get_config\`: delegates to \`config_to_dict(server._config, redact_secrets=True)\` and returns the result

Both added to \`.github/workflows/ci.yml\`.

## LOC impact

- \`dragon_voice/server.py\`: 1931 → **1803** (−128 this step)
- **Cumulative from original 2747: −944 (34% drop)**

## Final umbrella #65 state

\`\`\`
dragon_voice/
├── server.py      — 1803 LOC (down from 2747)
├── middleware/    — cors / security_headers / auth / rate_limit
├── handlers/      — debug / status / config_api
└── lifecycle/     — startup / shutdown / monitors / purge
\`\`\`

What stays in \`server.py\` after #65 closes: \`VoiceServer\` class definition + \`__init__\`, the adapter methods (one per extracted function), \`create_app()\` wiring, and the big WS voice handler family (\`_handle_ws_voice\` + \`_handle_register\` + \`_handle_text\` + \`_handle_user_media\` + \`_handle_disconnect\` + \`_safe_send_*\` helpers — ~1,370 LOC).

Decomposing the WS handler is a separate future initiative, explicitly non-goals of #65.

## Test plan

All run with \`DRAGON_API_TOKEN=ci-bearer-token\` + \`TINKERCLAW_TOKEN=ci-tc-token\`:

- [x] \`ruff --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006\` on \`dragon_voice/\` + both new test files → **All checks passed**
- [x] \`tests/test_status_handlers.py\` — **3/3 pass** (new)
- [x] \`tests/test_config_api_handlers.py\` — **4/4 pass** (new)
- [x] Full CI-named unit-test set incl. both new files → **116/116 pass**
- [x] \`from dragon_voice import server; from dragon_voice.handlers import config_api, status\` — clean import

## Explicit non-goals

- **Not touching the WS voice handler.** That's a separate initiative.
- **Not migrating existing tests away from adapter methods** — done in a later cleanup PR once all four steps have burned in.
- **Not adding type hints to the new handlers beyond what was there originally.**

## References

- Closes umbrella: **#65**
- Workflow rules: [CLAUDE.md](CLAUDE.md#workflow)
- Prior steps: #66 (middleware, merged) · #67 (debug handlers, merged) · #68 (lifecycle, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)