### PR TITLE
feat(scheduler): in-process scheduler core (ε1a / Phase 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
             tests/test_progress_bus_integration.py \
             tests/test_progress_emit.py \
             tests/test_progress_event.py \
+            tests/test_scheduler_manager.py \
+            tests/test_scheduler_tool.py \
+            tests/test_scheduler_when_parser.py \
             tests/test_config_redact.py \
             tests/test_device_evicted.py \
             tests/test_document_size_cap.py \

--- a/dragon_voice/lifecycle/shutdown.py
+++ b/dragon_voice/lifecycle/shutdown.py
@@ -66,6 +66,16 @@ async def run_shutdown(server: Any, app: web.Application) -> None:
         except (asyncio.CancelledError, Exception):
             pass
 
+    # Phase 5 ε1a (issue #128): cancel scheduler tasks BEFORE pipeline
+    # drain so an in-flight notification fire doesn't race with a
+    # closed WS.  Pattern matches the cancel-then-await discipline
+    # above (W14-M09 fix).
+    if getattr(server, "_scheduler_mgr", None):
+        try:
+            await server._scheduler_mgr.shutdown()
+        except Exception:
+            logger.debug("SchedulerManager shutdown raised", exc_info=True)
+
     # Drain per-connection pipelines
     tasks = []
     for _ws_id, conn in list(server._active_connections.items()):

--- a/dragon_voice/lifecycle/startup.py
+++ b/dragon_voice/lifecycle/startup.py
@@ -133,6 +133,32 @@ async def run_startup(server: Any, app: web.Application) -> None:
     server._surface_mgr = SurfaceManager()
     logger.info("SurfaceManager initialized")
 
+    # Phase 5 ε1a (issue #128): in-process scheduler.  In-memory
+    # store for Tier 1 — ε2 swaps in SqliteNotificationStore via a
+    # one-line change here.  Wired AFTER SurfaceManager + SessionManager
+    # exist (manager depends on both at fire time per RFC A3) and
+    # BEFORE widget-emitting tool registration so ScheduleReminderTool
+    # can be registered alongside its peers.
+    server._scheduler_mgr = None
+    try:
+        from dragon_voice.scheduler import (
+            InMemoryNotificationStore,
+            SchedulerManager,
+        )
+        server._scheduler_store = InMemoryNotificationStore()
+        server._scheduler_mgr = SchedulerManager(
+            store=server._scheduler_store,
+            surface_mgr=server._surface_mgr,
+            session_mgr=server._session_mgr,
+        )
+        await server._scheduler_mgr.start()
+        logger.info(
+            "SchedulerManager initialized (store=%s)",
+            type(server._scheduler_store).__name__,
+        )
+    except Exception as e:
+        logger.warning("SchedulerManager init failed: %s", e)
+
     # Register widget-emitting tools AFTER surface_mgr exists.
     if server._tool_registry is not None:
         try:
@@ -146,6 +172,21 @@ async def run_startup(server: Any, app: web.Application) -> None:
             logger.info("QuickPollTool registered (declarative widget skill)")
         except Exception as e:
             logger.warning("TimesenseTool registration failed: %s", e)
+
+        # Phase 5 ε1a: scheduler tool registration.  Separate try
+        # block so a tool-init error doesn't take down the rest of
+        # the registry.
+        if server._scheduler_mgr is not None:
+            try:
+                from dragon_voice.tools.schedule_reminder_tool import (
+                    ScheduleReminderTool,
+                )
+                server._tool_registry.register(
+                    ScheduleReminderTool(server._scheduler_mgr, server._db)
+                )
+                logger.info("ScheduleReminderTool registered (scheduler skill)")
+            except Exception as e:
+                logger.warning("ScheduleReminderTool registration failed: %s", e)
 
     # Conversation engine (shared LLM backend for text/API input)
     server._conversation = ConversationEngine(

--- a/dragon_voice/scheduler/__init__.py
+++ b/dragon_voice/scheduler/__init__.py
@@ -1,0 +1,29 @@
+"""Scheduler module — async push surface for Dragon.
+
+Phase 5 of the UX-gap remediation.  See docs/RFC-scheduler.md for
+the full architecture (split across ε1a / ε1b / ε2 PRs).
+
+Re-exports the public surface so callers don't need to know which
+submodule a symbol lives in.
+"""
+from dragon_voice.scheduler.manager import (
+    RUNAWAY_CAP_PER_DEVICE,
+    RunawayCapError,
+    SchedulerManager,
+)
+from dragon_voice.scheduler.models import Notification
+from dragon_voice.scheduler.parser import parse_when
+from dragon_voice.scheduler.store import (
+    InMemoryNotificationStore,
+    NotificationStore,
+)
+
+__all__ = [
+    "Notification",
+    "NotificationStore",
+    "InMemoryNotificationStore",
+    "SchedulerManager",
+    "RunawayCapError",
+    "RUNAWAY_CAP_PER_DEVICE",
+    "parse_when",
+]

--- a/dragon_voice/scheduler/manager.py
+++ b/dragon_voice/scheduler/manager.py
@@ -1,0 +1,278 @@
+"""SchedulerManager — owns the asyncio task per pending notification.
+
+Phase 5 ε1a (refs #126, #128).  See docs/RFC-scheduler.md Section B.4
+for the lifecycle wiring + Section A8 for why the
+NotificationStore Protocol matters.
+
+The manager:
+  * holds a ``dict[notif_id -> asyncio.Task]`` so cancel + reschedule
+    can find the right task to cancel
+  * delegates persistence to a ``NotificationStore`` (in-memory in
+    ε1a, SQLite in ε2 — same Protocol)
+  * delegates UI delivery to ``Tab5Surface.card(...)`` via SurfaceManager
+  * looks up the device's active session via SessionManager at fire
+    time (storage device-scoped, delivery session-scoped per A3)
+  * enforces the per-device runaway cap of 100 (RFC E2)
+
+Tier 1 contract: when the device has no active session at fire time,
+log + drop (mark fired anyway so the row doesn't leak as pending).
+ε2 will add an offline queue + boot replay; this manager's
+``_fire_one`` provides the seam where that goes.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, Optional
+
+from dragon_voice.scheduler.models import Notification
+from dragon_voice.scheduler.store import NotificationStore
+
+logger = logging.getLogger(__name__)
+
+
+# Per-device cap on pending notifications.  RFC E2 / R2: hostile LLM
+# or buggy caller schedules 1000 reminders by accident → memory blow
+# + Tab5 widget_card storm.  100 pending is generous for a real user
+# (a person doesn't have 100 active reminders) and tight enough that
+# a bug stops fast.
+RUNAWAY_CAP_PER_DEVICE = 100
+
+
+class RunawayCapError(RuntimeError):
+    """Raised when a device has hit RUNAWAY_CAP_PER_DEVICE pending
+    notifications.  Caller (tool / REST endpoint) catches and
+    surfaces a structured error.
+    """
+
+
+class SchedulerManager:
+    """Owns the in-process scheduler.
+
+    Constructed once per Dragon process via ``lifecycle/startup.py``
+    after SurfaceManager + SessionManager are ready.  Shut down via
+    ``lifecycle/shutdown.py`` BEFORE pipeline drain so in-flight
+    fires don't race against closed WSes.
+    """
+
+    def __init__(
+        self,
+        *,
+        store: NotificationStore,
+        surface_mgr,
+        session_mgr,
+    ) -> None:
+        self._store = store
+        self._surface_mgr = surface_mgr
+        self._session_mgr = session_mgr
+        # The hot-path map.  Tasks added by schedule(), removed in
+        # _fire_one's finally block + cancel() + reschedule().
+        self._tasks: dict[str, asyncio.Task] = {}
+        # set in start() — lets ε2 hook boot-replay here without
+        # changing the Tier-1 manager's __init__ signature.
+        self._started: bool = False
+
+    # ── Lifecycle ──────────────────────────────────────────────────
+
+    async def start(self) -> None:
+        """Currently a no-op for ε1a (in-memory store has nothing to
+        replay).  ε2 will add boot replay for due-but-unfired
+        notifications here."""
+        self._started = True
+        logger.debug("SchedulerManager.start: ε1a (in-memory) — no boot replay")
+
+    async def shutdown(self) -> None:
+        """Cancel every in-flight task + await each so the asyncio
+        loop reaps them cleanly.  Pattern matches the cancel-then-await
+        discipline in lifecycle/shutdown.py:42-67 (W14-M09 fix).
+
+        After shutdown, no further fires happen even if the loop
+        keeps running — the manager is dead.
+        """
+        tasks_snapshot = list(self._tasks.values())
+        for task in tasks_snapshot:
+            if not task.done():
+                task.cancel()
+        for task in tasks_snapshot:
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                # Cancellation is the expected outcome; swallow other
+                # exceptions to keep shutdown idempotent.
+                pass
+        self._tasks.clear()
+        self._started = False
+        logger.info("SchedulerManager shut down (cancelled %d in-flight task(s))",
+                    len(tasks_snapshot))
+
+    # ── Scheduling ─────────────────────────────────────────────────
+
+    async def schedule(self, notification: Notification) -> Notification:
+        """Persist + start an asyncio task that fires at fire_at.
+
+        Raises ``RunawayCapError`` if the device already has
+        RUNAWAY_CAP_PER_DEVICE pending notifications.  This is the
+        primary defence against an LLM scheduling 1000 reminders
+        in a tight loop (RFC R2).
+        """
+        if notification.device_id is not None:
+            # Device-scoped cap.  REST callers can pass device_id=None
+            # for "broadcast" (unused in Tier 1/2 but reserved); those
+            # bypass the cap and rely on REST-layer auth + future quota
+            # work.  The LLM tool always passes a device_id.
+            current = await self._store.count_pending_for_device(
+                notification.device_id
+            )
+            if current >= RUNAWAY_CAP_PER_DEVICE:
+                raise RunawayCapError(
+                    f"device {notification.device_id} already has "
+                    f"{current} pending notifications "
+                    f"(cap={RUNAWAY_CAP_PER_DEVICE})"
+                )
+
+        await self._store.create(notification)
+        self._tasks[notification.id] = asyncio.create_task(
+            self._run(notification.id, notification.fire_at)
+        )
+        logger.info(
+            "Scheduled notification %s for device=%s fire_at=%.0f",
+            notification.id, notification.device_id, notification.fire_at,
+        )
+        return notification
+
+    async def cancel(self, notif_id: str) -> bool:
+        """Cancel a pending notification.  Idempotent: returns False
+        if already fired / cancelled / missing."""
+        ok = await self._store.cancel(notif_id)
+        if not ok:
+            return False
+        task = self._tasks.pop(notif_id, None)
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+        return True
+
+    async def reschedule(self, notif_id: str, new_fire_at: float) -> bool:
+        """Move a pending notification's fire_at.  Replaces the
+        in-flight asyncio task with one targeted at the new time.
+        Returns False if the row is missing / not pending."""
+        ok = await self._store.update_fire_at(notif_id, new_fire_at)
+        if not ok:
+            return False
+        # Cancel old task, spawn new one
+        old = self._tasks.pop(notif_id, None)
+        if old is not None and not old.done():
+            old.cancel()
+            try:
+                await old
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._tasks[notif_id] = asyncio.create_task(
+            self._run(notif_id, new_fire_at)
+        )
+        return True
+
+    # ── Internal: per-notification task body ───────────────────────
+
+    async def _run(self, notif_id: str, fire_at: float) -> None:
+        """Sleep until fire_at, then fire.  Catches CancelledError
+        cleanly so cancel + reschedule + shutdown don't propagate."""
+        try:
+            sleep_for = max(0.0, fire_at - time.time())
+            await asyncio.sleep(sleep_for)
+            await self._fire_one(notif_id)
+        except asyncio.CancelledError:
+            # Cancel paths (user cancel, reschedule, shutdown) all
+            # land here.  Don't re-raise — caller already updated
+            # the store.
+            raise
+        finally:
+            # Remove ourself from the task map even on cancel so the
+            # dict doesn't leak references to done tasks.  The
+            # `pop(..., None)` guard handles the cancel/reschedule
+            # case where the caller already popped us.
+            self._tasks.pop(notif_id, None)
+
+    async def _fire_one(self, notif_id: str) -> None:
+        """Look up the notification, find the device's active session,
+        emit a widget_card via Tab5Surface, mark fired in store.
+
+        ε2 inserts the offline-queue write here when no active
+        session exists (instead of just dropping).
+        """
+        notif = await self._store.get(notif_id)
+        if notif is None or notif.status != "pending":
+            # Raced with cancel — nothing to do.
+            return
+
+        # Find the device's active session.  RFC A3: storage is
+        # device-scoped, delivery is session-scoped.
+        session = await self._lookup_active_session(notif.device_id)
+
+        if session is None:
+            # Tier 1 (RFC R4): log + drop.  Mark fired so it doesn't
+            # leak as pending forever.  ε2 will queue for replay.
+            logger.warning(
+                "Notification %s fired but device %s has no active "
+                "session — dropped (Tier 1 limitation)",
+                notif_id, notif.device_id,
+            )
+            await self._store.mark_fired(notif_id)
+            return
+
+        # Build the widget_card payload (RFC C.3).
+        surface = self._surface_mgr.surface_for(session["id"], "scheduler")
+        if surface is None:
+            logger.warning(
+                "Notification %s fired but no Tab5Surface for session %s — "
+                "dropped",
+                notif_id, session["id"],
+            )
+            await self._store.mark_fired(notif_id)
+            return
+
+        # Deterministic card_id so the dashboard can correlate to the
+        # notification row (RFC C.3).
+        card_id = f"sched_{notif_id.replace('sched_', '')[:8]}"
+
+        try:
+            await surface.card(
+                title=notif.title,
+                body=notif.body,
+                tone=notif.tone,
+                icon="bell",
+                action=("Dismiss", "scheduler.dismiss"),
+                card_id=card_id,
+                skill_id="scheduler",
+            )
+            logger.info(
+                "Notification %s fired → device=%s session=%s",
+                notif_id, notif.device_id, session["id"],
+            )
+        except Exception as e:
+            logger.warning(
+                "Notification %s fire delivery failed (still marking fired): %s",
+                notif_id, e,
+            )
+        await self._store.mark_fired(notif_id)
+
+    async def _lookup_active_session(
+        self, device_id: Optional[str],
+    ) -> Optional[dict]:
+        """Find the device's currently-active session, or None if the
+        device is offline / has no active session."""
+        if device_id is None:
+            return None
+        sessions = await self._session_mgr.list_sessions(
+            device_id=device_id,
+            status="active",
+            limit=1,
+        )
+        return sessions[0] if sessions else None
+
+
+__all__ = ["SchedulerManager", "RunawayCapError", "RUNAWAY_CAP_PER_DEVICE"]

--- a/dragon_voice/scheduler/models.py
+++ b/dragon_voice/scheduler/models.py
@@ -1,0 +1,79 @@
+"""Notification dataclass — the durable shape of a scheduled job.
+
+Phase 5 ε1a (refs #126, #128).  See docs/RFC-scheduler.md Section A3
+(device-scoped storage) and B.5 (SQLite schema for Tier 2) for the
+field rationale.
+
+Plain data, no behaviour — both the in-memory store (ε1a) and the
+SQLite store (ε2) round-trip the same dataclass shape.
+"""
+from __future__ import annotations
+
+import secrets
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+def _gen_notification_id() -> str:
+    """Short hex id matching the convention from sessions._generate_session_id
+    (`secrets.token_hex(6)` = 12 hex chars).  Wrapped in a `sched_` prefix
+    to make grepping logs trivial (see RFC C.3 — card_id derives from this)."""
+    return f"sched_{secrets.token_hex(6)}"
+
+
+@dataclass
+class Notification:
+    """A scheduled notification job.
+
+    Field semantics (read RFC Section A3 for storage-scope rationale):
+
+      id              short uuid, prefixed `sched_` for log-greppability
+      device_id       delivery target.  Reminders outlive sessions, so
+                      this is the durable handle.
+      originating_session_id
+                      the session that scheduled it — UX context only
+                      (NOT used for delivery target).  Will populate
+                      "you set this in your conversation about X" in v2.
+      fire_at         UTC epoch float.  Matches the `last_active_at REAL`
+                      convention in schema.sql.
+      title           ≤63 chars (widget_card.title cap)
+      body            ≤255 chars (widget_card.body cap)
+      tone            "info" | "warn" | "success" | "danger"
+      status          "pending" | "fired" | "cancelled" | "failed"
+      recurrence      reserved for Tier 2.5+; None in ε1/ε2
+      created_at      UTC epoch float — when this row was inserted
+      fired_at        UTC epoch float, None until status flips to fired
+      cancelled_at    UTC epoch float, None until status flips to cancelled
+    """
+
+    device_id: Optional[str]
+    fire_at: float
+    title: str = "Reminder"
+    body: str = ""
+    tone: str = "info"
+    originating_session_id: Optional[str] = None
+    status: str = "pending"
+    recurrence: Optional[str] = None
+    id: str = field(default_factory=_gen_notification_id)
+    created_at: float = field(default_factory=time.time)
+    fired_at: Optional[float] = None
+    cancelled_at: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        # Truncation guards — Tab5's widget_card has hard limits and
+        # Dragon shouldn't send oversized payloads expecting Tab5 to
+        # silently chop them.  Trim at the dataclass boundary so all
+        # downstream code (store, manager, REST response) sees the
+        # post-trim shape.
+        if len(self.title) > 63:
+            self.title = self.title[:63]
+        if len(self.body) > 255:
+            self.body = self.body[:255]
+        if self.tone not in ("info", "warn", "success", "danger"):
+            self.tone = "info"
+        if self.status not in ("pending", "fired", "cancelled", "failed"):
+            self.status = "pending"
+
+
+__all__ = ["Notification", "_gen_notification_id"]

--- a/dragon_voice/scheduler/parser.py
+++ b/dragon_voice/scheduler/parser.py
@@ -1,0 +1,207 @@
+"""Time-string grammar for the scheduler.
+
+Phase 5 ε1a (refs #126, #128).  See docs/RFC-scheduler.md A1 for the
+time-semantics decisions.
+
+This module is **pure** — no asyncio, no I/O, no hidden state.  Both
+the LLM-facing tool and the REST endpoint delegate here so a curl
+client and a voice command get identical semantics.
+
+Accepted grammar (RFC C.1):
+
+  * Relative duration:    ``5m``, ``2h``, ``1h30m``, ``90s``, ``1d``
+  * ISO 8601 absolute:    ``2026-04-26T15:00:00-04:00`` (with TZ)
+                          ``2026-04-27T15:00:00`` (resolves in tz=)
+  * Natural phrase:       ``today at 17:00``, ``tomorrow at 3pm``
+
+All resolve to a UTC epoch float (``time.time()`` shape).  Reject:
+  * Empty / unparseable input  → ValueError
+  * Past timestamps (ISO/natural)  → ValueError("past")
+  * Negative relative durations  → ValueError
+  * Anything > 365 days in the future  → ValueError("365")
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, tzinfo
+from typing import Optional
+
+
+# ───────────────────────── grammars
+
+# Relative duration: "5m", "1h30m", "90s", "1d2h".  Components in any
+# order; each unit appears 0 or 1 times.  Whole-number values only —
+# we don't support "1.5h" because it invites rounding bugs and the
+# user can write "90m" instead.
+_DURATION_PART = re.compile(r"(\d+)([smhd])")
+_DURATION_FULLMATCH = re.compile(r"^(?:\d+[smhd])+$")
+_UNIT_TO_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+
+# Natural phrase: "today at 17:00", "tomorrow at 3pm", "today at 3:30pm"
+_NATURAL = re.compile(
+    r"^\s*(today|tomorrow)\s+at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*$",
+    re.IGNORECASE,
+)
+
+# 365-day far-future cap (RFC E1)
+_MAX_FUTURE_SECONDS = 365 * 86400
+
+
+def parse_when(
+    s: str,
+    *,
+    now: float,
+    tz: tzinfo,
+) -> float:
+    """Parse a "when" string into a UTC epoch float.
+
+    Parameters
+    ----------
+    s:
+        The user / LLM input.  See module docstring for grammar.
+    now:
+        Current UTC epoch (``time.time()``).  Passed in as a parameter
+        instead of reading clock here — keeps the function pure +
+        testable with a fixed reference time.
+    tz:
+        Dragon's local timezone (``datetime.timezone(...)`` or a
+        ``zoneinfo.ZoneInfo``).  Used to resolve bare ISO timestamps
+        (no offset) and natural phrases.  Caller passes whatever
+        ``time.localtime()`` reports — the LLM tool and REST endpoint
+        each construct this once.
+
+    Returns
+    -------
+    float
+        UTC epoch timestamp at which the notification should fire.
+
+    Raises
+    ------
+    ValueError
+        On unparseable input, past timestamps, negative durations,
+        or far-future inputs (> 365 days).
+    """
+    if not isinstance(s, str) or not s.strip():
+        raise ValueError("empty when string")
+
+    s_clean = s.strip()
+
+    # ── 1. Relative duration ────────────────────────────────────────
+    fire_at = _try_parse_relative(s_clean, now=now)
+    if fire_at is not None:
+        _check_far_future(fire_at, now=now)
+        return fire_at
+
+    # ── 2. ISO 8601 ─────────────────────────────────────────────────
+    fire_at = _try_parse_iso(s_clean, tz=tz)
+    if fire_at is not None:
+        _check_past(fire_at, now=now)
+        _check_far_future(fire_at, now=now)
+        return fire_at
+
+    # ── 3. Natural phrase ───────────────────────────────────────────
+    fire_at = _try_parse_natural(s_clean, now=now, tz=tz)
+    if fire_at is not None:
+        _check_past(fire_at, now=now)
+        _check_far_future(fire_at, now=now)
+        return fire_at
+
+    raise ValueError(
+        f"could not parse 'when': {s!r} — expected '5m', "
+        f"ISO 8601 timestamp, or 'tomorrow at 3pm' shape"
+    )
+
+
+# ───────────────────────── helpers
+
+
+def _try_parse_relative(s: str, *, now: float) -> Optional[float]:
+    """Parse "5m" / "1h30m" / etc. or return None if not the shape."""
+    if not _DURATION_FULLMATCH.match(s):
+        # Negative durations like "-5m" intentionally don't match the
+        # full-string anchor — fall through and let the natural-phrase
+        # branch reject them with a generic error.  Pin the negative
+        # rejection here too so the error message is specific:
+        if s.startswith("-"):
+            raise ValueError(f"negative duration not allowed: {s!r}")
+        return None
+
+    total_seconds = 0
+    for value, unit in _DURATION_PART.findall(s):
+        total_seconds += int(value) * _UNIT_TO_SECONDS[unit]
+    return now + total_seconds
+
+
+def _try_parse_iso(s: str, *, tz: tzinfo) -> Optional[float]:
+    """Parse a full ISO 8601 string.  Returns None if it doesn't look
+    like ISO — the caller falls through to the natural-phrase branch."""
+    # Cheap shape check before invoking fromisoformat — saves a
+    # ValueError throw/catch on every relative-duration call that
+    # already failed the relative grammar.
+    if "T" not in s or len(s) < 10:
+        return None
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        # Bare timestamp, no offset → resolve in Dragon's local TZ.
+        dt = dt.replace(tzinfo=tz)
+    return dt.timestamp()
+
+
+def _try_parse_natural(s: str, *, now: float, tz: tzinfo) -> Optional[float]:
+    """Parse "today at 3pm" / "tomorrow at 17:00" / etc."""
+    m = _NATURAL.match(s)
+    if not m:
+        return None
+
+    day_word = m.group(1).lower()
+    hour = int(m.group(2))
+    minute = int(m.group(3) or "0")
+    ampm = (m.group(4) or "").lower()
+
+    if ampm == "pm" and hour != 12:
+        hour += 12
+    elif ampm == "am" and hour == 12:
+        hour = 0
+
+    if not (0 <= hour <= 23) or not (0 <= minute <= 59):
+        raise ValueError(f"invalid hour/minute in natural phrase: {s!r}")
+
+    # "today" = today's date in `tz`; "tomorrow" = +1 day.
+    today_local = datetime.fromtimestamp(now, tz=tz).date()
+    target_date = today_local
+    if day_word == "tomorrow":
+        target_date = today_local + timedelta(days=1)
+
+    target_dt = datetime(
+        target_date.year, target_date.month, target_date.day,
+        hour, minute, 0, tzinfo=tz,
+    )
+    return target_dt.timestamp()
+
+
+def _check_past(fire_at: float, *, now: float) -> None:
+    """Reject ISO/natural timestamps that resolve to the past.  Don't
+    apply to relative durations (those are computed from `now` so
+    can't naturally land in the past unless the caller passes negative
+    seconds, which `_try_parse_relative` already rejects)."""
+    if fire_at < now:
+        raise ValueError(
+            f"refusing to schedule reminder in the past "
+            f"(fire_at={fire_at}, now={now})"
+        )
+
+
+def _check_far_future(fire_at: float, *, now: float) -> None:
+    """RFC E1: cap at 365 days into the future.  Anything longer is
+    almost certainly a parser bug or hostile LLM hallucination."""
+    if fire_at - now > _MAX_FUTURE_SECONDS:
+        raise ValueError(
+            f"refusing to schedule reminder more than 365 days "
+            f"in the future (would fire at {fire_at}, now={now})"
+        )
+
+
+__all__ = ["parse_when"]

--- a/dragon_voice/scheduler/store.py
+++ b/dragon_voice/scheduler/store.py
@@ -1,0 +1,172 @@
+"""Notification storage backends.
+
+Phase 5 ε1a (refs #126, #128).
+
+The ``NotificationStore`` Protocol is the single seam between
+SchedulerManager and the durability layer.  ε1a ships
+``InMemoryNotificationStore`` (everything-lost-on-restart, fine for
+the audit's Tier-1 contract).  ε2 will add ``SqliteNotificationStore``
+as a sibling class — same Protocol, no manager-side changes.
+
+This is the architectural decision the RFC Section A8 calls "the
+single most important architectural decision in the RFC because it
+lets ε1 ship and bake without ε2 work being a rewrite".  Keep the
+Protocol narrow (7 methods) and don't leak SQL-isms across it.
+"""
+from __future__ import annotations
+
+from typing import Optional, Protocol, runtime_checkable
+
+from dragon_voice.scheduler.models import Notification
+
+
+@runtime_checkable
+class NotificationStore(Protocol):
+    """Storage interface every store implementation must satisfy.
+
+    All methods are async to match the SQLite store's natural shape;
+    the in-memory store implements them as ``async def`` returning
+    immediately so callers get one consistent contract.
+    """
+
+    async def create(self, notification: Notification) -> Notification:
+        """Persist + return the notification.  Raises if id collides."""
+        ...
+
+    async def get(self, notif_id: str) -> Optional[Notification]:
+        """Fetch by id, or None if missing."""
+        ...
+
+    async def list_pending(
+        self, device_id: Optional[str] = None,
+    ) -> list[Notification]:
+        """Pending notifications, optionally filtered to one device."""
+        ...
+
+    async def list_all(
+        self,
+        device_id: Optional[str] = None,
+        status: Optional[str] = None,
+    ) -> list[Notification]:
+        """All notifications matching optional device + status filters.
+
+        Used by the REST GET endpoint (ε1b) — needs to surface
+        cancelled / fired history, not just pending.  Pending-only
+        callers should use ``list_pending`` for clarity."""
+        ...
+
+    async def cancel(self, notif_id: str) -> bool:
+        """Mark cancelled.  Returns True if the row existed and was
+        pending; False otherwise (already fired / cancelled / missing).
+        Idempotent."""
+        ...
+
+    async def update_fire_at(self, notif_id: str, fire_at: float) -> bool:
+        """Reschedule.  Returns True if the row existed and was
+        pending.  False otherwise (rescheduling a fired/cancelled
+        job is a caller error — the manager surfaces a 400 in that
+        case rather than silently no-oping)."""
+        ...
+
+    async def list_due(self, now: float) -> list[Notification]:
+        """Pending notifications with fire_at <= now.  Used by ε2's
+        boot replay; ε1a's in-memory store always returns []
+        because nothing survives boot anyway."""
+        ...
+
+    async def mark_fired(self, notif_id: str) -> None:
+        """Flip status to fired + stamp fired_at.  Called after the
+        WS send returns (or after the safe-send swallow).  No-op if
+        the row is already non-pending."""
+        ...
+
+    async def count_pending_for_device(self, device_id: str) -> int:
+        """Used by SchedulerManager to enforce the per-device runaway
+        cap of 100 (RFC E2 / R2).  O(1) for in-memory; O(log N) via
+        index for SQLite."""
+        ...
+
+
+class InMemoryNotificationStore:
+    """Process-local storage.  Lost on Dragon restart by design (Tier 1).
+
+    The manager owns the single asyncio task per pending notification;
+    this store just remembers the metadata so the manager can answer
+    REST queries + enforce caps.  When the process dies, both go away
+    together — Tier 2 fixes that with SqliteNotificationStore.
+    """
+
+    def __init__(self) -> None:
+        self._by_id: dict[str, Notification] = {}
+
+    async def create(self, notification: Notification) -> Notification:
+        if notification.id in self._by_id:
+            raise ValueError(f"notification id collision: {notification.id}")
+        self._by_id[notification.id] = notification
+        return notification
+
+    async def get(self, notif_id: str) -> Optional[Notification]:
+        return self._by_id.get(notif_id)
+
+    async def list_pending(
+        self, device_id: Optional[str] = None,
+    ) -> list[Notification]:
+        out = [n for n in self._by_id.values() if n.status == "pending"]
+        if device_id is not None:
+            out = [n for n in out if n.device_id == device_id]
+        out.sort(key=lambda n: n.fire_at)
+        return out
+
+    async def list_all(
+        self,
+        device_id: Optional[str] = None,
+        status: Optional[str] = None,
+    ) -> list[Notification]:
+        out = list(self._by_id.values())
+        if device_id is not None:
+            out = [n for n in out if n.device_id == device_id]
+        if status is not None:
+            out = [n for n in out if n.status == status]
+        out.sort(key=lambda n: n.fire_at, reverse=True)
+        return out
+
+    async def cancel(self, notif_id: str) -> bool:
+        n = self._by_id.get(notif_id)
+        if n is None or n.status != "pending":
+            return False
+        import time as _time
+        n.status = "cancelled"
+        n.cancelled_at = _time.time()
+        return True
+
+    async def update_fire_at(self, notif_id: str, fire_at: float) -> bool:
+        n = self._by_id.get(notif_id)
+        if n is None or n.status != "pending":
+            return False
+        n.fire_at = fire_at
+        return True
+
+    async def list_due(self, now: float) -> list[Notification]:
+        # Tier 1: nothing survives a restart, so the boot-replay path
+        # always sees an empty store.  ε2 will return real results.
+        return [
+            n for n in self._by_id.values()
+            if n.status == "pending" and n.fire_at <= now
+        ]
+
+    async def mark_fired(self, notif_id: str) -> None:
+        n = self._by_id.get(notif_id)
+        if n is None or n.status != "pending":
+            return
+        import time as _time
+        n.status = "fired"
+        n.fired_at = _time.time()
+
+    async def count_pending_for_device(self, device_id: str) -> int:
+        return sum(
+            1 for n in self._by_id.values()
+            if n.status == "pending" and n.device_id == device_id
+        )
+
+
+__all__ = ["NotificationStore", "InMemoryNotificationStore"]

--- a/dragon_voice/tools/schedule_reminder_tool.py
+++ b/dragon_voice/tools/schedule_reminder_tool.py
@@ -1,0 +1,227 @@
+"""ScheduleReminderTool — LLM-facing scheduler tool.
+
+Phase 5 ε1a (refs #126, #128).  See docs/RFC-scheduler.md C.1/C.2
+for the schema + return shape.
+
+The tool is dumb: parse `when` via the shared parser, look up the
+device_id from the session_id (injected by ConversationEngine —
+see conversation.py:223), build a Notification, hand off to
+SchedulerManager.  Returns a structured dict the LLM can read to
+confirm with the user (`fires_in`, `fires_at_local`).
+
+The conversation engine injects `session_id` into every tool call
+(server.py:1130-ish via the on_tool_call closure flow).  The tool
+turns that into a `device_id` by looking up the session row.
+Without a valid session_id, the tool falls back to `device_id=None`
+and the manager handles the broadcast case (currently no-op).
+"""
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime
+from typing import Optional
+
+from dragon_voice.scheduler.manager import (
+    RUNAWAY_CAP_PER_DEVICE,
+    RunawayCapError,
+    SchedulerManager,
+)
+from dragon_voice.scheduler.models import Notification
+from dragon_voice.scheduler.parser import parse_when
+from dragon_voice.tools.base import Tool
+
+logger = logging.getLogger(__name__)
+
+
+# Tone mapping from LLM-facing priority enum → widget_card tone.
+# Pin here so a future schema addition (e.g. priority="urgent") is
+# a deliberate change in this dict, not silent fall-through.
+_PRIORITY_TONE = {
+    "normal": "info",
+    "important": "warn",
+}
+
+
+class ScheduleReminderTool(Tool):
+    """Schedule a reminder for the current user's device.
+
+    LLM-facing arg schema (RFC C.1):
+      when     — string.  Relative ("5m"), ISO 8601, or natural ("tomorrow at 3pm").
+      message  — string.  The reminder body shown to the user.
+      title    — string, optional.  Default "Reminder".
+      priority — "normal" | "important", optional.  Default "normal".
+
+    Returns (RFC C.2):
+      success → dict with notification_id, fires_at_iso, fires_at_local,
+                fires_in (human-readable), title, message
+      failure → dict with scheduled=False + error string
+    """
+
+    def __init__(self, scheduler_mgr: SchedulerManager, db) -> None:
+        self._mgr = scheduler_mgr
+        self._db = db
+
+    @property
+    def name(self) -> str:
+        return "schedule_reminder"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Schedule a reminder to fire later. The user will see a "
+            "card in their chat at the specified time."
+        )
+
+    @property
+    def parameters_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "when": {
+                    "type": "string",
+                    "description": (
+                        "When to fire the reminder. Accepts: relative "
+                        "duration ('5m', '2h30m', '1d'), ISO 8601 "
+                        "timestamp ('2026-04-26T15:00:00-04:00'), or a "
+                        "natural phrase ('tomorrow at 3pm', 'today at "
+                        "17:00'). Bare times ('3pm') resolve in the "
+                        "server's local timezone."
+                    ),
+                },
+                "message": {
+                    "type": "string",
+                    "description": "The reminder text the user will see (1-255 chars).",
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Optional short label (default 'Reminder', max 63 chars).",
+                },
+                "priority": {
+                    "type": "string",
+                    "enum": ["normal", "important"],
+                    "description": "Default 'normal'. 'important' renders with warn tone.",
+                },
+            },
+            "required": ["when", "message"],
+        }
+
+    async def execute(self, args: dict) -> dict:
+        when_str = (args.get("when") or "").strip()
+        message = (args.get("message") or "").strip()
+        title = (args.get("title") or "Reminder").strip()
+        priority = (args.get("priority") or "normal").strip().lower()
+
+        if not when_str:
+            return {"scheduled": False, "error": "'when' is required"}
+        if not message:
+            return {"scheduled": False, "error": "'message' is required"}
+
+        # Parse `when` against the local clock + Dragon's local TZ.
+        # The local TZ is `time.localtime().tm_zone`-derived — but
+        # `datetime.now().astimezone()` is the canonical way to get
+        # the current local TZ object.  Done once per call (cheap).
+        now = time.time()
+        local_tz = datetime.now().astimezone().tzinfo
+
+        try:
+            fire_at = parse_when(when_str, now=now, tz=local_tz)
+        except ValueError as e:
+            logger.info(
+                "ScheduleReminderTool rejected when=%r: %s", when_str, e,
+            )
+            return {
+                "scheduled": False,
+                "error": f"Could not parse 'when': {e}",
+            }
+
+        # Resolve session_id → device_id.  ConversationEngine injects
+        # session_id; the manager needs device_id for delivery.  If
+        # we can't resolve it, fall back to device_id=None and let
+        # the manager apply its broadcast-handling rules (currently
+        # log + drop at fire time).
+        session_id = args.get("session_id") or ""
+        device_id = await self._lookup_device_id(session_id)
+
+        notif = Notification(
+            device_id=device_id,
+            originating_session_id=session_id or None,
+            fire_at=fire_at,
+            title=title,
+            body=message,
+            tone=_PRIORITY_TONE.get(priority, "info"),
+        )
+
+        try:
+            scheduled = await self._mgr.schedule(notif)
+        except RunawayCapError as e:
+            logger.warning("ScheduleReminderTool runaway cap hit: %s", e)
+            return {
+                "scheduled": False,
+                "error": (
+                    f"Too many pending reminders for this device "
+                    f"(cap is {RUNAWAY_CAP_PER_DEVICE}).  Cancel some "
+                    f"existing reminders first."
+                ),
+            }
+
+        # Build the human-readable confirmation strings.  These go
+        # to the LLM, which will speak them back to the user — so
+        # they need to be natural, not raw timestamps.
+        fires_at_dt = datetime.fromtimestamp(fire_at, tz=local_tz)
+        fires_in_seconds = max(0, fire_at - now)
+        return {
+            "scheduled": True,
+            "notification_id": scheduled.id,
+            "fires_at_iso": fires_at_dt.isoformat(),
+            "fires_at_local": fires_at_dt.strftime("%-I:%M %p %Z").strip(),
+            "fires_in": _humanize_duration(fires_in_seconds),
+            "title": scheduled.title,
+            "message": scheduled.body,
+            "cancel_hint": (
+                "User can dismiss the card when it fires; cancel "
+                "earlier via the dashboard."
+            ),
+        }
+
+    async def _lookup_device_id(self, session_id: str) -> Optional[str]:
+        """Read device_id off the session row.  Returns None if the
+        session is missing — the manager treats that as broadcast."""
+        if not session_id:
+            return None
+        try:
+            session = await self._db.get_session(session_id)
+            return session.get("device_id") if session else None
+        except Exception as e:
+            logger.warning("device_id lookup failed for session %s: %s",
+                           session_id, e)
+            return None
+
+
+# ───────────────────────── helpers
+
+
+def _humanize_duration(seconds: float) -> str:
+    """Convert a seconds count to a short human-readable string.
+    "5 minutes", "2 hours", "1 hour 30 minutes", "3 days".  No
+    fractional units — keeps the LLM-spoken output natural."""
+    seconds = int(round(seconds))
+    if seconds <= 0:
+        return "now"
+    days, rem = divmod(seconds, 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes, secs = divmod(rem, 60)
+    parts: list[str] = []
+    if days:
+        parts.append(f"{days} day" + ("s" if days != 1 else ""))
+    if hours:
+        parts.append(f"{hours} hour" + ("s" if hours != 1 else ""))
+    if minutes:
+        parts.append(f"{minutes} minute" + ("s" if minutes != 1 else ""))
+    if not parts:
+        # Sub-minute: report seconds for clarity in tests + live use
+        return f"{secs} second" + ("s" if secs != 1 else "")
+    return " ".join(parts)
+
+
+__all__ = ["ScheduleReminderTool"]

--- a/tests/test_scheduler_manager.py
+++ b/tests/test_scheduler_manager.py
@@ -1,0 +1,292 @@
+"""Async tests for SchedulerManager.
+
+Phase 5 ε1a (refs #126, #128).
+
+Pattern: stub the ``NotificationStore`` (use the real
+InMemoryNotificationStore — it's already pure Python with no I/O,
+no point mocking it), patch ``asyncio.sleep`` so the tests don't
+burn wall-clock waits, and stub the SurfaceManager + SessionManager
+collaborators.
+
+Coverage map (RFC Section A9):
+  * scheduled job fires at right time
+  * cancel before fire suppresses fire (no widget_card sent)
+  * manager shutdown cancels in-flight jobs
+  * two jobs at same instant both fire
+  * runaway cap enforced (RFC E2 — per-device cap of 100)
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.scheduler.manager import SchedulerManager
+from dragon_voice.scheduler.models import Notification
+from dragon_voice.scheduler.store import InMemoryNotificationStore
+
+
+# ───────────────────────── helpers
+
+
+def _make_manager(
+    *,
+    surface_for_returns: Any = None,
+    active_session: dict | None = None,
+) -> tuple[SchedulerManager, list[dict], InMemoryNotificationStore]:
+    """Build a manager with a real InMemoryStore + stubbed surface_mgr +
+    stubbed session_mgr.  Returns (manager, captured_card_emits, store).
+
+    captured_card_emits is the list of widget_card payloads the
+    stubbed Tab5Surface received via .card(...) — lets tests assert
+    "the right frame was sent at the right time"."""
+    store = InMemoryNotificationStore()
+
+    captured_emits: list[dict] = []
+
+    # Stub Tab5Surface — only .card() is exercised.  Returns a card_id
+    # the manager doesn't actually care about (it built its own).
+    fake_surface = MagicMock()
+
+    async def _capture_card(**kwargs):
+        captured_emits.append(kwargs)
+        return kwargs.get("card_id", "stub_card_id")
+
+    fake_surface.card = _capture_card
+
+    # Stub SurfaceManager — surface_for(session_id, skill_id) returns
+    # the fake surface (or None if the test wants "no active surface").
+    fake_surface_mgr = MagicMock()
+    if surface_for_returns is None:
+        fake_surface_mgr.surface_for = MagicMock(return_value=fake_surface)
+    else:
+        fake_surface_mgr.surface_for = MagicMock(return_value=surface_for_returns)
+
+    # Stub SessionManager — list_sessions(device_id, status="active")
+    # returns either [active_session] or [] (offline / no session).
+    fake_session_mgr = MagicMock()
+    fake_session_mgr.list_sessions = AsyncMock(
+        return_value=[active_session] if active_session else []
+    )
+
+    mgr = SchedulerManager(
+        store=store,
+        surface_mgr=fake_surface_mgr,
+        session_mgr=fake_session_mgr,
+    )
+    return mgr, captured_emits, store
+
+
+def _patch_sleep_pass_through(monkeypatch):
+    """Replace ``asyncio.sleep`` inside scheduler.manager with a
+    no-op that yields once.  Lets the manager's "sleep until fire_at"
+    block return immediately so the test driver can observe the
+    fire-side behaviour without burning real seconds."""
+    real_sleep = asyncio.sleep
+
+    async def fast_sleep(secs: float, *args, **kwargs):
+        # Yield control once so other tasks can run, but don't wait.
+        await real_sleep(0)
+
+    import dragon_voice.scheduler.manager as mgr_mod
+    monkeypatch.setattr(mgr_mod.asyncio, "sleep", fast_sleep)
+
+
+# ───────────────────────── core scheduling
+
+
+@pytest.mark.asyncio
+async def test_schedule_fires_widget_card_at_fire_time(monkeypatch) -> None:
+    """The headline contract: scheduling a notification creates an
+    asyncio task that, when its sleep-to-fire-at returns, sends a
+    widget_card to the device's active session via SurfaceManager."""
+    _patch_sleep_pass_through(monkeypatch)
+    active_session = {"id": "sess123", "device_id": "dev_A"}
+    mgr, emits, store = _make_manager(active_session=active_session)
+
+    notif = Notification(
+        device_id="dev_A",
+        fire_at=time.time() + 0.001,  # essentially now (sleep is patched)
+        title="Reminder",
+        body="Take out the trash",
+    )
+    await mgr.schedule(notif)
+
+    # Drive the task to completion — the patched sleep returns
+    # immediately, so the manager's _fire_one runs after one yield.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    # Wait for the in-flight task to finish
+    if notif.id in mgr._tasks:
+        await mgr._tasks[notif.id]
+
+    assert len(emits) == 1, f"expected 1 widget_card emit, got {len(emits)}: {emits}"
+    payload = emits[0]
+    assert payload["title"] == "Reminder"
+    assert payload["body"] == "Take out the trash"
+    assert payload["tone"] == "info"
+    assert payload["skill_id"] == "scheduler"
+
+    # Store reflects the fire
+    after = await store.get(notif.id)
+    assert after is not None
+    assert after.status == "fired"
+
+
+@pytest.mark.asyncio
+async def test_cancel_before_fire_suppresses_widget_card(monkeypatch) -> None:
+    """If we cancel a pending notification before its fire_at, the
+    fire callback must NOT run."""
+    _patch_sleep_pass_through(monkeypatch)
+    active_session = {"id": "sess123", "device_id": "dev_A"}
+    mgr, emits, store = _make_manager(active_session=active_session)
+
+    notif = Notification(
+        device_id="dev_A",
+        fire_at=time.time() + 100,  # far future relative to wall clock
+        title="X",
+        body="Y",
+    )
+    await mgr.schedule(notif)
+
+    # Cancel before sleep returns
+    cancelled = await mgr.cancel(notif.id)
+    assert cancelled is True
+
+    # Drain any pending tasks
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert emits == [], f"expected no emits after cancel; got {emits}"
+    after = await store.get(notif.id)
+    assert after.status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_manager_shutdown_cancels_inflight_tasks(monkeypatch) -> None:
+    """Manager.shutdown() must cancel every pending asyncio task so
+    Dragon graceful-shutdown doesn't see "Task was destroyed but it
+    is pending!" warnings.  Pin the cancel-then-await pattern that
+    fixed W14-M09."""
+    _patch_sleep_pass_through(monkeypatch)
+    active_session = {"id": "s", "device_id": "dev_A"}
+    mgr, emits, store = _make_manager(active_session=active_session)
+
+    n1 = Notification(device_id="dev_A", fire_at=time.time() + 100, title="A", body="")
+    n2 = Notification(device_id="dev_A", fire_at=time.time() + 200, title="B", body="")
+    await mgr.schedule(n1)
+    await mgr.schedule(n2)
+
+    assert len(mgr._tasks) == 2
+
+    await mgr.shutdown()
+
+    # All tracked tasks done (cancelled or finished)
+    for task in mgr._tasks.values():
+        assert task.done()
+
+    # The store reflects: status stays pending (shutdown != cancel),
+    # but no fire happened.
+    n1_after = await store.get(n1.id)
+    n2_after = await store.get(n2.id)
+    assert n1_after.status == "pending"
+    assert n2_after.status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_runaway_cap_rejects_101st_notification(monkeypatch) -> None:
+    """RFC E2 / R2: per-device cap of 100 pending notifications.
+    The 101st must be rejected with a clear error so a hostile LLM
+    or buggy caller can't DoS the manager.  The cap is enforced
+    BEFORE store.create so the count stays accurate."""
+    from dragon_voice.scheduler.manager import RunawayCapError
+
+    _patch_sleep_pass_through(monkeypatch)
+    active_session = {"id": "s", "device_id": "dev_A"}
+    mgr, emits, store = _make_manager(active_session=active_session)
+
+    # Schedule 100 with very-far-future fire_at so they all stay pending
+    for i in range(100):
+        await mgr.schedule(Notification(
+            device_id="dev_A",
+            fire_at=time.time() + 86400,
+            title=f"R{i}",
+            body="",
+        ))
+
+    # 101st must reject
+    with pytest.raises(RunawayCapError):
+        await mgr.schedule(Notification(
+            device_id="dev_A",
+            fire_at=time.time() + 86400,
+            title="overflow",
+            body="",
+        ))
+
+    # Store still has exactly 100 pending for this device
+    pending = await store.list_pending(device_id="dev_A")
+    assert len(pending) == 100
+
+
+@pytest.mark.asyncio
+async def test_schedule_when_no_active_session_marks_fired_anyway(monkeypatch) -> None:
+    """Tier 1 contract (RFC A3 + R4): if the device has no active
+    session at fire time, log + drop.  The notification still
+    flips to ``fired`` in the store so it doesn't leak as pending
+    forever.  Tier 2 will queue for replay; Tier 1 just drops."""
+    _patch_sleep_pass_through(monkeypatch)
+    # active_session=None → SessionManager.list_sessions returns []
+    mgr, emits, store = _make_manager(active_session=None)
+
+    notif = Notification(
+        device_id="dev_offline",
+        fire_at=time.time() + 0.001,
+        title="x",
+        body="y",
+    )
+    await mgr.schedule(notif)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    if notif.id in mgr._tasks:
+        await mgr._tasks[notif.id]
+
+    # No widget_card was emitted (no session to send to)
+    assert emits == []
+    # But the notification flipped to fired (Tier 1: dropped, not retried)
+    after = await store.get(notif.id)
+    assert after.status == "fired"
+
+
+@pytest.mark.asyncio
+async def test_reschedule_updates_fire_at(monkeypatch) -> None:
+    """PATCH /api/v1/scheduler/notifications/{id} with new `when`
+    must replace the in-flight task with one targeted at the new
+    fire_at.  Pin so the asyncio task tracking doesn't leak the
+    old task."""
+    _patch_sleep_pass_through(monkeypatch)
+    active_session = {"id": "s", "device_id": "dev_A"}
+    mgr, emits, store = _make_manager(active_session=active_session)
+
+    notif = Notification(
+        device_id="dev_A",
+        fire_at=time.time() + 100,
+        title="x",
+        body="y",
+    )
+    await mgr.schedule(notif)
+    original_task = mgr._tasks[notif.id]
+
+    new_fire = time.time() + 200
+    rescheduled = await mgr.reschedule(notif.id, new_fire)
+    assert rescheduled is True
+
+    # The original task was cancelled, a new one tracked
+    assert mgr._tasks[notif.id] is not original_task
+    assert original_task.done()  # cancelled
+
+    # Store reflects the new fire_at
+    after = await store.get(notif.id)
+    assert after.fire_at == pytest.approx(new_fire)

--- a/tests/test_scheduler_tool.py
+++ b/tests/test_scheduler_tool.py
@@ -1,0 +1,178 @@
+"""Tests for ScheduleReminderTool — the LLM-facing scheduler tool.
+
+Phase 5 ε1a (refs #126, #128).
+
+The tool is mostly glue between parse_when + SchedulerManager — these
+tests pin the contract the LLM sees: parameter schema shape, the
+returned dict on success/failure, and runaway-cap propagation.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.scheduler.manager import RunawayCapError, SchedulerManager
+from dragon_voice.scheduler.models import Notification
+from dragon_voice.scheduler.store import InMemoryNotificationStore
+from dragon_voice.tools.schedule_reminder_tool import (
+    ScheduleReminderTool,
+    _humanize_duration,
+)
+
+
+def _make_tool() -> tuple[ScheduleReminderTool, AsyncMock]:
+    """Build a tool wired to a real SchedulerManager + InMemoryStore.
+    Returns (tool, db_get_session) so tests can swap session lookup."""
+    store = InMemoryNotificationStore()
+    surface_mgr = MagicMock()
+    surface_mgr.surface_for = MagicMock(return_value=MagicMock())
+    session_mgr = MagicMock()
+    session_mgr.list_sessions = AsyncMock(return_value=[])
+
+    mgr = SchedulerManager(
+        store=store,
+        surface_mgr=surface_mgr,
+        session_mgr=session_mgr,
+    )
+
+    db = MagicMock()
+    db.get_session = AsyncMock(return_value={"id": "sess1", "device_id": "dev_A"})
+
+    tool = ScheduleReminderTool(scheduler_mgr=mgr, db=db)
+    return tool, db
+
+
+# ───────────────────────── schema shape
+
+
+def test_tool_has_required_metadata() -> None:
+    """The Tool ABC contract: name, description, parameters_schema,
+    execute.  Pin so renames don't silently break the LLM-facing
+    invocation grammar."""
+    tool, _ = _make_tool()
+    assert tool.name == "schedule_reminder"
+    assert isinstance(tool.description, str) and tool.description
+    schema = tool.parameters_schema
+    assert schema["type"] == "object"
+    # Required fields are exactly `when` and `message` — keeping
+    # the schema tight for local-LLM tool-fire reliability (RFC A5).
+    assert set(schema["required"]) == {"when", "message"}
+    # Optional fields exist
+    assert "title" in schema["properties"]
+    assert "priority" in schema["properties"]
+
+
+# ───────────────────────── execute() success
+
+
+def test_execute_returns_scheduled_true_with_confirmation_fields() -> None:
+    """The headline LLM-facing contract: on success the returned
+    dict has the fields the LLM speaks back to confirm with the user."""
+    tool, _ = _make_tool()
+
+    result = asyncio.run(tool.execute({
+        "when": "5m",
+        "message": "Take out the trash",
+        "session_id": "sess1",
+    }))
+
+    assert result["scheduled"] is True
+    assert result["notification_id"].startswith("sched_")
+    assert "fires_at_iso" in result
+    assert "fires_at_local" in result
+    assert result["fires_in"] == "5 minutes"
+    assert result["title"] == "Reminder"
+    assert result["message"] == "Take out the trash"
+    assert "cancel_hint" in result
+
+
+def test_execute_uses_provided_title_and_priority() -> None:
+    """priority='important' maps to tone='warn' — pin the mapping
+    so a future schema change doesn't silently swap."""
+    tool, _ = _make_tool()
+
+    result = asyncio.run(tool.execute({
+        "when": "1h",
+        "message": "Doctor's appointment",
+        "title": "Important",
+        "priority": "important",
+        "session_id": "sess1",
+    }))
+
+    assert result["scheduled"] is True
+    assert result["title"] == "Important"
+    # Tone landed on the underlying notification (not visible in tool result,
+    # but verifiable by inspecting the stored notification)
+
+
+# ───────────────────────── execute() failure modes
+
+
+def test_execute_rejects_unparseable_when() -> None:
+    """Garbage `when` → scheduled=False with descriptive error.  No
+    notification persisted, no asyncio task spawned."""
+    tool, _ = _make_tool()
+
+    result = asyncio.run(tool.execute({
+        "when": "not a real time",
+        "message": "x",
+        "session_id": "sess1",
+    }))
+
+    assert result["scheduled"] is False
+    assert "error" in result
+    assert "Could not parse" in result["error"]
+
+
+def test_execute_rejects_missing_message() -> None:
+    """An empty `message` is a structural error — must reject before
+    even hitting the parser."""
+    tool, _ = _make_tool()
+
+    result = asyncio.run(tool.execute({
+        "when": "5m",
+        "message": "",
+        "session_id": "sess1",
+    }))
+
+    assert result["scheduled"] is False
+    assert "message" in result["error"].lower()
+
+
+def test_execute_surfaces_runaway_cap_as_user_friendly_error() -> None:
+    """When SchedulerManager raises RunawayCapError, the tool catches
+    it and returns a structured dict the LLM can use to back off
+    gracefully — NOT raise."""
+    tool, _ = _make_tool()
+
+    # Force the manager to throw on schedule
+    async def _raise(notif):
+        raise RunawayCapError("fake cap hit")
+    tool._mgr.schedule = _raise
+
+    result = asyncio.run(tool.execute({
+        "when": "5m",
+        "message": "x",
+        "session_id": "sess1",
+    }))
+
+    assert result["scheduled"] is False
+    assert "cap" in result["error"].lower() or "too many" in result["error"].lower()
+
+
+# ───────────────────────── helpers
+
+
+def test_humanize_duration_handles_common_cases() -> None:
+    """Spot-check the human-readable strings the LLM will speak.
+    Singular/plural matters because the LLM tends to copy the
+    string verbatim."""
+    assert _humanize_duration(0) == "now"
+    assert _humanize_duration(45) == "45 seconds"
+    assert _humanize_duration(60) == "1 minute"
+    assert _humanize_duration(90) == "1 minute"  # truncates seconds when minutes present
+    assert _humanize_duration(3600) == "1 hour"
+    assert _humanize_duration(3600 + 30 * 60) == "1 hour 30 minutes"
+    assert _humanize_duration(2 * 86400) == "2 days"

--- a/tests/test_scheduler_when_parser.py
+++ b/tests/test_scheduler_when_parser.py
@@ -1,0 +1,155 @@
+"""Unit tests for ``parse_when`` — the time-string grammar.
+
+Phase 5 ε1a (refs #126, #128).  Pure function, no asyncio.
+
+The parser is the single source of truth for what a "when" string
+means; both the LLM tool and the REST endpoint delegate to it so
+"5m" and "tomorrow at 3pm" mean the same thing whether the LLM or
+a curl client said them.
+
+Coverage map (RFC Section A9):
+  * relative durations (s/m/h/d, combinations like "1h30m")
+  * ISO 8601 with explicit TZ
+  * ISO 8601 without TZ → resolves in Dragon's local TZ
+  * natural phrases ("tomorrow at 3pm", "today at 17:00")
+  * malformed inputs raise ValueError
+  * far-future cap at 365 days (catches LLM hallucinations)
+  * past timestamps raise (you don't schedule a past reminder)
+"""
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from dragon_voice.scheduler.parser import parse_when
+
+
+# ───────────────────────── fixed reference time
+#
+# Computed (not hardcoded) so the test stays self-consistent
+# regardless of leap-second / epoch-math drift.  Reference moment:
+# 2026-04-26 14:00:00 UTC.
+
+_UTC = timezone.utc
+_FIXED_NOW = datetime(2026, 4, 26, 14, 0, 0, tzinfo=_UTC).timestamp()
+
+
+# ───────────────────────── relative duration grammar
+
+
+def test_relative_minutes() -> None:
+    """`5m` = now + 5 * 60 seconds.  Pin the unit suffix mapping."""
+    fire_at = parse_when("5m", now=_FIXED_NOW, tz=_UTC)
+    assert fire_at == pytest.approx(_FIXED_NOW + 5 * 60)
+
+
+def test_relative_combined_units() -> None:
+    """`1h30m` parses left-to-right as h + m, not as 1.5h.  Pin so a
+    future regex change can't silently swap units."""
+    fire_at = parse_when("1h30m", now=_FIXED_NOW, tz=_UTC)
+    assert fire_at == pytest.approx(_FIXED_NOW + 60 * 60 + 30 * 60)
+
+
+def test_relative_seconds_minimum() -> None:
+    """`30s` works.  Useful for the ε1b live E2E ("schedule a 30s
+    reminder, wait, observe widget_card")."""
+    fire_at = parse_when("30s", now=_FIXED_NOW, tz=_UTC)
+    assert fire_at == pytest.approx(_FIXED_NOW + 30)
+
+
+def test_relative_days() -> None:
+    """`2d` = 2 * 86400 s.  No DST math — relative durations are
+    wall-clock seconds, not calendar days."""
+    fire_at = parse_when("2d", now=_FIXED_NOW, tz=_UTC)
+    assert fire_at == pytest.approx(_FIXED_NOW + 2 * 86400)
+
+
+# ───────────────────────── ISO 8601
+
+
+def test_iso_with_explicit_tz() -> None:
+    """`2026-04-26T15:00:00-04:00` resolves to absolute UTC epoch
+    regardless of Dragon's local TZ.  The tz= parameter is irrelevant
+    when the input carries its own offset."""
+    iso = "2026-04-26T15:00:00-04:00"
+    expected_dt = datetime(2026, 4, 26, 19, 0, 0, tzinfo=_UTC)  # 15:00 EDT = 19:00 UTC
+    fire_at = parse_when(iso, now=_FIXED_NOW, tz=_UTC)
+    assert fire_at == pytest.approx(expected_dt.timestamp())
+
+
+def test_iso_without_tz_uses_dragon_tz() -> None:
+    """A bare `2026-04-26T15:00:00` (no offset) resolves in Dragon's
+    local TZ.  This matches the LLM's user-facing semantics —
+    "at 3pm" means "3pm where Dragon is".  Pin the policy."""
+    bare_iso = "2026-04-27T15:00:00"  # well in the future from FIXED_NOW
+    fire_at = parse_when(bare_iso, now=_FIXED_NOW, tz=_UTC)
+    # When tz=UTC, bare 2026-04-27T15:00:00 = 1777338000.0
+    expected = datetime(2026, 4, 27, 15, 0, 0, tzinfo=_UTC).timestamp()
+    assert fire_at == pytest.approx(expected)
+
+
+# ───────────────────────── natural phrases
+
+
+def test_natural_phrase_today_at_hour() -> None:
+    """`today at 17:00` resolves to 17:00 in Dragon's TZ on today's
+    date (relative to `now`).  If 17:00 is already past, raises —
+    "today" doesn't loop to tomorrow."""
+    # FIXED_NOW = 14:00 UTC.  "today at 17:00" should resolve to 17:00 UTC same day.
+    fire_at = parse_when("today at 17:00", now=_FIXED_NOW, tz=_UTC)
+    expected = datetime(2026, 4, 26, 17, 0, 0, tzinfo=_UTC).timestamp()
+    assert fire_at == pytest.approx(expected)
+
+
+def test_natural_phrase_tomorrow_at_hour() -> None:
+    """`tomorrow at 3pm` — pm form parses + jumps to next day."""
+    fire_at = parse_when("tomorrow at 3pm", now=_FIXED_NOW, tz=_UTC)
+    expected = datetime(2026, 4, 27, 15, 0, 0, tzinfo=_UTC).timestamp()
+    assert fire_at == pytest.approx(expected)
+
+
+# ───────────────────────── failure modes
+
+
+def test_garbage_raises_valueerror() -> None:
+    """Unparseable input → ValueError so the caller (REST or tool)
+    can return a clean 400 / structured tool error."""
+    with pytest.raises(ValueError):
+        parse_when("not a time at all", now=_FIXED_NOW, tz=_UTC)
+
+
+def test_empty_string_raises() -> None:
+    with pytest.raises(ValueError):
+        parse_when("", now=_FIXED_NOW, tz=_UTC)
+
+
+def test_far_future_capped_at_365_days() -> None:
+    """RFC E1: cap at 365 days into the future.  Anything longer is
+    almost certainly a parser bug or hostile LLM hallucination."""
+    with pytest.raises(ValueError, match="365"):
+        parse_when("400d", now=_FIXED_NOW, tz=_UTC)
+
+
+def test_past_relative_zero_seconds_allowed() -> None:
+    """`0s` (= now) is technically not in the past — should parse.
+    Pin so the cap-check doesn't false-fire on edge inputs."""
+    fire_at = parse_when("0s", now=_FIXED_NOW, tz=_UTC)
+    assert fire_at == pytest.approx(_FIXED_NOW)
+
+
+def test_past_iso_raises() -> None:
+    """An ISO timestamp before `now` raises.  You can't schedule a
+    reminder for yesterday — that would fire immediately and confuse
+    the user."""
+    past_iso = "2026-04-25T12:00:00+00:00"  # 1 day before FIXED_NOW
+    with pytest.raises(ValueError, match="past"):
+        parse_when(past_iso, now=_FIXED_NOW, tz=_UTC)
+
+
+def test_negative_relative_raises() -> None:
+    """`-5m` is a pathological input — must reject, not silently
+    treat as 5 minutes ago."""
+    with pytest.raises(ValueError):
+        parse_when("-5m", now=_FIXED_NOW, tz=_UTC)


### PR DESCRIPTION
Closes #128.  Refs #126, refs #89, refs #94.  PR2 of 4 in [Phase 5 (RFC)](docs/RFC-scheduler.md).

## What lands
The RFC's ε1a slice — pure foundation, no end-user behaviour change yet:
- **[\`dragon_voice/scheduler/__init__.py\`](dragon_voice/scheduler/__init__.py)** — public re-exports
- **[\`models.py\`](dragon_voice/scheduler/models.py)** — Notification dataclass with width-trim guards
- **[\`store.py\`](dragon_voice/scheduler/store.py)** — NotificationStore Protocol (the RFC A8 single-most-important architectural decision so ε2's SQLite store is a one-line wiring swap, not a rewrite) + InMemoryNotificationStore
- **[\`parser.py\`](dragon_voice/scheduler/parser.py)** — pure \`parse_when()\`. Single source of truth shared by REST + LLM tool. Accepts: relative (\`5m\`, \`1h30m\`), ISO 8601 with/without TZ, natural (\`tomorrow at 3pm\`). Rejects: garbage, past, negative, > 365 days
- **[\`manager.py\`](dragon_voice/scheduler/manager.py)** — SchedulerManager. Per-device runaway cap of 100 (RFC E2 / R2). _fire_one looks up active session via SessionManager and emits widget_card via Tab5Surface with \`action=("Dismiss", "scheduler.dismiss")\` for free dismiss. Tier 1 contract: no active session = log + drop (mark fired). Cancel-then-await on shutdown.
- **[\`tools/schedule_reminder_tool.py\`](dragon_voice/tools/schedule_reminder_tool.py)** — LLM-facing tool. Tight schema (RFC A5): \`when\` + \`message\` + optional \`title\`/\`priority\`. Returns dict with \`fires_in\` (humanized) for natural LLM speakback.
- **[\`lifecycle/startup.py\`](dragon_voice/lifecycle/startup.py)** — wire SchedulerManager AFTER SurfaceManager + SessionManager exist; register tool alongside other widget-emitting tools
- **[\`lifecycle/shutdown.py\`](dragon_voice/lifecycle/shutdown.py)** — cancel-then-await scheduler tasks BEFORE pipeline drain

## Tests (27 total — exceeded RFC's 15-test plan)
- **[\`test_scheduler_when_parser.py\`](tests/test_scheduler_when_parser.py)** — 14 unit tests covering every grammar branch
- **[\`test_scheduler_manager.py\`](tests/test_scheduler_manager.py)** — 6 async tests covering schedule-fire-emit, cancel suppression, shutdown task cleanup, runaway-cap rejection, no-active-session drop, reschedule swap
- **[\`test_scheduler_tool.py\`](tests/test_scheduler_tool.py)** — 7 tests covering schema shape, success/failure dict shapes, runaway-cap propagation, humanize spot-checks

## Verification
- [x] \`ruff check\` narrow gate clean
- [x] CI named-set: **263 passing** (pre: 236)
- [x] Full repo: **332 passing** (pre: 305 — +27 new)
- [x] **LIVE on Dragon sandbox** (port 3513) — boot logs show:
  ```
  SchedulerManager initialized (store=InMemoryNotificationStore)
  Tool registered: schedule_reminder
  ScheduleReminderTool registered (scheduler skill)
  ```
- [x] γ1 baseline (\`session_invalid\` + \`media_not_found\`) still passes on sandbox — zero regression
- [x] Sandbox journal clean — no tracebacks/exceptions from new code

## Out of scope (deferred per [RFC Section D](docs/RFC-scheduler.md))
- REST API at \`/api/v1/scheduler/*\` (ε1b — PR3)
- Live E2E with real reminder fire on Tab5 (ε1b — needs REST to drive)
- SqliteNotificationStore + boot replay + offline queue + snooze (ε2 — PR4)
- Tab5 firmware: ZERO changes needed (voice.c:1269 already handles widget_card)

🤖 Generated with [Claude Code](https://claude.com/claude-code)