### PR TITLE
feat(video): broadcast relay + web call client (Phase 3C)

### DIFF
--- a/dragon_voice/lifecycle/startup.py
+++ b/dragon_voice/lifecycle/startup.py
@@ -211,6 +211,19 @@ async def run_startup(server: Any, app: web.Application) -> None:
     )
     await server._conversation.initialize()
 
+    # #179: serve the minimal video-call web client at /call
+    # (matches the WS port so opening the page on a phone "just
+    # works" without configuring a separate dashboard host).
+    import os as _os
+    _static_dir = _os.path.join(_os.path.dirname(__file__), "..", "static")
+    if _os.path.isdir(_static_dir):
+        app.router.add_static("/static/", _os.path.realpath(_static_dir),
+                              show_index=False)
+        async def _call_redirect(_req):
+            from aiohttp import web as _web
+            raise _web.HTTPFound("/static/call.html")
+        app.router.add_get("/call", _call_redirect)
+
     # REST API routes (modular package)
     from dragon_voice.api import setup_all_routes
     setup_all_routes(

--- a/dragon_voice/middleware/auth.py
+++ b/dragon_voice/middleware/auth.py
@@ -26,6 +26,11 @@ PUBLIC_PREFIXES: tuple[str, ...] = (
     "/ws/voice",
     "/dashboard",
     "/api/media/",
+    # #179: video-call web client + its static assets — opens on a
+    # phone browser without an API token.  Sensitive surfaces stay
+    # under /api/v1/* which still gates auth.
+    "/call",
+    "/static/",
 )
 
 

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -704,6 +704,7 @@ class VoiceServer:
                             session_id=conn_state.get("session_id", ""),
                             device_id=conn_state.get("device_id", ""),
                             wire_bytes=msg.data,
+                            active_connections=self._active_connections,
                         )
                         continue
                     # Raw PCM audio data — forward to pipeline

