### PR TITLE
feat(voice): OPUS mic-uplink decoder + capability negotiation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
             tests/test_openrouter_tts_errors.py \
             tests/test_max_tool_calls_signal.py \
             tests/test_audio_resample.py \
+            tests/test_audio_codec.py \
             tests/test_dictation_post_process_race.py \
             tests/test_b6_hybrid_first_utterance.py \
             tests/test_config_update_rate_limit_signal.py \

--- a/dragon_voice/audio_codec.py
+++ b/dragon_voice/audio_codec.py
@@ -1,0 +1,131 @@
+"""Audio codec wrapper for the Tab5 ↔ Dragon voice WS (#173 / TinkerTab #262).
+
+Wraps `opuslib` for the specific shape of our pipeline: 16 kHz mono,
+16-bit PCM, 20 ms frames (320 samples = 640 B per chunk).
+
+Backward-compat: if `opuslib` is not importable (system missing libopus),
+the module still imports cleanly but `decode_uplink` / `encode_downlink`
+raise CodecUnavailable.  Callers should treat that as "OPUS not
+supported, stay on PCM".
+
+Negotiation lives in server.py + the WS register/config_update path;
+this module just does the per-frame conversion.
+"""
+
+from __future__ import annotations
+
+import logging
+import struct
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Wire-format constants — must match Tab5 voice.c / voice_codec.c.
+SAMPLE_RATE = 16_000
+CHANNELS = 1
+FRAME_MS = 20
+FRAME_SAMPLES = (SAMPLE_RATE // 1000) * FRAME_MS  # 320
+FRAME_BYTES_PCM = FRAME_SAMPLES * 2               # 640
+
+
+class CodecUnavailable(RuntimeError):
+    """Raised when the requested codec can't be initialised on this host."""
+
+
+try:
+    import opuslib  # type: ignore[import-untyped]
+    _HAVE_OPUSLIB = True
+except Exception as e:  # pragma: no cover - depends on system libopus
+    opuslib = None  # type: ignore[assignment]
+    _HAVE_OPUSLIB = False
+    _OPUSLIB_IMPORT_ERROR = e
+
+
+def have_opus() -> bool:
+    """True iff libopus + the python wrapper are available on this host."""
+    return _HAVE_OPUSLIB
+
+
+class OpusUplinkDecoder:
+    """Mic-uplink decoder.  Stateful — one instance per WS connection.
+
+    `decode(packet)` takes one OPUS packet (the bytes of one binary WS
+    frame from Tab5) and returns 16-bit PCM bytes (typically 640 B for
+    a 20 ms packet, but variable based on the encoder's frame size).
+    """
+
+    def __init__(self) -> None:
+        if not _HAVE_OPUSLIB:
+            raise CodecUnavailable(
+                f"opuslib not available: {_OPUSLIB_IMPORT_ERROR}"
+            )
+        self._dec = opuslib.Decoder(SAMPLE_RATE, CHANNELS)
+
+    def decode(self, packet: bytes) -> bytes:
+        if not packet:
+            return b""
+        # opuslib.Decoder.decode(data, frame_size) — frame_size is the
+        # max number of samples per channel the decoded frame might
+        # produce.  120 ms @ 16 kHz = 1920 is the absolute max OPUS
+        # supports; we use that to be safe.
+        try:
+            pcm = self._dec.decode(packet, 1920, decode_fec=False)
+        except Exception as e:
+            logger.warning("OPUS decode failed (len=%d): %s", len(packet), e)
+            return b""
+        return pcm
+
+
+class OpusDownlinkEncoder:
+    """TTS-downlink encoder (Phase 2B — used by the TTS send path).
+
+    `encode(pcm)` takes one 20 ms PCM frame (640 B) and returns the
+    OPUS-encoded packet.  Caller is responsible for chunking the TTS
+    stream into 20 ms frames.
+    """
+
+    def __init__(self, bitrate: int = 24_000) -> None:
+        if not _HAVE_OPUSLIB:
+            raise CodecUnavailable(
+                f"opuslib not available: {_OPUSLIB_IMPORT_ERROR}"
+            )
+        # OPUS application: VOIP — best for voice intelligibility at
+        # low-to-moderate bitrates.  Matches Tab5's encoder choice.
+        self._enc = opuslib.Encoder(SAMPLE_RATE, CHANNELS, opuslib.APPLICATION_VOIP)
+        try:
+            self._enc.bitrate = bitrate
+        except Exception:
+            # Some opuslib builds expose bitrate via .ctl(); fall back
+            # silently rather than failing — the default ~32 kbps is
+            # acceptable.
+            pass
+
+    def encode(self, pcm: bytes) -> bytes:
+        if len(pcm) % FRAME_BYTES_PCM != 0:
+            raise ValueError(
+                f"encode: pcm len {len(pcm)} not a multiple of {FRAME_BYTES_PCM}"
+            )
+        out = bytearray()
+        for off in range(0, len(pcm), FRAME_BYTES_PCM):
+            frame = pcm[off:off + FRAME_BYTES_PCM]
+            try:
+                pkt = self._enc.encode(frame, FRAME_SAMPLES)
+            except Exception as e:
+                logger.warning("OPUS encode failed: %s", e)
+                continue
+            out += pkt
+        return bytes(out)
+
+
+def negotiate_uplink(client_caps: Optional[list[str]]) -> str:
+    """Pick a codec given the client's advertised list.
+
+    Returns one of "pcm" / "opus".  Falls back to "pcm" if the client
+    didn't advertise (legacy) or if OPUS isn't available locally.
+    """
+    if not client_caps:
+        return "pcm"
+    wants_opus = any(c.lower() == "opus" for c in client_caps)
+    if wants_opus and have_opus():
+        return "opus"
+    return "pcm"

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -221,6 +221,13 @@ class VoicePipeline:
         self._last_voice_time = 0.0
         self._is_speaking = False
 
+        # #173 / TinkerTab #262: per-direction audio codec.  Default
+        # PCM (raw int16 binary frames as today).  set_uplink_codec()
+        # is called by server.py after the WS register handshake when
+        # the client advertised opus support.
+        self._uplink_codec = "pcm"
+        self._uplink_opus_dec = None  # OpusUplinkDecoder, lazy-init
+
         # Conversation history (last N turns) — only used without conversation_engine
         self._max_history = 10
 
@@ -311,17 +318,59 @@ class VoicePipeline:
             self._llm.name, " (pooled)" if self._pooled_llm else "",
         )
 
