### PR TITLE
docs(ux): mark H1 MERGED in UX-GAPS.md

### DIFF
--- a/docs/UX-GAPS.md
+++ b/docs/UX-GAPS.md
@@ -44,7 +44,7 @@ Per user direction:
 | L2 | `config_update` blocks WS read loop (~13 s worst case) | HIGH (was LOW) | ~2.5 h | 1 | **MERGED #92** |
 | C3 | Config-swap race during inference | non-issue | 15 min docs | 1 | **MERGED #92** (doc note) |
 | L4 | Cancel ack — late `llm` events arrive after Tab5 went READY | LOW | ~30 min | 1 | **MERGED #92 + TinkerTab#194** |
-| H1 | Tokens buffered for full LLM phase during tool turns | HIGH | ~90 min | 2 | OPEN |
+| H1 | Tokens buffered for full LLM phase during tool turns | HIGH | ~90 min | 2 | **MERGED #97** |
 | H2 | TTS sentence-boundary delay (incl. code-block false splits) | HIGH | ~110 min | 2 | OPEN |
 | H4 | Dictation post-process silent (no event during 10-20 s wait) | HIGH | ~95 min | 2 | **MERGED #95 + TinkerTab#195** |
 | L3 | Piper TTS not killed on timeout | LOW | ~35 min | 2 | OPEN |


### PR DESCRIPTION
Closes the H1 verdict-matrix row (PR #97 landed). Refs #94, #89.