### PR TITLE
feat(tools): widen parser for xLAM bracket-name dialect [NAME]{json}</NAME>

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,4 +65,5 @@ jobs:
             tests/test_debug_handlers.py \
             tests/test_lifecycle_monitors.py \
             tests/test_status_handlers.py \
-            tests/test_config_api_handlers.py
+            tests/test_config_api_handlers.py \
+            tests/test_tool_parser.py

--- a/dragon_voice/tools/registry.py
+++ b/dragon_voice/tools/registry.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 # XML-style markers for tool calls in LLM output.
 #
-# Two dialects are accepted:
+# Three dialects are accepted:
 #
 #   1. LEGACY (TinkerBox system-prompt format):
 #        <tool>NAME</tool><args>{"k": "v"}</args>
@@ -26,14 +26,23 @@ logger = logging.getLogger(__name__)
 #      were fine-tuned on.  Accepting it here means we don't have to fight
 #      the training prior of every FC model we want to run.
 #
-# Both shapes are extracted into the same `{"tool": name, "args": dict}`
+#   3. BRACKETED-NAME (xLAM quirk, surfaced during the dual-pipeline bench
+#      in #80 / #81 — issue #82):
+#        [NAME]{"k": "v"}</NAME>     — JSON args + matching close
+#        [NAME]UPPERCASE_IDENT()     — empty args, function-call-style noise
+#      The skill name IS the tag, with the open form using square brackets.
+#      To avoid false positives on user prose like `[note]` quoted in a
+#      chat reply, this dialect REQUIRES the name to be in the registered
+#      tool set.  Without that gate, parser would fire on innocent text.
+#
+# All three shapes are extracted into the same `{"tool": name, "args": dict}`
 # record, so downstream execute() + server eventing is format-agnostic.
 #
 # Tolerance knobs inherited from the prior implementation:
 #   - Stray `>` after JSON, missing `</args>`, extra whitespace all handled.
-#   - xLAM quirk: emits `[tool>` (left-bracket instead of left-angle) on
-#     the opening tag — the anchor regex now accepts either, since the
-#     closing `</tool>` still disambiguates unambiguously.
+#   - xLAM quirk on dialect 1: emits `[tool>` (left-bracket instead of
+#     left-angle) on the opening tag — the anchor regex accepts either,
+#     since the closing `</tool>` still disambiguates unambiguously.
 #
 # Tolerant regex: handles stray > after JSON, missing </args>, extra whitespace.
 # The `[<\[]tool[>\]]` open-tag class accepts `<tool>`, `[tool>`, `<tool]`, AND
@@ -42,6 +51,17 @@ logger = logging.getLogger(__name__)
 TOOL_PATTERN = re.compile(r'[<\[]tool[>\]](\w+)</tool>\s*<args>\s*({.*?})\s*>?\s*</args>', re.DOTALL)
 # Fallback: if </args> is missing entirely, grab JSON after <args>
 TOOL_PATTERN_LOOSE = re.compile(r'[<\[]tool[>\]](\w+)</tool>\s*<args>\s*({[^<]*})', re.DOTALL)
+
+# Dialect 3 cheap pre-check — used by has_tool_call.  Matches `[name]`
+# where `name` looks like a registered-tool identifier.  False positives
+# at this stage are fine; parse_tool_calls validates against the tool
+# registry before accepting.
+_BRACKET_NAME_PRECHECK = re.compile(r"\[([a-z_][a-z0-9_]*)\]")
+# Dialect 3 noise-args sanity check — the GETCURRENTDATEANDTIME() form
+# from xLAM should look like a function name (uppercase identifier),
+# not prose.  3-50 chars keeps real-world cases without exploding the
+# match window.
+_BRACKET_NOISE_IDENT = re.compile(r"^[A-Z][A-Z0-9_]{2,49}$")
 
 
 class ToolRegistry:
@@ -173,20 +193,102 @@ class ToolRegistry:
                 args = {}
             calls.append({"tool": name, "args": args})
 
