### PR TITLE
feat(errors): structured error taxonomy (Phase 3 γ1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
             tests/test_mcp_bridge.py \
             tests/test_notes_db_async.py \
             tests/test_config_redact.py \
+            tests/test_errors.py \
             tests/test_media_url_signer.py \
             tests/test_proxy_image_ssrf.py \
             tests/test_security_headers.py \

--- a/dragon_voice/errors.py
+++ b/dragon_voice/errors.py
@@ -1,0 +1,184 @@
+"""Structured error taxonomy for Dragon → Tab5 error frames.
+
+Phase 3 γ1 of the UX-gap remediation (see docs/UX-GAPS.md / issue #101).
+
+Pre-fix the codebase emitted ad-hoc `{"type":"error","message":"raw_string"}`
+frames from ~11 different sites with no shared schema.  Tab5
+(voice.c:754-764) routed every error to the voice-state caption buffer
+regardless of severity — implementation-detail strings like
+``[Ollama timeout after 300s]`` or raw `str(e)` Python exception text
+appeared in the voice overlay caption with no user-actionable context.
+
+This module introduces:
+
+* :class:`Severity` enum — TRANSIENT (retry-able, e.g. STT miss, LLM
+  timeout) vs FATAL (unrecoverable, e.g. session_invalid, auth_failed,
+  device_evicted).  Tab5 will use this in γ2 to route TRANSIENT errors
+  to a non-blocking toast and FATAL errors to the voice caption +
+  retry banner.
+* :class:`Scope` enum — which subsystem produced the error (STT, LLM,
+  TTS, TOOL, SESSION, DEVICE, GATEWAY, MEDIA).  Used by Tab5 to choose
+  an appropriate icon/colour for the toast, and by Dragon-side
+  observability to bucket errors in metrics / logs.
+* :func:`error_event` — the structured-frame builder.  All ad-hoc
+  emission sites are migrated to call this so the schema stays
+  consistent.
+* :class:`DragonError` exception — for raise/catch flows in backends
+  and tools that want to signal a structured error upward.  Carries
+  the same severity + scope + user-friendly message + machine code.
+
+Backward compatibility: the emitted frame still has the existing
+``type``, ``code``, and ``message`` fields — so an unmodified Tab5
+that reads only ``message`` keeps working.  The new ``severity`` and
+``scope`` fields are additive; Tab5 starts honouring them in γ2.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+
+class Severity(str, Enum):
+    """Error severity — drives Tab5's UI surface choice (toast vs
+    caption vs retry banner).
+
+    The string values are the on-the-wire representation in the JSON
+    frame's ``severity`` field, kept short for byte-budget on Tab5's
+    cJSON parser.
+    """
+
+    TRANSIENT = "transient"
+    """Retry is meaningful — e.g. STT didn't hear anything, LLM took too
+    long, network flap.  Tab5 should surface as a non-blocking toast
+    and stay in READY so the user can try again immediately."""
+
+    FATAL = "fatal"
+    """Retry won't help without operator action — e.g. session_invalid,
+    auth_failed, device_evicted, no LLM configured.  Tab5 should
+    surface in the voice caption (more permanent) and may stop
+    auto-reconnecting if appropriate."""
+
+
+class Scope(str, Enum):
+    """Which subsystem produced the error.
+
+    Used by Tab5 for icon/colour selection in γ2 and by Dragon-side
+    observability to bucket errors in metrics.
+    """
+
+    STT = "stt"
+    LLM = "llm"
+    TTS = "tts"
+    TOOL = "tool"
+    SESSION = "session"
+    DEVICE = "device"
+    GATEWAY = "gateway"
+    MEDIA = "media"
+    UNKNOWN = "unknown"
+
+
+def error_event(
+    *,
+    code: str,
+    message: str,
+    severity: Severity = Severity.TRANSIENT,
+    scope: Scope = Scope.UNKNOWN,
+) -> dict:
+    """Build a structured error event dict for WS emission.
+
+    Replaces ad-hoc ``{"type":"error","message":"..."}`` frames so
+    every emission site contributes the same schema.  Tab5 (γ2) uses
+    ``severity`` to route to the right UI surface; ``scope`` informs
+    icon/colour; ``code`` is the machine-readable identifier; and
+    ``message`` is the user-facing string (kept short — Tab5's caption
+    buffer is 128 chars).
+
+    Parameters
+    ----------
+    code:
+        Machine-readable identifier (e.g. ``"stt_empty"``, ``"llm_timeout"``,
+        ``"session_invalid"``).  Snake-case.  Stable enough for Tab5
+        to switch on; not stable enough to be considered a public API.
+    message:
+        User-facing message.  Short, actionable, no implementation
+        detail.  Don't pass ``str(e)`` — that leaks Python exception
+        types.  Bad: ``"list index out of range"``.  Good:
+        ``"Image analysis failed — please try again"``.
+    severity:
+        TRANSIENT (retry-able) vs FATAL (needs operator action).
+    scope:
+        Which subsystem (LLM, TTS, etc.).  UNKNOWN is acceptable when
+        the source is genuinely ambiguous.
+
+    Returns
+    -------
+    dict
+        Ready-to-send JSON dict.  Caller is responsible for the actual
+        ``ws.send_json`` / ``await self._on_event(...)`` call so this
+        helper stays a pure function (testable, no I/O).
+    """
+    return {
+        "type": "error",
+        "code": code,
+        "message": message,
+        "severity": severity.value,
+        "scope": scope.value,
+    }
+
+
+class DragonError(Exception):
+    """Exception form of a structured error.
+
+    Useful in backends (LLM, STT, TTS) and tools that want to ``raise``
+    a typed error upward instead of returning a status dict.  The
+    catching layer can convert to an emit via :meth:`to_event`.
+
+    Example::
+
+        if not gateway_reachable:
+            raise DragonError(
+                "TinkerClaw gateway is offline",
+                code="gateway_unreachable",
+                severity=Severity.FATAL,
+                scope=Scope.GATEWAY,
+            )
+
+        try:
+            ...
+        except DragonError as e:
+            await self._on_event(e.to_event())
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        severity: Severity = Severity.TRANSIENT,
+        scope: Scope = Scope.UNKNOWN,
+        cause: Optional[BaseException] = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
+        self.severity = severity
+        self.scope = scope
+        self.cause = cause
+
+    def to_event(self) -> dict:
+        """Convert to the standard error-event dict for WS emission."""
+        return error_event(
+            code=self.code,
+            message=self.message,
+            severity=self.severity,
+            scope=self.scope,
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"DragonError(code={self.code!r}, severity={self.severity.value!r}, "
+            f"scope={self.scope.value!r}, message={self.message!r})"
+        )
+
+
+__all__ = ["Severity", "Scope", "error_event", "DragonError"]

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -17,6 +17,7 @@ from typing import Callable, Awaitable, Optional
 import numpy as np
 
 from dragon_voice.config import VoiceConfig
