### PR TITLE
fix(server): wrap fires on bracket-noise replies, not just strict-empty

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -14,6 +14,7 @@ import copy
 import json
 import logging
 import os
+import re
 import time
 from typing import AsyncIterator, Optional
 
@@ -50,6 +51,55 @@ from dragon_voice.middleware import (
 from dragon_voice.pipeline import VoicePipeline
 from dragon_voice.sessions import SessionManager
 from dragon_voice.tools.response_wrap import synthesize_wrap
+
+
+# #75 phase 1b refinement: the "is the model's reply empty enough that we
+# should prefer the template wrap?" check.  Strict `not text.strip()` is
+# too narrow — gemma3:4b's 10-prompt G2 (math) emitted a single stray
+# bracket `<` that survived ConversationEngine's tool-XML stripping,
+# which made the original guard see "non-empty" and skip the wrap.
+# Net result: tool fires, wrap synthesised "456 * 789 = 359784", but the
+# user got a chat bubble containing just `<`.
+#
+# Heuristic: a reply is "useful" only if, after stripping whitespace and
+# stripping stray-bracket/punctuation noise, at least 3 word characters
+# remain.  Below that we treat it as junk and prefer the wrap.
+_BRACKET_NOISE = set("<>[]{}()\"'` \t\n\r")
+
+
+_RESIDUAL_XML_TAG = re.compile(r"<[^>]*>|\[[^]]*\]|\{[^}]*\}")
+
+
+def _looks_like_useful_text(text: str) -> bool:
+    """True if `text` carries enough signal to be worth showing the user
+    over a templated tool-result ack.  Designed to fail "open" — when in
+    doubt, treat the model's text as useful (avoid clobbering real content).
+
+    Heuristic:
+      1. If the input contains a closing-tag pattern like `</word>` it is
+         almost certainly a residual tool-XML leak (ConversationEngine
+         already strips well-formed tool blocks; what reaches here would
+         be a malformed remainder like `[tool]remember</tool><args>...`).
+         Treat as junk.
+      2. Otherwise strip well-formed `<…>` / `[…]` / `{…}` blocks,
+         strip whitespace + bracket-noise chars, and require ≥ 3
+         meaningful chars.
+    """
+    if not text:
+        return False
+    # Closing-tag fingerprint — proven residual leak from FC models like
+    # xLAM that emit `[tool]name</tool><args>{json}</args>` with broken
+    # opening brackets.  Stripping `[tool]` + `</tool>` + `<args>` +
+    # `</args>` + `{json}` would leave the literal tool name like
+    # "remember" which superficially looks like 8 meaningful chars but
+    # is just registry noise we don't want to show the user.
+    if re.search(r"</\w+>", text):
+        return False
+    stripped = _RESIDUAL_XML_TAG.sub("", text).strip()
+    if len(stripped) < 3:
+        return False
+    meaningful = [c for c in stripped if c not in _BRACKET_NOISE]
+    return len(meaningful) >= 3
 
 logger = logging.getLogger(__name__)
 
@@ -1504,14 +1554,17 @@ class VoiceServer:
             #      "Sorry, I couldn't generate a response."
             #   2. Fall through to the legacy W15-H09 generic apology
             #      when there were zero tool fires (e.g. real LLM error).
-            if not response_text.strip():
+            # #75 phase 1b refinement: trigger wrap when reply is
+            # bracket-noise-only too, not just strict-empty.  See
+            # _looks_like_useful_text above for the heuristic.
+            if not _looks_like_useful_text(response_text):
                 tool_calls = conn_state.get("tool_calls_this_turn") or []
                 if tool_calls:
                     fallback = synthesize_wrap(tool_calls)
                     logger.info(
-                        "#75 phase 1b: TC path produced zero LLM tokens but "
-                        "%d tool(s) fired — emitting template wrap (%d chars)",
-                        len(tool_calls), len(fallback),
+                        "#75 phase 1b: TC path produced near-empty LLM text "
+                        "(%r) but %d tool(s) fired — emitting template wrap (%d chars)",
+                        response_text[:30], len(tool_calls), len(fallback),
                     )
                 else:
                     fallback = (
@@ -1664,14 +1717,14 @@ class VoiceServer:
             # Tab5 doesn't render an empty bubble.  Same intent as the
             # TC-path guard above, just applied to the local/conversation
             # engine flow.
-            if not response_text.strip():
+            if not _looks_like_useful_text(response_text):
                 tool_calls = conn_state.get("tool_calls_this_turn") or []
                 if tool_calls:
                     wrap = synthesize_wrap(tool_calls)
                     logger.info(
-                        "#75 phase 1b: local text path emitted only tool "
-                        "calls (%d) — sending template wrap (%d chars)",
-                        len(tool_calls), len(wrap),
+                        "#75 phase 1b: local text path emitted near-empty text "
+                        "(%r) with %d tool fire(s) — sending template wrap (%d chars)",
+                        response_text[:30], len(tool_calls), len(wrap),
                     )
                     if not ws.closed:
                         await ws.send_json({"type": "llm", "text": wrap})
@@ -1897,13 +1950,13 @@ class VoiceServer:
         # #75 phase 1b: vision path gets the same empty-reply guard as
         # the text paths.  Multimodal models can fire a tool (e.g.
         # `note` to save a snapshot caption) and stop without text.
-        if not "".join(full_response).strip():
+        if not _looks_like_useful_text("".join(full_response)):
             tool_calls = conn_state.get("tool_calls_this_turn") or []
             if tool_calls:
                 wrap = synthesize_wrap(tool_calls)
                 logger.info(
-                    "#75 phase 1b: vision path emitted only tool calls "
-                    "(%d) — sending template wrap (%d chars)",
+                    "#75 phase 1b: vision path emitted near-empty text with "
+                    "%d tool fire(s) — sending template wrap (%d chars)",
                     len(tool_calls), len(wrap),
                 )
                 if not ws.closed:


### PR DESCRIPTION
## Summary
The 10-prompt sandbox gauntlet on the integration of just-merged #74/#76/#77 exposed a regression in #77's wrap-trigger condition.  gemma3:4b's G2 (math) turn fired the calculator tool correctly, but the model emitted ONE stray `<` character that survived ConversationEngine's tool-XML stripping.  The strict `if not response_text.strip()` guard saw "non-empty" and skipped the wrap — so the user got a chat bubble containing just `<` instead of "456 * 789 = 359784".

Same class affects xLAM-style residual leaks like `[tool]remember</tool><args>{}</args>` that arrive at the wrap site when the parser couldn't fully match the model's broken syntax.

## Fix
New helper `VoiceServer._looks_like_useful_text(text)` replaces `not response_text.strip()` at all 3 wrap sites (`_handle_text` TC bypass, `_handle_text` local path, `_handle_user_media` vision path).

Heuristic:
1. If the input contains `</word>` (closing-tag fingerprint), it's almost certainly residual tool-XML leak — treat as junk, fire wrap.
2. Otherwise strip well-formed `<…>` / `[…]` / `{…}` blocks, strip whitespace + bracket-noise chars, and require ≥ 3 meaningful chars.

Designed to fail "open" — when in doubt, treat the model's text as useful so we never clobber a real reply with a templated one.

## Tests
21 unit cases pass: empty, single bracket, two-digit math, residual XML only, XML wrapping real text, xLAM bracket leaks (with/without args), emoji-only, boolean strings, etc.

## Verification
Sandbox deploy, gemma3:4b on `What is four hundred fifty six times seven hundred eighty nine`:
- Pre-fix: tool fired correctly, but reply was empty (single `<` survived)
- Post-fix: **"456 * 789 = 359784.0."** in 91.2s, tool_calls=1

## Acceptable false positive
Replies that genuinely mention literal `</em>`-style HTML tags get treated as junk → wrap fires.  LLM output rarely contains literal tag mentions in user-facing replies, so the rare miss is worth the catch on the much more common XML-leak pattern.

## Bonus: also resolves the "WS-reset 0.02s race"
The 2-5/10 connection-reset failures we attributed to a server-side P13 race were actually **the test client generating colliding `hardware_id` MACs that violated `UNIQUE(devices.hardware_id)`**.  Server is fine. Test client patched separately (no PR needed; it's `/tmp/ws_keepalive_test.py`).

Refs #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)