+        # Dialect 3 — bracketed-name (xLAM quirk, issue #82).
+        # `[recall]{"query":"…"}</recall>` or `[datetime]GETCURRENTTIME()`.
+        # The skill name IS the tag, so without a registry validation step
+        # we'd false-positive on prose like `[note]` quoted in a chat
+        # reply.  Skip the pass entirely if no tools are registered (the
+        # validation gate would reject everything anyway).
+        if self._tools:
+            for m in _BRACKET_NAME_PRECHECK.finditer(text):
+                name = m.group(1)
+                if name not in self._tools:
+                    continue
+                i = m.end()
+                # Skip whitespace immediately after the opening bracket.
+                while i < len(text) and text[i] in " \t\n\r":
+                    i += 1
+                if i >= len(text):
+                    continue
+
+                args: Optional[dict] = None
+
+                if text[i] == "{":
+                    # Sub-form A: `[NAME]{json}</NAME>` — JSON args + close.
+                    end = _walk_json(text, i)
+                    if end < 0:
+                        continue
+                    try:
+                        parsed_args = json.loads(text[i:end])
+                    except json.JSONDecodeError:
+                        logger.warning(
+                            "Failed to parse bracket-name args for %s: %s",
+                            name, text[i:end][:100],
+                        )
+                        continue
+                    if not isinstance(parsed_args, dict):
+                        continue
+                    args = parsed_args
+                    # The matching `</NAME>` close tag is *encouraged* but not
+                    # required — xLAM emits it cleanly on most prompts but
+                    # truncates on others.  We accept either way.
+                else:
+                    # Sub-form B: `[NAME]IDENT()` — empty args, function-name
+                    # noise.  Bail if the noise spans more than ~50 chars
+                    # (real-world cases like GETCURRENTDATEANDTIME stay
+                    # well under that) or doesn't look like an identifier.
+                    paren = text.find("()", i, i + 80)
+                    if paren < 0:
+                        continue
+                    noise = text[i:paren].strip()
+                    if not _BRACKET_NOISE_IDENT.match(noise):
+                        continue
+                    args = {}
+
+                if args is not None:
+                    calls.append({"tool": name, "args": args})
+
         return calls
 
     def has_tool_call(self, text: str) -> bool:
         """Quick check if text contains a tool call marker.
-        Accepts both dialects the parser understands: the legacy
-        `<tool>NAME</tool>` shape and the industry-standard
-        `<tool_call>{...}</tool_call>` shape.
+        Accepts the three dialects the parser understands: the legacy
+        `<tool>NAME</tool>` shape, the industry-standard
+        `<tool_call>{...}</tool_call>` shape, and the bracketed-name
+        xLAM quirk `[NAME]{json}</NAME>` / `[NAME]IDENT()` (gated on the
+        name actually matching a registered tool, so prose like
+        `[note]` in a chat reply doesn't fire).
         """
         has_legacy = (
             ("<tool>" in text or "[tool>" in text or "[tool]" in text or "<tool]" in text)
             and "</tool>" in text
         )
         has_std = "<tool_call>" in text and "</tool_call>" in text
