### PR TITLE
docs(ux): Phase 2 complete — H2 + L3 MERGED

### DIFF
--- a/docs/UX-GAPS.md
+++ b/docs/UX-GAPS.md
@@ -45,9 +45,9 @@ Per user direction:
 | C3 | Config-swap race during inference | non-issue | 15 min docs | 1 | **MERGED #92** (doc note) |
 | L4 | Cancel ack — late `llm` events arrive after Tab5 went READY | LOW | ~30 min | 1 | **MERGED #92 + TinkerTab#194** |
 | H1 | Tokens buffered for full LLM phase during tool turns | HIGH | ~90 min | 2 | **MERGED #97** |
-| H2 | TTS sentence-boundary delay (incl. code-block false splits) | HIGH | ~110 min | 2 | OPEN |
+| H2 | TTS sentence-boundary delay (incl. code-block false splits) | HIGH | ~110 min | 2 | **MERGED #99** |
 | H4 | Dictation post-process silent (no event during 10-20 s wait) | HIGH | ~95 min | 2 | **MERGED #95 + TinkerTab#195** |
-| L3 | Piper TTS not killed on timeout | LOW | ~35 min | 2 | OPEN |
+| L3 | Piper TTS not killed on timeout | LOW | ~35 min | 2 | **MERGED #99** |
 | H8 | Raw error strings on wrong UI surface (voice caption vs toast) | HIGH | ~4 h | 3 | OPEN |
 | M1 | Tool parser silent on malformed JSON args | MED | ~3 h | 3 | OPEN |
 | M2 | WS upgrade rejection plain text (401/503) | MED | ~3.5 h | 3 | OPEN |


### PR DESCRIPTION
Closes the H2 and L3 verdict-matrix rows (PR #99 landed). All 4 Phase 2 gaps now closed (H1 #97, H2 #99, H4 #95, L3 #99). Refs #94, #89.