### PR TITLE
fix(observability): inference_executor metrics + media-render progress (audit D3 + D4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,4 +101,5 @@ jobs:
             tests/test_tc_pre_stream_cap.py \
             tests/test_dictation_buffer_cap_signal.py \
             tests/test_hybrid_tts_fast_path.py \
-            tests/test_missing_key_gamma_arch.py
+            tests/test_missing_key_gamma_arch.py \
+            tests/test_d_tier_polish.py

--- a/dragon_voice/api/system.py
+++ b/dragon_voice/api/system.py
@@ -87,6 +87,26 @@ class SystemRoutes:
             "active_connections": active,
         }
 
+        # Audit D3 (#137): expose inference_executor depth so the
+        # dashboard can spot Moonshine / Piper backpressure (queued
+        # work growing while busy is at max_workers means STT/TTS is
+        # the bottleneck).  Pre-fix this was invisible — operators
+        # had to guess from CPU + log timestamps.
+        try:
+            from dragon_voice.pipeline import inference_executor as _exec
+            queue = getattr(_exec, "_work_queue", None)
+            threads = getattr(_exec, "_threads", None)
+            queued = queue.qsize() if queue is not None else 0
+            busy = len(threads) if threads is not None else 0
+            result["inference_executor"] = {
+                "max_workers": getattr(_exec, "_max_workers", 0),
+                "busy": busy,         # threads currently spawned
+                "queued": queued,     # work items waiting for a worker
+            }
+        except Exception:
+            # Don't let metrics-collection break the endpoint.
+            pass
+
         # DB stats if available
         if self._db:
             try:

--- a/dragon_voice/media/pipeline.py
+++ b/dragon_voice/media/pipeline.py
@@ -123,6 +123,26 @@ class MediaPipeline:
 
     # ── Public API ───────────────────────────────────────────────────────────
 