-        return has_legacy or has_std
+        if has_legacy or has_std:
+            return True
+
+        if not self._tools:
+            return False
+        for m in _BRACKET_NAME_PRECHECK.finditer(text):
+            if m.group(1) not in self._tools:
+                continue
+            # Peek past whitespace for the `{` (sub-form A) or
+            # `<word>(` (sub-form B) that distinguishes a real call
+            # from prose that happens to mention `[recall]`.  Without
+            # this guard, `has_tool_call` over-fires on chat replies
+            # whenever a tool name appears in brackets.
+            j = m.end()
+            while j < len(text) and text[j] in " \t\n\r":
+                j += 1
+            if j >= len(text):
+                continue
+            if text[j] == "{":
+                return True
+            # Sub-form B: identifier+`()` should appear within the same
+            # window parse_tool_calls scans.
+            if "()" in text[j:j + 80]:
+                return True
+        return False
 
     def format_for_llm(self, compact: bool = False) -> str:
         """Format tool descriptions for injection into LLM system prompt.

--- a/tests/test_tool_parser.py
+++ b/tests/test_tool_parser.py
@@ -1,0 +1,228 @@
+"""Unit tests for `ToolRegistry.parse_tool_calls` / `has_tool_call`.
+
+Covers all three accepted dialects and verifies that user prose that
+*looks* like a bracket-tag tool call (but doesn't match a registered
+tool, or doesn't have valid args) does NOT false-positive.
+
+Dialect 3 (xLAM bracket-name) is the headline addition from issue #82
+— see registry.py module docstring for the dialect taxonomy and PR #74
+for dialects 1 + 2.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from dragon_voice.tools.base import Tool
+from dragon_voice.tools.registry import ToolRegistry
+
+
+class _FakeTool(Tool):
+    """Minimal Tool stub — the parser only cares about `.name` so the
+    registry's name set is populated correctly for dialect-3
+    validation."""
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return f"fake tool {self._name}"
+
+    @property
+    def parameters_schema(self) -> dict:
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, args: dict) -> dict:  # pragma: no cover
+        return {"ok": True}
+
+
+def _registry_with(*names: str) -> ToolRegistry:
+    r = ToolRegistry()
+    for n in names:
+        r.register(_FakeTool(n))
+    return r
+
+
+# ───────────────────────── Dialect 1 — legacy <tool>NAME</tool><args>{…}</args>
+
+
+def test_dialect1_clean_call() -> None:
+    r = _registry_with("calculator")
+    out = r.parse_tool_calls(
+        '<tool>calculator</tool><args>{"expression": "2+2"}</args>'
+    )
+    assert out == [{"tool": "calculator", "args": {"expression": "2+2"}}]
+    assert r.has_tool_call(
+        '<tool>calculator</tool><args>{"expression": "2+2"}</args>'
+    )
+
+
+def test_dialect1_xlam_bracket_quirk_open_tag() -> None:
+    # All four bracket permutations on the opening tag must parse.
+    r = _registry_with("recall")
+    for opener in ("<tool>", "[tool>", "<tool]", "[tool]"):
+        text = f'{opener}recall</tool><args>{{"query": "x"}}</args>'
+        out = r.parse_tool_calls(text)
+        assert out == [{"tool": "recall", "args": {"query": "x"}}], opener
+
+
+def test_dialect1_handles_nested_json_args() -> None:
+    # The JSON walker (not the `{.*?}` non-greedy regex) must survive
+    # nested objects that the original parser truncated at the first `}`.
+    r = _registry_with("memory")
+    out = r.parse_tool_calls(
+        '<tool>memory</tool><args>{"filter": {"k": "v"}, "limit": 5}</args>'
+    )
+    assert out == [
+        {
+            "tool": "memory",
+            "args": {"filter": {"k": "v"}, "limit": 5},
+        }
+    ]
+
+
+# ───────────────────────── Dialect 2 — <tool_call>{json}</tool_call>
+
+
+def test_dialect2_clean_call_arguments_key() -> None:
+    r = _registry_with("web_search")
+    out = r.parse_tool_calls(
+        '<tool_call>{"name": "web_search", "arguments": {"query": "esp32"}}</tool_call>'
+    )
+    assert out == [{"tool": "web_search", "args": {"query": "esp32"}}]
+
+
+def test_dialect2_accepts_args_alias_for_arguments() -> None:
+    r = _registry_with("datetime")
+    out = r.parse_tool_calls(
+        '<tool_call>{"name": "datetime", "args": {}}</tool_call>'
+    )
+    assert out == [{"tool": "datetime", "args": {}}]
+
+
+def test_dialect2_skips_call_with_missing_name() -> None:
+    r = _registry_with("anything")
+    out = r.parse_tool_calls(
+        '<tool_call>{"arguments": {"x": 1}}</tool_call>'
+    )
+    assert out == []
+
+
+# ───────────────────────── Dialect 3 — bracket-name xLAM quirk (#82)
+
+
+def test_dialect3a_json_args_with_close_tag() -> None:
+    # Canonical FC dialect xLAM emits — JSON args + matching close.
+    r = _registry_with("recall")
+    out = r.parse_tool_calls(
+        '[recall]{"query": "How much disk space is left?"}</recall>'
+    )
+    assert out == [
+        {"tool": "recall", "args": {"query": "How much disk space is left?"}}
+    ]
+    assert r.has_tool_call(
+        '[recall]{"query": "x"}</recall>'
+    )
+
+
+def test_dialect3a_json_args_without_close_tag_still_accepted() -> None:
+    # xLAM truncates the close tag on some prompts — be tolerant.
+    r = _registry_with("calculator")
+    out = r.parse_tool_calls('[calculator]{"expression": "2+2"}')
+    assert out == [{"tool": "calculator", "args": {"expression": "2+2"}}]
+
+
+def test_dialect3b_function_call_style_noise_with_empty_args() -> None:
+    # The `[datetime]GETCURRENTDATEANDTIME()` form xLAM emitted in the
+    # dual-pipeline bench.  Treat as call with empty args.
+    r = _registry_with("datetime")
+    out = r.parse_tool_calls("[datetime]GETCURRENTDATEANDTIME()")
+    assert out == [{"tool": "datetime", "args": {}}]
+
+
+def test_dialect3_unknown_name_does_not_fire() -> None:
+    # No `note` registered — `[note]` in user prose must NOT trigger.
+    r = _registry_with("calculator")
+    text = "I want to add [note] this for later, please remember it."
+    assert r.parse_tool_calls(text) == []
+    assert not r.has_tool_call(text)
+
+
+def test_dialect3_known_name_in_prose_without_payload_does_not_fire() -> None:
+    # `[recall]` mentioned in conversation but with no `{...}` JSON or
+    # `IDENT()` after it — must NOT false-positive.
+    r = _registry_with("recall")
+    text = "The user mentioned [recall] earlier but didn't ask for it."
+    assert r.parse_tool_calls(text) == []
+    assert not r.has_tool_call(text)
+
+
+def test_dialect3b_lowercase_noise_rejected() -> None:
+    # The noise-args form REQUIRES uppercase identifier (function-name
+    # shape) so prose like `[note]some thing()` doesn't fire.
+    r = _registry_with("note")
+    out = r.parse_tool_calls("[note]some thing()")
+    assert out == []
+
+
+def test_dialect3b_oversize_noise_rejected() -> None:
+    # 80-char window only — sentence-length noise can't be a function name.
+    r = _registry_with("datetime")
+    out = r.parse_tool_calls(
+        "[datetime] " + "X" * 90 + "()"
+    )
+    assert out == []
+
+
+def test_dialect3_bare_bracket_recall_skipped() -> None:
+    # xLAM solo G8 emitted just `[recall]` with no payload at all.
+    # That's an unfinished call; we leave it for the responder to handle
+    # rather than firing with no args.
+    r = _registry_with("recall")
+    assert r.parse_tool_calls("[recall]") == []
+
+
+# ───────────────────────── Cross-dialect / mixed input
+
+
+def test_mixed_dialects_all_fire() -> None:
+    r = _registry_with("calculator", "recall", "datetime")
+    text = (
+        '<tool>calculator</tool><args>{"expression": "1+1"}</args>'
+        ' some prose '
+        '<tool_call>{"name": "recall", "arguments": {"query": "x"}}</tool_call>'
+        ' more prose '
+        '[datetime]GETCURRENTTIME()'
+    )
+    out = r.parse_tool_calls(text)
+    assert {c["tool"] for c in out} == {"calculator", "recall", "datetime"}
+
+
+def test_has_tool_call_false_on_pure_prose() -> None:
+    r = _registry_with("recall", "calculator")
+    assert not r.has_tool_call("Hello, how are you today?")
+    assert not r.has_tool_call("")
+
+
+def test_empty_registry_falls_back_safely_on_dialect3() -> None:
+    # Without any registered tool, dialect-3 must be a complete no-op
+    # (the validation gate would reject every match anyway).  Existing
+    # dialects 1 + 2 must still work.
+    r = ToolRegistry()
+    assert r.parse_tool_calls('[recall]{"query": "x"}</recall>') == []
+    assert r.parse_tool_calls(
+        '<tool_call>{"name": "x", "arguments": {}}</tool_call>'
+    ) == [{"tool": "x", "args": {}}]
+
+
+# Quick sanity: register and execute path still works end-to-end.
+def test_registered_tool_executes() -> None:
+    r = _registry_with("calculator")
+    out = asyncio.run(r.execute("calculator", {"expression": "2+2"}))
+    assert out["tool"] == "calculator"
+    assert out["result"] == {"ok": True}


