### PR TITLE
feat(tools): emit tool_args_invalid on parser JSON failure (γ2-M1)

### DIFF
--- a/dragon_voice/conversation.py
+++ b/dragon_voice/conversation.py
@@ -303,6 +303,7 @@ class ConversationEngine:
         audio_duration_s: Optional[float] = None,
         on_tool_call=None,
         on_tool_result=None,
+        on_tool_error=None,
     ) -> AsyncIterator[str]:
         """Process text input with streaming response and tool-calling support.
 
@@ -313,6 +314,12 @@ class ConversationEngine:
             audio_duration_s: Duration of voice input (None for text).
             on_tool_call: Optional async callback(call_dict) for tool call events.
             on_tool_result: Optional async callback(result_dict) for tool result events.
+            on_tool_error: Optional async callback(error_dict) — fires once
+                per failed tool-call parse (γ2-M1, issue #104).  Pre-fix
+                these failures were silent `logger.warning` lines; the
+                WS handler wires this to a `tool_args_invalid` error
+                frame so the user sees a transient toast instead of an
+                empty/generic LLM reply.
 
         Yields:
             Text tokens as they arrive from the LLM.
@@ -385,7 +392,22 @@ class ConversationEngine:
                     and self._tool_registry.has_tool_call(response_text)
                     and tool_calls_made < MAX_TOOL_CALLS):
 
-                tool_calls = self._tool_registry.parse_tool_calls(response_text)
+                # γ2-M1 (issue #104): use the error-surfacing variant so
+                # malformed tool-call attempts emit a `tool_args_invalid`
+                # WS frame instead of silently disappearing into a
+                # logger.warning.  Errors are reported even when there's
+                # at least one successful call in the same response —
+                # the user wants to know "tool A worked, tool B was
+                # skipped" rather than just seeing the partial result.
+                tool_calls, tool_errors = (
+                    self._tool_registry.parse_tool_calls_with_errors(response_text)
+                )
+                if tool_errors and on_tool_error:
+                    for err in tool_errors:
+                        try:
+                            await on_tool_error(err)
+                        except Exception as e:
+                            logger.debug("on_tool_error callback error: %s", e)
                 if tool_calls:
                     tool_call = tool_calls[0]  # Execute one at a time
                     tool_calls_made += 1

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -1138,8 +1138,36 @@ class VoiceServer:
                 except Exception:
                     logger.debug("widget_list auto-emit failed", exc_info=True)
 
+            async def _on_tool_error(err: dict):
+                """γ2-M1 (issue #104): emit a `tool_args_invalid` error
+                frame when the parser swallows malformed JSON args.
+
+                Pre-fix the failure was a silent `logger.warning` —
+                the LLM continued without firing the tool and the
+                user saw an empty/generic reply with zero signal that
+                anything was attempted.  Now we surface a TRANSIENT
+                error in the TOOL scope so Tab5 (γ2-H8) can render a
+                non-blocking toast.
+
+                The raw args are deliberately NOT included in the
+                user-facing message — they may contain prompt-injection
+                content from the LLM and Tab5's caption isn't a safe
+                place to render arbitrary text.  Server log already
+                carries the full failure for ops debugging.
+                """
+                if ws.closed:
+                    return
+                tool_name = err.get("name") or "(unknown)"
+                await self._safe_send_json(ws, error_event(
+                    code="tool_args_invalid",
+                    message=f"Tool '{tool_name}' had invalid arguments — skipped.",
+                    severity=Severity.TRANSIENT,
+                    scope=Scope.TOOL,
+                ))
+
             conn_state["on_tool_call"] = _on_tool_call
             conn_state["on_tool_result"] = _on_tool_result
+            conn_state["on_tool_error"] = _on_tool_error
 
         # Send session_start IMMEDIATELY — before slow pipeline init.
         # Use _safe_send_json so a transient transport close (the Tab5
@@ -1536,6 +1564,7 @@ class VoiceServer:
                     input_mode="text",
                     on_tool_call=conn_state.get("on_tool_call"),
                     on_tool_result=conn_state.get("on_tool_result"),
+                    on_tool_error=conn_state.get("on_tool_error"),
                 ):
                     full_response.append(token)
                     pending += token

--- a/dragon_voice/tools/registry.py
+++ b/dragon_voice/tools/registry.py
@@ -114,9 +114,48 @@ class ToolRegistry:
         truncate at the first `}` it encounters -- a nested JSON value
         like {"filter": {"k": "v"}} lost its outer closer.  We now
         balance braces manually after the regex anchors the position.
+
+        γ2-M1 (issue #104): pre-fix this method swallowed JSON-decode
+        errors silently — `parse_tool_calls_with_errors` is the
+        error-surfacing sibling.  This method preserves the original
+        list-only signature for backward compatibility (16 existing
+        unit tests + 2 conversation.py call sites).
+        """
+        calls, _errors = self.parse_tool_calls_with_errors(text)
+        return calls
+
+    def parse_tool_calls_with_errors(
+        self, text: str
+    ) -> tuple[list[dict], list[dict]]:
+        """Like :meth:`parse_tool_calls`, but also returns parse errors.
+
+        γ2-M1 (issue #104, refs #89, refs #101).  The Phase-2 audit
+        identified the silent JSON-decode swallow as user-invisible
+        agentic failure: the LLM emits a tool call, the parser fails
+        to load the args, the tool never fires, and the user sees a
+        generic / empty reply with no signal that anything was tried.
+
+        Returns
+        -------
+        (calls, errors)
+            ``calls`` is identical to what :meth:`parse_tool_calls`
+            returns (list of ``{"tool": name, "args": dict}``).
+            ``errors`` is a list of error records:
+
+                {"dialect": 1|2|3,
+                 "name": str | None,
+                 "reason": "json_decode"}
+
+            ``name`` is ``None`` for dialect-2 errors, where the JSON
+            parse fails before the FC envelope's ``name`` field can be
+            read.  ``reason`` is currently always ``"json_decode"`` —
+            the only failure mode worth surfacing today; structurally-
+            wrong FC envelopes (e.g. missing ``name``) stay silent
+            because they look indistinguishable from prose-shaped JSON.
         """
         import re as _re
-        calls = []
+        calls: list[dict] = []
+        errors: list[dict] = []
 
         def _walk_json(text: str, start: int) -> int:
             """Return index one past the matching `}` for the JSON object
@@ -165,6 +204,9 @@ class ToolRegistry:
             except json.JSONDecodeError:
                 logger.warning("Failed to parse tool args for %s: %s",
                                name, args_str[:100])
+                errors.append({
+                    "dialect": 1, "name": name, "reason": "json_decode",
+                })
 
         # Dialect 2 — industry-standard `<tool_call>{"name": "X",
         # "arguments": {...}}</tool_call>`.  Walk the JSON directly from
@@ -182,6 +224,9 @@ class ToolRegistry:
             except json.JSONDecodeError:
                 logger.warning("Failed to parse <tool_call> body: %s",
                                body[:120])
+                errors.append({
+                    "dialect": 2, "name": None, "reason": "json_decode",
+                })
                 continue
             if not isinstance(parsed, dict):
                 continue
@@ -225,6 +270,9 @@ class ToolRegistry:
                             "Failed to parse bracket-name args for %s: %s",
                             name, text[i:end][:100],
                         )
+                        errors.append({
+                            "dialect": 3, "name": name, "reason": "json_decode",
+                        })
                         continue
                     if not isinstance(parsed_args, dict):
                         continue
@@ -248,7 +296,7 @@ class ToolRegistry:
                 if args is not None:
                     calls.append({"tool": name, "args": args})
 
-        return calls
+        return calls, errors
 
     def has_tool_call(self, text: str) -> bool:
         """Quick check if text contains a tool call marker.

--- a/tests/test_incremental_tool_marker_detection.py
+++ b/tests/test_incremental_tool_marker_detection.py
@@ -273,6 +273,90 @@ def test_with_marker_holds_back_until_tool_executed() -> None:
     assert "The answer is 42." in joined
 
 
+def test_malformed_tool_args_fires_on_tool_error_callback() -> None:
+    """γ2-M1 (issue #104): when the LLM emits a tool block with
+    malformed JSON args, the parse failure must surface to the WS
+    handler via the new ``on_tool_error`` callback so a
+    ``tool_args_invalid`` error frame can be sent to Tab5 instead of
+    the user seeing nothing.
+
+    Pre-fix this case was a silent ``logger.warning`` line — Tab5 got
+    no error frame, the LLM continued (or stopped, depending on the
+    model), and the user saw an empty / generic reply with zero hint
+    that anything was attempted."""
+    eng, _ = _make_engine(
+        [
+            "Sure, ",
+            '<tool>calculator</tool><args>{not valid json}</args>',
+        ],
+        with_registry=True,
+    )
+    seen_errors: list[dict] = []
+
+    async def _capture(err: dict) -> None:
+        seen_errors.append(err)
+
+    asyncio.run(_drain(
+        eng.process_text_stream("s1", "x", on_tool_error=_capture)
+    ))
+
+    assert len(seen_errors) == 1, (
+        f"Expected exactly one on_tool_error call; got {seen_errors}"
+    )
+    err = seen_errors[0]
+    assert err["dialect"] == 1
+    assert err["name"] == "calculator"
+    assert err["reason"] == "json_decode"
+
+
+def test_clean_tool_call_does_not_fire_on_tool_error() -> None:
+    """Pin the boundary: a successful tool-call must NOT spuriously
+    fire ``on_tool_error``.  Without this guard a future regression
+    that flips the error/success branches could go unnoticed because
+    Tab5 would just see an extra toast on every successful tool turn —
+    annoying but not test-breaking."""
+    eng, _ = _make_engine(
+        [
+            "Sure, ", "let me ", "look ",
+            '<tool>', 'web_search', '</tool>',
+            '<args>', '{"q":"x"}', '</args>',
+        ],
+        with_registry=True,
+    )
+    seen_errors: list[dict] = []
+
+    async def _capture(err: dict) -> None:
+        seen_errors.append(err)
+
+    asyncio.run(_drain(
+        eng.process_text_stream("s1", "find x", on_tool_error=_capture)
+    ))
+    assert seen_errors == []
+
+
+def test_on_tool_error_callback_exception_is_swallowed() -> None:
+    """Defensive: a buggy callback must not break the streaming turn.
+    Pre-fix the existing on_tool_call/on_tool_result wrappers swallow
+    callback errors at debug level; preserve that contract for the
+    new on_tool_error path so a flaky WS send doesn't tear down the
+    LLM turn."""
+    eng, _ = _make_engine(
+        [
+            '<tool>calculator</tool><args>{not valid}</args>',
+        ],
+        with_registry=True,
+    )
+
+    async def _boom(err: dict) -> None:
+        raise RuntimeError("simulated callback failure")
+
+    # Should NOT raise out of process_text_stream — the loop terminates
+    # cleanly even when the user-supplied callback explodes.
+    asyncio.run(_drain(
+        eng.process_text_stream("s1", "x", on_tool_error=_boom)
+    ))
+
+
 def test_tail_partial_marker_does_not_flush_prematurely() -> None:
     """If the LLM emits `<too` and then keeps going, the tail must wait
     for the next token before flushing."""

--- a/tests/test_tool_parser.py
+++ b/tests/test_tool_parser.py
@@ -226,3 +226,118 @@ def test_registered_tool_executes() -> None:
     out = asyncio.run(r.execute("calculator", {"expression": "2+2"}))
     assert out["tool"] == "calculator"
     assert out["result"] == {"ok": True}
+
+
+# ───────────────────────── γ2-M1 (issue #104): expose parse errors
+#
+# Pre-fix `parse_tool_calls` swallowed JSON-decode errors silently
+# (`logger.warning(...)`) — the LLM continued without firing the tool
+# and the user saw an empty / generic response with zero signal that
+# anything was attempted.  γ2-M1 adds `parse_tool_calls_with_errors`
+# which surfaces failed parses so the WS handler can emit a
+# `tool_args_invalid` error frame (γ1 taxonomy).
+
+
+def test_with_errors_returns_empty_lists_for_clean_input() -> None:
+    r = _registry_with("calculator")
+    calls, errors = r.parse_tool_calls_with_errors("just some prose")
+    assert calls == []
+    assert errors == []
+
+
+def test_with_errors_returns_calls_for_clean_dialect1() -> None:
+    r = _registry_with("calculator")
+    calls, errors = r.parse_tool_calls_with_errors(
+        '<tool>calculator</tool><args>{"expression": "2+2"}</args>'
+    )
+    assert calls == [{"tool": "calculator", "args": {"expression": "2+2"}}]
+    assert errors == []
+
+
+def test_with_errors_dialect1_malformed_json_surfaces_error() -> None:
+    """`<tool>X</tool><args>{not json}</args>` — pre-fix this was a
+    silent warning; now must produce a structured error record so
+    the WS handler can emit a tool_args_invalid frame."""
+    r = _registry_with("calculator")
+    calls, errors = r.parse_tool_calls_with_errors(
+        '<tool>calculator</tool><args>{not valid json}</args>'
+    )
+    assert calls == []
+    assert len(errors) == 1
+    err = errors[0]
+    assert err["dialect"] == 1
+    assert err["name"] == "calculator"
+    assert err["reason"] == "json_decode"
+
+
+def test_with_errors_dialect2_malformed_json_surfaces_error() -> None:
+    """`<tool_call>{...</tool_call>` — JSON parse fails before we can
+    read the `name` field, so name is None."""
+    r = _registry_with("anything")
+    calls, errors = r.parse_tool_calls_with_errors(
+        '<tool_call>{not valid json}</tool_call>'
+    )
+    assert calls == []
+    assert len(errors) == 1
+    err = errors[0]
+    assert err["dialect"] == 2
+    assert err["name"] is None
+    assert err["reason"] == "json_decode"
+
+
+def test_with_errors_dialect3_malformed_json_surfaces_error() -> None:
+    """`[NAME]{bad json}` — name is known (gated on registry) so the
+    error carries it."""
+    r = _registry_with("recall")
+    calls, errors = r.parse_tool_calls_with_errors(
+        '[recall]{not valid json}</recall>'
+    )
+    assert calls == []
+    assert len(errors) == 1
+    err = errors[0]
+    assert err["dialect"] == 3
+    assert err["name"] == "recall"
+    assert err["reason"] == "json_decode"
+
+
+def test_with_errors_mixed_good_and_bad_returns_both() -> None:
+    """One well-formed + one malformed in the same response.  User
+    should get the good tool result AND know one was skipped."""
+    r = _registry_with("calculator", "recall")
+    text = (
+        '<tool>calculator</tool><args>{"expression": "2+2"}</args>'
+        ' then '
+        '<tool>recall</tool><args>{not valid}</args>'
+    )
+    calls, errors = r.parse_tool_calls_with_errors(text)
+    assert calls == [{"tool": "calculator", "args": {"expression": "2+2"}}]
+    assert len(errors) == 1
+    assert errors[0]["name"] == "recall"
+
+
+def test_parse_tool_calls_backcompat_unchanged() -> None:
+    """Pre-existing callers (and the 16 tests above) call the bare
+    `parse_tool_calls` and expect just the success list.  That signature
+    is preserved — the new error info only flows through the *_with_errors
+    sibling.  This guards against an accidental break of the public API."""
+    r = _registry_with("calculator")
+    out = r.parse_tool_calls(
+        '<tool>calculator</tool><args>{not valid}</args>'
+    )
+    assert out == []  # malformed → still 0 calls; no exception, no errors leaked
+    assert isinstance(out, list)
+
+
+def test_with_errors_does_not_emit_when_dialect2_lacks_name_field() -> None:
+    """Dialect-2 input that decodes cleanly but has no `name` is a
+    silently-skipped call (existing test_dialect2_skips_call_with_missing_name).
+    That's not a parse failure — it's a malformed FC envelope.  Don't
+    emit a tool_args_invalid error for it; the parser just declines to
+    fire the tool.  This test pins that boundary so we don't regress
+    into noisy error frames for prose-shaped JSON."""
+    r = _registry_with("anything")
+    calls, errors = r.parse_tool_calls_with_errors(
+        '<tool_call>{"arguments": {"x": 1}}</tool_call>'
+    )
+    assert calls == []
+    assert errors == []


### PR DESCRIPTION
Closes #104.  Refs #89, refs #101.  Phase 3 γ2 sub-piece.

## What changes
1. **[`dragon_voice/tools/registry.py`](dragon_voice/tools/registry.py)** — adds `parse_tool_calls_with_errors(text) -> (calls, errors)` exposing the JSON-decode failures that `parse_tool_calls` previously swallowed silently across all 3 dialects.  Pre-existing `parse_tool_calls` becomes a thin wrapper preserving the list-only signature (16 prior tests + 2 caller sites unchanged).
2. **[`dragon_voice/conversation.py`](dragon_voice/conversation.py)** — `process_text_stream` gains an optional `on_tool_error` callback that fires once per failed parse, even when other calls in the same response succeeded.
3. **[`dragon_voice/server.py`](dragon_voice/server.py)** — `_on_tool_error` per-connection callback emits `error_event(code="tool_args_invalid", severity=TRANSIENT, scope=TOOL)` (γ1 taxonomy from #102).

## Why
Per [docs/UX-GAPS.md M1](docs/UX-GAPS.md#m1--tool-parser-silent-on-malformed-json) — pre-fix the LLM emits a tool call, the parser logs `Failed to parse tool args for X: ...` and continues, the tool never fires, and the user sees an empty / generic LLM reply with **zero signal** that anything was attempted.  Now Tab5 gets a structured TRANSIENT/TOOL error frame it can render as a toast (γ2-H8).

## Defensive choices
- Raw args are NOT included in the user-facing message — may carry prompt-injection content from the LLM, and Tab5's caption isn't a safe place for arbitrary text.  Server log keeps the existing first-100-char debug snippet.
- Callback exceptions swallowed at debug level (matches `on_tool_call`/`on_tool_result` pattern).
- Dialect-2 envelopes that decode cleanly but lack a `name` field stay silent (the boundary pinned by `test_dialect2_skips_call_with_missing_name`) — those look indistinguishable from prose-shaped JSON.

## Test plan
- [x] **7 new unit tests** in [`tests/test_tool_parser.py`](tests/test_tool_parser.py) covering all 3 dialects, mixed good/bad, backward-compat preservation
- [x] **3 new integration tests** in [`tests/test_incremental_tool_marker_detection.py`](tests/test_incremental_tool_marker_detection.py) exercising the callback wiring through `process_text_stream`
- [x] `ruff check` narrow gate clean
- [x] CI named-set: **194 passing** (pre: 185)
- [x] Full repo: **237 passing** (`pytest tests/ --ignore=tests/audit`)
- [x] Sandbox-deployed on Dragon `:3513` — boot clean, γ1 error frames (`session_invalid` FATAL/SESSION + `media_not_found` TRANSIENT/MEDIA from #102) still land cleanly post-deploy
- [ ] CI green on this PR

## Out of scope (follow-ups)
- Tab5-side rendering of the new toast (γ2-H8).
- Wiring `on_tool_error` through `ConversationEngine.process_text` (sync), the REST SSE chat path, and the voice pipeline path — those don't have WS-event consumers yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)