### PR TITLE
feat(llm): TC gateway fast-fail health check (γ2-M6)

### DIFF
--- a/dragon_voice/llm/tinkerclaw_llm.py
+++ b/dragon_voice/llm/tinkerclaw_llm.py
@@ -10,14 +10,30 @@ import asyncio
 import json
 import logging
 import re
+import time
 from typing import AsyncIterator, Optional
 
 import aiohttp
 
 from dragon_voice.config import LLMConfig
+from dragon_voice.errors import DragonError, Scope, Severity
 from dragon_voice.llm.base import LLMBackend
 
 logger = logging.getLogger(__name__)
+
+# γ2-M6 (issue #106) — fast-fail health check budget.
+#
+# HEALTH_CHECK_TIMEOUT_S = how long a single /health probe is allowed
+# to block.  5 s is well under Tab5's PONG-watch (~30 s) so a probe
+# during a slow-startup-recovery scenario can't itself trip the
+# eviction race.
+#
+# HEALTH_CACHE_TTL_S = how long a probe result is reused before re-
+# probing.  30 s is short enough that recovery after the gateway
+# comes back is felt within a turn or two, but long enough that the
+# happy path doesn't pay 5 s on every single user turn.
+HEALTH_CHECK_TIMEOUT_S = 5
+HEALTH_CACHE_TTL_S = 30
 
 # Wave 14 W14-M07: per-line + total-stream caps for the TinkerClaw SSE
 # parser.  The gateway is trusted in theory, but a bug on the other
@@ -111,6 +127,12 @@ class TinkerClawBackend(LLMBackend):
         self._model = config.tinkerclaw_model or "minimax/MiniMax-M2.5"
         self._session: Optional[aiohttp.ClientSession] = None
         self._session_key: Optional[str] = None
+        # γ2-M6 (issue #106): cached health-check state.
+        # _health_cache_until=0.0 means "no cached result, must probe
+        # on next is_healthy() call".  Both fields are set together
+        # by is_healthy() and seeded by initialize().
+        self._health_cache_ok: bool = False
+        self._health_cache_until: float = 0.0
 
     async def initialize(self) -> None:
         headers = {"Content-Type": "application/json"}
@@ -129,15 +151,69 @@ class TinkerClawBackend(LLMBackend):
             headers=headers,
         )
 
-        # Health check — verify gateway is reachable (non-fatal if down)
+        # γ2-M6 (issue #106): seed the health cache so the first request
+        # after boot is fast — no extra 5 s probe just because we forgot
+        # we already checked at init.  Force=True bypasses the empty
+        # cache check and writes the result regardless.
+        await self.is_healthy(force=True)
+
+    async def is_healthy(self, force: bool = False) -> bool:
+        """Probe the TC gateway's /health endpoint with caching.
+
+        γ2-M6 (issue #106) — the audit identified that when the gateway
+        is reachable at TCP layer but hung / dead at app layer, the
+        first POST blocks for the full 600 s sock_read window.  This
+        method gives ``generate_stream_with_messages`` a 5 s yes/no
+        answer with 30 s caching so the user doesn't wait 10 minutes
+        before the connection-error fallback fires.
+
+        Parameters
+        ----------
+        force:
+            If True, bypass the cache and always re-probe.  Use for
+            ops debugging (manual recovery check after restarting the
+            gateway) — production callers leave it False.
+
+        Returns
+        -------
+        bool
+            True if /health returned 200 within HEALTH_CHECK_TIMEOUT_S,
+            False otherwise (any non-200, ClientError, TimeoutError).
+            Never raises.
+        """
+        now = time.monotonic()
+        if not force and now < self._health_cache_until:
+            return self._health_cache_ok
+
+        if self._session is None or self._session.closed:
+            # No live session means we haven't initialised yet.
+            self._health_cache_ok = False
+            self._health_cache_until = now + HEALTH_CACHE_TTL_S
+            return False
+
+        ok = False
         try:
-            async with self._session.get(f"{self._url}/health") as resp:
-                if resp.status == 200:
-                    logger.info("TinkerClaw gateway connected at %s", self._url)
+            async with self._session.get(
+                f"{self._url}/health",
+                timeout=aiohttp.ClientTimeout(total=HEALTH_CHECK_TIMEOUT_S),
+            ) as resp:
+                ok = resp.status == 200
+                if not ok:
+                    logger.warning(
+                        "TinkerClaw health check returned %d", resp.status
+                    )
                 else:
-                    logger.warning("TinkerClaw health check returned %d", resp.status)
-        except aiohttp.ClientError as e:
-            logger.warning("TinkerClaw gateway not reachable at %s: %s (will retry on first request)", self._url, e)
+                    logger.debug("TinkerClaw health check OK")
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            logger.warning(
+                "TinkerClaw health check failed: %s (cached for %ds)",
+                e, HEALTH_CACHE_TTL_S,
+            )
+        # Cache regardless of outcome — both healthy and unhealthy
+        # results get the TTL so we don't spam-probe a down gateway.
+        self._health_cache_ok = ok
+        self._health_cache_until = now + HEALTH_CACHE_TTL_S
+        return ok
 
     def set_session_key(self, session_key: str) -> None:
         """Set the session key for conversation continuity.
@@ -183,6 +259,20 @@ class TinkerClawBackend(LLMBackend):
         """
         if not self._session or self._session.closed:
             await self.initialize()
+
+        # γ2-M6 (issue #106): fast-fail before the 600 s POST when the
+        # gateway is known to be down.  is_healthy() uses a 30 s cached
+        # result so the happy path doesn't pay for a probe per turn;
+        # only the first turn after the gateway goes down (or after the
+        # cache expires) waits the 5 s probe budget.
+        if not await self.is_healthy():
+            raise DragonError(
+                "TinkerClaw agent gateway isn't responding — "
+                "fall back to local mode and try again.",
+                code="gateway_unreachable",
+                severity=Severity.FATAL,
+                scope=Scope.GATEWAY,
+            )
 
         payload = {
             "model": self._model,

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -17,7 +17,7 @@ from typing import Callable, Awaitable, Optional
 import numpy as np
 
 from dragon_voice.config import VoiceConfig
-from dragon_voice.errors import Scope, Severity, error_event
+from dragon_voice.errors import DragonError, Scope, Severity, error_event
 from dragon_voice.stt import create_stt, STTBackend
 from dragon_voice.tts import create_tts, TTSBackend
 from dragon_voice.llm import create_llm, LLMBackend
@@ -993,6 +993,19 @@ class VoicePipeline:
 
         except asyncio.CancelledError:
             logger.info("Pipeline processing was cancelled")
+        except DragonError as e:
+            # γ2-M6 (issue #106): structured γ-arch errors (e.g. TC
+            # gateway fast-fail) carry severity + scope already.
+            # Forward as-is instead of collapsing to the generic
+            # `pipeline_failed` toast — Tab5 routes by scope (γ2-H8).
+            logger.warning(
+                "Pipeline received structured error: %s (code=%s, scope=%s)",
+                e.message, e.code, e.scope.value,
+            )
+            try:
+                await self._on_event(e.to_event())
+            except (ConnectionError, RuntimeError) as _e:
+                logger.debug("structured-error notice not delivered: %s", _e)
         except Exception:
             logger.exception("Pipeline processing error")
             try:

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -30,7 +30,7 @@ from dragon_voice.config import (
 )
 from dragon_voice.conversation import ConversationEngine
 from dragon_voice.db import Database
-from dragon_voice.errors import Scope, Severity, error_event
+from dragon_voice.errors import DragonError, Scope, Severity, error_event
 from dragon_voice.messages import MessageStore
 from dragon_voice.handlers import (
     config_api as _handlers_config_api,
@@ -1411,13 +1411,30 @@ class VoiceServer:
             # slow for a 90 s 4 B-class Ollama turn.  See docs/AUDIT.md
             # "Local-mode gauntlet" for the observed P13-eviction race.
             full_response = []
-            async with self._ws_keepalive_during_inference(ws, label="tc_text"):
-                async for token in llm.generate_stream_with_messages([
-                    {"role": "user", "content": text}
-                ]):
-                    full_response.append(token)
-                    if not ws.closed:
-                        await ws.send_json({"type": "llm", "text": token})
+            try:
+                async with self._ws_keepalive_during_inference(ws, label="tc_text"):
+                    async for token in llm.generate_stream_with_messages([
+                        {"role": "user", "content": text}
+                    ]):
+                        full_response.append(token)
+                        if not ws.closed:
+                            await ws.send_json({"type": "llm", "text": token})
+            except DragonError as e:
+                # γ2-M6 (issue #106): TC gateway pre-flight health check
+                # failed in ≤ 5 s.  Emit the structured γ1 error frame
+                # so Tab5 can surface a FATAL/GATEWAY banner — pre-fix
+                # the user waited the full 600 s sock_read timeout
+                # before the connection-error fallback fired.
+                logger.warning(
+                    "TC text path fast-failed: %s (code=%s)",
+                    e.message, e.code,
+                )
+                if not ws.closed:
+                    await self._safe_send_json(ws, e.to_event())
+                    await ws.send_json({
+                        "type": "llm_done", "llm_ms": 0, "text": "",
+                    })
+                return
 
             response_text = "".join(full_response)
 

--- a/tests/test_tinkerclaw_health_check.py
+++ b/tests/test_tinkerclaw_health_check.py
@@ -1,0 +1,344 @@
+"""Unit tests for the TinkerClaw fast-fail health check.
+
+γ2-M6 (issue #106) of the UX-gap remediation (refs #89, #101, #94).
+
+Pre-fix the TC backend ate the full 600 s ``sock_read`` timeout when
+the gateway was reachable at TCP layer but hung / dead at app layer
+— users saw nothing for 10 minutes before the connection-error
+fallback fired.  The fix adds a cached pre-request ``/health`` probe
+(5 s timeout, 30 s TTL) and raises a structured ``DragonError`` with
+``code="gateway_unreachable"``, ``severity=FATAL``, ``scope=GATEWAY``
+when it fails.
+
+These tests pin:
+  * the cache TTL behaviour (no spam-probing on every turn)
+  * ``initialize()`` seeds the cache so the first request is fast
+  * ``generate_stream_with_messages`` raises ``DragonError`` with the
+    γ1 taxonomy when health is bad
+  * the ``force=True`` escape hatch works (for ops debugging)
+
+aiohttp is mocked at the ``ClientSession`` level — the real network
+is never touched, so these run in the CI named-set without a live
+gateway.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from dragon_voice.config import LLMConfig
+from dragon_voice.errors import DragonError, Scope, Severity
+from dragon_voice.llm.tinkerclaw_llm import (
+    HEALTH_CACHE_TTL_S,
+    HEALTH_CHECK_TIMEOUT_S,
+    TinkerClawBackend,
+)
+
+
+def _backend(token: str = "test-token") -> TinkerClawBackend:
+    cfg = LLMConfig(
+        backend="tinkerclaw",
+        tinkerclaw_url="http://localhost:18789",
+        tinkerclaw_token=token,
+    )
+    return TinkerClawBackend(cfg)
+
+
+class _FakeHealthResponse:
+    """Minimal aiohttp response stand-in for /health probes."""
+
+    def __init__(self, status: int):
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class _FakeSession:
+    """In-memory aiohttp ClientSession that records GET /health calls
+    and returns scripted responses (or raises a scripted error)."""
+
+    def __init__(self, responses=None, raises=None):
+        self._responses = responses or []
+        self._raises = raises  # exception to raise on every call, or None
+        self.get_calls: list[tuple[str, float | None]] = []
+        self.closed = False
+
+    def get(self, url: str, *, timeout=None, **kwargs):
+        # Record the timeout so tests can assert HEALTH_CHECK_TIMEOUT_S.
+        timeout_s = (
+            timeout.total if isinstance(timeout, aiohttp.ClientTimeout) else None
+        )
+        self.get_calls.append((url, timeout_s))
+        if self._raises is not None:
+            raise self._raises
+        if not self._responses:
+            raise RuntimeError("FakeSession ran out of scripted responses")
+        return self._responses.pop(0)
+
+    async def close(self):
+        self.closed = True
+
+
+# ───────────────────────── caching
+
+
+def test_constants_are_sensible() -> None:
+    """Pin the wire-side budget so a future tweak doesn't silently
+    blow past Tab5's PONG-watch (~30 s) or hammer the gateway."""
+    # 5 s probe — Tab5's PONG-watch tolerates this without churn.
+    assert 1 <= HEALTH_CHECK_TIMEOUT_S <= 10
+    # 30 s cache — avoids re-probing on every turn while keeping
+    # recovery latency low after the gateway comes back.
+    assert 10 <= HEALTH_CACHE_TTL_S <= 120
+
+
+def test_is_healthy_caches_within_ttl() -> None:
+    """Two calls in quick succession should result in exactly ONE
+    GET /health round-trip — the second hits the cache."""
+    backend = _backend()
+    session = _FakeSession(responses=[_FakeHealthResponse(200)])
+    backend._session = session
+
+    async def go():
+        ok1 = await backend.is_healthy()
+        ok2 = await backend.is_healthy()
+        return ok1, ok2
+
+    ok1, ok2 = asyncio.run(go())
+    assert ok1 is True
+    assert ok2 is True
+    assert len(session.get_calls) == 1, (
+        f"Expected cache hit on second call; got {session.get_calls}"
+    )
+
+
+def test_is_healthy_force_bypasses_cache() -> None:
+    """``force=True`` is the ops-debug escape hatch — must always
+    re-probe regardless of cache freshness."""
+    backend = _backend()
+    session = _FakeSession(
+        responses=[_FakeHealthResponse(200), _FakeHealthResponse(200)]
+    )
+    backend._session = session
+
+    async def go():
+        await backend.is_healthy()
+        await backend.is_healthy(force=True)
+
+    asyncio.run(go())
+    assert len(session.get_calls) == 2
+
+
+def test_is_healthy_uses_short_timeout() -> None:
+    """The probe must use ``HEALTH_CHECK_TIMEOUT_S`` (5 s) — NOT the
+    600 s default ``ClientSession`` timeout that's tuned for full
+    agent runs.  This is the entire point of M6."""
+    backend = _backend()
+    session = _FakeSession(responses=[_FakeHealthResponse(200)])
+    backend._session = session
+
+    asyncio.run(backend.is_healthy())
+    _url, timeout_s = session.get_calls[0]
+    assert timeout_s == HEALTH_CHECK_TIMEOUT_S
+
+
+def test_is_healthy_returns_false_on_non_200() -> None:
+    backend = _backend()
+    session = _FakeSession(responses=[_FakeHealthResponse(503)])
+    backend._session = session
+
+    assert asyncio.run(backend.is_healthy()) is False
+
+
+def test_is_healthy_returns_false_on_client_error() -> None:
+    """Connection refused / DNS failure / etc. — must catch and
+    return False, not bubble the exception up to the caller."""
+    backend = _backend()
+    session = _FakeSession(raises=aiohttp.ClientError("connection refused"))
+    backend._session = session
+
+    assert asyncio.run(backend.is_healthy()) is False
+
+
+def test_is_healthy_returns_false_on_asyncio_timeout() -> None:
+    """Hung gateway — the probe itself times out at HEALTH_CHECK_TIMEOUT_S.
+    Must come back False, not raise."""
+    backend = _backend()
+    session = _FakeSession(raises=asyncio.TimeoutError())
+    backend._session = session
+
+    assert asyncio.run(backend.is_healthy()) is False
+
+
+def test_is_healthy_re_probes_after_ttl_expires() -> None:
+    """After cache TTL expires, the next call MUST re-probe.  Pin this
+    so a future refactor that uses ``time.time()`` instead of
+    ``time.monotonic()`` (or vice versa) doesn't break recovery
+    detection."""
+    backend = _backend()
+    session = _FakeSession(
+        responses=[_FakeHealthResponse(200), _FakeHealthResponse(200)]
+    )
+    backend._session = session
+
+    async def go():
+        await backend.is_healthy()
+        # Force cache expiry by rewinding the recorded time.
+        backend._health_cache_until = time.monotonic() - 1.0
+        await backend.is_healthy()
+
+    asyncio.run(go())
+    assert len(session.get_calls) == 2
+
+
+# ───────────────────────── initialize() seeds the cache
+
+
+def test_initialize_seeds_cache_on_healthy_gateway() -> None:
+    """``initialize()`` already does a one-shot health check; it must
+    feed the result into the cache so the first request after boot
+    is fast (no extra 5 s probe just because we forgot we already
+    checked)."""
+    backend = _backend()
+
+    async def go():
+        with patch("aiohttp.ClientSession") as mock_cs:
+            session = _FakeSession(responses=[_FakeHealthResponse(200)])
+            mock_cs.return_value = session
+            await backend.initialize()
+        # Now is_healthy() should hit the cache, not re-probe.
+        return await backend.is_healthy()
+
+    ok = asyncio.run(go())
+    assert ok is True
+    # The fake session received exactly one /health call (the seed),
+    # not two (seed + post-init probe).
+    assert len(backend._session.get_calls) == 1
+
+
+def test_initialize_marks_unhealthy_on_failure() -> None:
+    """If the gateway is down at boot, the cache must reflect that —
+    the first request then raises DragonError immediately instead
+    of attempting a fresh probe."""
+    backend = _backend()
+
+    async def go():
+        with patch("aiohttp.ClientSession") as mock_cs:
+            session = _FakeSession(raises=aiohttp.ClientError("refused"))
+            mock_cs.return_value = session
+            await backend.initialize()
+
+    asyncio.run(go())
+    assert backend._health_cache_ok is False
+    assert backend._health_cache_until > time.monotonic()
+
+
+# ───────────────────────── generate_stream_with_messages raises structured error
+
+
+def test_generate_stream_raises_dragon_error_when_unhealthy() -> None:
+    """The headline M6 outcome: don't waste 600 s on a known-down
+    gateway — raise a structured γ1-taxonomy error immediately."""
+    backend = _backend()
+    # Pre-populate cache as unhealthy (avoid actual probe).
+    backend._health_cache_ok = False
+    backend._health_cache_until = time.monotonic() + 30.0
+    backend._session = _FakeSession()  # no responses — must NOT be touched
+
+    async def go():
+        async for _token in backend.generate_stream_with_messages(
+            [{"role": "user", "content": "hi"}]
+        ):
+            pass
+
+    with pytest.raises(DragonError) as exc_info:
+        asyncio.run(go())
+    err = exc_info.value
+    assert err.code == "gateway_unreachable"
+    assert err.severity is Severity.FATAL
+    assert err.scope is Scope.GATEWAY
+    # User-facing message must NOT leak implementation details
+    assert "600" not in err.message
+    assert "sock_read" not in err.message
+    assert "aiohttp" not in err.message
+
+
+def test_generate_stream_does_not_post_when_unhealthy() -> None:
+    """Belt-and-suspenders: an unhealthy gateway means we MUST short-
+    circuit before issuing the POST.  This test guards against a
+    future refactor that catches DragonError too early and falls
+    through to the request loop."""
+    backend = _backend()
+    backend._health_cache_ok = False
+    backend._health_cache_until = time.monotonic() + 30.0
+    session = _FakeSession()
+    session.post = MagicMock(
+        side_effect=AssertionError("must NOT call POST when unhealthy")
+    )
+    backend._session = session
+
+    async def go():
+        async for _token in backend.generate_stream_with_messages(
+            [{"role": "user", "content": "hi"}]
+        ):
+            pass
+
+    with pytest.raises(DragonError):
+        asyncio.run(go())
+    # The post mock was never invoked
+    session.post.assert_not_called()
+
+
+def test_generate_stream_proceeds_when_healthy() -> None:
+    """Regression guard: when the cache says healthy, the POST path
+    must run normally.  Verifies the fast-fail gate doesn't block
+    the happy path."""
+    backend = _backend()
+    backend._health_cache_ok = True
+    backend._health_cache_until = time.monotonic() + 30.0
+
+    # Mock the POST + SSE response.  We just need it to short-circuit
+    # past the SSE loop so the stream completes without yielding.
+    class _FakePostResponse:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        @property
+        def content(self):
+            class _Reader:
+                async def readline(self_inner):
+                    return b""  # EOF immediately
+            return _Reader()
+
+    session = MagicMock()
+    session.closed = False
+    session.post = MagicMock(return_value=_FakePostResponse())
+    backend._session = session
+
+    async def go():
+        out: list[str] = []
+        async for token in backend.generate_stream_with_messages(
+            [{"role": "user", "content": "hi"}]
+        ):
+            out.append(token)
+        return out
+
+    out = asyncio.run(go())
+    # Empty stream + no [DONE] → the connection-drop fallback fires.
+    # Important assertion: POST was actually called (we didn't fast-
+    # fail) and we got the friendly fallback string back.
+    session.post.assert_called_once()
+    assert out  # something was yielded — the existing fallback path


### PR DESCRIPTION
Closes #106.  Refs #89, refs #101.  Phase 3 γ2 sub-piece.

## Symptom (per [docs/UX-GAPS.md M6](docs/UX-GAPS.md#m6--tc-gateway-down--600-s-timeout))
When the TC gateway is reachable at TCP layer but hung / dead at app layer, the first POST to `/v1/chat/completions` blocks for the full **600 s** sock_read timeout (bumped from 90→600 s in #58 to cover real agent workloads).  The boot-time `/health` check goes stale within seconds, so a gateway that dies between turns gets no fast-fail.

## What changes
1. **[`dragon_voice/llm/tinkerclaw_llm.py`](dragon_voice/llm/tinkerclaw_llm.py)** — adds `is_healthy(force=False)` with 30 s cached result + 5 s probe timeout.  `initialize()` seeds the cache.  `generate_stream_with_messages` pre-checks and raises `DragonError(code="gateway_unreachable", severity=FATAL, scope=GATEWAY)` (γ1 taxonomy from #102) when unhealthy.
2. **[`dragon_voice/server.py`](dragon_voice/server.py)** — `_handle_text` TC bypass catches `DragonError` and emits the structured frame.
3. **[`dragon_voice/pipeline.py`](dragon_voice/pipeline.py)** — `_process_utterance` adds `except DragonError` ABOVE the generic `pipeline_failed` handler so γ-arch errors survive instead of being collapsed to a generic toast.

## Defensive choices
- 5 s probe timeout — well under Tab5's PONG-watch (~30 s) so the probe itself can't trip the eviction race.
- 30 s cache TTL — short enough that recovery is felt within a turn or two, long enough that the happy path doesn't pay 5 s per turn.
- User-facing message strips implementation detail (no "600 s", no "sock_read", no "aiohttp").
- Existing string-yield fallback ("I'm having trouble connecting…") stays as a SECOND-LAYER safety net for the case where /health succeeds but the request itself fails (401, proxy 502, etc.).
- Existing config_update-time pre-check (server.py:1876-1899) intentionally untouched — boot/swap-time validation with auto-fallback is a separate concern from per-turn detection.

## Test plan
- [x] **13 new unit tests** in [`tests/test_tinkerclaw_health_check.py`](tests/test_tinkerclaw_health_check.py): cache TTL respected; force=True bypass works; short-timeout asserted; all probe failure modes return False; init seeds cache; raise-on-unhealthy with correct γ1 taxonomy; no POST when unhealthy; happy path proceeds without regression
- [x] aiohttp ClientSession mocked at `_FakeSession` — no live gateway needed, runs in CI named-set
- [x] `ruff check` narrow gate clean
- [x] CI named-set: **207 passing** (pre: 194)
- [x] Full repo: **250 passing** (`pytest tests/ --ignore=tests/audit`)
- [x] **LIVE on Dragon sandbox** (port 3513) — in-session fast-fail proven end-to-end:
   - Switched to voice_mode=3 with TC up → pre-check passed
   - Stopped `tinkerclaw-gateway` externally
   - Waited 31 s for is_healthy() cache to expire
   - Sent text turn → fast-failed in **0.01 s** with structured frame `{code: "gateway_unreachable", severity: "fatal", scope: "gateway"}` (TCP ECONNREFUSED hits the probe instantly; 5 s budget protects against the slow-hang case)
   - Pre-fix this would have blocked for **600 s**
- [x] γ1 baseline smoke from #102 still passes — zero regression on `session_invalid` + `media_not_found` error frames

## Out of scope (follow-ups)
- `config_update`-style auto-fallback to local mode after a fast-fail (Tab5 follow-up).
- Tab5-side rendering of FATAL/GATEWAY banner (γ2-H8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)