### PR TITLE
feat(server): WS keepalive-during-inference (#75 phase 1a)

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -1558,39 +1558,45 @@ class VoiceServer:
                 r"<tool>[\s\S]*?</tool>\s*<args>[\s\S]*?</args>\s*>?",
                 _re.IGNORECASE,
             )
-            async for token in self._conversation.process_text_stream(
-                session_id=session_id,
-                text=content,
-                input_mode="text",
-                on_tool_call=conn_state.get("on_tool_call"),
-                on_tool_result=conn_state.get("on_tool_result"),
-            ):
-                full_response.append(token)
-                pending += token
-                # Strip any complete tool blocks sitting in the pending
-                # buffer. Substitute in-place so remaining prose still
-                # flushes below.
-                stripped = _TOOL_RE_LOCAL.sub("", pending)
-                if stripped != pending:
-                    pending = stripped
-                # Hold back the tail if it looks like a partial tool
-                # marker so we don't flush `<tool>dat` to the client and
-                # then have to retract it.
-                hold_at = -1
-                for marker in ("<tool>", "<tool", "</tool", "<args", "</args"):
-                    idx = pending.rfind(marker)
-                    if idx >= 0 and idx > hold_at:
-                        hold_at = idx
-                if hold_at >= 0:
-                    flush, pending = pending[:hold_at], pending[hold_at:]
-                else:
-                    flush, pending = pending, ""
-                if flush and not ws.closed:
-                    await ws.send_json({"type": "llm", "text": flush})
-            # End-of-stream: flush whatever remains, stripped one more time.
-            pending = _TOOL_RE_LOCAL.sub("", pending)
-            if pending and not ws.closed:
-                await ws.send_json({"type": "llm", "text": pending})
+            # #75 phase 1a: same PING-during-inference protection used
+            # on the TC + vision paths above.  Local Ollama + ConversationEngine
+            # text turns on 4 B-class models routinely exceed 60 s, which
+            # trips Tab5's PONG-watch (~30 s) without this helper and
+            # triggers the P13 eviction race.
+            async with self._ws_keepalive_during_inference(ws, label="local_text"):
+                async for token in self._conversation.process_text_stream(
+                    session_id=session_id,
+                    text=content,
+                    input_mode="text",
+                    on_tool_call=conn_state.get("on_tool_call"),
+                    on_tool_result=conn_state.get("on_tool_result"),
+                ):
+                    full_response.append(token)
+                    pending += token
+                    # Strip any complete tool blocks sitting in the pending
+                    # buffer. Substitute in-place so remaining prose still
+                    # flushes below.
+                    stripped = _TOOL_RE_LOCAL.sub("", pending)
+                    if stripped != pending:
+                        pending = stripped
+                    # Hold back the tail if it looks like a partial tool
+                    # marker so we don't flush `<tool>dat` to the client and
+                    # then have to retract it.
+                    hold_at = -1
+                    for marker in ("<tool>", "<tool", "</tool", "<args", "</args"):
+                        idx = pending.rfind(marker)
+                        if idx >= 0 and idx > hold_at:
+                            hold_at = idx
+                    if hold_at >= 0:
+                        flush, pending = pending[:hold_at], pending[hold_at:]
+                    else:
+                        flush, pending = pending, ""
+                    if flush and not ws.closed:
+                        await ws.send_json({"type": "llm", "text": flush})
+                # End-of-stream: flush whatever remains, stripped one more time.
+                pending = _TOOL_RE_LOCAL.sub("", pending)
+                if pending and not ws.closed:
+                    await ws.send_json({"type": "llm", "text": pending})
 
             response_text = _TOOL_RE_LOCAL.sub("", "".join(full_response))
 

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -9,12 +9,13 @@ refs #16, #17, #18
 """
 
 import asyncio
+import contextlib
 import copy
 import json
 import logging
 import os
 import time
-from typing import Optional
+from typing import AsyncIterator, Optional
 
 import aiohttp
 from aiohttp import web, WSMsgType
@@ -358,6 +359,99 @@ class VoiceServer:
         except Exception as e:
             logger.debug("_safe_send_bytes suppressed: %s", e)
             return False
+
+    @staticmethod
+    @contextlib.asynccontextmanager
+    async def _ws_keepalive_during_inference(
+        ws: web.WebSocketResponse,
+        *,
+        interval_s: float = 5.0,
+        ping_timeout_s: float = 5.0,
+        label: str = "inference",
+    ) -> AsyncIterator[None]:
+        """Fire WS-level PING frames every `interval_s` seconds while the
+        context is active.  Keeps Tab5's WS library from tripping its
+        PONG-watch timeout (and triggering a reconnect → P13 eviction)
+        when an LLM stream takes longer than Tab5's own tolerance window.
+
+        The outer `web.WebSocketResponse(heartbeat=...)` timer is sized
+        for idle sockets (60 s between pings).  That cadence is too slow
+        for a 90 s Ollama turn on a local 4 B model — the event loop
+        gets starved, the heartbeat task doesn't tick, Tab5 declares
+        Dragon dead, Tab5 reconnects, and the P13 "Device already has
+        connection" guard evicts the original WS mid-stream.  This
+        helper pings 12× more often, only during inference, and stops
+        the moment the caller exits the `async with`.
+
+        Usage::
+
+            async with self._ws_keepalive_during_inference(ws):
+                async for token in llm.generate_stream_with_messages(...):
+                    await self._safe_send_json(ws, {"type": "llm", "text": token})
+
+        Parameters
+        ----------
+        ws : WebSocketResponse
+            The live WS to ping.  If already closed, the helper is a no-op.
+        interval_s : float, default 5.0
+            Seconds between PING frames.  5 s is safely under every
+            Tab5 firmware revision's PONG-watch window (30–45 s).
+        ping_timeout_s : float, default 5.0
+            How long to wait for the individual `ws.ping()` call to
+            return before treating it as a failed ping.  Short so GIL
+            contention from inference doesn't pile up.
+        label : str, default "inference"
+            Free-form tag used in the exit log so multiple concurrent
+            helpers are distinguishable.
+
+        Notes
+        -----
+        * Replaces and generalises the ad-hoc `_keepalive()` pattern
+          that was previously inlined in `_handle_text` (TC path only).
+        * Safe to use on a WS that has no in-flight work; the helper
+          runs its own task that simply exits on context exit.
+        * Exceptions from `ws.ping()` (connection reset, cancelled)
+          are swallowed — the surrounding inference loop's own
+          `ws.closed` check is the authoritative closure signal.
+        """
+        if ws.closed:
+            yield
+            return
+
+        alive = True
+
+        async def _tick() -> None:
+            while alive:
+                try:
+                    await asyncio.sleep(interval_s)
+                except asyncio.CancelledError:
+                    break
+                if not alive or ws.closed:
+                    break
+                try:
+                    await asyncio.wait_for(ws.ping(), timeout=ping_timeout_s)
+                except asyncio.TimeoutError:
+                    logger.debug(
+                        "ws_keepalive(%s) ping timeout after %.1fs — event loop stalled?",
+                        label, ping_timeout_s,
+                    )
+                    # Keep trying; caller's loop is the real arbiter of
+                    # whether the stream is still worth waiting for.
+                    continue
+                except (ConnectionResetError, RuntimeError):
+                    break
+                except Exception as e:
+                    logger.debug("ws_keepalive(%s) suppressed: %s", label, e)
+                    break
+
+        task = asyncio.create_task(_tick())
+        try:
+            yield
+        finally:
+            alive = False
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
 
     async def _handle_ws_voice(self, request: web.Request) -> web.WebSocketResponse:
         """Main voice WebSocket endpoint.