+    def set_uplink_codec(self, codec: str) -> str:
+        """Switch the uplink decoder.  Returns the codec actually applied.
+
+        If the requested codec can't be initialised (e.g. opuslib not
+        importable), falls back to "pcm" and logs a warning so the
+        caller's config_update reply matches reality.
+        """
+        codec = (codec or "pcm").lower()
+        if codec == "pcm":
+            self._uplink_codec = "pcm"
+            self._uplink_opus_dec = None
+            return "pcm"
+        if codec == "opus":
+            from . import audio_codec as ac
+            try:
+                self._uplink_opus_dec = ac.OpusUplinkDecoder()
+            except ac.CodecUnavailable as e:
+                logger.warning("OPUS uplink unavailable: %s — staying PCM", e)
+                self._uplink_codec = "pcm"
+                self._uplink_opus_dec = None
+                return "pcm"
+            self._uplink_codec = "opus"
+            logger.info("Uplink codec: PCM -> OPUS")
+            return "opus"
+        logger.warning("set_uplink_codec: unknown codec %r — staying %s",
+                       codec, self._uplink_codec)
+        return self._uplink_codec
+
+    def get_uplink_codec(self) -> str:
+        return self._uplink_codec
+
     async def feed_audio(self, audio_bytes: bytes) -> None:
         """Feed incoming PCM int16 audio data into the pipeline.
 
         Buffers audio and uses simple VAD to detect end of speech.
         When silence is detected after speech, triggers processing.
         In dictation mode, Tab5 handles VAD — Dragon just buffers.
+
+        #173: if uplink codec is OPUS, the incoming bytes are an OPUS
+        packet — decode to PCM before buffering.
         """
         # US-P01: drop all incoming audio while backends are being swapped.
         # Prevents stale audio from accumulating during the swap window.
         if self._swapping:
             return