--- a/dragon_voice/static/call.html
+++ b/dragon_voice/static/call.html
@@ -1,0 +1,157 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>TinkerClaw Call</title>
+<style>
+  :root { color-scheme: dark; }
+  html, body { margin:0; padding:0; background:#000; color:#eee; font-family:system-ui, sans-serif; }
+  header { padding:8px 12px; background:#111; display:flex; gap:12px; align-items:center; flex-wrap:wrap; }
+  header input, header button { padding:6px 10px; font-size:14px; border:1px solid #333; background:#111; color:#eee; border-radius:4px; }
+  header button { cursor:pointer; }
+  #status { font-size:12px; color:#aaa; margin-left:auto; }
+  #stage  { display:grid; grid-template-columns: 1fr 240px; gap:8px; padding:8px; }
+  #remoteWrap { background:#111; aspect-ratio: 1280/720; display:flex; align-items:center; justify-content:center; min-height:240px; }
+  #remote { max-width:100%; max-height:100%; object-fit:contain; }
+  #localWrap { background:#111; }
+  video#local { width:100%; display:block; transform: scaleX(-1); }
+  #stats { font-size:11px; color:#888; padding:4px 8px; }
+  #log { max-height:120px; overflow:auto; font-family: ui-monospace, monospace; font-size:11px; padding:4px 8px; color:#bbb; background:#111; }
+</style>
+</head>
+<body>
+<header>
+  <strong>TinkerClaw Call</strong>
+  <label>Server <input id="server" value="" placeholder="ws://192.168.1.91:3502/ws/voice" size="40"/></label>
+  <label>Token <input id="token" placeholder="dragon API token (optional)" size="36"/></label>
+  <label>FPS <input id="fps" type="number" value="3" min="1" max="10" style="width:50px"/></label>
+  <button id="connect">Connect</button>
+  <button id="disconnect" disabled>Disconnect</button>
+  <span id="status">disconnected</span>
+</header>
+<section id="stage">
+  <div id="remoteWrap"><img id="remote" alt="remote video" /></div>
+  <div id="localWrap">
+    <video id="local" autoplay playsinline muted></video>
+    <div id="stats">no stats yet</div>
+  </div>
+</section>
+<section id="log"></section>
+
+<script>
+(() => {
+  const $ = (id) => document.getElementById(id);
+  const VIDEO_MAGIC = new Uint8Array([0x56, 0x49, 0x44, 0x30]); // "VID0"
+
+  function log(msg) {
+    const ts = new Date().toLocaleTimeString();
+    $('log').innerHTML = `[${ts}] ${msg}<br>` + $('log').innerHTML;
+  }
+
+  // Default WS URL: same host as the page, port 3502.
+  $('server').value = `ws://${location.hostname || '192.168.1.91'}:3502/ws/voice`;
+
+  let ws = null;
+  let stream = null;
+  let timer = null;
+  let stats = { sent: 0, recv: 0, bytesSent: 0, bytesRecv: 0 };
+
+  async function connect() {
+    const url = $('server').value.trim();
+    const token = $('token').value.trim();
+    const wsUrl = token ? `${url}?token=${encodeURIComponent(token)}` : url;
+    log('connecting ' + wsUrl);
+    ws = new WebSocket(wsUrl);
+    ws.binaryType = 'arraybuffer';
+
+    ws.onopen = async () => {
+      log('connected');
+      $('status').textContent = 'connected';
+      $('disconnect').disabled = false;
+      $('connect').disabled = true;
+      // Minimal register so Dragon knows we're a real client.
+      const did = 'webcall_' + Math.random().toString(16).slice(2,8);
+      ws.send(JSON.stringify({
+        type: 'register',
+        device_id: did,
+        hardware_id: did + '_hw',
+        name: 'WebCall',
+        firmware_ver: 'web',
+        platform: 'web',
+        session_id: null,
+        capabilities: { video_send: true, video_recv: true },
+      }));
+      // Start camera + frame loop.
+      stream = await navigator.mediaDevices.getUserMedia({ video: { width:640, height:480 }, audio:false });
+      $('local').srcObject = stream;
+      const fps = Math.max(1, Math.min(10, +$('fps').value || 3));
+      const period = 1000 / fps;
+      const cv = document.createElement('canvas');
+      cv.width = 640; cv.height = 480;
+      const ctx = cv.getContext('2d');
+      timer = setInterval(async () => {
+        if (!ws || ws.readyState !== 1) return;
+        ctx.drawImage($('local'), 0, 0, cv.width, cv.height);
+        const blob = await new Promise(r => cv.toBlob(r, 'image/jpeg', 0.6));
+        if (!blob) return;
+        const ab = await blob.arrayBuffer();
+        const len = ab.byteLength;
+        const wire = new Uint8Array(8 + len);
+        wire.set(VIDEO_MAGIC, 0);
+        // 4-byte BE length
+        wire[4] = (len >>> 24) & 0xff;
+        wire[5] = (len >>> 16) & 0xff;
+        wire[6] = (len >>> 8)  & 0xff;
+        wire[7] = (len)        & 0xff;
+        wire.set(new Uint8Array(ab), 8);
+        ws.send(wire.buffer);
+        stats.sent++;
+        stats.bytesSent += wire.byteLength;
+        $('stats').textContent = `sent ${stats.sent} (${(stats.bytesSent/1024).toFixed(0)} KB) | recv ${stats.recv} (${(stats.bytesRecv/1024).toFixed(0)} KB)`;
+      }, period);
+    };
+
+    ws.onmessage = (ev) => {
+      if (typeof ev.data === 'string') {
+        log('text: ' + ev.data.slice(0, 200));
+        return;
+      }
+      const buf = new Uint8Array(ev.data);
+      // Check VID0 magic
+      if (buf.length < 8 || buf[0] !== 0x56 || buf[1] !== 0x49 || buf[2] !== 0x44 || buf[3] !== 0x30) return;
+      const len = (buf[4]<<24) | (buf[5]<<16) | (buf[6]<<8) | buf[7];
+      const jpeg = buf.slice(8, 8 + len);
+      const blob = new Blob([jpeg], { type: 'image/jpeg' });
+      const url = URL.createObjectURL(blob);
+      const prev = $('remote').src;
+      $('remote').src = url;
+      if (prev && prev.startsWith('blob:')) URL.revokeObjectURL(prev);
+      stats.recv++;
+      stats.bytesRecv += buf.byteLength;
+      $('stats').textContent = `sent ${stats.sent} (${(stats.bytesSent/1024).toFixed(0)} KB) | recv ${stats.recv} (${(stats.bytesRecv/1024).toFixed(0)} KB)`;
+    };
+
+    ws.onclose = (ev) => {
+      log('closed (' + ev.code + ' ' + ev.reason + ')');
+      $('status').textContent = 'closed';
+      cleanup();
+    };
+    ws.onerror = (e) => log('error: ' + (e?.message || e));
+  }
+
+  function cleanup() {
+    if (timer) { clearInterval(timer); timer = null; }
+    if (stream) { stream.getTracks().forEach(t => t.stop()); stream = null; }
+    $('local').srcObject = null;
+    ws = null;
+    $('disconnect').disabled = true;
+    $('connect').disabled = false;
+  }
+
+  $('connect').onclick = () => connect().catch(e => { log('connect failed: ' + e); cleanup(); });
+  $('disconnect').onclick = () => { if (ws) ws.close(); cleanup(); };
+})();
+</script>
+</body>
+</html>

--- a/dragon_voice/video_upstream.py
+++ b/dragon_voice/video_upstream.py
@@ -1,17 +1,27 @@
-"""Video upstream from Tab5 (#175 / TinkerTab #266).
+"""Video upstream from Tab5 (#175 / TinkerTab #266) + relay (#179 Phase 3C).
 
 Accepts JPEG frames sent by Tab5 over the existing voice WebSocket as
 binary frames prefixed with the 4-byte magic tag ``b"VID0"`` + a
-big-endian uint32 length.  Frames are stored to disk (most-recent only,
-in /tmp) for now; Phase 3C will swap that out for a relay queue
-delivering to a peer client.
+big-endian uint32 length.
+
+Two consumers per inbound frame:
+- Disk snapshot (most-recent frame at /home/radxa/media/...) for
+  inspection + the dashboard preview.
+- **Relay broadcast**: forwards the wire bytes verbatim to every
+  other connected client so two Tab5s (or a Tab5 + a web client) see
+  each other's video in real time.  This is the simplest possible
+  pairing model — anyone who's connected and isn't the sender gets
+  the frame.
 
 Caller pattern (server.py binary handler):
 
     from .video_upstream import parse_video_frame, get_handler
 
     if parse_video_frame.peek(msg.data):
-        await get_handler().on_frame(session_id, device_id, msg.data)
+        await get_handler().on_frame(
+            session_id, device_id, msg.data,
+            active_connections=server._active_connections,
+        )
     else:
         await pipeline.feed_audio(msg.data)
 """
@@ -59,11 +69,14 @@ class VideoUpstreamHandler:
         session_id: str,
         device_id: str,
         wire_bytes: bytes,
+        active_connections: dict | None = None,
     ) -> None:
-        """Validate + extract the JPEG payload + store it.
+        """Validate + extract + persist + relay.
 
-        Quietly drops malformed frames (logs at debug level so noisy
-        clients don't spam the journal).
+        `active_connections` is the server-wide ws_id → conn_state
+        registry; when provided, every other connected client receives
+        the same wire bytes verbatim.  Quietly drops malformed frames
+        so noisy clients don't spam the journal.
         """
         s = self._stats.setdefault(session_id, _SessionVideoStats())
         try:
@@ -89,10 +102,29 @@ class VideoUpstreamHandler:
         except OSError as e:
             logger.warning("video latest-write failed: %s", e)
 
+        # Relay broadcast: forward the wire bytes to every other
+        # connected client.  Phase 3C minimum-viable pairing; later
+        # work will add explicit call signaling so unpaired peers
+        # don't see each other's feeds.
+        relayed = 0
+        if active_connections:
+            for conn in list(active_connections.values()):
+                if conn.get("session_id") == session_id:
+                    continue
+                ws = conn.get("ws")
+                if ws is None or getattr(ws, "closed", False):
+                    continue
+                try:
+                    await ws.send_bytes(wire_bytes)
+                    relayed += 1
+                except Exception as e:
+                    logger.debug("video relay drop: %s", e)
+
         if s.frames == 1 or s.frames % 20 == 0:
             logger.info(
-                "video frame #%d from %s session=%s (%d B JPEG, %d B wire)",
-                s.frames, device_id, session_id, len(jpeg), len(wire_bytes),
+                "video frame #%d from %s session=%s (%d B JPEG, %d B wire) relayed=%d",
+                s.frames, device_id, session_id,
+                len(jpeg), len(wire_bytes), relayed,
             )
 
     def stats(self, session_id: str) -> dict:

--- a/tests/test_video_upstream.py
+++ b/tests/test_video_upstream.py
@@ -79,3 +79,46 @@ def test_handler_counts_parse_errors_quietly(tmp_path):
     assert s["frames"] == 0
     assert s["parse_errors"] == 1
     assert not latest.exists()
+
+
+# Phase 3C relay: any frame from one session is broadcast to all OTHER
+# connected sessions verbatim.
+
+class _FakeWS:
+    def __init__(self):
+        self.sent = []
+        self.closed = False
+    async def send_bytes(self, b):
+        if self.closed: raise RuntimeError("closed")
+        self.sent.append(bytes(b))
+
+
+def test_relay_broadcasts_to_other_sessions(tmp_path):
+    h = VideoUpstreamHandler(latest_path=str(tmp_path / "latest.jpg"))
+    ws_a, ws_b, ws_c = _FakeWS(), _FakeWS(), _FakeWS()
+    conns = {
+        "ws_a": {"session_id": "S_A", "ws": ws_a},
+        "ws_b": {"session_id": "S_B", "ws": ws_b},
+        "ws_c": {"session_id": "S_C", "ws": ws_c},
+    }
+    wire = _wrap(b"\xff\xd8\xff\xd9JPEGBYTES")
+    asyncio.run(h.on_frame("S_A", "dev_a", wire, active_connections=conns))
+    # Sender does NOT receive its own frame.
+    assert ws_a.sent == []
+    # Other clients each receive the wire bytes verbatim.
+    assert ws_b.sent == [wire]
+    assert ws_c.sent == [wire]
+
+
+def test_relay_skips_closed_peers(tmp_path):
+    h = VideoUpstreamHandler(latest_path=str(tmp_path / "latest.jpg"))
+    ws_a, ws_b = _FakeWS(), _FakeWS()
+    ws_b.closed = True
+    conns = {
+        "ws_a": {"session_id": "S_A", "ws": ws_a},
+        "ws_b": {"session_id": "S_B", "ws": ws_b},
+    }
+    wire = _wrap(b"\xff\xd8\xff\xd9JPEG")
+    asyncio.run(h.on_frame("S_A", "dev_a", wire, active_connections=conns))
+    # Closed peer is silently skipped — no exception.
+    assert ws_b.sent == []


### PR DESCRIPTION
## Summary
- Inbound video frames are broadcast to every other connected client. Two clients = effective 1:1 call. N clients = multicast room.
- New \`dragon_voice/static/call.html\`: minimal web client (camera via getUserMedia, JPEG via canvas, same VID0 wire format as Tab5).
- Served at \`GET /call\` (redirect to \`/static/call.html\`).  Auth-public so a phone can open it directly.
- Closes #179.  Pairs with TinkerTab #268 / #269 / #267 / #176.

## Test plan
- [x] pytest tests/test_video_upstream.py + tests/test_video_inject.py — 14 passed
- [x] Ruff gate clean
- [ ] Deploy + manual: open /call on a phone → see Tab5's camera; Tab5 sees the phone's camera

🤖 Generated with [Claude Code](https://claude.com/claude-code)