### PR TITLE
feat(video): /api/video/inject debug endpoint (Phase 3B Dragon)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
             tests/test_audio_resample.py \
             tests/test_audio_codec.py \
             tests/test_video_upstream.py \
+            tests/test_video_inject.py \
             tests/test_dictation_post_process_race.py \
             tests/test_b6_hybrid_first_utterance.py \
             tests/test_config_update_rate_limit_signal.py \

--- a/dragon_voice/api/__init__.py
+++ b/dragon_voice/api/__init__.py
@@ -16,6 +16,7 @@ from dragon_voice.api.media_routes import MediaRoutes
 from dragon_voice.api.synthesize import SynthesizeRoutes
 from dragon_voice.api.completions import CompletionRoutes
 from dragon_voice.api.system import SystemRoutes
+from dragon_voice.api.video_inject import VideoInjectRoutes
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +63,9 @@ def setup_all_routes(
     # System info + backend listing
     if voice_config and get_active_connections:
         SystemRoutes(voice_config, start_time, get_active_connections, get_db=db).register(app)
+        # #177 / Phase 3B: video downlink debug injector — uses the
+        # same connection registry to find the target Tab5's WS.
+        VideoInjectRoutes(get_active_connections).register(app)
 
     # Agentic routes (Sprint 2 — registered when available)
     if tool_registry:

--- a/dragon_voice/api/video_inject.py
+++ b/dragon_voice/api/video_inject.py
@@ -1,0 +1,98 @@
+"""POST /api/video/inject — debug endpoint for Phase 3B video downlink.
+
+Wraps a JPEG payload in the same wire format Tab5 uses for the uplink
+(\"VID0\" + 4-byte BE length + JPEG bytes) and pushes it as a binary WS
+frame to the connected Tab5 identified by session_id (or device_id).
+
+Phase 3C will replace this debug endpoint with a relay queue between
+two paired Tab5s; this exists to validate Tab5's downlink decode +
+ui_video_pane render path without needing a second client.
+"""
+
+from __future__ import annotations
+
+import logging
+import struct
+from typing import Callable
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+VIDEO_MAGIC = b"VID0"
+VIDEO_MAX_PAYLOAD = 96 * 1024   # match Tab5 voice_video.c slot ceiling
+
+
+def _wrap_video_frame(jpeg: bytes) -> bytes:
+    """Apply the on-wire framing: magic + 4-byte BE length + payload."""
+    return VIDEO_MAGIC + struct.pack(">I", len(jpeg)) + jpeg
+
+
+class VideoInjectRoutes:
+    """REST routes that push video frames to a connected Tab5.
+
+    The route handler resolves a session_id (or device_id) to an open
+    WebSocket via `get_active_connections()` (the same accessor the
+    System routes use) and sends the framed bytes via ws.send_bytes.
+    """
+
+    def __init__(self, get_active_connections: Callable[[], dict]) -> None:
+        self._get_conns = get_active_connections
+
+    def register(self, app: web.Application) -> None:
+        app.router.add_post("/api/video/inject", self.inject)
+
+    async def inject(self, request: web.Request) -> web.Response:
+        target_session = request.query.get("session_id")
+        target_device  = request.query.get("device_id")
+        if not target_session and not target_device:
+            return web.json_response(
+                {"error": "session_id or device_id required"}, status=400,
+            )
+
+        body = await request.read()
+        if not body:
+            return web.json_response({"error": "empty body"}, status=400)
+        if len(body) > VIDEO_MAX_PAYLOAD:
+            return web.json_response(
+                {"error": f"payload too large ({len(body)} > {VIDEO_MAX_PAYLOAD})"},
+                status=413,
+            )
+
+        # Find the matching connection.  Active connections are keyed
+        # by ws_id; we scan because session/device counts are tiny.
+        conns = self._get_conns()
+        match = None
+        for conn in conns.values():
+            sid = conn.get("session_id", "")
+            did = conn.get("device_id", "")
+            if target_session and sid == target_session:
+                match = conn
+                break
+            if target_device and did == target_device:
+                match = conn
+                break
+
+        if not match:
+            return web.json_response(
+                {"error": "session not connected",
+                 "session_id": target_session, "device_id": target_device},
+                status=404,
+            )
+
+        ws = match.get("ws")
+        if ws is None or ws.closed:
+            return web.json_response({"error": "ws closed"}, status=410)
+
+        wire = _wrap_video_frame(body)
+        try:
+            await ws.send_bytes(wire)
+        except Exception as e:
+            logger.warning("video_inject send_bytes failed: %s", e)
+            return web.json_response({"error": f"send failed: {e}"}, status=502)
+
+        return web.json_response({
+            "sent":   True,
+            "bytes":  len(wire),
+            "jpeg":   len(body),
+        })

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -642,6 +642,7 @@ class VoiceServer:
         # Connection state — populated after register
         conn_state: dict = {
             "ws_id": ws_id,
+            "ws": ws,                # #177: route handlers (video_inject) need the live WS
             "pipeline": None,
             "session_id": None,
             "device_id": None,

--- a/tests/test_video_inject.py
+++ b/tests/test_video_inject.py
@@ -1,0 +1,38 @@
+"""Tests for dragon_voice.api.video_inject.
+
+Just the framing helper — the route handler is exercised end-to-end
+in the live deploy smoke (no live aiohttp test rig in the named CI set
+yet for upload-style endpoints).
+"""
+
+from __future__ import annotations
+
+import struct
+
+from dragon_voice.api.video_inject import (
+    VIDEO_MAGIC,
+    VIDEO_MAX_PAYLOAD,
+    _wrap_video_frame,
+)
+
+
+def test_wrap_prepends_magic_and_be_length():
+    payload = b"\xff\xd8\xff\xd9"
+    out = _wrap_video_frame(payload)
+    assert out[:4] == VIDEO_MAGIC
+    (length,) = struct.unpack(">I", out[4:8])
+    assert length == len(payload)
+    assert out[8:] == payload
+
+
+def test_wrap_round_trips_through_parser():
+    """Should produce bytes the Tab5 / Dragon parser accepts."""
+    from dragon_voice.video_upstream import parse_video_frame
+    jpeg = b"\xff\xd8\xff\xd9" + b"x" * 1000
+    wire = _wrap_video_frame(jpeg)
+    body = parse_video_frame(wire)
+    assert body == jpeg
+
+
+def test_payload_ceiling_is_sane():
+    assert VIDEO_MAX_PAYLOAD == 96 * 1024


### PR DESCRIPTION
## Summary
- POST /api/video/inject?session_id=<id> wraps a JPEG body in the VID0 + length framing Tab5 uses for the uplink, pushes as binary WS to the connected Tab5.
- 404 if session not connected, 413 if >96 KB payload, 400 if missing query param.
- Stores live \`ws\` reference in conn_state so the route handler can resolve session → ws.
- Closes #177. Pairs with TinkerTab #268.

## Test plan
- [x] pytest tests/test_video_inject.py + tests/test_video_upstream.py — 12 passed
- [x] Ruff gate clean
- [ ] Deploy + end-to-end: POST a known JPEG → Tab5 video pane shows it (next step in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)