### PR TITLE
fix(tts): TTS fast-path gates on TTS backend not LLM (audit C9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,4 +99,5 @@ jobs:
             tests/test_config_update_rate_limit_signal.py \
             tests/test_voice_tts_timeout.py \
             tests/test_tc_pre_stream_cap.py \
-            tests/test_dictation_buffer_cap_signal.py
+            tests/test_dictation_buffer_cap_signal.py \
+            tests/test_hybrid_tts_fast_path.py

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -955,7 +955,15 @@ class VoicePipeline:
             # flush doesn't false-fire on `def foo():` style colons.
             last_flush_ts = time.monotonic()
             in_code_block = False
-            is_local = self._config.llm.backend in ("ollama", "npu_genie", "lmstudio")
+            # Audit C9 (#137): the fast-path flush decisions below
+            # (clause-flush min chars + word-boundary timeout flush)
+            # are TTS-bound, not LLM-bound — tiny cloud TTS chunks
+            # cost a per-chunk network round-trip and cause choppy
+            # playback (P08).  Pre-fix this gated on LLM backend, so
+            # Hybrid mode (local LLM + cloud TTS) inherited the
+            # local-mode flushing thresholds and hammered the
+            # OpenRouter TTS endpoint with 20-char chunks.
+            is_local_tts = self._config.tts.backend != "openrouter"
             async for token in llm_stream:
                 if self._cancelled:
                     return
@@ -1023,7 +1031,7 @@ class VoicePipeline:
                 # Phase 2 H2: SKIP clause flush inside a code block — `:`
                 # in `def foo():` is structural, not a natural pause.
                 elif _CLAUSE_END.search(sentence_buffer) and not in_code_block:
-                    clause_min_chars = 20 if is_local else 60
+                    clause_min_chars = 20 if is_local_tts else 60
                     if len(sentence_buffer) >= clause_min_chars:
                         if sentence_buffer.strip():
                             await self._synthesize_and_send(sentence_buffer.strip())
@@ -1038,7 +1046,7 @@ class VoicePipeline:
                 # clause threshold smooths it well enough.  Skip inside
                 # code blocks (would chop code mid-line).
                 elif (
-                    is_local
+                    is_local_tts
                     and not in_code_block
                     and len(sentence_buffer) >= _LOCAL_TIMEOUT_FLUSH_MIN_CHARS
                     and (time.monotonic() - last_flush_ts) > _LOCAL_TIMEOUT_FLUSH_S

--- a/tests/test_hybrid_tts_fast_path.py
+++ b/tests/test_hybrid_tts_fast_path.py
@@ -1,0 +1,35 @@
+"""Test for C9 (#137): TTS fast-path flush gating switched from
+LLM-backend to TTS-backend.
+
+Pre-fix Hybrid mode (local LLM + cloud TTS) inherited the local-mode
+clause-flush threshold (20 chars) and word-boundary timeout flush.
+Both produced tiny chunks fed to OpenRouter TTS — choppy playback +
+per-chunk network round-trip cost.
+
+Pinning via source inspection so a refactor that reverts to the
+LLM-backend gate breaks loudly.
+"""
+from __future__ import annotations
+
+import inspect
+
+from dragon_voice.pipeline import VoicePipeline
+
+
+def test_fast_path_gates_on_tts_backend_not_llm() -> None:
+    src = inspect.getsource(VoicePipeline._process_utterance)
+    # New gating variable must exist and be derived from tts.backend.
+    assert "is_local_tts = self._config.tts.backend != \"openrouter\"" in src, (
+        "C9 expects is_local_tts derived from tts.backend, not llm.backend"
+    )
+    # The clause-flush + word-boundary branches must use the new variable.
+    assert "clause_min_chars = 20 if is_local_tts else 60" in src, (
+        "clause-flush gating must use is_local_tts"
+    )
+    assert "is_local_tts\n                    and not in_code_block" in src, (
+        "word-boundary timeout flush must use is_local_tts"
+    )
+    # The pre-fix gating must be GONE.
+    assert "is_local = self._config.llm.backend in" not in src, (
+        "stale llm-backend gating still present"
+    )


### PR DESCRIPTION
## Summary

Hybrid mode's tiny-chunk flushing was gated on the LLM backend, not the TTS backend — so 20-char clause flushes were sent to OpenRouter TTS with a per-chunk network round-trip + choppy playback.  Fix is one variable rename + the gate.

## Test plan

- [x] Source-inspection test pins the new gating
- [x] CI ruff gate clean