### PR TITLE
fix(audio): dictation buffer cap emits γ-arch event once per session (audit C6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,4 +98,5 @@ jobs:
             tests/test_b6_hybrid_first_utterance.py \
             tests/test_config_update_rate_limit_signal.py \
             tests/test_voice_tts_timeout.py \
-            tests/test_tc_pre_stream_cap.py
+            tests/test_tc_pre_stream_cap.py \
+            tests/test_dictation_buffer_cap_signal.py

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -317,6 +317,15 @@ class VoicePipeline:
         if self._swapping:
             return
 
+        # Audit C6 (#137): reset the buffer-cap-emitted latches at the
+        # start of a fresh recording session (both buffers empty).
+        # Without this a user who hit the cap, stopped, and started a
+        # new recording would never see the warning again because the
+        # latch from the previous session is still set.
+        if not self._audio_buffer and not self._segment_buffer:
+            self._dictation_cap_emitted = False
+            self._audio_cap_emitted = False
+
         if self._dictation_mode:
             # Dictation: buffer in segment buffer, no Dragon-side VAD.
             # Tab5 sends {"type":"segment"} markers when it detects pauses.
@@ -326,6 +335,18 @@ class VoicePipeline:
                     "P06: segment buffer full (%d bytes), dropping audio",
                     len(self._segment_buffer),
                 )
+                # Audit C6 (#137): emit ONCE so Tab5 can show the user
+                # "Recording length limit reached -- stopping dictation"
+                # instead of silently capping at 5 min while they keep
+                # talking.  Latched per buffer-fill so we don't spam at
+                # 50 fps until they tap stop.
+                if not getattr(self, "_dictation_cap_emitted", False):
+                    self._dictation_cap_emitted = True
+                    await self._on_event(error_event(
+                        code="dictation_buffer_full",
+                        message="Recording reached 5-minute limit — finish to save.",
+                        severity=Severity.TRANSIENT, scope=Scope.MEDIA,
+                    ))
                 return
             self._segment_buffer.extend(audio_bytes)
             return
@@ -339,6 +360,17 @@ class VoicePipeline:
                 "P06: audio buffer full (%d bytes), dropping audio",
                 len(self._audio_buffer),
             )
+            # Audit C6 (#137): same latched user-visible signal as the
+            # dictation branch above so non-dictation long-utterance
+            # cases (e.g. user holds the orb open without speaking)
+            # also surface a clean "we hit the cap" frame.
+            if not getattr(self, "_audio_cap_emitted", False):
+                self._audio_cap_emitted = True
+                await self._on_event(error_event(
+                    code="audio_buffer_full",
+                    message="Recording reached 5-minute limit — finishing.",
+                    severity=Severity.TRANSIENT, scope=Scope.MEDIA,
+                ))
             return
         self._audio_buffer.extend(audio_bytes)
 
@@ -465,6 +497,10 @@ class VoicePipeline:
         self._cancelled = False
         self._audio_buffer.clear()
         self._segment_buffer.clear()
+        # Audit C6 (#137): cancel ends the recording session — reset
+        # the buffer-cap latches so the next session can emit again.
+        self._dictation_cap_emitted = False
+        self._audio_cap_emitted = False
         logger.info("Pipeline processing cancelled")
 
     # ── Dictation mode ─────────────────────────────────────────────

