### PR TITLE
fix(scheduler): add schedule_reminder to local-LLM priority tool list (#134)

### DIFF
--- a/dragon_voice/tools/registry.py
+++ b/dragon_voice/tools/registry.py
@@ -356,10 +356,17 @@ class ToolRegistry:
         """Minimal tool format for small models (qwen3:1.7b etc).
 
         Uses fewer tokens and simpler structure to avoid confusing small models.
-        Only shows the 4 most commonly used tools to reduce context bloat.
+        Only shows the most commonly used tools to reduce context bloat.
         """
-        # Core tools that small models handle well
-        priority_tools = ["web_search", "datetime", "remember", "recall", "calculator"]
+        # Core tools that small models handle well.  Issue #134:
+        # `schedule_reminder` was missing — local LLM hallucinated
+        # "no such tool available" when the user asked for a reminder.
+        # Adding ~30 tokens to the system prompt is a worthwhile
+        # trade for unlocking a high-value capability.
+        priority_tools = [
+            "web_search", "datetime", "remember", "recall",
+            "calculator", "schedule_reminder",
+        ]
         tools = [t for t in self._tools.values() if t.name in priority_tools]
         if not tools:
             tools = list(self._tools.values())[:4]

--- a/tests/test_tool_parser.py
+++ b/tests/test_tool_parser.py
@@ -341,3 +341,47 @@ def test_with_errors_does_not_emit_when_dialect2_lacks_name_field() -> None:
     )
     assert calls == []
     assert errors == []
+
+
+# ───────────────────────── #134 — schedule_reminder visibility
+
+
+def test_schedule_reminder_in_compact_priority_list() -> None:
+    """Issue #134: local LLM (compact format) was missing
+    schedule_reminder from its priority list, causing it to
+    hallucinate "no such tool" when users asked for reminders.
+
+    Pin so future priority-list refactors don't drop it again.
+    """
+    from dragon_voice.tools.base import Tool
+
+    class _StubReminder(Tool):
+        @property
+        def name(self) -> str:
+            return "schedule_reminder"
+        @property
+        def description(self) -> str:
+            return "Schedule a reminder"
+        @property
+        def parameters_schema(self) -> dict:
+            return {"type": "object", "properties": {"when": {"type": "string"}}, "required": ["when"]}
+        async def execute(self, args):
+            return {"ok": True}
+
+    r = ToolRegistry()
+    r.register(_StubReminder())
+    # also register some non-priority tools to verify filtering
+    r.register(_FakeTool("calculator"))
+    r.register(_FakeTool("note"))
+    r.register(_FakeTool("weather"))
+
+    compact = r.format_for_llm(compact=True)
+    assert "schedule_reminder" in compact, (
+        "Issue #134 regression: schedule_reminder missing from compact "
+        "format — local LLM will hallucinate 'no such tool'"
+    )
+    # And the existing priority tools are still there
+    assert "calculator" in compact
+    # Non-priority tools NOT in compact (note + weather should be excluded)
+    assert "note: " not in compact  # avoid matching schedule_reminder description
+    assert "weather: " not in compact


### PR DESCRIPTION
Closes #134.  Refs #126.

## Symptom
Caught by live workflow test on real Tab5 in voice_mode=0 (Local).  User text `use the schedule_reminder tool to remind me in 90 seconds...` got back: *"No schedulereminder tool available. I can only help with current context."*

## Root cause
`registry._format_compact()` (used for local LLMs to keep context tight) only injected 5 priority tools — `schedule_reminder` was missing.  Local LLM didn't see it in its system prompt → hallucinated rejection.

## Fix
Append `schedule_reminder` to `priority_tools`.  ~30 extra tokens in the compact format is a worthwhile trade for unlocking LLM-driven scheduling on local mode.

## Test plan
- [x] 1 new regression test in test_tool_parser.py
- [x] Full repo: 356/356 passing (was 354 — +1 new + 1 from earlier session)
- [x] `ruff check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)