### PR TITLE
fix(ws): missing-key + TC-unreachable use γ-arch error_event (audit D5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,4 +100,5 @@ jobs:
             tests/test_voice_tts_timeout.py \
             tests/test_tc_pre_stream_cap.py \
             tests/test_dictation_buffer_cap_signal.py \
-            tests/test_hybrid_tts_fast_path.py
+            tests/test_hybrid_tts_fast_path.py \
+            tests/test_missing_key_gamma_arch.py

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -1999,22 +1999,40 @@ class VoiceServer:
                     # Audit G5 (2026-04-20): revert to Local so Tab5 doesn't
                     # sit wedged on mode 3 showing an error. Matches the
                     # OpenRouter-key-missing path below.
+                    # Audit D5 (#137): same γ-arch shape as B7 / OR-key
+                    # for consistency — error_event + plain config_update
+                    # revert.
                     if not ws.closed:
-                        await ws.send_json({
+                        await self._safe_send_json(ws, error_event(
+                            code="tc_gateway_unreachable",
+                            message="TinkerClaw gateway is not reachable — reverted to local.",
+                            severity=Severity.FATAL,
+                            scope=Scope.GATEWAY,
+                        ))
+                        await self._safe_send_json(ws, {
                             "type": "config_update",
-                            "error": "TinkerClaw gateway is not reachable",
                             "voice_mode": 0,
                         })
                     return
 
             # Validate API key for cloud modes (1=Hybrid, 2=Cloud need OpenRouter)
-            # Mode 3 (TinkerClaw) doesn't need Dragon's OpenRouter key — uses own gateway
+            # Mode 3 (TinkerClaw) doesn't need Dragon's OpenRouter key — uses own gateway.
+            #
+            # Audit D5 (#137): pre-fix the toast was a bare
+            # `config_update.error` raw-string that didn't tell the user
+            # what happened next.  Migrated to the same γ-arch error_event
+            # + revert pattern as B7 (TC token check) for consistency.
             if voice_mode in (1, 2) and not conn_config.llm.openrouter_api_key:
                 logger.error("Cloud mode requested but no API key configured")
                 if not ws.closed:
-                    await ws.send_json({
+                    await self._safe_send_json(ws, error_event(
+                        code="openrouter_key_missing",
+                        message="OpenRouter key not configured — reverted to local.",
+                        severity=Severity.FATAL,
+                        scope=Scope.LLM,
+                    ))
+                    await self._safe_send_json(ws, {
                         "type": "config_update",
-                        "error": "No OpenRouter API key configured",
                         "voice_mode": 0,
                     })
                 return

--- a/tests/test_missing_key_gamma_arch.py
+++ b/tests/test_missing_key_gamma_arch.py
@@ -1,0 +1,60 @@
+"""Test for D5 (#137): cloud-mode missing-key + TC-gateway-unreachable
+checks emit γ-arch error_event matching the B7 (TC token) shape.
+
+Pre-fix both paths used a bare `config_update.error` raw-string —
+inconsistent with the B7 fix and the audit's "γ-arch hygiene
+completion" cross-cutting note.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+
+from dragon_voice.config import VoiceConfig
+from dragon_voice.server import VoiceServer
+
+
+class _FakeWS:
+    closed = False
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+
+    async def send_json(self, payload: dict) -> None:
+        self.sent.append(payload)
+
+
+def test_missing_openrouter_key_emits_gamma_arch_error_event() -> None:
+    srv = VoiceServer(VoiceConfig())
+    ws = _FakeWS()
+    conn_state: dict[str, Any] = {"ws_id": "ws0"}
+    cfg = VoiceConfig()
+    cfg.llm.openrouter_api_key = ""  # explicitly missing
+    cmd = {"type": "config_update", "voice_mode": 1}  # Hybrid
+
+    async def go():
+        await srv._handle_config_update(ws, conn_state, cfg, cmd)
+
+    asyncio.run(go())
+
+    errors = [s for s in ws.sent if s.get("type") == "error"]
+    assert any(e.get("code") == "openrouter_key_missing" for e in errors), (
+        f"expected openrouter_key_missing γ-arch error, got {ws.sent!r}"
+    )
+    err = next(e for e in errors if e.get("code") == "openrouter_key_missing")
+    assert err.get("severity") == "fatal"
+    assert err.get("scope") == "llm"
+    assert "reverted to local" in err.get("message", "").lower()
+
+    # Revert frame must be present and must NOT carry the legacy `error` key.
+    reverts = [
+        s for s in ws.sent
+        if s.get("type") == "config_update" and s.get("voice_mode") == 0
+    ]
+    assert reverts, f"expected config_update revert, got {ws.sent!r}"
+    assert "error" not in reverts[0], (
+        f"revert frame leaked legacy `error` key: {reverts[0]!r}"
+    )


### PR DESCRIPTION
## Summary

Migrate two remaining \`config_update.error\` raw-string sites (missing OpenRouter key + TC gateway unreachable) to the same γ-arch \`error_event\` + revert pattern as B7.  Closes the cross-cutting "γ-arch hygiene completion" note from #137.

## Test plan

- [x] Unit test pins OR-key path uses new γ-arch shape
- [x] Pre-fix verified failing
- [x] CI ruff gate clean