@@ -1335,32 +1429,23 @@ class VoiceServer:
             if not ws.closed:
                 await ws.send_json({"type": "llm", "text": ""})
 
-            # Also start a keepalive task that pings every 10s during processing.
-            # 5s timeout on each send prevents blocking if the event loop is
-            # delayed by inference GIL contention (US-DQ05).
-            keepalive_active = True
-            async def _keepalive():
-                while keepalive_active:
-                    await asyncio.sleep(10)
-                    if keepalive_active and not ws.closed:
-                        try:
-                            await asyncio.wait_for(ws.ping(), timeout=5.0)
-                        except (asyncio.TimeoutError, Exception):
-                            break
-
-            keepalive_task = asyncio.create_task(_keepalive())
-
+            # #75 phase 1a: WS-level PING every 5 s while the LLM is
+            # generating.  Previously inlined here as `_keepalive()` at
+            # 10 s; now the shared helper lives on the class so the
+            # vision-upload path (below in _handle_user_media) gets the
+            # same protection instead of running bare.  5 s is safely
+            # under every Tab5 firmware's PONG-watch window (30–45 s);
+            # the outer `WebSocketResponse(heartbeat=60)` timer is too
+            # slow for a 90 s 4 B-class Ollama turn.  See docs/AUDIT.md
+            # "Local-mode gauntlet" for the observed P13-eviction race.
             full_response = []
