### PR TITLE
feat(tools): template wrap for tool-only LLM responses (#75 phase 1b)

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -1165,6 +1165,18 @@ class VoiceServer:
         # Store tool event callbacks per-connection (NOT on shared conversation engine)
         if self._tool_registry:
             async def _on_tool_call(call):
+                # #75 phase 1b: pre-register the call + args in the
+                # per-turn tracker so `_on_tool_result` can merge the
+                # result into the same record.  The wrap synthesiser
+                # reads both sides (e.g. `remember` needs the `fact`
+                # from args to write "Got it — {fact}.").
+                try:
+                    conn_state.setdefault("tool_calls_this_turn", []).append({
+                        "tool": call.get("tool"),
+                        "args": call.get("args") or {},
+                    })
+                except Exception:
+                    logger.debug("tool_calls_this_turn pre-register suppressed", exc_info=True)
                 if not ws.closed:
                     await self._safe_send_json(ws, {
                         "type": "tool_call",
@@ -1176,14 +1188,25 @@ class VoiceServer:
                 if ws.closed:
                     return
                 await ws.send_json({"type": "tool_result", **result})
-                # #75 phase 1b: remember this result for end-of-turn
-                # template-wrap synthesis in case the LLM produced no
-                # user-facing text (common with FC-trained models that
-                # only emit tool calls and never natural language).
+                # #75 phase 1b: merge result into the most-recent
+                # pre-registered call for this tool name (fills the
+                # FIRST pending slot so same-tool-twice-in-one-turn
+                # still maps 1:1).  If no pre-register exists (some
+                # code paths emit tool_result only), append the bare
+                # result so the wrap still has something to describe.
                 try:
-                    conn_state.setdefault("tool_calls_this_turn", []).append(result)
+                    tracker = conn_state.setdefault("tool_calls_this_turn", [])
+                    merged = False
+                    for rec in tracker:
+                        if rec.get("tool") == result.get("tool") and "result" not in rec:
+                            rec["result"] = result.get("result")
+                            rec["execution_ms"] = result.get("execution_ms")
+                            merged = True
+                            break
+                    if not merged:
+                        tracker.append(result)
                 except Exception:
-                    logger.debug("tool_calls_this_turn append suppressed", exc_info=True)
+                    logger.debug("tool_calls_this_turn merge suppressed", exc_info=True)
                 # v4·D Phase 4c: auto-emit widget_list for web_search results
                 # so the Tab5 home live-slot surfaces the top hits without
                 # the LLM having to orchestrate a widget call itself.

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -48,6 +48,7 @@ from dragon_voice.middleware import (
 )
 from dragon_voice.pipeline import VoicePipeline
 from dragon_voice.sessions import SessionManager
+from dragon_voice.tools.response_wrap import synthesize_wrap
 
 logger = logging.getLogger(__name__)
 
@@ -1175,6 +1176,14 @@ class VoiceServer:
                 if ws.closed:
                     return
                 await ws.send_json({"type": "tool_result", **result})
+                # #75 phase 1b: remember this result for end-of-turn
+                # template-wrap synthesis in case the LLM produced no
+                # user-facing text (common with FC-trained models that
+                # only emit tool calls and never natural language).
+                try:
+                    conn_state.setdefault("tool_calls_this_turn", []).append(result)
+                except Exception:
+                    logger.debug("tool_calls_this_turn append suppressed", exc_info=True)
                 # v4·D Phase 4c: auto-emit widget_list for web_search results
                 # so the Tab5 home live-slot surfaces the top hits without
                 # the LLM having to orchestrate a widget call itself.
@@ -1320,6 +1329,12 @@ class VoiceServer:
         text = content
         logger.info("Text input on session %s: %s", session_id, text[:80])
 
+        # #75 phase 1b: reset the per-turn tool-call tracker.  Each
+        # incoming text starts a new turn; the `_on_tool_result`
+        # callback accumulates here so the end-of-turn empty-reply guard
+        # can synthesise a template wrap from what actually fired.
+        conn_state["tool_calls_this_turn"] = []
+
         # TinkerClaw mode: bypass ConversationEngine, use ConversationEngine's
         # swapped LLM (not pipeline._llm which may be stale after swap race)
         conn_cfg = conn_state.get("config")
@@ -1364,22 +1379,41 @@ class VoiceServer:
 
             response_text = "".join(full_response)
 
-            # Wave 15 W15-H09: same empty-response guard as the voice
-            # pipeline.  When MiniMax / the TinkerClaw agent halts after
-            # a failed tool call without formulating a user-facing reply
-            # (e.g. brave_search returns missing_brave_api_key), we'd
+            # Wave 15 W15-H09 + #75 phase 1b: empty-response guard.  When
+            # MiniMax / the TinkerClaw agent halts after a failed tool
+            # call without formulating a user-facing reply, OR when an
+            # FC-trained local model (xLAM, functiongemma, …) only
+            # emitted tool calls with no natural-language wrap, we'd
             # otherwise send llm_done with text="" and Tab5 silently
-            # drops the chat bubble.  Emit a fallback so the user always
-            # sees something in the chat view.
+            # drops the chat bubble.
+            #
+            # Preference order:
+            #   1. If any tool fired this turn, synthesise a per-tool
+            #      template wrap from `conn_state["tool_calls_this_turn"]`
+            #      (response_wrap.synthesize_wrap).  Fast, deterministic,
+            #      describes what actually ran — users get a useful ack
+            #      like "Got it — magenta." rather than a frustrating
+            #      "Sorry, I couldn't generate a response."
+            #   2. Fall through to the legacy W15-H09 generic apology
+            #      when there were zero tool fires (e.g. real LLM error).
             if not response_text.strip():
-                fallback = (
-                    "Sorry, I couldn't generate a response for that. "
-                    "Please try rephrasing, or try again in a moment."
-                )
-                logger.warning(
-                    "W15-H09: TinkerClaw text path produced zero tokens — "
-                    "emitting fallback response"
-                )
+                tool_calls = conn_state.get("tool_calls_this_turn") or []
+                if tool_calls:
+                    fallback = synthesize_wrap(tool_calls)
+                    logger.info(
+                        "#75 phase 1b: TC path produced zero LLM tokens but "
+                        "%d tool(s) fired — emitting template wrap (%d chars)",
+                        len(tool_calls), len(fallback),
+                    )
+                else:
+                    fallback = (
+                        "Sorry, I couldn't generate a response for that. "
+                        "Please try rephrasing, or try again in a moment."
+                    )
+                    logger.warning(
+                        "W15-H09: TinkerClaw text path produced zero tokens — "
+                        "emitting fallback response"
+                    )
                 if not ws.closed:
                     await ws.send_json({"type": "llm", "text": fallback})
                 response_text = fallback
@@ -1508,6 +1542,26 @@ class VoiceServer:
                 await ws.send_json({"type": "llm", "text": pending})
 
             response_text = _TOOL_RE_LOCAL.sub("", "".join(full_response))
+
+            # #75 phase 1b: if the local model fired tools but never
+            # produced user-facing text (common with FC-trained small
+            # models like xLAM that emit tool calls then stop), wrap
+            # the tool results in a templated natural-language ack so
+            # Tab5 doesn't render an empty bubble.  Same intent as the
+            # TC-path guard above, just applied to the local/conversation
+            # engine flow.
+            if not response_text.strip():
+                tool_calls = conn_state.get("tool_calls_this_turn") or []
+                if tool_calls:
+                    wrap = synthesize_wrap(tool_calls)
+                    logger.info(
+                        "#75 phase 1b: local text path emitted only tool "
+                        "calls (%d) — sending template wrap (%d chars)",
+                        len(tool_calls), len(wrap),
+                    )
+                    if not ws.closed:
+                        await ws.send_json({"type": "llm", "text": wrap})
+                    response_text = wrap
 
             if not ws.closed:
                 await ws.send_json({"type": "llm_done", "llm_ms": 0})
@@ -1695,6 +1749,9 @@ class VoiceServer:
             ]
         }]
 
