### PR TITLE
fix(tc): pre-stream max_tokens cap in TC payload (audit C7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,4 +97,5 @@ jobs:
             tests/test_dictation_post_process_race.py \
             tests/test_b6_hybrid_first_utterance.py \
             tests/test_config_update_rate_limit_signal.py \
-            tests/test_voice_tts_timeout.py
+            tests/test_voice_tts_timeout.py \
+            tests/test_tc_pre_stream_cap.py

--- a/dragon_voice/llm/tinkerclaw_llm.py
+++ b/dragon_voice/llm/tinkerclaw_llm.py
@@ -43,6 +43,16 @@ _SSE_MAX_LINE_BYTES = 256 * 1024          # 256 KiB — one SSE "data: ..." fram
 _SSE_MAX_STREAM_BYTES = 16 * 1024 * 1024  # 16 MiB — whole response total
 _SSE_MAX_TOKENS = 50_000                  # ~200 KB of text, generous
 
+# Audit C7 (#137): pre-stream max_tokens cap.  The TC gateway used to
+# receive payloads with no max_tokens, letting MiniMax (or whichever
+# upstream model TC routed to) generate unbounded — Dragon's
+# server-side _SSE_MAX_TOKENS abort would only fire after we'd
+# already paid for the over-generated tokens.  Sending a sane cap in
+# the payload tells the upstream to stop early.  4096 is a generous
+# voice-reply budget (~16 KB of text) while still well under the
+# server-side abort threshold.
+_TC_REPLY_MAX_TOKENS = 4096
+
 # #B1 (TinkerTab audit 2026-04-24): chain-of-thought / tool-loop preamble
 # that TinkerClaw agents routinely leak into the user-facing reply when a
 # tool fails ("That didn't work well. Let me try another approach:…Let me
@@ -278,6 +288,9 @@ class TinkerClawBackend(LLMBackend):
             "model": self._model,
             "messages": messages,
             "stream": True,
+            # Audit C7 (#137): pre-stream cap so the upstream model
+            # doesn't generate beyond what we'll accept (and bill).
+            "max_tokens": _TC_REPLY_MAX_TOKENS,
         }
         if self._session_key:
             payload["user"] = self._session_key

--- a/tests/test_tc_pre_stream_cap.py
+++ b/tests/test_tc_pre_stream_cap.py
@@ -1,0 +1,87 @@
+"""Test for C7 (#137): TC backend includes max_tokens in the SSE
+payload so the upstream model doesn't generate beyond what we'll
+accept (and bill).
+
+Pre-fix the payload had {model, messages, stream}.  The upstream
+model could generate unbounded — Dragon's server-side _SSE_MAX_TOKENS
+abort fired only after we'd paid for the over-generated tokens.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from dragon_voice.config import LLMConfig
+from dragon_voice.llm.tinkerclaw_llm import TinkerClawBackend, _TC_REPLY_MAX_TOKENS
+
+
+def test_payload_includes_max_tokens_pre_stream() -> None:
+    """The POST payload must carry `max_tokens` so the upstream caps
+    early, not after we've burned tokens that would be aborted."""
+    cfg = LLMConfig(backend="tinkerclaw", tinkerclaw_token="test-token")
+    b = TinkerClawBackend(cfg)
+    b._health_cache_ok = True
+    b._health_cache_until = time.monotonic() + 30
+
+    captured: dict = {}
+
+    class _FakeResponse:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        @property
+        def content(self):
+            class _Reader:
+                async def readline(self_inner):
+                    return b"data: [DONE]\n"
+            return _Reader()
+
+    def _fake_post(url: str, json: dict) -> _FakeResponse:
+        captured["url"] = url
+        captured["json"] = json
+        return _FakeResponse()
+
+    session = MagicMock()
+    session.closed = False
+    session.post = _fake_post  # type: ignore[assignment]
+    b._session = session
+
+    async def go():
+        out = []
+        async for chunk in b.generate_stream_with_messages(
+            [{"role": "user", "content": "hi"}]
+        ):
+            out.append(chunk)
+        return out
+
+    asyncio.run(go())
+
+    assert "json" in captured, "post payload was never built"
+    assert captured["json"].get("max_tokens") == _TC_REPLY_MAX_TOKENS, (
+        f"expected max_tokens={_TC_REPLY_MAX_TOKENS} in payload, "
+        f"got {captured['json'].get('max_tokens')!r}"
+    )
+    # Sanity: the rest of the schema didn't drift.
+    assert captured["json"].get("stream") is True
+    assert "messages" in captured["json"]
+    assert "model" in captured["json"]
+
+
+def test_max_tokens_constant_is_below_server_side_abort() -> None:
+    """Sanity: the pre-stream cap must be well below the server-side
+    abort threshold (else the cap is meaningless — we'd hit the
+    server abort first)."""
+    from dragon_voice.llm.tinkerclaw_llm import _SSE_MAX_TOKENS
+    assert _TC_REPLY_MAX_TOKENS < _SSE_MAX_TOKENS, (
+        f"_TC_REPLY_MAX_TOKENS ({_TC_REPLY_MAX_TOKENS}) must be < "
+        f"_SSE_MAX_TOKENS ({_SSE_MAX_TOKENS}) so the pre-stream cap "
+        f"actually capped before the server abort"
+    )


### PR DESCRIPTION
## Summary

TC SSE payload had no \`max_tokens\` — upstream model could generate unbounded; Dragon's server-side abort only fired after the over-generated tokens were already billed.  Add \`_TC_REPLY_MAX_TOKENS = 4096\` to the payload.

## Test plan

- [x] 2 unit tests in \`tests/test_tc_pre_stream_cap.py\` — pre-fix verified failing
- [x] CI ruff gate clean
- [x] Existing 20-case TC test set still passes