+    @staticmethod
+    def has_renderable_content(text: str) -> bool:
+        """True if `text` contains at least one detection target (code
+        block, markdown table, or inline image URL).
+
+        Audit D4 (#137): callers use this to decide whether to emit a
+        `media_rendering` progress frame before `process_response` —
+        the render itself can take 1-3 s for code blocks (Pygments +
+        Pillow) and another 1-2 s per image, which without a progress
+        signal looks to Tab5 like a stalled response between
+        `llm_done` and the eventual `media` frames.
+        """
+        if not text:
+            return False
+        if _RE_CODE_BLOCK.search(text):
+            return True
+        if _RE_IMAGE_URL.search(text):
+            return True
+        return bool(_extract_table(text))
+
     async def process_response(self, text: str, session_id: str = "") -> list[dict]:
         """Detect renderable content in *text* and return media event dicts.
 

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -1158,8 +1158,17 @@ class VoicePipeline:
                 except Exception:
                     logger.debug("fallback receipt also failed", exc_info=True)
 
-            # Rich media detection on full response
+            # Rich media detection on full response.
+            # Audit D4 (#137): emit progress before render — voice path
+            # is less prone to perceived stalls (TTS is playing) but
+            # the dashboard chat view + non-speaking response_mode
+            # benefit from the same progress signal as the text path.
             if self._media_pipeline and full_response:
+                if self._media_pipeline.has_renderable_content(full_response):
+                    await self._on_event({
+                        "type": "media_rendering",
+                        "stage": "start",
+                    })
                 try:
                     media_events = await self._media_pipeline.process_response(
                         full_response, self._session_id or ""

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -1644,8 +1644,16 @@ class VoiceServer:
                 except Exception:
                     logger.debug("TC receipt emit failed", exc_info=True)
 
-            # Rich media detection for TinkerClaw responses too
+            # Rich media detection for TinkerClaw responses too.
+            # Audit D4 (#137): emit a progress signal BEFORE rendering
+            # if there's renderable content, so Tab5 doesn't perceive
+            # the 1-3 s code-block render as a stalled reply.
             if full_response and self._media_pipeline:
+                if not ws.closed and self._media_pipeline.has_renderable_content(response_text):
+                    await self._safe_send_json(ws, {
+                        "type": "media_rendering",
+                        "stage": "start",
+                    })
                 try:
                     media_events = await self._media_pipeline.process_response(
                         response_text, session_id
@@ -1765,6 +1773,14 @@ class VoiceServer:
             # clears the streamed markdown bubble; media events then append
             # the rendered JPEG below.
             if full_response:
+                # Audit D4 (#137): emit progress before render so Tab5
+                # doesn't perceive the 1-3 s code-block render as a
+                # stalled reply.
+                if not ws.closed and self._media_pipeline.has_renderable_content(response_text):
+                    await self._safe_send_json(ws, {
+                        "type": "media_rendering",
+                        "stage": "start",
+                    })
                 try:
                     media_events = await self._media_pipeline.process_response(
                         response_text, session_id

--- a/tests/test_d_tier_polish.py
+++ b/tests/test_d_tier_polish.py
@@ -1,0 +1,94 @@
+"""Tests for D-tier polish:
+  * D3 (#137): /api/v1/system exposes inference_executor depth
+  * D4 (#137): MediaPipeline.has_renderable_content + the call sites
+    emit a media_rendering progress frame when there's renderable
+    content to render
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+# ─────────────────────────── D3 — has_renderable_content
+
+
+from dragon_voice.media.pipeline import MediaPipeline  # noqa: E402
+
+
+def test_has_renderable_content_detects_code_block() -> None:
+    text = "Sure, here's the snippet:\n```python\nprint('hi')\n```"
+    assert MediaPipeline.has_renderable_content(text) is True
+
+
+def test_has_renderable_content_detects_image_url() -> None:
+    text = "See https://example.com/diagram.png for the layout."
+    assert MediaPipeline.has_renderable_content(text) is True
+
+
+def test_has_renderable_content_detects_markdown_table() -> None:
+    text = (
+        "| Col1 | Col2 |\n"
+        "| ---- | ---- |\n"
+        "| a    | b    |\n"
+    )
+    assert MediaPipeline.has_renderable_content(text) is True
+
+
+def test_has_renderable_content_returns_false_for_plain_text() -> None:
+    text = "The capital of France is Paris.  Anything else you'd like to know?"
+    assert MediaPipeline.has_renderable_content(text) is False
+
+
+def test_has_renderable_content_handles_empty_input() -> None:
+    assert MediaPipeline.has_renderable_content("") is False
+    assert MediaPipeline.has_renderable_content(None) is False  # type: ignore[arg-type]
+
+
+# ─────────────────────────── D3 — system endpoint exposes executor metrics
+
+
+def test_system_endpoint_includes_inference_executor_block() -> None:
+    """The /api/v1/system handler must include an `inference_executor`
+    block carrying max_workers, busy, queued.  Verified by inspecting
+    the source of `system_info`."""
+    import inspect
+    from dragon_voice.api.system import SystemRoutes
+    src = inspect.getsource(SystemRoutes.system_info)
+    assert "inference_executor" in src, (
+        "system_info must build the inference_executor metrics block (D3)"
+    )
+    assert "max_workers" in src and "queued" in src and "busy" in src, (
+        "expected max_workers/queued/busy keys in inference_executor block"
+    )
+
+
+# ─────────────────────────── D4 — render-progress emit at call sites
+
+
+def test_text_path_emits_media_rendering_progress_before_render() -> None:
+    """Pin via source inspection so a refactor that drops the progress
+    emit re-opens the perceived-stall window between llm_done and
+    media frames."""
+    import inspect
+    from dragon_voice.server import VoiceServer
+    src = inspect.getsource(VoiceServer._handle_text)
+    assert "has_renderable_content(response_text)" in src, (
+        "_handle_text must guard the progress emit on has_renderable_content"
+    )
+    assert '"media_rendering"' in src and '"start"' in src, (
+        "_handle_text must emit type=media_rendering, stage=start"
+    )
+
+
+def test_voice_path_emits_media_rendering_progress_before_render() -> None:
+    """Same D4 guard for the voice path in pipeline._process_utterance."""
+    import inspect
+    from dragon_voice.pipeline import VoicePipeline
+    src = inspect.getsource(VoicePipeline._process_utterance)
+    assert "has_renderable_content(full_response)" in src, (
+        "_process_utterance must guard progress emit on has_renderable_content"
+    )
+    assert '"media_rendering"' in src, (
+        "_process_utterance must emit type=media_rendering"
+    )


### PR DESCRIPTION
## Summary

**D3** — \`/api/v1/system\` now exposes \`inference_executor.{max_workers, busy, queued}\` so the dashboard can spot Moonshine / Piper backpressure.

**D4** — \`MediaPipeline.has_renderable_content\` predicate; the three media-render call sites (TC text, local text, voice) emit a \`media_rendering\` progress frame before render to close the 1-3 s perceived-stall between \`llm_done\` and the eventual media frames.

## Test plan

- [x] 8-case unit suite covering both polish items
- [x] CI ruff gate clean