+        # #75 phase 1b: reset per-turn tool tracker on this path too.
+        conn_state["tool_calls_this_turn"] = []
+
         full_response = []
         llm = conn_state.get("conversation")
         if llm and hasattr(llm, '_llm'):
@@ -1717,6 +1774,22 @@ class VoiceServer:
             if not ws.closed:
                 await ws.send_json({"type": "error", "message": str(e)})
             return
+
+        # #75 phase 1b: vision path gets the same empty-reply guard as
+        # the text paths.  Multimodal models can fire a tool (e.g.
+        # `note` to save a snapshot caption) and stop without text.
+        if not "".join(full_response).strip():
+            tool_calls = conn_state.get("tool_calls_this_turn") or []
+            if tool_calls:
+                wrap = synthesize_wrap(tool_calls)
+                logger.info(
+                    "#75 phase 1b: vision path emitted only tool calls "
+                    "(%d) — sending template wrap (%d chars)",
+                    len(tool_calls), len(wrap),
+                )
+                if not ws.closed:
+                    await ws.send_json({"type": "llm", "text": wrap})
+                full_response.append(wrap)
 
         if not ws.closed:
             await ws.send_json({"type": "llm_done", "llm_ms": 0})

--- a/dragon_voice/tools/response_wrap.py
+++ b/dragon_voice/tools/response_wrap.py
@@ -1,0 +1,339 @@
+"""Tool-response natural-language wrap synthesis.
+
+Purpose
+-------
+Some function-calling-fine-tuned LLMs (Salesforce/xLAM, distil-labs/
+functiongemma, LiquidAI/LFM2.5-FC, …) emit a tool call and then stop,
+leaving no conversational text for the user.  ConversationEngine
+faithfully strips the tool-call markup from the user-visible text
+stream — net result is an empty chat bubble even when the tool itself
+fired correctly and did real work.
+
+This module contains a small per-tool template library that synthesises
+a one-line natural-language acknowledgement from the *tool result*
+(not from another LLM inference — the whole point is to be fast +
+deterministic + free).  Dragon's server wires this up so it runs only
+when:
+
+  (a) at least one tool fired during the turn, AND
+  (b) the LLM's own final-text output was empty or stripped to empty.
+
+Happy-path turns where the LLM wrote a real reply get no wrap — the
+natural-language text the model produced is always preferred.
+
+Design constraints
+------------------
+* Zero LLM calls.  All wrap synthesis is templated Python string ops.
+* Never block.  Each template is a pure function taking a dict.
+* Never overwrite the model's reply.  Only fills an empty one.
+* Stay short.  One sentence.  Match Dragon's "concise assistant" tone.
+* Degrade gracefully.  If a tool isn't in the registry, return a
+  generic "done" ack rather than raise.
+
+See docs/AUDIT.md "Local-mode gauntlet Round 2 + 3" for the observed
+empty-bubble pattern that motivates this module.  Refs #75.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+# Each wrap function takes the tool result dict (same shape as
+# ToolRegistry.execute returns — {"tool": name, "result": ..., "execution_ms": N})
+# and returns a user-facing one-liner, or None to signal "no good
+# template for this result, fall through to the generic wrap."
+Wrap = Callable[[dict], Optional[str]]
+
+
+def _result_of(call: dict) -> Any:
+    """Extract the tool's `result` payload regardless of whether it came
+    in as the full execute() envelope or a raw value."""
+    if isinstance(call, dict) and "result" in call:
+        return call["result"]
+    return call
+
+
+def _wrap_datetime(call: dict) -> Optional[str]:
+    r = _result_of(call)
+    if isinstance(r, dict):
+        time_str = r.get("time") or r.get("datetime") or r.get("now")
+        tz = r.get("timezone") or r.get("tz")
+        if time_str and tz:
+            return f"It's {time_str} ({tz})."
+        if time_str:
+            return f"It's {time_str}."
+    if isinstance(r, str) and r:
+        return f"It's {r}."
+    return None
+
+
+def _wrap_calculator(call: dict) -> Optional[str]:
+    r = _result_of(call)
+    if isinstance(r, dict):
+        val = r.get("result") if "result" in r else r.get("value")
+        expr = r.get("expression") or r.get("input")
+        if val is not None and expr:
+            return f"{expr} = {val}."
+        if val is not None:
+            return f"That's {val}."
+    if isinstance(r, (int, float, str)) and r != "":
+        return f"That's {r}."
+    return None
+
+
+def _wrap_unit_converter(call: dict) -> Optional[str]:
+    r = _result_of(call)
+    if isinstance(r, dict):
+        val = r.get("value") or r.get("result")
+        unit = r.get("unit") or r.get("to_unit")
+        if val is not None and unit:
+            return f"That's {val} {unit}."
+        if val is not None:
+            return f"That's {val}."
+    return None
+
+
+def _wrap_weather(call: dict) -> Optional[str]:
+    r = _result_of(call)
+    if isinstance(r, dict):
+        loc = r.get("location") or r.get("city") or "there"
+        temp = r.get("temperature") or r.get("temp")
+        summary = r.get("summary") or r.get("conditions") or r.get("description")
+        if temp is not None and summary:
+            return f"In {loc}: {summary}, {temp}°."
+        if summary:
+            return f"In {loc}: {summary}."
+        if temp is not None:
+            return f"It's {temp}° in {loc}."
+    return None
+
+
+def _wrap_remember(call: dict) -> Optional[str]:
+    """Used by both `remember` and `store_fact` tool names."""
+    # Try to pull the stored fact from args first (the call's input),
+    # then from result.  Clients pass the call record {tool, args, result…}.
+    fact = None
+    if isinstance(call, dict):
+        args = call.get("args") or {}
+        if isinstance(args, dict):
+            fact = args.get("fact") or args.get("content") or args.get("text")
+    r = _result_of(call)
+    if not fact and isinstance(r, dict):
+        fact = r.get("stored") or r.get("fact")
+    if fact:
+        # Trim trailing period/punctuation to avoid ".." in output.
+        clean = str(fact).rstrip(".!?,;:").strip()
+        return f"Got it — {clean}."
+    return "Got it — noted."
+
+
+def _wrap_recall(call: dict) -> Optional[str]:
+    r = _result_of(call)
+    if isinstance(r, dict):
+        # recall_facts returns a list of facts under "results" or "facts"
+        items = r.get("results") or r.get("facts") or r.get("hits") or []
+        if isinstance(items, list) and items:
+            first = items[0]
+            text = first.get("content") if isinstance(first, dict) else str(first)
+            if text:
+                if len(items) == 1:
+                    return str(text).strip().rstrip(".") + "."
+                return f"{str(text).strip().rstrip('.')}. (+{len(items)-1} more.)"
+        return "I don't have anything stored about that yet."
+    return None
+
+
+def _wrap_forget(call: dict) -> Optional[str]:
+    return "OK — forgotten."
+
+
+def _wrap_web_search(call: dict) -> Optional[str]:
+    r = _result_of(call)
+    if isinstance(r, dict):
+        items = r.get("results") or r.get("hits") or []
+        if isinstance(items, list) and items:
+            first = items[0]
+            title = first.get("title") if isinstance(first, dict) else str(first)
+            if title:
+                return f"Top hit: {title}."
+        return "I searched but didn't find a good match."
+    return None
+
+
+def _wrap_system_info(call: dict) -> Optional[str]:
+    r = _result_of(call)
+    if isinstance(r, dict):
+        # Hand the user a short human-readable summary of whatever
+        # system_info returned (ram/cpu/disk keys commonly present).
+        bits: list[str] = []
+        for key in ("ram", "cpu", "disk", "uptime"):
+            v = r.get(key)
+            if isinstance(v, (str, int, float)) and v != "":
+                bits.append(f"{key}: {v}")
+        if bits:
+            return "Dragon: " + ", ".join(bits) + "."
+    return None
+
+
+def _wrap_stock_ticker(call: dict) -> Optional[str]:
+    r = _result_of(call)
+    if isinstance(r, dict):
+        sym = r.get("symbol") or r.get("ticker")
+        price = r.get("price") or r.get("last")
+        if sym and price is not None:
+            return f"{sym} is at {price}."
+    return None
+
+
+def _wrap_timer(call: dict) -> Optional[str]:
+    """Plain timer (not the widget-emitting `timesense`)."""
+    r = _result_of(call)
+    duration: Any = None
+    if isinstance(r, dict):
+        duration = r.get("duration_s") or r.get("seconds") or r.get("duration")
+    if duration is None and isinstance(call, dict):
+        args = call.get("args") or {}
+        if isinstance(args, dict):
+            duration = args.get("duration_s") or args.get("seconds") or args.get("duration")
+    if duration is not None:
+        return f"Timer running for {duration} seconds."
+    return "Timer started."
+
+
+def _wrap_timesense(call: dict) -> Optional[str]:
+    """Widget-emitting timer.  Live updates come via `widget_live`; the
+    wrap only needs to acknowledge the setup."""
+    r = _result_of(call)
+    duration: Any = None
+    if isinstance(r, dict):
+        duration = r.get("duration_s") or r.get("seconds") or r.get("duration")
+    if duration is None and isinstance(call, dict):
+        args = call.get("args") or {}
+        if isinstance(args, dict):
+            duration = args.get("duration_s") or args.get("seconds") or args.get("duration")
+    if duration is not None:
+        return f"Timer set for {duration} seconds."
+    return "Timer set."
+
+
+def _wrap_quick_poll(call: dict) -> Optional[str]:
+    """Poll widget acks via the widget_prompt ack, so the wrap here
+    just nudges the user to tap."""
+    return "Tap one."
+
+
+def _wrap_note(call: dict) -> Optional[str]:
+    r = _result_of(call)
+    if isinstance(r, dict):
+        title = r.get("title") or r.get("name")
+        if title:
+            return f"Saved note: {title}."
+    return "Noted."
+
+
+# Tool-name → wrap function.  Dragon ships with a handful of tools
+# under two names each (e.g. `remember` and `store_fact` both hit the
+# same store-fact tool) so we register aliases explicitly rather than
+# trying to guess.  Unlisted tools fall through to `generic_wrap`.
+_WRAPS: dict[str, Wrap] = {
+    "datetime": _wrap_datetime,
+    "calculator": _wrap_calculator,
+    "unit_converter": _wrap_unit_converter,
+    "weather": _wrap_weather,
+    "remember": _wrap_remember,
+    "store_fact": _wrap_remember,
+    "recall": _wrap_recall,
+    "recall_facts": _wrap_recall,
+    "forget": _wrap_forget,
+    "forget_fact": _wrap_forget,
+    "web_search": _wrap_web_search,
+    "system_info": _wrap_system_info,
+    "stock_ticker": _wrap_stock_ticker,
+    "timer": _wrap_timer,
+    "timesense": _wrap_timesense,
+    "quick_poll": _wrap_quick_poll,
+    "note": _wrap_note,
+}
+
+
+def generic_wrap(calls: list[dict]) -> str:
+    """Fallback when either no per-tool template matches or the tool is
+    not in our table.  Keeps the user informed that Dragon did
+    *something* on their behalf without pretending it was meaningful."""
+    if not calls:
+        return "Done."
+    names = []
+    for c in calls:
+        if isinstance(c, dict):
+            n = c.get("tool") or c.get("name")
+            if n:
+                names.append(str(n))
+    if not names:
+        return "Done."
+    if len(names) == 1:
+        return f"OK — ran {names[0]}."
+    unique = list(dict.fromkeys(names))
+    return "OK — ran " + ", ".join(unique) + "."
+
+
+def synthesize_wrap(calls: list[dict]) -> str:
+    """Public entrypoint.  Takes the list of tool-call records collected
+    during the turn (each a dict with at least `tool` / `args` / `result`)
+    and returns a single sentence the server can send to the user as
+    the assistant's reply.
+
+    Selection rules:
+      * If exactly one tool fired AND the per-tool template yielded a
+        non-empty string → return that.
+      * If multiple tools fired → join up to three per-tool snippets
+        with spaces.  Dedup identical ones.
+      * If a tool has no template or its template returned None →
+        include it in the generic fallback instead.
+      * If `calls` is empty (defensive) → return "Done." (the caller
+        should normally not invoke us on an empty list).
+
+    Never raises.  Always returns a non-empty string.
+    """
+    if not calls:
+        return "Done."
+
+    snippets: list[str] = []
+    untemplated: list[dict] = []
+
+    for call in calls:
+        if not isinstance(call, dict):
+            continue
+        name = call.get("tool") or call.get("name")
+        wrap = _WRAPS.get(str(name or ""))
+        if wrap is None:
+            untemplated.append(call)
+            continue
+        try:
+            snippet = wrap(call)
+        except Exception:
+            snippet = None
+        if snippet:
+            snippets.append(snippet)
+        else:
+            untemplated.append(call)
+
+    # Dedup in order — repeated identical snippets read badly
+    # (xLAM sometimes fires the same tool twice in a loop).
+    seen: set[str] = set()
+    unique_snippets: list[str] = []
+    for s in snippets:
+        if s not in seen:
+            unique_snippets.append(s)
+            seen.add(s)
+
+    if untemplated:
+        unique_snippets.append(generic_wrap(untemplated))
+
+    if not unique_snippets:
+        return generic_wrap(calls)
+
+    # Cap at 3 snippets to keep replies readable.
+    if len(unique_snippets) > 3:
+        unique_snippets = unique_snippets[:3] + [f"(+{len(unique_snippets)-3} more)"]
+
+    return " ".join(unique_snippets)


### PR DESCRIPTION
## Summary
New module `dragon_voice/tools/response_wrap.py` + `server.py` wiring so function-calling LLMs that emit a tool call with no conversational text produce a sensible user-facing reply instead of an empty chat bubble.

Per-tool templates synthesise a one-liner from the tool's result dict:

- `remember`/`store_fact` → "Got it — {fact}."
- `datetime` → "It's {time} ({timezone})."
- `calculator` → "{expression} = {result}."
- `unit_converter` → "That's {value} {unit}."
- `recall` → "{top_fact}.(+N more)."
- `web_search` → "Top hit: {title}."
- `weather`, `stock_ticker`, `system_info`, `timer`, `timesense`, `quick_poll`, `note`, `forget` — all covered.
- Unknown tools fall through to "OK — ran {name}."

Zero LLM inference.  All synthesis is pure Python string ops.

## Why
The 2026-04-24 Local-mode gauntlet (see #75 + `docs/AUDIT.md` "Local-mode gauntlet Round 2 + 3") found FC-fine-tuned small models (Salesforce/xLAM, distil-labs/functiongemma, LiquidAI/LFM2.5-FC) reliably emit a tool call and then stop — they were SFT'd on tool-only outputs, no conversational head.  Dragon's ConversationEngine faithfully strips the tool markup from the user-visible stream.  Net: tool fires, memory DB row lands, calculator returns the right number — but Tab5's chat bubble stays empty.

Observed: xLAM-2-1b-fc-r on Local mode, 4/5 tool fires, 0/5 user-visible replies.

## End-to-end validation (sandbox)
Integration branch (parser PR #74 + phase 1a keepalive #76 + this phase 1b) deployed to `/home/radxa/tinkerbox_sandbox_repo/` on port 3513 with separate SQLite DB, ollama_model swapped to `hf.co/Salesforce/xLAM-2-1b-fc-r-gguf:Q4_K_M`:

| Prompt | Before #75 | After #75 |
|---|---|---|
| "Remember my favorite color is cyan" | empty bubble (tools=0 or tools=1 with XML leak) | **"Got it — My favorite color is cyan."** (`remember` tool fired, DB row confirmed in `memory_facts`, 21.2 s) |
| "What time is it right now" | empty bubble | "It's 20:52:01 (UTC)." (18.4 s) |
| "Remember my favorite color is magenta" | empty bubble | "Got it — Magenta is not a real color." *(xLAM interpreted the fact before storing it — wrap faithfully echoed what xLAM passed; upstream model behaviour not a wrap issue)* |

Memory DB verified: sandbox's `memory_facts` table has the new rows.  No changes leaked into prod (prod on port 3502 untouched throughout, Tab5 user still on `voice_mode=3` TinkerClaw with no UX impact).

## Wiring
`server.py` additions (non-invasive):
- `_handle_text` resets `conn_state["tool_calls_this_turn"] = []` at turn start.
- `_on_tool_call` pre-registers `{tool, args}` into that tracker.
- `_on_tool_result` merges the result into the most-recent pending record for that tool name (1:1 even if same tool fires twice).
- End-of-turn guards on all 3 paths (TC bypass, local ConversationEngine, vision) check for empty `response_text` + non-empty `tool_calls_this_turn` and emit `synthesize_wrap(tool_calls)` as a final `llm` frame before `llm_done`.

## What did NOT change
- Non-empty model replies pass through unchanged — the wrap is only emitted when the model produced zero user-visible text.
- Legacy W15-H09 generic apology still fires when BOTH text is empty AND no tools fired (real LLM error path).
- Voice pipeline (`pipeline.py`) is out of scope; it doesn't surface per-turn tool aggregation the same way.

## Depends on
- PR #74 (parser dialect widening) — without it, xLAM's `[tool]...` output never parses so no tool fires, so no wrap target.  Both this PR and #74 need to merge for the xLAM demo to work end-to-end.
- PR #76 (#75 phase 1a keepalive) is independent but naturally complementary — long tool chains benefit from both.

Refs #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)