### PR TITLE
feat(pipeline): TTS timeout-flush + code-block guard + Piper kill (Phase 2 H2/L3, refs #94)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,4 +70,5 @@ jobs:
             tests/test_dual_llm.py \
             tests/test_ws_dispatcher_cancellation.py \
             tests/test_dictation_post_process_events.py \
-            tests/test_incremental_tool_marker_detection.py
+            tests/test_incremental_tool_marker_detection.py \
+            tests/test_tts_flush_and_kill.py

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -49,6 +49,31 @@ _SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
 # Triggers on comma/semicolon/colon/dash with 20+ chars buffered
 _CLAUSE_END = re.compile(r"[,;:\u2014—]\s*$")
 
+# Phase 2 H2 (issue #94): word-boundary timeout-flush regex — finds the
+# last whitespace position so the timeout flush splits at a word break,
+# not mid-word.  Used only when the LLM has been silent on punctuation
+# for >300 ms AND the buffer has enough content to make a meaningful
+# TTS chunk.
+_LAST_WORD_BOUNDARY = re.compile(r"\s\S*$")
+
+# Phase 2 H2 (issue #94): triple-backtick toggle for code-block
+# detection.  While inside a code block the clause-flush is suppressed
+# (a colon in `def foo():` is structural, not a natural pause).  The
+# sentence-flush (.!?) still applies because periods are rare in code
+# blocks and a `.` is usually meaningful (e.g. `obj.method()`).
+# Timeout-flush also suppressed in code so the whole block emits as
+# one TTS unit.
+_TRIPLE_BACKTICK = "```"
+
+# Phase 2 H2 (issue #94): timeout-flush parameters.  300 ms is long
+# enough that a normal punctuation-rich response never trips it
+# (sentences land their `.` well within 300 ms of each other on any
+# model > 5 tok/s) but short enough that an LLM rambling without
+# punctuation still feels responsive.  Minimum buffer of 20 chars
+# prevents micro-stuttered chunks.
+_LOCAL_TIMEOUT_FLUSH_S = 0.30
+_LOCAL_TIMEOUT_FLUSH_MIN_CHARS = 20
+
 # Hallucination stop patterns — LLMs sometimes simulate user turns or continue
 # generating after answering. Truncate response at these markers.
 _HALLUCINATION_STOPS = re.compile(
@@ -725,6 +750,16 @@ class VoicePipeline:
             # length so a marker straddling a token boundary still hits.
             scan_watermark = 0
             OVERLAP = 32
+            # Phase 2 H2 (issue #94): track last successful TTS flush so
+            # we can word-boundary-flush after _LOCAL_TIMEOUT_FLUSH_S of
+            # punctuation silence.  Pre-fix, an LLM rambling without
+            # punctuation could buffer 60+ chars before any TTS chunk
+            # left Dragon, producing a noticeable mid-reply silence.
+            # Also track triple-backtick code-block state so the clause
+            # flush doesn't false-fire on `def foo():` style colons.
+            last_flush_ts = time.monotonic()
+            in_code_block = False
+            is_local = self._config.llm.backend in ("ollama", "npu_genie", "lmstudio")
             async for token in llm_stream:
                 if self._cancelled:
                     return
@@ -755,7 +790,21 @@ class VoicePipeline:
                 await self._on_event({"type": "llm", "text": token})
                 sentence_buffer += token
 
+                # Phase 2 H2 (issue #94): toggle code-block state on
+                # every triple-backtick boundary in the new token.  We
+                # only check the freshly-arrived token to avoid
+                # double-counting a backtick that was already in
+                # sentence_buffer.
+                if _TRIPLE_BACKTICK in token:
+                    n_marks = token.count(_TRIPLE_BACKTICK)
+                    if n_marks % 2 == 1:
+                        in_code_block = not in_code_block
+
                 # Check for sentence boundary — flush to TTS
+                # (Sentence-flush still fires inside code blocks because
+                # `.` is rare in code AND meaningful when present —
+                # `obj.method()` etc.  Suppressing it would cause a
+                # whole code response to wait for end-of-stream.)
                 if _SENTENCE_END.search(sentence_buffer):
                     sentences = _SENTENCE_SPLIT.split(sentence_buffer)
                     # Send all complete sentences, keep incomplete tail
@@ -768,19 +817,46 @@ class VoicePipeline:
                             # Last fragment is incomplete — keep buffering
                             remainder = sentence
                     sentence_buffer = remainder
+                    last_flush_ts = time.monotonic()
                 # Clause-level flushing: flush on comma/semicolon/colon/dash
                 # when buffer reaches a minimum length. Threshold is mode-aware:
                 #  - Local backends (low latency): 20 chars — start TTS early
                 #  - Cloud/hybrid backends (bursty tokens): 60 chars — buffer
                 #    a full sentence-length clause to smooth over latency spikes
                 #    and avoid choppy playback (P08)
-                elif _CLAUSE_END.search(sentence_buffer):
-                    is_local = self._config.llm.backend in ("ollama", "npu_genie", "lmstudio")
+                # Phase 2 H2: SKIP clause flush inside a code block — `:`
+                # in `def foo():` is structural, not a natural pause.
+                elif _CLAUSE_END.search(sentence_buffer) and not in_code_block:
                     clause_min_chars = 20 if is_local else 60
                     if len(sentence_buffer) >= clause_min_chars:
                         if sentence_buffer.strip():
                             await self._synthesize_and_send(sentence_buffer.strip())
                         sentence_buffer = ""
+                        last_flush_ts = time.monotonic()
+                # Phase 2 H2 (issue #94): timeout word-boundary flush.
+                # If neither sentence nor clause flush fired AND the LLM
+                # has been silent on punctuation for >300 ms, flush at
+                # the last word boundary so the user hears progress
+                # instead of staring at a frozen orb.  Local mode only —
+                # cloud TTS is fast and bursty, the existing 60-char
+                # clause threshold smooths it well enough.  Skip inside
+                # code blocks (would chop code mid-line).
+                elif (
+                    is_local
+                    and not in_code_block
+                    and len(sentence_buffer) >= _LOCAL_TIMEOUT_FLUSH_MIN_CHARS
+                    and (time.monotonic() - last_flush_ts) > _LOCAL_TIMEOUT_FLUSH_S
+                ):
+                    m = _LAST_WORD_BOUNDARY.search(sentence_buffer)
+                    if m and m.start() >= 10:
+                        # Flush up to (but not including) the whitespace,
+                        # keep the partial trailing word for the next
+                        # iteration.
+                        flush_text = sentence_buffer[: m.start()].strip()
+                        sentence_buffer = sentence_buffer[m.start():].lstrip()
+                        if flush_text:
+                            await self._synthesize_and_send(flush_text)
+                            last_flush_ts = time.monotonic()
 
             # Flush remaining text
             if sentence_buffer.strip() and not self._cancelled:
@@ -995,6 +1071,16 @@ class VoicePipeline:
                     self._tts.synthesize(text), timeout=30
                 )
             except (Exception, asyncio.TimeoutError) as tts_err:
+                # Phase 2 L3 (issue #94): kill any in-flight Piper
+                # subprocess BEFORE falling back / raising.  Piper has
+                # its own internal timeout which usually catches stalls,
+                # but the OpenRouter→Piper fallback path below could
+                # trigger a SECOND Piper synthesis on top of an already-
+                # stalled one.  Without explicit kill_active_procs the
+                # zombie holds the audio device + an FD until the Python
+                # process exits.
+                if hasattr(self._tts, "kill_active_procs"):
+                    self._tts.kill_active_procs()
                 if self._config.tts.backend == "openrouter":
                     logger.error("Cloud TTS failed: %s — falling back to local", tts_err)
                     # v4·D audit P1 fix: cache fallback Piper instance so
@@ -1006,7 +1092,20 @@ class VoicePipeline:
                         self._fallback_tts = create_tts(TTSConfig(backend="piper"))
                         await self._fallback_tts.initialize()
                         logger.info("Pre-warmed fallback TTS (piper) cached")
-                    audio_bytes = await self._fallback_tts.synthesize(text)
+                    # Phase 2 L3 (issue #94): the fallback Piper itself
+                    # can stall — wrap with the same 30s wait_for and
+                    # kill its procs on a second timeout.  Without the
+                    # second guard a TTS-down scenario with no second
+                    # fallback could leak indefinitely.
+                    try:
+                        audio_bytes = await asyncio.wait_for(
+                            self._fallback_tts.synthesize(text), timeout=30
+                        )
+                    except (Exception, asyncio.TimeoutError) as fb_err:
+                        if hasattr(self._fallback_tts, "kill_active_procs"):
+                            self._fallback_tts.kill_active_procs()
+                        logger.error("Fallback Piper TTS also failed: %s", fb_err)
+                        raise
                     await self._on_event({
                         "type": "config_update",
                         "error": "Cloud TTS unavailable, reverted to local",

--- a/tests/test_tts_flush_and_kill.py
+++ b/tests/test_tts_flush_and_kill.py
@@ -1,0 +1,210 @@
+"""Unit tests for the voice-pipeline TTS flush logic + Piper kill-on-timeout.
+
+Phase 2 H2 + L3 of the UX-gap remediation (see docs/UX-GAPS.md / issue #94).
+
+H2 — Pre-fix the LLM stream loop only flushed buffered tokens to TTS on
+sentence boundary (`.!?`) or clause boundary (`,;:—` past 20/60 chars).
+A reply with no early punctuation could buffer 60+ chars before any TTS
+chunk left Dragon — audible mid-reply silence.  Code blocks containing
+`def foo():` triggered false clause-flushes that sent `def foo():`
+verbatim to Piper.
+
+L3 — Pre-fix `_synthesize_and_send`'s except branch handled OpenRouter
+fallback to Piper but never called `kill_active_procs()`.  A stalled
+in-flight Piper subprocess holding the audio device + an FD could
+linger past the timeout.  The fallback Piper itself had no second
+timeout, so a TTS-down scenario could leak indefinitely.
+
+Tests cover the two helper-level concerns + the lifecycle behavior
+that's exercisable without spinning a real LLM/STT/TTS:
+
+  - Word-boundary regex (`_LAST_WORD_BOUNDARY`)
+  - Triple-backtick toggle correctness
+  - Constants are sane
+  - kill_active_procs is invoked on Piper TTS timeout (mocked TTS)
+  - Fallback Piper second-timeout also calls kill_active_procs
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+from unittest.mock import patch
+
+import pytest
+
+from dragon_voice.config import VoiceConfig
+from dragon_voice.pipeline import (
+    VoicePipeline,
+    _LAST_WORD_BOUNDARY,
+    _LOCAL_TIMEOUT_FLUSH_MIN_CHARS,
+    _LOCAL_TIMEOUT_FLUSH_S,
+    _TRIPLE_BACKTICK,
+)
+
+
+# ───────────────────────── helper-level
+
+
+def test_last_word_boundary_finds_last_space() -> None:
+    """The timeout flush splits at the LAST whitespace before the trailing
+    word so we don't chop a word in half."""
+    s = "Let me search for that information"
+    m = _LAST_WORD_BOUNDARY.search(s)
+    assert m is not None
+    # Match starts at the space before "information"
+    assert s[m.start()] == " "
+    assert s[: m.start()] == "Let me search for that"
+    assert s[m.start():].lstrip() == "information"
+
+
+def test_last_word_boundary_no_space() -> None:
+    """Single-word buffer has no boundary — caller should hold the whole
+    thing for the next iteration."""
+    assert _LAST_WORD_BOUNDARY.search("supercalifragilistic") is None
+
+
+def test_last_word_boundary_trailing_whitespace() -> None:
+    """Buffer ending in whitespace — last boundary is that whitespace."""
+    s = "Hello "
+    m = _LAST_WORD_BOUNDARY.search(s)
+    assert m is not None
+    assert s[: m.start()] == "Hello"
+
+
+def test_constants_are_sane() -> None:
+    """Don't ship a regression where someone sets MIN_CHARS=1 (would
+    micro-stutter every word) or TIMEOUT=0.05 (would over-fire)."""
+    assert 0.10 <= _LOCAL_TIMEOUT_FLUSH_S <= 1.0, (
+        "300 ms is the sweet spot — too low chops every word; too high "
+        "and the user feels the gap"
+    )
+    assert _LOCAL_TIMEOUT_FLUSH_MIN_CHARS >= 10, (
+        "Need enough buffer to make a meaningful TTS chunk"
+    )
+    assert _TRIPLE_BACKTICK == "```", "Code-block marker is the markdown standard"
+
+
+# ───────────────────────── code-block toggle (parity with the in-loop logic)
+
+
+def test_triple_backtick_toggle_parity() -> None:
+    """Mirror of the toggle logic at pipeline.py: count backticks per
+    token, toggle if odd.  This test pins down the contract so a refactor
+    doesn't accidentally start using a different rule."""
+    in_code = False
+    tokens = ["here is code: ", "```python\n", "def foo():\n", "    return 1\n", "```", " end"]
+    snapshots: list[bool] = []
+    for tok in tokens:
+        if _TRIPLE_BACKTICK in tok:
+            n = tok.count(_TRIPLE_BACKTICK)
+            if n % 2 == 1:
+                in_code = not in_code
+        snapshots.append(in_code)
+    # After "here is code: ": False (no backtick)
+    # After "```python\n": True (entered code)
+    # After "def foo():": True (still in code — colon would NOT trigger
+    # clause flush in the production path)
+    # After "    return 1": True
+    # After "```": False (exited code)
+    # After " end": False
+    assert snapshots == [False, True, True, True, False, False]
+
+
+def test_triple_backtick_inline_pair_no_toggle() -> None:
+    """An inline ``code`` pair in one token (two backticks total) is
+    even — net no toggle, stays out of code-block mode."""
+    in_code = False
+    tok = "use ```code``` like that"
+    if _TRIPLE_BACKTICK in tok:
+        n = tok.count(_TRIPLE_BACKTICK)
+        if n % 2 == 1:
+            in_code = not in_code
+    assert in_code is False
+
+
+# ───────────────────────── kill_active_procs on TTS timeout
+
+
+class _StallTTS:
+    """TTS that always raises asyncio.TimeoutError after a tiny delay,
+    and tracks whether kill_active_procs was called."""
+    sample_rate = 22050
+    def __init__(self) -> None:
+        self.killed = 0
+    async def synthesize(self, text: str) -> bytes:
+        # The wait_for at the call site has timeout=30; we raise the same
+        # exception type the wait_for would raise on a real timeout.
+        raise asyncio.TimeoutError("simulated piper stall")
+    def kill_active_procs(self) -> None:
+        self.killed += 1
+
+
+class _OkTTS:
+    """TTS that returns 1024 bytes immediately (used as fallback)."""
+    sample_rate = 22050
+    def __init__(self) -> None:
+        self.synth_calls = 0
+        self.killed = 0
+    async def synthesize(self, text: str) -> bytes:
+        self.synth_calls += 1
+        return b"\x00\x00" * 512  # 1024 bytes of silence
+    def kill_active_procs(self) -> None:
+        self.killed += 1
+
+
+def _make_pipeline_with_tts(tts) -> VoicePipeline:
+    cfg = VoiceConfig()
+    async def on_audio(_: bytes) -> None: pass
+    async def on_event(_ev: dict) -> None: pass
+    p = VoicePipeline(cfg, on_audio, on_event, conversation_engine=None, session_id="t")
+    p._tts = tts
+    return p
+
+
+def test_kill_active_procs_called_on_local_tts_timeout() -> None:
+    """Local Piper TTS times out → kill_active_procs is called.  The
+    outer try/except in `_synthesize_and_send` swallows the exception
+    (production caller doesn't expect propagation — voice loop continues
+    on TTS failure), so we verify side-effect rather than raise.  Pre-fix
+    the zombie subprocess held the audio device until process exit."""
+    tts = _StallTTS()
+    p = _make_pipeline_with_tts(tts)
+    # Default config is backend="ollama" + tts.backend="piper" — local
+    # path → exception re-raises but is swallowed by outer except
+    asyncio.run(p._synthesize_and_send("hello world"))
+    assert tts.killed == 1, (
+        f"kill_active_procs should be called exactly once on local TTS "
+        f"timeout; got {tts.killed}"
+    )
+
+
+def test_kill_active_procs_called_on_openrouter_then_fallback_succeeds() -> None:
+    """OpenRouter TTS times out → kill_active_procs called → falls back
+    to a fresh Piper instance which succeeds."""
+    primary = _StallTTS()
+    fallback = _OkTTS()
+    p = _make_pipeline_with_tts(primary)
+    p._config.tts.backend = "openrouter"
+    p._fallback_tts = fallback  # pre-cached so we skip the create_tts call
+    # Should NOT raise — fallback succeeded
+    asyncio.run(p._synthesize_and_send("hello world"))
+    assert primary.killed == 1, "primary TTS killed on timeout"
+    assert fallback.synth_calls == 1, "fallback synth was attempted"
+    assert fallback.killed == 0, "fallback TTS succeeded — no kill needed"
+
+
+def test_fallback_piper_also_killed_on_second_timeout() -> None:
+    """OpenRouter times out → kill primary → fallback Piper also times
+    out → kill fallback → exception swallowed by outer except.
+    Pre-fix the second fallback timeout silently leaked the zombie."""
+    primary = _StallTTS()
+    fallback = _StallTTS()  # also stalls
+    p = _make_pipeline_with_tts(primary)
+    p._config.tts.backend = "openrouter"
+    p._fallback_tts = fallback
+    asyncio.run(p._synthesize_and_send("hello world"))
+    assert primary.killed == 1
+    assert fallback.killed == 1, (
+        "Pre-fix this would have been 0 — fallback would silently leak "
+        "a zombie subprocess"
+    )


### PR DESCRIPTION
Refs #94 (Phase 2 master). Refs #89 (audit master tracker).

Closes the H2 + L3 rows in [\`docs/UX-GAPS.md\`](../blob/main/docs/UX-GAPS.md). Bundled because they touch the same file (\`pipeline.py\`) and overlap conceptually.

## H2 — Voice TTS sentence-boundary delay

Pre-fix the LLM stream loop only flushed buffered tokens to TTS on:
- sentence boundary (\`.!?\`), OR
- clause boundary (\`,;:—\`) past 20 chars (local) / 60 chars (cloud)

A reply with no early punctuation could buffer 60+ chars before any TTS chunk left Dragon — audible mid-reply silence on local-mode turns where the LLM rambles without commas.

**Two new behaviours:**

| Mechanism | When | Effect |
|---|---|---|
| Word-boundary timeout flush | Local mode, > 300 ms since last flush, buffer ≥ 20 chars | Flush at last whitespace; user hears progress instead of orb sitting silent |
| Triple-backtick code-block guard | While \`in_code_block\` is true | Suppresses BOTH clause flush AND timeout flush (so \`def foo():\` doesn't get spoken on the colon).  Sentence flush still fires inside code (rare but meaningful) |

Cloud mode unaffected — already responsive at the 60-char clause threshold.

## L3 — Piper TTS subprocess not killed on timeout

Pre-fix \`_synthesize_and_send\`'s except branch handled OpenRouter fallback to Piper but never called \`kill_active_procs()\`. A stalled in-flight Piper subprocess held the audio device + an FD until the Python process exited. The fallback Piper itself had no second timeout — a TTS-down scenario could leak indefinitely.

**Two changes:**
- \`kill_active_procs()\` called BEFORE either fallback or re-raise on the primary TTS instance
- Fallback Piper synthesize now wrapped in its own \`asyncio.wait_for(timeout=30)\`; on second timeout the fallback also gets \`kill_active_procs()\` called

## Test plan
- [x] 9 new unit tests in \`tests/test_tts_flush_and_kill.py\`
- [x] **175 total CI tests pass** (166 prior + 9 new) — zero regression
- [x] Ruff lint passes
- [x] No Tab5 changes — TTS happens server-side; Tab5 just consumes the audio chunks

## What this PR does NOT do (deliberate scope)
- Doesn't strip code blocks from TTS entirely (audit's mention).  Skipping a block requires parsing the LLM stream to remove it before sending, which is a bigger fix; deferred to Phase 6 polish.
- Doesn't add a third TTS fallback if the second Piper also fails; today the exception propagates to the outer try-except in \`_synthesize_and_send\` which logs and continues the voice loop without audio for that sentence.  That's the existing contract; my change ensures the zombie subprocess gets cleaned up so subsequent sentences can use the TTS device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)