+from dragon_voice.errors import Scope, Severity, error_event
 from dragon_voice.stt import create_stt, STTBackend
 from dragon_voice.tts import create_tts, TTSBackend
 from dragon_voice.llm import create_llm, LLMBackend
@@ -391,7 +392,11 @@ class VoicePipeline:
             logger.error("Pipeline processing timed out after %ds (backend=%s)", timeout, backend)
             self._processing = False
             try:
-                await self._on_event({"type": "error", "message": f"Processing timed out after {timeout}s"})
+                await self._on_event(error_event(
+                    code="llm_timeout",
+                    message="Thinking took too long — try a shorter question.",
+                    severity=Severity.TRANSIENT, scope=Scope.LLM,
+                ))
                 # Send tts_end so Tab5 doesn't hang
                 if self._tts_started:
                     await self._on_event({"type": "tts_end", "tts_ms": 0})
@@ -684,8 +689,11 @@ class VoicePipeline:
                             len(audio_data), self._config.stt.backend)
                 await self._on_event({"type": "stt", "text": "", "stt_ms": round(stt_ms)})
                 # User-friendly error — Tab5 shows this on voice overlay
-                await self._on_event({"type": "error",
-                                      "message": "Couldn't hear you — try again"})
+                await self._on_event(error_event(
+                    code="stt_empty",
+                    message="Couldn't hear you — try again.",
+                    severity=Severity.TRANSIENT, scope=Scope.STT,
+                ))
                 return
 
             logger.info("STT (%.0fms): %s", stt_ms, transcript)
@@ -988,9 +996,11 @@ class VoicePipeline:
         except Exception:
             logger.exception("Pipeline processing error")
             try:
-                await self._on_event(
-                    {"type": "error", "message": "Processing failed — see server logs"}
-                )
+                await self._on_event(error_event(
+                    code="pipeline_failed",
+                    message="Something went wrong — please try again.",
+                    severity=Severity.TRANSIENT, scope=Scope.LLM,
+                ))
             except (ConnectionError, RuntimeError) as _e:
                 # Wave 13 H5: the WS is already torn down — don't mask the
                 # original exception with a secondary send failure.

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -30,6 +30,7 @@ from dragon_voice.config import (
 )
 from dragon_voice.conversation import ConversationEngine
 from dragon_voice.db import Database