### PR DESCRIPTION
Closes #82.

Adds a 3rd dialect to the tool-call parser to handle the two xLAM bracket-name forms surfaced during the dual-pipeline bench:

| Sub-form | Example | Notes |
|---|---|---|
| A — JSON args + close | \`[recall]{\"query\": \"How much disk left?\"}</recall>\` | xLAM emits this on most FC prompts; close tag tolerated when missing |
| B — function-name noise | \`[datetime]GETCURRENTDATEANDTIME()\` | empty args, treated as plain call; uppercase-ident noise filter rejects prose |

Both gated on \`NAME\` being in the registered tool set — without that guard, prose like \`[note] this for later\` would false-fire.  Bare \`[recall]\` (no payload) is intentionally not matched.

## Why

Discovered during PR #81's dual-pipeline validation.  xLAM solo bench currently scores **7/10** tool fires; G8 + G9 missed because the parser only knew dialects 1 + 2.  After this lands, xLAM solo expects **9/10**.  Side benefit: the dual mode no longer renders raw \`[datetime]GETCURRENTDATEANDTIME()\` in chat bubbles — that form now fires the tool and the responder writes the user reply over the result.

## What's in here

| File | Change |
|---|---|
| \`dragon_voice/tools/registry.py\` | +dialect-3 anchor in \`parse_tool_calls\`, +cheap pre-check in \`has_tool_call\`, +module docstring updates |
| \`tests/test_tool_parser.py\` | NEW — 18 unit tests covering all 3 dialects + false-positive guards |
| \`.github/workflows/ci.yml\` | +\`tests/test_tool_parser.py\` in the named CI test set |

## Test coverage (18 tests)

- **Dialect 1 (legacy \`<tool>NAME</tool>\`)**: clean call, all 4 xLAM bracket-quirk openers (\`<tool>\`, \`[tool>\`, \`<tool]\`, \`[tool]\`), nested JSON args
- **Dialect 2 (standard \`<tool_call>{json}</tool_call>\`)**: clean call, \`args\`/\`arguments\` alias, missing-name skipped
- **Dialect 3 (this PR)**: JSON+close, JSON-only (tolerant), function-name noise, unknown name rejected, bare-bracket prose rejected, lowercase noise rejected, oversize noise rejected, bare \`[recall]\` skipped
- **Cross-dialect**: all three dialects in one input fire correctly
- **\`has_tool_call\`**: false on pure prose, false on bracket-name without payload
- **Empty registry**: dialect 3 no-ops cleanly

## False-positive guards (the registry-validation gate)

- Sub-form A (JSON args): name MUST be in \`self._tools\`; JSON walker requires balanced \`{}\`
- Sub-form B (noise+\`()\`): name MUST be in \`self._tools\`; noise MUST match \`^[A-Z][A-Z0-9_]{2,49}$\` (uppercase identifier, no spaces); 80-char window cap

## Test plan
- [x] 18 new tests pass
- [x] All 130 CI tests pass locally
- [x] Ruff gate passes
- [x] Module docstring documents the 3 dialects + the validation gate's design

## Refs
- Closes #82
- Refs #74 (original parser widening for dialects 1 + 2)
- Refs #81 (dual-pipeline PR that surfaced these missing dialects)
- LEARNINGS #79 (parser-fragmentation entry that anticipated this work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)