+
+        # #173: decode OPUS upstream if active.  PCM is the bytes-as-is
+        # path matching the legacy behavior.
+        if self._uplink_codec == "opus" and self._uplink_opus_dec is not None:
+            decoded = self._uplink_opus_dec.decode(audio_bytes)
+            if not decoded:
+                return  # decode failure — already logged
+            audio_bytes = decoded
 
         # Audit C6 (#137): reset the buffer-cap-emitted latches at the
         # start of a fresh recording session (both buffers empty).

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -1429,6 +1429,31 @@ class VoiceServer:
         conn_state["pipeline"] = pipeline
         logger.info("Pipeline ready for %s", ws_id)
 
+        # #173 / TinkerTab #262: codec negotiation.  Tab5 advertises
+        # capabilities.audio_codec = ["pcm", "opus"]; pick OPUS if both
+        # sides support it, send a config_update reply telling Tab5 to
+        # switch its encoder.  Backward-compat: legacy clients without
+        # the capability stay on PCM by default — no config_update
+        # needed for them.
+        try:
+            from . import audio_codec as _ac
+            client_codecs = (caps or {}).get("audio_codec") if isinstance(caps, dict) else None
+            if isinstance(client_codecs, list):
+                chosen = _ac.negotiate_uplink(client_codecs)
+                applied = pipeline.set_uplink_codec(chosen)
+                logger.info(
+                    "Audio codec negotiation %s: client=%s chosen=%s applied=%s",
+                    device_id, client_codecs, chosen, applied,
+                )
+                if applied != "pcm" and not ws.closed:
+                    await self._safe_send_json(ws, {
+                        "type": "config_update",
+                        "audio_uplink_codec": applied,
+                        "reason": "codec_negotiation",
+                    })
+        except Exception:
+            logger.exception("audio codec negotiation failed (non-fatal)")
+
     async def _spawn_handler_task(
         self,
         conn_state: dict,
@@ -2021,6 +2046,23 @@ class VoiceServer:
         cloud_mode = cmd.get("cloud_mode")
         if cloud_mode is not None and voice_mode is None:
             voice_mode = 2 if cloud_mode else 0
+
+        # #173 / TinkerTab #262: client-driven codec switch.  Tab5 may
+        # send config_update with audio_uplink_codec to swap mid-session
+        # (e.g. from a Settings toggle).  Apply via pipeline; reply with
+        # the codec actually applied so a fallback (opus -> pcm because
+        # libopus missing) is observable on the client.
+        client_uplink_codec = cmd.get("audio_uplink_codec") or cmd.get("audio_codec")
+        if client_uplink_codec is not None:
+            pipeline = conn_state.get("pipeline")
+            if pipeline is not None:
+                applied = pipeline.set_uplink_codec(str(client_uplink_codec))
+                if not ws.closed:
+                    await self._safe_send_json(ws, {
+                        "type": "config_update",
+                        "audio_uplink_codec": applied,
+                        "reason": "codec_negotiation",
+                    })
 
         if voice_mode is not None:
             # STT+TTS: local for mode 0, cloud for mode 1+2+3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ Pygments>=2.17.0
 zeroconf>=0.131.0
 pyyaml>=6.0
 numpy>=1.24
+# OPUS codec for the voice WS (#173 / TinkerTab #262).  ctypes wrapper
+# around libopus — apt-get install libopus0 on Dragon if needed.
+opuslib>=3.0.1

--- a/tests/test_audio_codec.py
+++ b/tests/test_audio_codec.py
@@ -1,0 +1,79 @@
+"""Tests for dragon_voice.audio_codec — the OPUS codec wrapper.
+
+Covers:
+- have_opus() reports a bool that matches what import succeeds
+- negotiate_uplink picks the right codec
+- OpusUplinkDecoder + OpusDownlinkEncoder roundtrip a known PCM signal
+  back to recognisable PCM (within OPUS lossy bounds)
+- Both classes raise CodecUnavailable cleanly when libopus is missing
+"""
+
+from __future__ import annotations
+
+import math
+import struct
+
+import pytest
+
+from dragon_voice import audio_codec as ac
+
+
+def _sine_pcm(samples: int, freq: float = 440.0, sr: int = 16_000) -> bytes:
+    """Generate a clean sine wave as int16 LE bytes."""
+    out = bytearray()
+    for i in range(samples):
+        v = int(0.4 * 32767 * math.sin(2 * math.pi * freq * i / sr))
+        out += struct.pack("<h", v)
+    return bytes(out)
+
+
+def test_have_opus_returns_bool():
+    assert isinstance(ac.have_opus(), bool)
+
+
+def test_negotiate_no_caps_picks_pcm():
+    assert ac.negotiate_uplink(None) == "pcm"
+    assert ac.negotiate_uplink([]) == "pcm"
+
+
+def test_negotiate_pcm_only_picks_pcm():
+    assert ac.negotiate_uplink(["pcm"]) == "pcm"
+
+
+def test_negotiate_opus_picks_opus_when_supported():
+    if ac.have_opus():
+        assert ac.negotiate_uplink(["pcm", "opus"]) == "opus"
+    else:
+        assert ac.negotiate_uplink(["pcm", "opus"]) == "pcm"
+
+
+def test_negotiate_case_insensitive():
+    if ac.have_opus():
+        assert ac.negotiate_uplink(["OPUS"]) == "opus"
+    else:
+        assert ac.negotiate_uplink(["OPUS"]) == "pcm"
+
+
+@pytest.mark.skipif(not ac.have_opus(), reason="opuslib not available")
+def test_opus_roundtrip_preserves_signal_shape():
+    # 20 ms = 320 samples
+    pcm_in = _sine_pcm(ac.FRAME_SAMPLES, freq=440.0)
+    enc = ac.OpusDownlinkEncoder(bitrate=24_000)
+    dec = ac.OpusUplinkDecoder()
+    pkt = enc.encode(pcm_in)
+    assert len(pkt) > 0 and len(pkt) < len(pcm_in), \
+        f"compressed {len(pcm_in)} -> {len(pkt)} bytes"
+    pcm_out = dec.decode(pkt)
+    # OPUS is lossy — exact match impossible.  Just check we got a
+    # plausibly-sized PCM frame back (at least one frame, in 20 ms
+    # multiples).
+    assert len(pcm_out) >= ac.FRAME_BYTES_PCM
+    assert len(pcm_out) % 2 == 0  # int16 boundary
+
+
+@pytest.mark.skipif(ac.have_opus(), reason="only meaningful when libopus is missing")
+def test_codec_unavailable_when_no_libopus():
+    with pytest.raises(ac.CodecUnavailable):
+        ac.OpusUplinkDecoder()
+    with pytest.raises(ac.CodecUnavailable):
+        ac.OpusDownlinkEncoder()


### PR DESCRIPTION
## Summary
- New \`dragon_voice/audio_codec.py\` wrapping \`opuslib\` for our pipeline shape (16 kHz mono int16, 20 ms / 320-sample frames).
- \`pipeline.set_uplink_codec()\` switches per-connection decoder; \`feed_audio\` decodes OPUS → PCM before the existing buffer + VAD path.
- \`server.py\` register handler picks OPUS via \`negotiate_uplink\` + replies with \`config_update.audio_uplink_codec\` so Tab5 switches its encoder.
- \`_handle_config_update\` also accepts client-driven \`audio_uplink_codec\` for mid-session swaps.
- Closes #173. Pairs with TinkerTab #263.

## Test plan
- [x] Ruff gate clean on changed files
- [x] \`pytest tests/test_audio_codec.py tests/test_media_pipeline.py\` — 37 passed, 1 skipped
- [x] CI: added \`tests/test_audio_codec.py\` to the named set
- [ ] Deploy to Dragon and run end-to-end OPUS round-trip with Tab5 (next step in this session)

## Backward compat
- Clients without \`capabilities.audio_codec\` stay on PCM as today.
- A Dragon without libopus installed (e.g. \`apt install libopus0\` not run) refuses OPUS gracefully and falls back to PCM, logging a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)