--- a/tests/test_dictation_buffer_cap_signal.py
+++ b/tests/test_dictation_buffer_cap_signal.py
@@ -1,0 +1,114 @@
+"""Test for C6 (#137): dictation MAX_AUDIO_BUFFER cap emits a γ-arch
+event once per recording session instead of silently dropping audio.
+
+Pre-fix the cap was a bare `logger.warning` + `return` — the user
+kept dictating past 5 minutes and got a transcript that ended at the
+cap with no signal anything was wrong.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from dragon_voice import pipeline as pipeline_mod
+from dragon_voice.config import VoiceConfig
+from dragon_voice.pipeline import VoicePipeline, MAX_AUDIO_BUFFER
+
+
+def _make_pipeline() -> tuple[VoicePipeline, list[dict]]:
+    cfg = VoiceConfig()
+    events: list[dict] = []
+
+    async def on_event(e: dict) -> None:
+        events.append(e)
+
+    async def on_audio(b: bytes) -> None:
+        return None
+
+    p = VoicePipeline(cfg, on_audio=on_audio, on_event=on_event)
+    return p, events
+
+
+def test_dictation_buffer_cap_emits_once_then_latches() -> None:
+    p, events = _make_pipeline()
+    p._dictation_mode = True
+    # Pre-fill the segment buffer to MAX_AUDIO_BUFFER size so any
+    # extra byte trips the cap.
+    p._segment_buffer.extend(b"\x00" * MAX_AUDIO_BUFFER)
+
+    async def go():
+        # Three feed calls in quick succession at the cap.
+        for _ in range(3):
+            await p.feed_audio(b"\x00\x00")  # 2 bytes — over the cap
+
+    asyncio.run(go())
+
+    cap_errors = [
+        e for e in events
+        if e.get("type") == "error" and e.get("code") == "dictation_buffer_full"
+    ]
+    assert len(cap_errors) == 1, (
+        f"latch should fire once per recording session, got {len(cap_errors)}"
+    )
+    assert cap_errors[0].get("severity") == "transient"
+    assert cap_errors[0].get("scope") == "media"
+
+
+def test_dictation_buffer_cap_relatches_after_cancel_session_boundary() -> None:
+    """User hits cap, taps stop (cancel), restarts dictation → next
+    overflow must re-emit.  The latch is per-session and `cancel()` is
+    the canonical session-boundary hook."""
+    p, events = _make_pipeline()
+    p._dictation_mode = True
+    p._segment_buffer.extend(b"\x00" * MAX_AUDIO_BUFFER)
+
+    async def go():
+        await p.feed_audio(b"\x00\x00")  # first cap event
+        # User stops — `cancel()` resets the latch + clears buffers.
+        await p.cancel()
+        # New recording session starts; refill to cap.
+        p._dictation_mode = True  # cancel() doesn't touch this
+        p._segment_buffer.extend(b"\x00" * MAX_AUDIO_BUFFER)
+        await p.feed_audio(b"\x00\x00")  # should emit again
+
+    asyncio.run(go())
+
+    cap_errors = [
+        e for e in events
+        if e.get("type") == "error" and e.get("code") == "dictation_buffer_full"
+    ]
+    assert len(cap_errors) == 2, (
+        f"latch must reset on cancel(); got {len(cap_errors)} emits"
+    )
+
+
+def test_audio_buffer_cap_in_non_dictation_mode_emits_too() -> None:
+    p, events = _make_pipeline()
+    # Default mode (not dictation).
+    p._audio_buffer.extend(b"\x00" * MAX_AUDIO_BUFFER)
+
+    async def go():
+        await p.feed_audio(b"\x00\x00")
+
+    asyncio.run(go())
+
+    cap_errors = [
+        e for e in events
+        if e.get("type") == "error" and e.get("code") == "audio_buffer_full"
+    ]
+    assert len(cap_errors) == 1
+
+
+def test_under_cap_emits_nothing() -> None:
+    """Regression guard: feeding audio that fits below the cap must
+    NOT emit any error frame."""
+    p, events = _make_pipeline()
+
+    async def go():
+        await p.feed_audio(b"\x00\x00" * 100)  # tiny chunk
+
+    asyncio.run(go())
+
+    cap_errors = [e for e in events if e.get("type") == "error"]
+    assert cap_errors == [], f"unexpected cap emit: {cap_errors!r}"


### PR DESCRIPTION
## Summary

Pre-fix \`feed_audio\` silently dropped audio at MAX_AUDIO_BUFFER (5 min @ 16 kHz).  User got a transcript that ended mid-sentence with no signal.

## Fix

Latched γ-arch \`error_event\` (\`dictation_buffer_full\` / \`audio_buffer_full\`, TRANSIENT/MEDIA).  Reset on \`cancel()\` so the next recording session can emit again.

## Test plan

- [x] 4-case unit suite — pre-fix verified 3/4 failing
- [x] CI ruff gate clean