### PR TITLE
docs(ux): Phase 5 (scheduler) COMPLETE — F-T1 + F-T2 merged

### DIFF
--- a/docs/UX-GAPS.md
+++ b/docs/UX-GAPS.md
@@ -58,8 +58,8 @@ Per user direction:
 | D-mem | Memory facts unbounded (downgraded — sqlite-vec confirmed loaded) | LOW (was MED) | ~1 h | 4 | OPEN (deferred — perf fine at 100k facts; ship if/when ops sees a real issue) |
 | D-docs | Document ingest no size cap | MED | ~1 h | 4 | **MERGED #119** |
 | L1 | POST 413 returns `Connection: close` | LOW | 10 min | 6 | **MERGED #122** |
-| F-T1 | Scheduler tier 1 (in-process) | DESIGN | ~7 h | 5 | OPEN |
-| F-T2 | Scheduler tier 2 (durable + offline queue) | DESIGN | +6 h | 5 | OPEN |
+| F-T1 | Scheduler tier 1 (in-process) | DESIGN | ~7 h | 5 | **MERGED #129 + #130** |
+| F-T2 | Scheduler tier 2 (durable + offline queue) | DESIGN | +6 h | 5 | **MERGED #132** |
 
 **Architectural patterns (collapse multiple gaps into single abstractions):**
 
@@ -166,9 +166,9 @@ and risk register.  Read the RFC before starting any implementation PR.
 
 | PR | Scope | Effort |
 |---|---|---|
-| ε-design | RFC: scheduler architecture + Tab5 notification UI surface decision | ~2 h |
-| ε1 | F-T1 in-process scheduler (asyncio task + REST API + ScheduleReminderTool + WS `notification` message) | ~4 h Dragon + ~3 h Tab5 |
-| ε2 | F-T2 SQLite-backed durable + offline queue + boot replay | ~6 h Dragon |
+| ε-design | RFC: scheduler architecture + Tab5 notification UI surface decision | **MERGED #127** |
+| ε1 | F-T1 in-process scheduler (asyncio task + REST API + ScheduleReminderTool + WS `notification` message) | **MERGED #129 (ε1a) + #130 (ε1b)** |
+| ε2 | F-T2 SQLite-backed durable + offline queue + boot replay | **MERGED #132** |
 
 **E2E acceptance:**
 - "Remind me in 5 minutes" → 5 minutes later a card appears in chat with


### PR DESCRIPTION
## Summary
Phase 5 of the UX-gap remediation is shipped end-to-end:
- **ε-design** (RFC) → #127
- **ε1a** (in-process core) → #129
- **ε1b** (REST API + live E2E) → #130
- **ε2** (SQLite + boot replay + offline queue + snooze) → #132

Production-deployed and live-validated on real Tab5 (192.168.1.90):
\`POST /api/v1/scheduler/notifications {when:"30s", message:"...", device_id:"30eda0ea8e33"}\` → 30s later \`Notification sched_9f2716f7f202 fired → device=30eda0ea8e33 session=bdc4b7e2a3d8\` → widget_card lands in chat.

## What's complete after this PR
The active Phases 1-6 + Phase 5 are all done.  Only items still open in UX-GAPS are explicitly deferred:
- **D-mem** — sqlite-vec loaded, perf fine at 100k facts
- **δ-arch** — Phase 4 already shipped clean point-fixes
- Cross-device delivery + push-when-offline — RFC H non-goals

## Test plan
- [x] Doc-only — no code touched
- [ ] CI green
🤖 Generated with [Claude Code](https://claude.com/claude-code)