### PR TITLE
refactor(audio): dedup PCM resample helper across voice + text TTS paths (closes #150)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,4 +92,5 @@ jobs:
             tests/test_looks_like_useful_text.py \
             tests/test_tinkerclaw_streaming.py \
             tests/test_openrouter_tts_errors.py \
-            tests/test_max_tool_calls_signal.py
+            tests/test_max_tool_calls_signal.py \
+            tests/test_audio_resample.py

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -682,3 +682,10 @@ sequentially across the whole file (don't restart per section).
 - **Prevention:**
   1. **Every "if X and Y" gate where Y can flip false at runtime is a candidate for a "Y was the false clause" signal.**  Audit pattern: search for `< MAX_`, `< _MAX_`, `< limit`, etc., and check whether the false case is observable to the user.
   2. **A callback that handles "thing went wrong, here's a code+message" should not hardcode the code on the receiving side.**  The receiver should respect the sender's `code`/`message` fields and only fall back to its own defaults when the sender omitted them.
+
+### 87. PCM resample duplicated voice-vs-text TTS — extracted to dragon_voice.audio (audit B8)
+- **Date:** 2026-04-26 (PR for #150)
+- **Symptom:** Quality work on the resample (e.g. swapping linear interp for a polyphase filter) would silently miss the parallel callsite.  Same divergence shape as #83 (voice-vs-text post-process).
+- **Root Cause:** Two near-identical 10-line linear-interp resample blocks lived inline in `pipeline._synthesize_and_send` and `server._handle_text`.  No shared helper.
+- **Fix:** Extracted to `dragon_voice/audio.py:resample_pcm16(audio_bytes, src_rate, dst_rate)`.  Same-rate fast path short-circuits with no allocation.  Empty input + 1-sample edge cases handled.  8-case unit test pins behaviour, including a byte-identical match to the pre-extraction formula so any future polyphase swap requires an explicit test update.
+- **Prevention:** Use the file-split smell test from CLAUDE.md ("what stakeholder cares about the code I'm moving?") in reverse — when the *same* code lives in two files maintained by the *same* concern (audio plumbing), that's the smell that the helper's natural home doesn't exist yet.  Build it before the third copy arrives.

--- a/dragon_voice/audio.py
+++ b/dragon_voice/audio.py
@@ -1,0 +1,39 @@
+"""Pure audio-utility helpers shared by the voice and text TTS paths.
+
+Audit B8 (#137): pre-fix this module didn't exist; the same linear
+PCM-resample block was duplicated in `pipeline._synthesize_and_send`
+and in `server._handle_text`'s text-path TTS branch.  Any quality fix
+to one (e.g. swapping linear interpolation for a polyphase filter)
+would silently miss the other.  Centralising here means future quality
+work has exactly one site to change.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = ["resample_pcm16"]
+
+
+def resample_pcm16(audio_bytes: bytes, src_rate: int, dst_rate: int) -> bytes:
+    """Linear-interpolation resample of a raw PCM int16 buffer.
+
+    Returns the input unchanged when the rates already match (this is
+    common — Piper outputs 22050 Hz to a 22050 Hz Tab5 fallback path
+    and the resample would be wasted CPU + a needless allocation).
+
+    Empty input returns empty output without raising.
+    """
+    if src_rate == dst_rate or not audio_bytes:
+        return audio_bytes
+    src = np.frombuffer(audio_bytes, dtype=np.int16)
+    if src.size == 0:
+        return audio_bytes
+    ratio = dst_rate / src_rate
+    new_len = int(src.size * ratio)
+    if new_len <= 0:
+        return b""
+    indices = np.arange(new_len) / ratio
+    idx_floor = np.clip(indices.astype(np.int32), 0, src.size - 2)
+    frac = indices - idx_floor
+    out = (src[idx_floor] * (1 - frac) + src[idx_floor + 1] * frac).astype(np.int16)
+    return out.tobytes()

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -23,6 +23,7 @@ from dragon_voice.progress_emit import emit_progress_pair
 from dragon_voice.stt import create_stt, STTBackend
 from dragon_voice.tts import create_tts, TTSBackend
 from dragon_voice.llm import create_llm, LLMBackend
+from dragon_voice.audio import resample_pcm16
 from dragon_voice.tools.response_wrap import looks_like_useful_text, synthesize_wrap
 
 logger = logging.getLogger(__name__)
@@ -1268,24 +1269,12 @@ class VoicePipeline:
             tts_ms = (time.monotonic() - t0) * 1000
 
             if audio_bytes:
-                # Resample from TTS sample rate to 16kHz for Tab5 playback
+                # Resample from TTS sample rate to 16kHz for Tab5 playback.
+                # Audit B8 (#137): shared with the text-path TTS branch
+                # in server._handle_text via dragon_voice.audio.resample_pcm16.
                 tts_rate = self._tts.sample_rate if self._tts else 22050
                 target_rate = self._config.audio.input_sample_rate  # 16000
-
-                if tts_rate != target_rate:
-                    audio_i16 = np.frombuffer(audio_bytes, dtype=np.int16)
-                    # Simple linear interpolation resample
-                    ratio = target_rate / tts_rate
-                    new_len = int(len(audio_i16) * ratio)
-                    indices = np.arange(new_len) / ratio
-                    indices_floor = indices.astype(np.int32)
-                    indices_floor = np.clip(indices_floor, 0, len(audio_i16) - 2)
-                    frac = indices - indices_floor
-                    resampled = (
-                        audio_i16[indices_floor] * (1 - frac)
-                        + audio_i16[indices_floor + 1] * frac
-                    ).astype(np.int16)
-                    audio_bytes = resampled.tobytes()
+                audio_bytes = resample_pcm16(audio_bytes, tts_rate, target_rate)
 
                 logger.debug(
                     "TTS (%.0fms): %d bytes @ %dHz for '%.40s...'",

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -52,6 +52,7 @@ from dragon_voice.middleware import (
 )
 from dragon_voice.pipeline import VoicePipeline
 from dragon_voice.sessions import SessionManager
+from dragon_voice.audio import resample_pcm16
 from dragon_voice.tools.response_wrap import looks_like_useful_text, synthesize_wrap
 
 
@@ -1784,18 +1785,12 @@ class VoiceServer:
                     tts_ms = (time.monotonic() - t0) * 1000
 
                     if audio_bytes:
+                        # Audit B8 (#137): shared resample with the
+                        # voice-path TTS branch in
+                        # pipeline._synthesize_and_send.
                         tts_rate = pipeline._tts.sample_rate
                         target_rate = conn_cfg.audio.input_sample_rate if conn_cfg else 16000
-                        if tts_rate != target_rate:
-                            import numpy as np
-                            audio_i16 = np.frombuffer(audio_bytes, dtype=np.int16)
-                            ratio = target_rate / tts_rate
-                            new_len = int(len(audio_i16) * ratio)
-                            indices = np.arange(new_len) / ratio
-                            idx_floor = np.clip(indices.astype(np.int32), 0, len(audio_i16) - 2)
-                            frac = indices - idx_floor
-                            audio_bytes = (audio_i16[idx_floor] * (1 - frac)
-                                         + audio_i16[idx_floor + 1] * frac).astype(np.int16).tobytes()
+                        audio_bytes = resample_pcm16(audio_bytes, tts_rate, target_rate)
 
                         chunk_size = 4096
                         pace_sleep = (chunk_size / 2) / target_rate * 0.8

--- a/tests/test_audio_resample.py
+++ b/tests/test_audio_resample.py
@@ -1,0 +1,100 @@
+"""Tests for `dragon_voice.audio.resample_pcm16` (audit B8 / #137).
+
+The helper extracts the linear-interpolation PCM resample that was
+duplicated between `pipeline._synthesize_and_send` and `server._handle_text`.
+This file is the behaviour-pinning test so any future quality fix
+(e.g. swapping linear interp for a polyphase filter) has a single
+green-bar gate to satisfy.
+"""
+from __future__ import annotations
+
+import struct
+
+import numpy as np
+import pytest
+
+from dragon_voice.audio import resample_pcm16
+
+
+def _pcm16(samples: list[int]) -> bytes:
+    return struct.pack(f"<{len(samples)}h", *samples)
+
+
+def test_same_rate_returns_input_unchanged() -> None:
+    """No-op fast path — the byte object should be returned identically
+    (no allocation, no resample) when src_rate == dst_rate."""
+    buf = _pcm16([100, 200, 300, 400])
+    out = resample_pcm16(buf, 16000, 16000)
+    assert out is buf, "same-rate path must short-circuit without allocation"
+
+
+def test_empty_input_returns_empty() -> None:
+    assert resample_pcm16(b"", 22050, 16000) == b""
+
+
+def test_downsample_22050_to_16000_reduces_sample_count() -> None:
+    src_rate, dst_rate = 22050, 16000
+    src_samples = list(range(220))  # 220 samples = 10 ms @ 22050 Hz
+    out = resample_pcm16(_pcm16(src_samples), src_rate, dst_rate)
+    expected_len = int(len(src_samples) * dst_rate / src_rate)
+    assert len(out) == expected_len * 2  # int16 = 2 bytes/sample
+
+
+def test_upsample_22050_to_24000_increases_sample_count() -> None:
+    """OpenRouter TTS occasionally outputs 22050 (when fallback to Piper
+    happens), Tab5 expects 16k — verify the helper handles upsample too."""
+    src_rate, dst_rate = 22050, 24000
+    src_samples = [100, 200, 300, 400, 500, 600, 700, 800]
+    out = resample_pcm16(_pcm16(src_samples), src_rate, dst_rate)
+    expected_len = int(len(src_samples) * dst_rate / src_rate)
+    assert len(out) == expected_len * 2
+
+
+def test_resample_preserves_endpoint_values_approximately() -> None:
+    """A linear ramp should remain monotonic after resample, with the
+    first sample preserved exactly (it's at index 0 in the source)."""
+    src_rate, dst_rate = 22050, 16000
+    src_samples = list(range(0, 22050, 100))  # 0, 100, 200, ... — monotonic ramp
+    out = resample_pcm16(_pcm16(src_samples), src_rate, dst_rate)
+    out_arr = np.frombuffer(out, dtype=np.int16)
+    assert out_arr[0] == 0
+    # Strictly non-decreasing.
+    assert all(out_arr[i] <= out_arr[i + 1] + 1 for i in range(len(out_arr) - 1))
+
+
+def test_resample_matches_pre_extraction_linear_formula() -> None:
+    """Pin the exact algorithm so a polyphase swap is an explicit
+    test-suite update.  Compares the helper's output to the inline
+    formula that lived in pipeline._synthesize_and_send pre-B8."""
+    src_rate, dst_rate = 22050, 16000
+    src_samples = [int(np.sin(i / 4) * 10000) for i in range(64)]
+    src_bytes = _pcm16(src_samples)
+
+    # Inline reference (the pre-B8 formula).
+    audio_i16 = np.frombuffer(src_bytes, dtype=np.int16)
+    ratio = dst_rate / src_rate
+    new_len = int(len(audio_i16) * ratio)
+    indices = np.arange(new_len) / ratio
+    idx_floor = np.clip(indices.astype(np.int32), 0, len(audio_i16) - 2)
+    frac = indices - idx_floor
+    expected = (audio_i16[idx_floor] * (1 - frac)
+                + audio_i16[idx_floor + 1] * frac).astype(np.int16).tobytes()
+
+    actual = resample_pcm16(src_bytes, src_rate, dst_rate)
+    assert actual == expected
+
+
+def test_extremely_short_input_does_not_crash() -> None:
+    """A 1-sample input shouldn't blow up (the inline formula clipped
+    indices to len-2, which would underflow for len=1)."""
+    out = resample_pcm16(_pcm16([42]), 22050, 16000)
+    # 1 sample @ 22050 → ratio 0.725 → new_len = 0 → empty bytes.
+    assert out == b""
+
+
+def test_zero_destination_rate_clamps_to_empty() -> None:
+    """Defensive: dst_rate=0 would cause a divide-by-zero in ratio.
+    Helper should fall through cleanly via the new_len <= 0 guard."""
+    out = resample_pcm16(_pcm16([100, 200]), 22050, 0)
+    # ratio = 0 → new_len = 0 → empty bytes (no exception).
+    assert out == b""


### PR DESCRIPTION
## Summary

Extract the duplicated linear-interp PCM resample to \`dragon_voice/audio.py:resample_pcm16\`.  Both \`pipeline._synthesize_and_send\` and \`server._handle_text\` now import it.

## Test plan

- [x] 8-case unit suite (\`tests/test_audio_resample.py\`) — including byte-identical match to the pre-extraction formula
- [x] CI ruff gate clean
- [x] 27 tests pass on local nearby slice
- [ ] Live smoke after merge: voice + text TTS in Hybrid mode still produces clean audio