### PR TITLE
fix(ws): config_update rate-limit emits γ-arch error instead of silent drop (audit C1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,4 +95,5 @@ jobs:
             tests/test_max_tool_calls_signal.py \
             tests/test_audio_resample.py \
             tests/test_dictation_post_process_race.py \
-            tests/test_b6_hybrid_first_utterance.py
+            tests/test_b6_hybrid_first_utterance.py \
+            tests/test_config_update_rate_limit_signal.py

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -1904,10 +1904,24 @@ class VoiceServer:
         # v4·D audit P1: rate-limit config_update to 2/sec/conn.  A buggy
         # skill or trigger-happy test harness could storm mode swaps that
         # each do heavy backend init.
+        #
+        # Audit C1 (#137): pre-fix this was a silent `logger.debug` +
+        # `return` — Tab5's mode-toggle UI sat on its previous local
+        # state and the user assumed the swap landed.  Now we emit a
+        # γ-arch TRANSIENT/SESSION error so Tab5 (γ2-H8) can render a
+        # toast like "Slow down — give the swap a moment."  Defensive:
+        # only emit if the WS is still open.
         _now_cfg = time.monotonic()
         _last_cfg = conn_state.get("_last_config_update_ts", 0.0)
         if _now_cfg - _last_cfg < 0.5:
             logger.debug("config_update rate-limited on %s", ws_id)
+            if not ws.closed:
+                await self._safe_send_json(ws, error_event(
+                    code="config_update_rate_limited",
+                    message="Mode swap rate-limited — try again in a moment.",
+                    severity=Severity.TRANSIENT,
+                    scope=Scope.SESSION,
+                ))
             return
         conn_state["_last_config_update_ts"] = _now_cfg
 

--- a/tests/test_config_update_rate_limit_signal.py
+++ b/tests/test_config_update_rate_limit_signal.py
@@ -1,0 +1,90 @@
+"""Test for C1 (#137): config_update rate-limit no longer silent.
+
+Pre-fix the rate-limit branch in `_handle_config_update` was a bare
+`logger.debug` + `return` — Tab5's mode-toggle UI sat on its previous
+local state and the user assumed the swap landed.
+
+Post-fix the branch emits a `config_update_rate_limited` γ-arch
+TRANSIENT/SESSION error frame so Tab5 (γ2-H8) can render a toast.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+
+from dragon_voice.config import VoiceConfig
+from dragon_voice.server import VoiceServer
+
+
+class _FakeWS:
+    closed = False
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+
+    async def send_json(self, payload: dict) -> None:
+        self.sent.append(payload)
+
+
+def test_rate_limited_config_update_emits_gamma_arch_error() -> None:
+    """Two config_update calls inside the 0.5 s window must produce
+    exactly one structured error frame for the second call."""
+    srv = VoiceServer(VoiceConfig())
+
+    ws = _FakeWS()
+    conn_state: dict[str, Any] = {"ws_id": "ws0"}
+    cmd = {"type": "config_update", "voice_mode": 0}
+    cfg = VoiceConfig()
+
+    async def go():
+        # First call sets the rate-limit timestamp; subsequent body
+        # processing requires more state we don't want to set up — so
+        # we manually seed the timestamp to 'just now' and send the
+        # SECOND call to exercise the rate-limit branch.
+        conn_state["_last_config_update_ts"] = time.monotonic()
+        await srv._handle_config_update(ws, conn_state, cfg, cmd)
+
+    asyncio.run(go())
+
+    # Find the rate-limit error frame.
+    errors = [s for s in ws.sent if s.get("type") == "error"]
+    assert any(
+        e.get("code") == "config_update_rate_limited" for e in errors
+    ), f"expected config_update_rate_limited error, got sent={ws.sent!r}"
+    err = next(e for e in errors if e.get("code") == "config_update_rate_limited")
+    assert err.get("severity") == "transient"
+    assert err.get("scope") == "session"
+    assert "rate-limited" in err.get("message", "").lower() or "moment" in err.get("message", "").lower()
+
+
+def test_first_config_update_is_not_rate_limited() -> None:
+    """Defensive: the first call (no prior timestamp) must NOT emit
+    the rate-limit error.  We can't easily run the full body in a
+    unit test (requires DB + session manager + pipeline) so we just
+    assert no rate-limit error in the first 1 ms of the call."""
+    srv = VoiceServer(VoiceConfig())
+    ws = _FakeWS()
+    conn_state: dict[str, Any] = {"ws_id": "ws0"}
+    cmd = {"type": "config_update", "voice_mode": 0}
+    cfg = VoiceConfig()
+
+    async def go():
+        try:
+            await srv._handle_config_update(ws, conn_state, cfg, cmd)
+        except Exception:
+            # Body will fail when it hits DB/pipeline calls — that's
+            # fine, we only care that the rate-limit branch didn't fire.
+            pass
+
+    asyncio.run(go())
+
+    rate_limit_errors = [
+        s for s in ws.sent
+        if s.get("type") == "error" and s.get("code") == "config_update_rate_limited"
+    ]
+    assert rate_limit_errors == [], (
+        f"first call should not be rate-limited: sent={ws.sent!r}"
+    )


### PR DESCRIPTION
## Summary

Pre-fix the config_update rate-limit branch silently dropped the second swap with a \`logger.debug\` and no Tab5 frame.  Now emits a \`config_update_rate_limited\` γ-arch TRANSIENT/SESSION error.

## Test plan

- [x] 2 unit tests (\`tests/test_config_update_rate_limit_signal.py\`) — pre-fix verified 1/2 failing
- [x] CI ruff gate clean