### PR TITLE
fix(tts): voice-path TTS timeout matches text-path's mode-aware 90/30 (audit C3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,4 +96,5 @@ jobs:
             tests/test_audio_resample.py \
             tests/test_dictation_post_process_race.py \
             tests/test_b6_hybrid_first_utterance.py \
-            tests/test_config_update_rate_limit_signal.py
+            tests/test_config_update_rate_limit_signal.py \
+            tests/test_voice_tts_timeout.py

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -1252,9 +1252,15 @@ class VoicePipeline:
                 self._tts_started = True
 
             t0 = time.monotonic()
+            # Audit C3 (#137): mode-aware TTS budget.  Pre-fix the voice
+            # path used a flat 30 s, which was OK for cloud but tight
+            # for local Piper on a long sentence (Piper takes 15-25 s
+            # for a 200-word reply on Q6A ARM64).  Match the text-path's
+            # 90 s for non-OpenRouter / 30 s for OpenRouter.
+            tts_timeout = 30 if self._config.tts.backend == "openrouter" else 90
             try:
                 audio_bytes = await asyncio.wait_for(
-                    self._tts.synthesize(text), timeout=30
+                    self._tts.synthesize(text), timeout=tts_timeout
                 )
             except (Exception, asyncio.TimeoutError) as tts_err:
                 # Phase 2 L3 (issue #94): kill any in-flight Piper
@@ -1279,13 +1285,15 @@ class VoicePipeline:
                         await self._fallback_tts.initialize()
                         logger.info("Pre-warmed fallback TTS (piper) cached")
                     # Phase 2 L3 (issue #94): the fallback Piper itself
-                    # can stall — wrap with the same 30s wait_for and
-                    # kill its procs on a second timeout.  Without the
-                    # second guard a TTS-down scenario with no second
-                    # fallback could leak indefinitely.
+                    # can stall — wrap with a wait_for and kill its
+                    # procs on a second timeout.  Without the second
+                    # guard a TTS-down scenario with no second fallback
+                    # could leak indefinitely.
+                    # Audit C3 (#137): use the same 90 s budget as the
+                    # primary path now that we know Piper can need it.
                     try:
                         audio_bytes = await asyncio.wait_for(
-                            self._fallback_tts.synthesize(text), timeout=30
+                            self._fallback_tts.synthesize(text), timeout=90
                         )
                     except (Exception, asyncio.TimeoutError) as fb_err:
                         if hasattr(self._fallback_tts, "kill_active_procs"):

--- a/tests/test_voice_tts_timeout.py
+++ b/tests/test_voice_tts_timeout.py
@@ -1,0 +1,36 @@
+"""Test for C3 (#137): voice-path TTS timeout matches text-path's
+mode-aware 90 s / 30 s budget.
+
+Pre-fix the voice path used a flat 30 s, which clipped long Piper
+sentences (15-25 s for a 200-word reply on Q6A ARM64) — the timeout
+fired before the synthesis completed and the user heard silence.
+
+Pinning via source inspection so a refactor that drifts the value
+back to a flat 30 s breaks this test loudly rather than silently
+re-introducing the regression.
+"""
+from __future__ import annotations
+
+import inspect
+
+from dragon_voice.pipeline import VoicePipeline
+
+
+def test_voice_path_uses_mode_aware_tts_timeout() -> None:
+    src = inspect.getsource(VoicePipeline._synthesize_and_send)
+    # The new computation:
+    assert "tts_timeout = 30 if self._config.tts.backend == \"openrouter\" else 90" in src, (
+        "C3 expects mode-aware tts_timeout (30 cloud / 90 local); refactor "
+        "must keep this or update the audit + this test together"
+    )
+    # And the call must use the variable, not the old flat 30:
+    assert "timeout=tts_timeout" in src, "primary synth must use tts_timeout"
+
+
+def test_fallback_piper_timeout_is_90s() -> None:
+    src = inspect.getsource(VoicePipeline._synthesize_and_send)
+    # The fallback path was a hardcoded 30 s; bumped to 90 s to match
+    # the new mode-aware budget for the primary local path.
+    assert "self._fallback_tts.synthesize(text), timeout=90" in src, (
+        "C3 expects fallback Piper timeout=90 (was 30)"
+    )


### PR DESCRIPTION
## Summary

Voice path used a flat 30 s wait_for; text path has been mode-aware (90 s local / 30 s cloud) since v4·D P1.  Long Piper sentences clipped on the voice path.  Bring it in line.

## Test plan

- [x] 2 source-inspection tests pin the new values
- [x] CI ruff gate clean