+from dragon_voice.errors import Scope, Severity, error_event
 from dragon_voice.messages import MessageStore
 from dragon_voice.handlers import (
     config_api as _handlers_config_api,
@@ -966,8 +967,11 @@ class VoiceServer:
         requested_session = cmd.get("session_id")
 
         if not device_id:
-            await ws.send_json({"type": "error", "code": "session_invalid",
-                                "message": "device_id is required"})
+            await ws.send_json(error_event(
+                code="session_invalid",
+                message="device_id is required",
+                severity=Severity.FATAL, scope=Scope.SESSION,
+            ))
             return
 
         ws_id = conn_state["ws_id"]
@@ -1234,8 +1238,14 @@ class VoiceServer:
         except Exception as e:
             logger.exception("Failed to initialize pipeline for %s", ws_id)
             if not ws.closed:
-                await ws.send_json({"type": "error", "code": "internal",
-                                    "message": f"Pipeline init failed: {e}"})
+                # Don't leak the raw exception to the user — Tab5
+                # surfaces this in the voice caption.  Operator can
+                # see the actual `e` in the journal.
+                await ws.send_json(error_event(
+                    code="pipeline_init_failed",
+                    message="Voice pipeline failed to start.  Try reconnecting.",
+                    severity=Severity.FATAL, scope=Scope.SESSION,
+                ))
             return
 
         conn_state["pipeline"] = pipeline
@@ -1328,8 +1338,11 @@ class VoiceServer:
         """Handle text input message — goes directly to conversation engine."""
         session_id = conn_state.get("session_id")
         if not session_id or not self._conversation:
-            await ws.send_json({"type": "error", "code": "session_invalid",
-                                "message": "Not registered — send register first"})
+            await ws.send_json(error_event(
+                code="session_invalid",
+                message="Not registered — send register first.",
+                severity=Severity.FATAL, scope=Scope.SESSION,
+            ))
             return
 
         content = cmd.get("content", "").strip()
@@ -1717,8 +1730,11 @@ class VoiceServer:
         except Exception:
             logger.exception("Text processing error on session %s", session_id)
             if not ws.closed:
-                await ws.send_json({"type": "error", "code": "llm_failed",
-                                    "message": "Text processing failed"})
+                await ws.send_json(error_event(
+                    code="llm_failed",
+                    message="Text processing failed — please try again.",
+                    severity=Severity.TRANSIENT, scope=Scope.LLM,
+                ))
 
     async def _handle_config_update(
         self,
@@ -2045,16 +2061,21 @@ class VoiceServer:
         image_path = await self._media_store.get_path(media_id)
         if not image_path:
             if not ws.closed:
-                await ws.send_json({"type": "error", "message": "Image not found"})
+                await ws.send_json(error_event(
+                    code="media_not_found",
+                    message="Image not found — please retake the photo.",
+                    severity=Severity.TRANSIENT, scope=Scope.MEDIA,
+                ))
             return
 
         backend = conn_config.llm.backend
         if backend == "ollama" and "vision" not in conn_config.llm.ollama_model:
             if not ws.closed:
-                await ws.send_json({
-                    "type": "error",
-                    "message": "Image analysis needs Cloud or TinkerClaw mode"
-                })
+                await ws.send_json(error_event(
+                    code="vision_unsupported",
+                    message="Image analysis needs Cloud or TinkerClaw mode.",
+                    severity=Severity.FATAL, scope=Scope.LLM,
+                ))
             return
 
         # Wave 13 H2: image may be up to ~8 MB (camera JPEG) -- reading on the
@@ -2085,7 +2106,11 @@ class VoiceServer:
 
         if not llm_backend:
             if not ws.closed:
-                await ws.send_json({"type": "error", "message": "No LLM available"})
+                await ws.send_json(error_event(
+                    code="no_llm_available",
+                    message="No language model is configured.  Check Settings.",
+                    severity=Severity.FATAL, scope=Scope.LLM,
+                ))
             return
 
         try:
@@ -2101,7 +2126,16 @@ class VoiceServer:
         except Exception as e:
             logger.error("user_media LLM failed: %s", e)
             if not ws.closed:
-                await ws.send_json({"type": "error", "message": str(e)})
+                # Phase 3 γ1: was raw `str(e)` — leaked Python exception
+                # text (e.g. "list index out of range") into Tab5's voice
+                # caption.  Now a stable, user-friendly message keyed by
+                # `vision_failed`; cause kept in the server log only.
+                await ws.send_json(error_event(
+                    code="vision_failed",
+                    message="Image analysis failed — please try again.",
+                    severity=Severity.TRANSIENT,
+                    scope=Scope.LLM,
+                ))
             return
 
         # #75 phase 1b: vision path gets the same empty-reply guard as

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,139 @@
+"""Unit tests for the structured error taxonomy.
+
+Phase 3 γ1 of the UX-gap remediation (see docs/UX-GAPS.md / issue #101).
+"""
+from __future__ import annotations
+
+import pytest
+
+from dragon_voice.errors import DragonError, Scope, Severity, error_event
+
+
+# ───────────────────────── enum on-the-wire shape
+
+
+def test_severity_values_are_short_strings() -> None:
+    """Tab5's cJSON parser has byte budget — keep wire values terse."""
+    assert Severity.TRANSIENT.value == "transient"
+    assert Severity.FATAL.value == "fatal"
+    # No accidental lowercase-hash collisions
+    assert {s.value for s in Severity} == {"transient", "fatal"}
+
+
+def test_scope_covers_all_subsystems_in_audit() -> None:
+    """The Phase-2 audit identified these 8 subsystems as error-emitting.
+    Pin them down so a future addition is a deliberate enum extension,
+    not silent drift."""
+    expected = {"stt", "llm", "tts", "tool", "session", "device", "gateway", "media", "unknown"}
+    actual = {s.value for s in Scope}
+    assert actual == expected
+
+
+# ───────────────────────── error_event() shape
+
+
+def test_error_event_has_all_fields() -> None:
+    ev = error_event(
+        code="llm_timeout",
+        message="Thinking took too long — try a shorter question",
+        severity=Severity.TRANSIENT,
+        scope=Scope.LLM,
+    )
+    assert ev["type"] == "error"
+    assert ev["code"] == "llm_timeout"
+    assert ev["message"] == "Thinking took too long — try a shorter question"
+    assert ev["severity"] == "transient"
+    assert ev["scope"] == "llm"
+
+
+def test_error_event_defaults_are_safe() -> None:
+    """If a caller forgets to specify severity/scope, default to
+    TRANSIENT/UNKNOWN — the LEAST disruptive interpretation
+    (Tab5 will toast it instead of permanently displaying)."""
+    ev = error_event(code="x", message="y")
+    assert ev["severity"] == "transient"
+    assert ev["scope"] == "unknown"
+
+
+def test_error_event_is_pure() -> None:
+    """No hidden state, no I/O — callable repeatedly with same args
+    returns equal dicts (important for unit-testing emission sites)."""
+    ev1 = error_event(code="x", message="y", severity=Severity.FATAL, scope=Scope.SESSION)
+    ev2 = error_event(code="x", message="y", severity=Severity.FATAL, scope=Scope.SESSION)
+    assert ev1 == ev2
+
+
+# ───────────────────────── DragonError exception class
+
+
+def test_dragon_error_round_trips_via_to_event() -> None:
+    """A raised + caught DragonError can be serialised via to_event()
+    and matches what error_event() would have built directly."""
+    e = DragonError(
+        "TinkerClaw gateway is offline",
+        code="gateway_unreachable",
+        severity=Severity.FATAL,
+        scope=Scope.GATEWAY,
+    )
+    ev = e.to_event()
+    assert ev == error_event(
+        code="gateway_unreachable",
+        message="TinkerClaw gateway is offline",
+        severity=Severity.FATAL,
+        scope=Scope.GATEWAY,
+    )
+
+
+def test_dragon_error_is_a_real_exception() -> None:
+    """Can be raised + caught + str()-ed without losing the message."""
+    with pytest.raises(DragonError) as exc_info:
+        raise DragonError("test error", code="t", severity=Severity.TRANSIENT, scope=Scope.STT)
+    assert str(exc_info.value) == "test error"
+    assert exc_info.value.code == "t"
+    assert exc_info.value.severity is Severity.TRANSIENT
+    assert exc_info.value.scope is Scope.STT
+
+
+def test_dragon_error_carries_cause_for_chained_exceptions() -> None:
+    """When a backend wraps an underlying exception, the cause should
+    be preserved for logging purposes (not user-visible)."""
+    underlying = ValueError("bad input")
+    e = DragonError(
+        "Image analysis failed",
+        code="image_decode_failed",
+        severity=Severity.TRANSIENT,
+        scope=Scope.MEDIA,
+        cause=underlying,
+    )
+    assert e.cause is underlying
+    # to_event() must NOT leak the cause string into the user message
+    assert "bad input" not in e.to_event()["message"]
+
+
+def test_dragon_error_repr_is_useful_for_logs() -> None:
+    e = DragonError("x", code="y", severity=Severity.FATAL, scope=Scope.LLM)
+    r = repr(e)
+    assert "DragonError" in r
+    assert "code='y'" in r
+    assert "fatal" in r
+    assert "llm" in r
+
+
+# ───────────────────────── frame is JSON-serializable
+
+
+def test_error_event_is_json_serializable() -> None:
+    """Callers pass the dict to ws.send_json / asyncio event hooks —
+    must be plain JSON-friendly."""
+    import json
+    ev = error_event(
+        code="x",
+        message="y",
+        severity=Severity.FATAL,
+        scope=Scope.DEVICE,
+    )
+    # Round-trip through json — no enums leaking through
+    encoded = json.dumps(ev)
+    decoded = json.loads(encoded)
+    assert decoded["severity"] == "fatal"
+    assert decoded["scope"] == "device"


### PR DESCRIPTION
## Summary
- New `dragon_voice.errors` module: `Severity` (TRANSIENT/FATAL) + `Scope` (STT/LLM/TTS/TOOL/SESSION/DEVICE/GATEWAY/MEDIA/UNKNOWN) + `error_event()` builder + `DragonError` exception.
- Migrates **all 11** ad-hoc `{"type":"error","message":"…"}` emission sites (3 in [`dragon_voice/pipeline.py`](dragon_voice/pipeline.py), 8 in [`dragon_voice/server.py`](dragon_voice/server.py)) to the new structured frame.
- 10 new unit tests in [`tests/test_errors.py`](tests/test_errors.py), wired into the CI named-set ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)).