-            try:
+            async with self._ws_keepalive_during_inference(ws, label="tc_text"):
                 async for token in llm.generate_stream_with_messages([
                     {"role": "user", "content": text}
                 ]):
                     full_response.append(token)
                     if not ws.closed:
                         await ws.send_json({"type": "llm", "text": token})
-            finally:
-                keepalive_active = False
-                keepalive_task.cancel()
 
             response_text = "".join(full_response)
 
@@ -1708,10 +1793,15 @@ class VoiceServer:
             return
 
         try:
-            async for token in llm_backend.generate_stream_with_messages(messages):
-                full_response.append(token)
-                if not ws.closed:
-                    await ws.send_json({"type": "llm", "text": token})
+            # #75 phase 1a: same PING-during-inference protection as the
+            # TC text path above — vision-upload LLM turns can run 30+ s
+            # on multimodal models, long enough for Tab5's PONG-watch to
+            # trip without the helper.
+            async with self._ws_keepalive_during_inference(ws, label="vision"):
+                async for token in llm_backend.generate_stream_with_messages(messages):
+                    full_response.append(token)
+                    if not ws.closed:
+                        await ws.send_json({"type": "llm", "text": token})
         except Exception as e:
             logger.error("user_media LLM failed: %s", e)
             if not ws.closed:


### PR DESCRIPTION
## Summary
Extracts the ad-hoc 10 s ping-during-inference task that was already inline in `_handle_text`'s TinkerClaw bypass path into a reusable async context manager `VoiceServer._ws_keepalive_during_inference`.  Applies it to the three inference sites in `server.py` so the WS stays alive under any model latency:

1. `_handle_text` TinkerClaw bypass path (replaces inline `_keepalive()`)
2. `_handle_text` local/ConversationEngine path (was bare)
3. `_handle_user_media` vision path (was bare)

Uses 5 s PING interval vs the old 10 s (matches audit recommendation) and is safely under every Tab5 firmware's PONG-watch window (30–45 s).

## Why
The 2026-04-24 Local-mode gauntlet (see `docs/AUDIT.md` "Local-mode gauntlet Round 2 + 3" and issue #75) found 4 B-class Ollama models are effectively unusable in `voice_mode=0`: inference takes 90–110 s while Tab5's PONG-watch is ~30 s.  When it trips, Tab5 reconnects, Dragon's P13 "Device already has connection" guard evicts the in-flight stream, and the user sees an empty chat bubble.  The outer `WebSocketResponse(heartbeat=60)` timer can't save this — 60 s is too slow, and the event loop itself gets starved by inference so the heartbeat task misses ticks.

The inline TC-path fix was working but one-off; other inference sites were exposed.  This PR generalises the pattern.

## What did NOT change
- Outer `WebSocketResponse(heartbeat=60, receive_timeout=600)` — untouched; still handles idle-socket detection.
- The `_ws_keepalive` JSON data-frame task at `:451` (ngrok idle keepalive) — independent concern, left alone.
- `conversation.py` / `pipeline.py` inference loops — no direct `ws` access from there, out of scope for this phase.

## Test plan
- [x] Sandbox deploy at `/home/radxa/tinkerbox_sandbox_repo/` on port 3513 with separate SQLite DB (keeps prod untouched at 3502).
- [x] `ministral-3:3b` WS test: 67 s inference, full reply landed, connection never closed.  Without the helper this would have been a P13 eviction at ~30 s with an empty bubble.
- [ ] `qwen3:4b` WS test — deferred (model itself had upstream issues during gauntlet unrelated to the keepalive).
- [x] No regression on short turns — the helper exits cleanly on context close.
- [x] Syntax + import checks pass locally.

## Scope: one concern per PR
This PR is keepalive only.  The sibling PR for tool-response template wrap (#75 phase 1b) is separate.

Refs #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)