### PR TITLE
feat(video): accept Tab5 video upstream JPEG frames (Phase 3A Dragon)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
             tests/test_max_tool_calls_signal.py \
             tests/test_audio_resample.py \
             tests/test_audio_codec.py \
+            tests/test_video_upstream.py \
             tests/test_dictation_post_process_race.py \
             tests/test_b6_hybrid_first_utterance.py \
             tests/test_config_update_rate_limit_signal.py \

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -691,6 +691,20 @@ class VoiceServer:
                 _last_client_msg_time = time.monotonic()
 
                 if msg.type == WSMsgType.BINARY:
+                    # #175: video frames carry a 4-byte magic prefix
+                    # ("VID0").  Sniff the first bytes; if it matches,
+                    # route to the video handler instead of the audio
+                    # pipeline.  Audio frames are unprefixed raw PCM as
+                    # before, so absence of magic falls through to the
+                    # existing feed_audio path.
+                    from .video_upstream import parse_video_frame, get_handler as _vget
+                    if parse_video_frame.peek(msg.data):
+                        await _vget().on_frame(
+                            session_id=conn_state.get("session_id", ""),
+                            device_id=conn_state.get("device_id", ""),
+                            wire_bytes=msg.data,
+                        )
+                        continue
                     # Raw PCM audio data — forward to pipeline
                     # Note: feed_audio is NOT locked (US-P10) — it only
                     # appends to the audio buffer and the VAD check is

