### PR TITLE
docs(ux): mark Phase 4 (H6/H7/D-docs) MERGED in #115/#117/#119

### DIFF
--- a/docs/UX-GAPS.md
+++ b/docs/UX-GAPS.md
@@ -53,10 +53,10 @@ Per user direction:
 | M2 | WS upgrade rejection plain text (401/503) | MED | ~3.5 h | 3 | **MERGED #112 + TinkerTab#199** |
 | M5 | Device-id collision silent eviction | MED | ~3 h | 3 | **MERGED #109 + TinkerTab#197** |
 | M6 | TC gateway down → 600 s timeout, no fast-fail | MED | ~4 h | 3 | **MERGED #107** |
-| H6 | Idle paused sessions never purge | HIGH | ~2-3 h | 4 | OPEN |
-| H7 | Media cleanup 1 h delay before first run | HIGH | ~1 h | 4 | OPEN |
-| D-mem | Memory facts unbounded (downgraded — sqlite-vec confirmed loaded) | LOW (was MED) | ~1 h | 4 | OPEN |
-| D-docs | Document ingest no size cap | MED | ~1 h | 4 | OPEN |
+| H6 | Idle paused sessions never purge | HIGH | ~2-3 h | 4 | **MERGED #117** |
+| H7 | Media cleanup 1 h delay before first run | HIGH | ~1 h | 4 | **MERGED #115** |
+| D-mem | Memory facts unbounded (downgraded — sqlite-vec confirmed loaded) | LOW (was MED) | ~1 h | 4 | OPEN (deferred — perf fine at 100k facts; ship if/when ops sees a real issue) |
+| D-docs | Document ingest no size cap | MED | ~1 h | 4 | **MERGED #119** |
 | L1 | POST 413 returns `Connection: close` | LOW | 10 min | 6 | OPEN |
 | F-T1 | Scheduler tier 1 (in-process) | DESIGN | ~7 h | 5 | OPEN |
 | F-T2 | Scheduler tier 2 (durable + offline queue) | DESIGN | +6 h | 5 | OPEN |
@@ -146,9 +146,9 @@ PRs.
 
 | PR | Scope | Effort |
 |---|---|---|
-| δ1 | H7 media cleanup runs immediately on startup | ~1 h |
-| δ2 | H6 paused-session retention policy (`paused_session_retention_days`) | ~2-3 h |
-| δ3 | D-docs document size cap; D-mem fact cap (low-priority since sqlite-vec confirmed loaded) | ~2 h |
+| δ1 | H7 media cleanup runs immediately on startup | **MERGED #115** |
+| δ2 | H6 paused-session retention policy (`paused_session_retention_days`) | **MERGED #117** |
+| δ3 | D-docs document size cap; D-mem fact cap (low-priority since sqlite-vec confirmed loaded) | **D-docs MERGED #119** (D-mem deferred) |
 
 **E2E acceptance:**
 - Soak Dragon for ~1 hour with media uploads on startup → `/home/radxa/media`


### PR DESCRIPTION
## Summary
Marks Phase 4 sub-pieces as MERGED in [docs/UX-GAPS.md](docs/UX-GAPS.md):
- **H7** → #115 (\`δ1\` — media cleanup runs immediately on startup)
- **H6** → #117 (\`δ2\` — \`paused_session_retention_days\` config + auto-end old paused sessions)
- **D-docs** → #119 (\`δ3\` — \`max_document_bytes\` cap + HTTP 413 + structured JSON)
- **D-mem** → intentionally deferred (sqlite-vec loaded, perf fine at 100k facts)

End-to-end live-validated on production Dragon :3502 + real Tab5 192.168.1.90.

The active "fix the broken stuff" arc is now complete: Phase 1 (WS dispatcher discipline) + Phase 2 (streaming feedback) + Phase 3 (error visibility) + Phase 4 (long-uptime hygiene).  Phase 5 (scheduler) and Phase 6 (architectural follow-ups) are NEW capability surfaces awaiting product direction.

## Test plan
- [x] Doc-only — no code touched
- [ ] CI green
🤖 Generated with [Claude Code](https://claude.com/claude-code)