### PR TITLE
feat(call): broadcast AUD0 audio + web client mic/playback (Phase 3E)

### DIFF
--- a/dragon_voice/audio_codec.py
+++ b/dragon_voice/audio_codec.py
@@ -117,6 +117,39 @@ class OpusDownlinkEncoder:
         return bytes(out)
 
 
+# #181 / TinkerTab #272: in-call audio framing.  When Tab5 is in a
+# video call (voice_video_is_in_call() == true), mic frames are
+# wrapped with this 4-byte magic + 4-byte BE length so Dragon
+# broadcasts them to peers instead of feeding STT.  Symmetric on the
+# downlink — peers' tagged frames play through Tab5's existing
+# playback ring buffer.  Wire body is raw int16 LE PCM @ 16 kHz mono
+# (or whatever the mic uplink codec produces).
+CALL_AUDIO_MAGIC = b"AUD0"
+CALL_AUDIO_HEADER_LEN = 8
+
+
+def peek_call_audio_magic(data: bytes) -> bool:
+    """True iff `data` starts with the AUD0 magic."""
+    return len(data) >= 4 and data[:4] == CALL_AUDIO_MAGIC
+
+
+def parse_call_audio_frame(wire_bytes: bytes) -> bytes:
+    """Parse one AUD0-framed audio chunk; return the body (PCM) bytes.
+
+    Raises ValueError on malformed input — server.py logs at debug
+    level so noisy clients don't spam the journal.
+    """
+    if len(wire_bytes) < CALL_AUDIO_HEADER_LEN:
+        raise ValueError(f"too short: {len(wire_bytes)} B")
+    if wire_bytes[:4] != CALL_AUDIO_MAGIC:
+        raise ValueError("bad magic")
+    (length,) = struct.unpack(">I", wire_bytes[4:8])
+    body = wire_bytes[CALL_AUDIO_HEADER_LEN:]
+    if len(body) != length:
+        raise ValueError(f"len mismatch: header={length} body={len(body)}")
+    return body
+
+
 def negotiate_uplink(client_caps: Optional[list[str]]) -> str:
     """Pick a codec given the client's advertised list.
 

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -707,6 +707,26 @@ class VoiceServer:
                             active_connections=self._active_connections,
                         )
                         continue
+
+                    # #181 / TinkerTab #272: in-call audio frames carry
+                    # the AUD0 magic.  Broadcast verbatim to other
+                    # connected clients and bypass STT — same model as
+                    # the video relay.  Bytes are raw int16 PCM (or
+                    # OPUS) inside; peers handle playback locally.
+                    from .audio_codec import peek_call_audio_magic
+                    if peek_call_audio_magic(msg.data):
+                        sender_sid = conn_state.get("session_id", "")
+                        for c in list(self._active_connections.values()):
+                            if c.get("session_id") == sender_sid:
+                                continue
+                            peer_ws = c.get("ws")
+                            if peer_ws is None or peer_ws.closed:
+                                continue
+                            try:
+                                await peer_ws.send_bytes(msg.data)
+                            except Exception as e:
+                                logger.debug("call-audio relay drop: %s", e)
+                        continue
                     # Raw PCM audio data — forward to pipeline
                     # Note: feed_audio is NOT locked (US-P10) — it only
                     # appends to the audio buffer and the VAD check is

--- a/dragon_voice/static/call.html
+++ b/dragon_voice/static/call.html
@@ -43,6 +43,7 @@
 (() => {
   const $ = (id) => document.getElementById(id);
   const VIDEO_MAGIC = new Uint8Array([0x56, 0x49, 0x44, 0x30]); // "VID0"
+  const AUDIO_MAGIC = new Uint8Array([0x41, 0x55, 0x44, 0x30]); // "AUD0"
 
   function log(msg) {
     const ts = new Date().toLocaleTimeString();
@@ -80,10 +81,13 @@
         firmware_ver: 'web',
         platform: 'web',
         session_id: null,
-        capabilities: { video_send: true, video_recv: true },
+        capabilities: { video_send: true, video_recv: true, audio_call: true },
       }));
-      // Start camera + frame loop.
-      stream = await navigator.mediaDevices.getUserMedia({ video: { width:640, height:480 }, audio:false });
+      // Start camera + microphone + frame loops.
+      stream = await navigator.mediaDevices.getUserMedia({
+        video: { width:640, height:480 },
+        audio: { echoCancellation: true, noiseSuppression: true, sampleRate: 16000 },
+      });
       $('local').srcObject = stream;
       const fps = Math.max(1, Math.min(10, +$('fps').value || 3));
       const period = 1000 / fps;
@@ -110,7 +114,70 @@
         stats.bytesSent += wire.byteLength;
         $('stats').textContent = `sent ${stats.sent} (${(stats.bytesSent/1024).toFixed(0)} KB) | recv ${stats.recv} (${(stats.bytesRecv/1024).toFixed(0)} KB)`;
       }, period);
+
+      /* Audio capture: AudioContext at 16 kHz (browser may resample
+       * from 48 kHz internally), AudioWorkletNode-equivalent via the
+       * deprecated-but-widely-supported ScriptProcessorNode.  Buffer
+       * 320 samples = 20 ms = 640 B int16 — same shape Tab5 uses.
+       * Wrap with AUD0 magic + length and send. */
+      try {
+        const aud = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: 16000 });
+        const src = aud.createMediaStreamSource(stream);
+        const proc = aud.createScriptProcessor(2048, 1, 1);
+        let f32buf = new Float32Array(0);
+        proc.onaudioprocess = (ev) => {
+          if (!ws || ws.readyState !== 1) return;
+          const inp = ev.inputBuffer.getChannelData(0);
+          const merged = new Float32Array(f32buf.length + inp.length);
+          merged.set(f32buf, 0);
+          merged.set(inp, f32buf.length);
+          const FRAME = 320;
+          let off = 0;
+          while (merged.length - off >= FRAME) {
+            const i16 = new Int16Array(FRAME);
+            for (let i = 0; i < FRAME; i++) {
+              const v = Math.max(-1, Math.min(1, merged[off + i]));
+              i16[i] = v < 0 ? v * 0x8000 : v * 0x7fff;
+            }
+            const body = new Uint8Array(i16.buffer);
+            const wire = new Uint8Array(8 + body.length);
+            wire.set(AUDIO_MAGIC, 0);
+            wire[4] = (body.length >>> 24) & 0xff;
+            wire[5] = (body.length >>> 16) & 0xff;
+            wire[6] = (body.length >>> 8)  & 0xff;
+            wire[7] = (body.length)        & 0xff;
+            wire.set(body, 8);
+            ws.send(wire.buffer);
+            off += FRAME;
+          }
+          f32buf = merged.slice(off);
+        };
+        src.connect(proc);
+        proc.connect(aud.destination);
+        log('audio uplink ready (16 kHz)');
+      } catch (e) {
+        log('audio init failed: ' + e);
+      }
     };
+
+    /* Lazy-init shared AudioContext for inbound playback. */
+    let playCtx = null;
+    let playClock = 0;
+    function playPcm(int16) {
+      if (!playCtx) {
+        playCtx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: 16000 });
+        playClock = playCtx.currentTime + 0.05;   // small lead
+      }
+      const buf = playCtx.createBuffer(1, int16.length, playCtx.sampleRate);
+      const ch = buf.getChannelData(0);
+      for (let i = 0; i < int16.length; i++) ch[i] = int16[i] / 32768;
+      const node = playCtx.createBufferSource();
+      node.buffer = buf;
+      node.connect(playCtx.destination);
+      const startAt = Math.max(playClock, playCtx.currentTime + 0.005);
+      node.start(startAt);
+      playClock = startAt + buf.duration;
+    }
 
     ws.onmessage = (ev) => {
       if (typeof ev.data === 'string') {
@@ -118,18 +185,29 @@
         return;
       }
       const buf = new Uint8Array(ev.data);
-      // Check VID0 magic
-      if (buf.length < 8 || buf[0] !== 0x56 || buf[1] !== 0x49 || buf[2] !== 0x44 || buf[3] !== 0x30) return;
-      const len = (buf[4]<<24) | (buf[5]<<16) | (buf[6]<<8) | buf[7];
-      const jpeg = buf.slice(8, 8 + len);
-      const blob = new Blob([jpeg], { type: 'image/jpeg' });
-      const url = URL.createObjectURL(blob);
-      const prev = $('remote').src;
-      $('remote').src = url;
-      if (prev && prev.startsWith('blob:')) URL.revokeObjectURL(prev);
-      stats.recv++;
-      stats.bytesRecv += buf.byteLength;
-      $('stats').textContent = `sent ${stats.sent} (${(stats.bytesSent/1024).toFixed(0)} KB) | recv ${stats.recv} (${(stats.bytesRecv/1024).toFixed(0)} KB)`;
+      if (buf.length < 8) return;
+      // VID0?
+      if (buf[0] === 0x56 && buf[1] === 0x49 && buf[2] === 0x44 && buf[3] === 0x30) {
+        const len = (buf[4]<<24) | (buf[5]<<16) | (buf[6]<<8) | buf[7];
+        const jpeg = buf.slice(8, 8 + len);
+        const blob = new Blob([jpeg], { type: 'image/jpeg' });
+        const url = URL.createObjectURL(blob);
+        const prev = $('remote').src;
+        $('remote').src = url;
+        if (prev && prev.startsWith('blob:')) URL.revokeObjectURL(prev);
+        stats.recv++;
+        stats.bytesRecv += buf.byteLength;
+        $('stats').textContent = `sent ${stats.sent} (${(stats.bytesSent/1024).toFixed(0)} KB) | recv ${stats.recv} (${(stats.bytesRecv/1024).toFixed(0)} KB)`;
+        return;
+      }
+      // AUD0?
+      if (buf[0] === 0x41 && buf[1] === 0x55 && buf[2] === 0x44 && buf[3] === 0x30) {
+        const len = (buf[4]<<24) | (buf[5]<<16) | (buf[6]<<8) | buf[7];
+        // 2-byte aligned int16 view of the body
+        const body = buf.slice(8, 8 + len);
+        const i16 = new Int16Array(body.buffer, body.byteOffset, body.byteLength / 2);
+        playPcm(i16);
+      }
     };
 
     ws.onclose = (ev) => {

--- a/tests/test_audio_codec.py
+++ b/tests/test_audio_codec.py
@@ -77,3 +77,40 @@ def test_codec_unavailable_when_no_libopus():
         ac.OpusUplinkDecoder()
     with pytest.raises(ac.CodecUnavailable):
         ac.OpusDownlinkEncoder()
+
+
+# #181 / TinkerTab #272: AUD0-framed call-audio helpers.
+
+def _wrap_call_audio(pcm: bytes) -> bytes:
+    return ac.CALL_AUDIO_MAGIC + struct.pack(">I", len(pcm)) + pcm
+
+
+def test_peek_call_audio_magic_recognises():
+    assert ac.peek_call_audio_magic(_wrap_call_audio(b"\x00" * 8))
+
+
+def test_peek_call_audio_magic_rejects_video_and_pcm():
+    # Video frame magic
+    assert not ac.peek_call_audio_magic(b"VID0" + b"\x00" * 4)
+    # Plain PCM (raw int16)
+    assert not ac.peek_call_audio_magic(b"\x00\x80\x00\x80")
+    # Too short
+    assert not ac.peek_call_audio_magic(b"AU")
+
+
+def test_parse_call_audio_extracts_body():
+    pcm = bytes(range(40))
+    body = ac.parse_call_audio_frame(_wrap_call_audio(pcm))
+    assert body == pcm
+
+
+def test_parse_call_audio_rejects_bad_magic():
+    bad = b"BAD!" + struct.pack(">I", 4) + b"\x00\x00\x00\x00"
+    with pytest.raises(ValueError, match="bad magic"):
+        ac.parse_call_audio_frame(bad)
+
+
+def test_parse_call_audio_rejects_len_mismatch():
+    bad = ac.CALL_AUDIO_MAGIC + struct.pack(">I", 100) + b"only10byte"
+    with pytest.raises(ValueError, match="len mismatch"):
+        ac.parse_call_audio_frame(bad)


### PR DESCRIPTION
## Summary
- AUD0-magic detection + broadcast on the WS binary handler.  Bypasses STT — frames go straight to other connected clients verbatim.
- audio_codec.py grows the framing helpers + tests.
- /call web client adds 16 kHz audio capture (AudioContext + ScriptProcessorNode) and 16 kHz playback (createBuffer + BufferSource).
- Closes #181. Pairs with TinkerTab #272.

## Test plan
- [x] pytest tests/test_audio_codec.py — 11 passed
- [x] Ruff gate clean
- [ ] End-to-end after deploy + Tab5 flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)