--- a/dragon_voice/video_upstream.py
+++ b/dragon_voice/video_upstream.py
@@ -1,0 +1,144 @@
+"""Video upstream from Tab5 (#175 / TinkerTab #266).
+
+Accepts JPEG frames sent by Tab5 over the existing voice WebSocket as
+binary frames prefixed with the 4-byte magic tag ``b"VID0"`` + a
+big-endian uint32 length.  Frames are stored to disk (most-recent only,
+in /tmp) for now; Phase 3C will swap that out for a relay queue
+delivering to a peer client.
+
+Caller pattern (server.py binary handler):
+
+    from .video_upstream import parse_video_frame, get_handler
+
+    if parse_video_frame.peek(msg.data):
+        await get_handler().on_frame(session_id, device_id, msg.data)
+    else:
+        await pipeline.feed_audio(msg.data)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import struct
+import time
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+VIDEO_MAGIC = b"VID0"
+VIDEO_HEADER_LEN = 8         # 4 magic + 4 length
+DEFAULT_LATEST_PATH = "/tmp/tab5_video_latest.jpg"
+
+
+@dataclass
+class _SessionVideoStats:
+    frames: int = 0
+    bytes_in: int = 0
+    last_jpeg_bytes: int = 0
+    last_ts: float = 0.0
+    parse_errors: int = 0
+
+
+class VideoUpstreamHandler:
+    """Per-server singleton that processes inbound video frames.
+
+    Currently only persists the most recent frame to disk so a human
+    can spot-check the pipeline.  Future phases plug a relay queue +
+    optional vision-LLM dispatch in here.
+    """
+
+    def __init__(self, latest_path: str = DEFAULT_LATEST_PATH) -> None:
+        self._latest_path = latest_path
+        self._stats: dict[str, _SessionVideoStats] = {}
+
+    async def on_frame(
+        self,
+        session_id: str,
+        device_id: str,
+        wire_bytes: bytes,
+    ) -> None:
+        """Validate + extract the JPEG payload + store it.
+
+        Quietly drops malformed frames (logs at debug level so noisy
+        clients don't spam the journal).
+        """
+        s = self._stats.setdefault(session_id, _SessionVideoStats())
+        try:
+            jpeg = parse_video_frame(wire_bytes)
+        except ValueError as e:
+            s.parse_errors += 1
+            logger.debug("video parse error sess=%s dev=%s: %s",
+                         session_id, device_id, e)
+            return
+
+        s.frames += 1
+        s.bytes_in += len(wire_bytes)
+        s.last_jpeg_bytes = len(jpeg)
+        s.last_ts = time.time()
+
+        # Most-recent-frame snapshot.  Atomic-ish write so a reader
+        # never sees a half-written file.
+        tmp = self._latest_path + ".part"
+        try:
+            with open(tmp, "wb") as f:
+                f.write(jpeg)
+            os.replace(tmp, self._latest_path)
+        except OSError as e:
+            logger.warning("video latest-write failed: %s", e)
+
+        if s.frames == 1 or s.frames % 20 == 0:
+            logger.info(
+                "video frame #%d from %s session=%s (%d B JPEG, %d B wire)",
+                s.frames, device_id, session_id, len(jpeg), len(wire_bytes),
+            )
+
+    def stats(self, session_id: str) -> dict:
+        s = self._stats.get(session_id)
+        if not s:
+            return {"frames": 0, "bytes_in": 0, "last_jpeg_bytes": 0,
+                    "last_ts": 0.0, "parse_errors": 0}
+        return {
+            "frames":          s.frames,
+            "bytes_in":        s.bytes_in,
+            "last_jpeg_bytes": s.last_jpeg_bytes,
+            "last_ts":         s.last_ts,
+            "parse_errors":    s.parse_errors,
+        }
+
+
+_handler: VideoUpstreamHandler | None = None
+
+
+def get_handler() -> VideoUpstreamHandler:
+    global _handler
+    if _handler is None:
+        _handler = VideoUpstreamHandler()
+    return _handler
+
+
+def parse_video_frame(wire_bytes: bytes) -> bytes:
+    """Parse one wire-format frame; return the JPEG payload bytes.
+
+    Raises ValueError on any malformed prefix.
+    """
+    if len(wire_bytes) < VIDEO_HEADER_LEN:
+        raise ValueError(f"too short: {len(wire_bytes)} B")
+    if wire_bytes[:4] != VIDEO_MAGIC:
+        raise ValueError("bad magic")
+    (length,) = struct.unpack(">I", wire_bytes[4:8])
+    body = wire_bytes[VIDEO_HEADER_LEN:]
+    if len(body) != length:
+        raise ValueError(f"len mismatch: header={length} body={len(body)}")
+    return body
+
+
+def _peek(wire_bytes: bytes) -> bool:
+    """True iff this looks like a video frame (4-byte magic match)."""
+    return len(wire_bytes) >= 4 and wire_bytes[:4] == VIDEO_MAGIC
+
+
+# Expose .peek as a bound attribute so callers can write
+#   parse_video_frame.peek(data)
+# instead of importing two names.
+parse_video_frame.peek = _peek  # type: ignore[attr-defined]

--- a/tests/test_video_upstream.py
+++ b/tests/test_video_upstream.py
@@ -1,0 +1,81 @@
+"""Tests for dragon_voice.video_upstream — the Tab5 → Dragon video frame parser."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import struct
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from dragon_voice.video_upstream import (
+    VIDEO_HEADER_LEN,
+    VIDEO_MAGIC,
+    VideoUpstreamHandler,
+    parse_video_frame,
+)
+
+
+def _wrap(jpeg: bytes) -> bytes:
+    return VIDEO_MAGIC + struct.pack(">I", len(jpeg)) + jpeg
+
+
+def test_peek_recognises_magic():
+    assert parse_video_frame.peek(_wrap(b"\xff\xd8\xff\xd9"))
+
+
+def test_peek_rejects_short_audio_bytes():
+    assert not parse_video_frame.peek(b"\x00")
+    assert not parse_video_frame.peek(b"\x12\x34\x56\x78\x9a")  # raw PCM-ish
+
+
+def test_peek_rejects_empty():
+    assert not parse_video_frame.peek(b"")
+
+
+def test_parse_extracts_jpeg_payload():
+    jpeg = b"\xff\xd8\xff\xd9" + b"hello" * 10
+    body = parse_video_frame(_wrap(jpeg))
+    assert body == jpeg
+
+
+def test_parse_rejects_bad_magic():
+    bad = b"BAD!" + struct.pack(">I", 4) + b"\xff\xd8\xff\xd9"
+    with pytest.raises(ValueError, match="bad magic"):
+        parse_video_frame(bad)
+
+
+def test_parse_rejects_short_frame():
+    with pytest.raises(ValueError, match="too short"):
+        parse_video_frame(b"VID")  # 3 bytes
+
+
+def test_parse_rejects_len_mismatch():
+    bad = VIDEO_MAGIC + struct.pack(">I", 100) + b"only10byte"
+    with pytest.raises(ValueError, match="len mismatch"):
+        parse_video_frame(bad)
+
+
+def test_handler_writes_latest_frame_to_disk(tmp_path):
+    latest = tmp_path / "latest.jpg"
+    h = VideoUpstreamHandler(latest_path=str(latest))
+    jpeg = b"\xff\xd8\xff\xd9" + b"x" * 64
+    asyncio.run(h.on_frame("sess1", "dev1", _wrap(jpeg)))
+    assert latest.exists()
+    assert latest.read_bytes() == jpeg
+    s = h.stats("sess1")
+    assert s["frames"] == 1
+    assert s["last_jpeg_bytes"] == len(jpeg)
+    assert s["parse_errors"] == 0
+
+
+def test_handler_counts_parse_errors_quietly(tmp_path):
+    latest = tmp_path / "latest.jpg"
+    h = VideoUpstreamHandler(latest_path=str(latest))
+    asyncio.run(h.on_frame("s", "d", b"BAD!" + b"\x00" * 4 + b"junk"))
+    s = h.stats("s")
+    assert s["frames"] == 0
+    assert s["parse_errors"] == 1
+    assert not latest.exists()


### PR DESCRIPTION
## Summary
- Detects the 4-byte \`b\"VID0\"\` magic on inbound WS binary frames and routes to a new \`VideoUpstreamHandler\` instead of \`pipeline.feed_audio\`.
- Stores the most-recent frame to \`/tmp/tab5_video_latest.jpg\` for inspection; per-session frame/byte/error counters.
- Audio path is unchanged (no magic = raw PCM as before).
- Closes #175.  Pairs with TinkerTab #266.

## Test plan
- [x] \`pytest tests/test_video_upstream.py\` — 9 passed (parser happy/sad paths + handler disk-write + error counter)
- [x] Ruff gate clean
- [ ] Deploy + end-to-end with Tab5: \`/video/start?fps=3\` → frames arrive → \`/tmp/tab5_video_latest.jpg\` is a valid JPEG (next step in this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)