## Motivation (Phase 2 audit, refs #89, refs #101)
Pre-fix, error frames were unstructured strings emitted from 11 inconsistent sites.  The worst offender ([server.py:2128](dragon_voice/server.py#L2128)) was a raw `str(e)` that surfaced Python exception text like `"list index out of range"` directly in Tab5's voice caption.  Pipeline init failures leaked `f"Pipeline init failed: {e}"`.  Tab5 ([voice.c:754-764](https://github.com/lorcan35/TinkerTab/blob/main/main/voice.c#L754-L764)) routes every error to the voice-state caption regardless of severity — there's no way to distinguish "tap to retry" from "go to Settings".

## Backward compatibility
Frames keep `type` / `code` / `message`.  `severity` / `scope` are additive — an unmodified Tab5 that reads only `message` keeps working.  γ2 (next PR set) starts honouring `severity` to route TRANSIENT → toast, FATAL → caption + retry banner.

## Site classification
| Site | code | severity | scope |
|------|------|----------|-------|
| pipeline.py LLM timeout | `llm_timeout` | TRANSIENT | LLM |
| pipeline.py STT empty | `stt_empty` | TRANSIENT | STT |
| pipeline.py generic failure | `pipeline_failed` | TRANSIENT | LLM |
| server.py device_id required | `session_invalid` | FATAL | SESSION |
| server.py pipeline init failed | `pipeline_init_failed` | FATAL | SESSION |
| server.py not registered | `session_invalid` | FATAL | SESSION |
| server.py text processing | `llm_failed` | TRANSIENT | LLM |
| server.py image not found | `media_not_found` | TRANSIENT | MEDIA |
| server.py vision unsupported | `vision_unsupported` | FATAL | LLM |
| server.py no LLM available | `no_llm_available` | FATAL | LLM |
| server.py user_media exception (was raw `str(e)`) | `vision_failed` | TRANSIENT | LLM |

## Test plan
- [x] `ruff check` narrow gate clean (F821,F722,F811,F823,B006,B904,E722,B007,RUF006)
- [x] CI named-set: **185/185 passing** (was 175 + 10 new errors tests)
- [x] Full repo suite (`pytest tests/ --ignore=tests/audit`): **226/226 passing**
- [x] Sandbox deploy on Dragon `:3513` — `session_invalid` (unregistered-text) and `media_not_found` (bogus media_id) paths verified end-to-end with the new `severity` + `scope` fields on the wire
- [x] Sandbox journal clean — zero tracebacks/exceptions post-deploy
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)