### PR TITLE
fix(audio): async resample wrapper to unblock event loop on long TTS replies (audit C8)

### DIFF
--- a/dragon_voice/audio.py
+++ b/dragon_voice/audio.py
@@ -6,12 +6,28 @@ and in `server._handle_text`'s text-path TTS branch.  Any quality fix
 to one (e.g. swapping linear interpolation for a polyphase filter)
 would silently miss the other.  Centralising here means future quality
 work has exactly one site to change.
+
+Audit C8 (#137): added `resample_pcm16_async` so callers can run the
+numpy work off the event loop on long replies without blocking other
+WS frames (cancels, voice frames from another tab, etc.).  The sync
+form stays for tests + tiny buffers where the dispatch overhead
+dwarfs the work.
 """
 from __future__ import annotations
 
+import asyncio
+
 import numpy as np
 
-__all__ = ["resample_pcm16"]
+__all__ = ["resample_pcm16", "resample_pcm16_async"]
+
+
+# Below this size the GIL-bound thread-dispatch round-trip costs more
+# than just running synchronously.  Calibrated against ~2 KB
+# (≈ 60 ms of 16 kHz audio) — a single sentence-flush chunk on
+# Piper.  Empirical, not theoretical; revisit if profiling shows
+# resample as a hotspot.
+_ASYNC_RESAMPLE_MIN_BYTES = 2048
 
 
 def resample_pcm16(audio_bytes: bytes, src_rate: int, dst_rate: int) -> bytes:
@@ -37,3 +53,28 @@ def resample_pcm16(audio_bytes: bytes, src_rate: int, dst_rate: int) -> bytes:
     frac = indices - idx_floor
     out = (src[idx_floor] * (1 - frac) + src[idx_floor + 1] * frac).astype(np.int16)
     return out.tobytes()
+
+
+async def resample_pcm16_async(
+    audio_bytes: bytes, src_rate: int, dst_rate: int
+) -> bytes:
+    """Async wrapper that hops the resample to a worker thread when
+    the buffer is large enough that the numpy pass would block the
+    event loop noticeably.
+
+    Audit C8 (#137): pre-fix the resample ran synchronously on the
+    asyncio loop.  A 2-paragraph TTS reply (~150 KB at 22 kHz) takes
+    ~10-20 ms of numpy time on Q6A — long enough to delay cancel /
+    ping / voice frames from other connections served by the same
+    process.  The threshold below avoids dispatch overhead on small
+    sentence-flush chunks.
+    """
+    if (
+        src_rate == dst_rate
+        or not audio_bytes
+        or len(audio_bytes) < _ASYNC_RESAMPLE_MIN_BYTES
+    ):
+        return resample_pcm16(audio_bytes, src_rate, dst_rate)
+    return await asyncio.to_thread(
+        resample_pcm16, audio_bytes, src_rate, dst_rate
+    )

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -23,7 +23,7 @@ from dragon_voice.progress_emit import emit_progress_pair
 from dragon_voice.stt import create_stt, STTBackend
 from dragon_voice.tts import create_tts, TTSBackend
 from dragon_voice.llm import create_llm, LLMBackend
-from dragon_voice.audio import resample_pcm16
+from dragon_voice.audio import resample_pcm16_async
 from dragon_voice.tools.response_wrap import looks_like_useful_text, synthesize_wrap
 
 logger = logging.getLogger(__name__)
@@ -1304,11 +1304,14 @@ class VoicePipeline:
 
             if audio_bytes:
                 # Resample from TTS sample rate to 16kHz for Tab5 playback.
-                # Audit B8 (#137): shared with the text-path TTS branch
-                # in server._handle_text via dragon_voice.audio.resample_pcm16.
+                # Audit B8 (#137) + C8 (#137): shared async helper hops
+                # large buffers off the event loop so cancels / voice
+                # frames from other connections aren't delayed.
                 tts_rate = self._tts.sample_rate if self._tts else 22050
                 target_rate = self._config.audio.input_sample_rate  # 16000
-                audio_bytes = resample_pcm16(audio_bytes, tts_rate, target_rate)
+                audio_bytes = await resample_pcm16_async(
+                    audio_bytes, tts_rate, target_rate
+                )
 
                 logger.debug(
                     "TTS (%.0fms): %d bytes @ %dHz for '%.40s...'",

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -52,7 +52,7 @@ from dragon_voice.middleware import (
 )
 from dragon_voice.pipeline import VoicePipeline
 from dragon_voice.sessions import SessionManager
-from dragon_voice.audio import resample_pcm16
+from dragon_voice.audio import resample_pcm16_async
 from dragon_voice.tools.response_wrap import looks_like_useful_text, synthesize_wrap
 
 
@@ -1785,12 +1785,16 @@ class VoiceServer:
                     tts_ms = (time.monotonic() - t0) * 1000
 
                     if audio_bytes:
-                        # Audit B8 (#137): shared resample with the
-                        # voice-path TTS branch in
-                        # pipeline._synthesize_and_send.
+                        # Audit B8 (#137) + C8 (#137): shared async
+                        # resample with the voice-path TTS branch.
+                        # Long replies (~150 KB) hop to a worker thread
+                        # so this WS read loop stays free for cancels /
+                        # other frames.
                         tts_rate = pipeline._tts.sample_rate
                         target_rate = conn_cfg.audio.input_sample_rate if conn_cfg else 16000
-                        audio_bytes = resample_pcm16(audio_bytes, tts_rate, target_rate)
+                        audio_bytes = await resample_pcm16_async(
+                            audio_bytes, tts_rate, target_rate
+                        )
 
                         chunk_size = 4096
                         pace_sleep = (chunk_size / 2) / target_rate * 0.8

--- a/tests/test_audio_resample.py
+++ b/tests/test_audio_resample.py
@@ -98,3 +98,74 @@ def test_zero_destination_rate_clamps_to_empty() -> None:
     out = resample_pcm16(_pcm16([100, 200]), 22050, 0)
     # ratio = 0 → new_len = 0 → empty bytes (no exception).
     assert out == b""
+
+
+# ─────────────────────────── async wrapper (audit C8 / #137)
+
+import asyncio  # noqa: E402
+
+from dragon_voice.audio import resample_pcm16_async  # noqa: E402
+
+
+def test_async_wrapper_matches_sync_helper_for_small_buffers() -> None:
+    """Below the dispatch threshold the async wrapper short-circuits
+    to the sync helper — no thread hop, identical bytes."""
+    src_rate, dst_rate = 22050, 16000
+    src = _pcm16([int(np.sin(i / 4) * 10000) for i in range(64)])
+    sync_out = resample_pcm16(src, src_rate, dst_rate)
+    async_out = asyncio.run(resample_pcm16_async(src, src_rate, dst_rate))
+    assert async_out == sync_out
+
+
+def test_async_wrapper_matches_sync_helper_for_large_buffers() -> None:
+    """Above the dispatch threshold the helper hops to a worker thread.
+    Verify the bytes are identical to the sync path so dispatch doesn't
+    silently corrupt audio."""
+    src_rate, dst_rate = 22050, 16000
+    # ~150 KB to comfortably exceed _ASYNC_RESAMPLE_MIN_BYTES (2 KB).
+    samples = [int(np.sin(i / 50) * 20000) for i in range(75_000)]
+    src = _pcm16(samples)
+    sync_out = resample_pcm16(src, src_rate, dst_rate)
+    async_out = asyncio.run(resample_pcm16_async(src, src_rate, dst_rate))
+    assert async_out == sync_out
+
+
+def test_async_wrapper_does_not_block_event_loop_on_large_buffer() -> None:
+    """C8 contract: a large resample must allow other tasks to run on
+    the loop concurrently.  We schedule a 5 ms tick task alongside the
+    resample and assert the tick fires at least once during it."""
+    src_rate, dst_rate = 22050, 16000
+    samples = [int(np.sin(i / 50) * 20000) for i in range(150_000)]  # ~300 KB
+    src = _pcm16(samples)
+
+    ticks: list[float] = []
+
+    async def tick():
+        for _ in range(20):
+            await asyncio.sleep(0.005)
+            ticks.append(asyncio.get_event_loop().time())
+
+    async def go():
+        await asyncio.gather(
+            resample_pcm16_async(src, src_rate, dst_rate),
+            tick(),
+        )
+
+    asyncio.run(go())
+    # If the resample blocked the loop, the tick task wouldn't have
+    # fired its full 20 iterations during the resample window.
+    assert len(ticks) == 20, (
+        f"event loop appears blocked during resample; only {len(ticks)} ticks fired"
+    )
+
+
+def test_async_wrapper_same_rate_short_circuits() -> None:
+    """Same-rate must not spin up a thread."""
+    buf = _pcm16([100, 200, 300])
+    out = asyncio.run(resample_pcm16_async(buf, 16000, 16000))
+    assert out is buf
+
+
+def test_async_wrapper_empty_input_returns_empty() -> None:
+    out = asyncio.run(resample_pcm16_async(b"", 22050, 16000))
+    assert out == b""


### PR DESCRIPTION
## Summary

Pre-fix the resample (now centralised by B8 / #150) ran synchronously on the asyncio loop.  A ~150 KB buffer takes 10-20 ms of numpy time on Q6A — long enough to delay cancels / pings / other-tab frames.

## Fix

Add \`resample_pcm16_async\` that hops to a worker thread above the 2 KB dispatch threshold.  Both voice and text TTS paths use it.  Sync helper stays for tests + small buffers.

## Test plan

- [x] 5 new cases in \`tests/test_audio_resample.py\`:
  - sync + async produce identical bytes (small + large buffers)
  - async wrapper allows other loop tasks to run during a large resample (the C8 contract)
  - same-rate / empty fast paths short-circuit without thread dispatch
- [x] CI ruff gate clean
- [x] All 13 audio resample tests pass
- [ ] Live smoke after merge: long TTS reply on prod doesn't visibly stall other concurrent WS frames