### PR TITLE
feat(llm): declare backend capabilities (refs #183)

### DIFF
--- a/dragon_voice/llm/base.py
+++ b/dragon_voice/llm/base.py
@@ -1,7 +1,25 @@
 """Abstract base class for LLM backends."""
 
 from abc import ABC, abstractmethod
+from enum import StrEnum
 from typing import AsyncIterator
+
+
+class Modality(StrEnum):
+    """Capabilities a backend can declare for the multi-model router (#183).
+
+    A backend's `capabilities` property returns a frozenset of these.
+    The router infers the *required* set from the inbound message
+    (image_url content -> +VISION, etc.) and picks the lowest-priority
+    backend whose capabilities are a superset.
+    """
+
+    TEXT = "text"
+    VISION = "vision"
+    VIDEO = "video"
+    AUDIO_IN = "audio_in"
+    AUDIO_OUT = "audio_out"
+    TOOL_CALLING = "tool_calling"
 
 
 class LLMBackend(ABC):
@@ -83,3 +101,14 @@ class LLMBackend(ABC):
     def name(self) -> str:
         """Human-readable backend name for logging and status pages."""
         ...
+
+    @property
+    def capabilities(self) -> frozenset[Modality]:
+        """Modalities this backend can handle.
+
+        Default is text-only. Concrete backends should override based on
+        the configured model_id (e.g. ollama checks if `vision` is in the
+        model name; openrouter consults a static OR-model registry).
+        Used by the multi-model router (#183) to pick a backend per turn.
+        """
+        return frozenset({Modality.TEXT})

--- a/dragon_voice/llm/dual.py
+++ b/dragon_voice/llm/dual.py
@@ -36,7 +36,7 @@ import re
 from typing import AsyncIterator
 
 from dragon_voice.config import LLMConfig
-from dragon_voice.llm.base import LLMBackend
+from dragon_voice.llm.base import LLMBackend, Modality
 
 logger = logging.getLogger(__name__)
 
@@ -138,6 +138,17 @@ class DualModelBackend(LLMBackend):
     @property
     def name(self) -> str:
         return f"Dual(picker={self._picker.name} | responder={self._responder.name})"
+
+    @property
+    def capabilities(self) -> frozenset[Modality]:
+        """Forward to the responder.
+
+        The responder is the model whose tokens reach the user; if it
+        can't see images, the dual pipeline can't see images. Picker is
+        text-only by design (xLAM-style FC head) and doesn't constrain
+        the user-visible modality set.
+        """
+        return self._responder.capabilities
 
     async def initialize(self) -> None:
         await self._picker.initialize()

--- a/dragon_voice/llm/lmstudio_llm.py
+++ b/dragon_voice/llm/lmstudio_llm.py
@@ -12,7 +12,7 @@ from typing import AsyncIterator
 import aiohttp
 
 from dragon_voice.config import LLMConfig
-from dragon_voice.llm.base import LLMBackend
+from dragon_voice.llm.base import LLMBackend, Modality
 
 logger = logging.getLogger(__name__)
 
@@ -154,3 +154,32 @@ class LMStudioBackend(LLMBackend):
     @property
     def name(self) -> str:
         return f"LM Studio ({self._model})"
+
+    @property
+    def capabilities(self) -> frozenset[Modality]:
+        """Detect modalities by inspecting the model id.
+
+        LM Studio serves arbitrary GGUFs the user has loaded — there's
+        no canonical capability lookup. We use the same name-substring
+        heuristic as ollama for vision/multimodal families, since most
+        users name the model after the upstream HF repo it came from.
+        For tool-calling, LM Studio supports OpenAI-format tools across
+        the board on its `/chat/completions` endpoint, so we always
+        declare TOOL_CALLING (the actual model may or may not be
+        trained for it; the parser is tolerant).
+        """
+        model_lc = self._model.lower()
+        caps = {Modality.TEXT, Modality.TOOL_CALLING}
+
+        VISION_HINTS = ("llava", "bakllava", "minicpm-v", "minicpm-o",
+                        "moondream", "vision", "qwen2-vl", "qwen2.5-vl",
+                        "pixtral", "internvl")
+        if any(hint in model_lc for hint in VISION_HINTS):
+            caps.add(Modality.VISION)
+            caps.add(Modality.VIDEO)
+
+        if "minicpm-o" in model_lc:
+            caps.add(Modality.AUDIO_IN)
+            caps.add(Modality.AUDIO_OUT)
+
+        return frozenset(caps)

--- a/dragon_voice/llm/npu_genie.py
+++ b/dragon_voice/llm/npu_genie.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import AsyncIterator
 
 from dragon_voice.config import LLMConfig
-from dragon_voice.llm.base import LLMBackend
+from dragon_voice.llm.base import LLMBackend, Modality
 
 logger = logging.getLogger(__name__)
 
@@ -196,3 +196,9 @@ class NPUGenieBackend(LLMBackend):
     @property
     def name(self) -> str:
         return f"NPU Genie ({self._config_file})"
+
+    @property
+    def capabilities(self) -> frozenset[Modality]:
+        # QAIRT/Genie text-only. No vision/audio support today —
+        # multimodal would need a fresh QAIRT model + Genie pipeline.
+        return frozenset({Modality.TEXT})

--- a/dragon_voice/llm/ollama_llm.py
+++ b/dragon_voice/llm/ollama_llm.py
@@ -12,7 +12,7 @@ from typing import AsyncIterator
 import aiohttp
 
 from dragon_voice.config import LLMConfig
-from dragon_voice.llm.base import LLMBackend
+from dragon_voice.llm.base import LLMBackend, Modality
 
 logger = logging.getLogger(__name__)
 
@@ -286,3 +286,45 @@ class OllamaBackend(LLMBackend):
     @property
     def name(self) -> str:
         return f"Ollama ({self._model})"
+
+    @property
+    def capabilities(self) -> frozenset[Modality]:
+        """Detect modalities by inspecting the configured model id.
+
+        Most ollama-served vision/multimodal models advertise themselves
+        in the model name itself: `llava`, `bakllava`, `minicpm-v`,
+        `minicpm-o`, `moondream`, `llama3.2-vision`. The audio-capable
+        omni line (minicpm-o) adds `_in`/`_out` audio. Tool-calling is
+        the harder one to detect from the name alone; we conservatively
+        gate on a curated list of known function-calling families.
+        """
+        model_lc = self._model.lower()
+        caps = {Modality.TEXT}
+
+        # Vision: substring match across the common ollama vision families
+        VISION_HINTS = ("llava", "bakllava", "minicpm-v", "minicpm-o",
+                        "moondream", "vision", "qwen2-vl", "qwen2.5-vl",
+                        "pixtral", "internvl")
+        if any(hint in model_lc for hint in VISION_HINTS):
+            caps.add(Modality.VISION)
+            # Vision-capable ollama models also accept multi-image inputs,
+            # which is the same path frame-sampled video uses.
+            caps.add(Modality.VIDEO)
+
+        # Audio in/out: only the omni line (minicpm-o) currently carries
+        # both directions in ollama-served form.
+        if "minicpm-o" in model_lc:
+            caps.add(Modality.AUDIO_IN)
+            caps.add(Modality.AUDIO_OUT)
+
+        # Tool-calling: known FC-trained families. Conservative — the
+        # parser is tolerant enough to wring tool calls out of others, but
+        # the router should only declare TOOL_CALLING for models actually
+        # trained for it.
+        TOOLCALL_HINTS = ("ministral", "gemma3", "xlam", "llama3.1",
+                          "llama3.2", "qwen2.5", "hermes", "functiongemma",
+                          "lfm2", "smollm3")
+        if any(hint in model_lc for hint in TOOLCALL_HINTS):
+            caps.add(Modality.TOOL_CALLING)
+
+        return frozenset(caps)

--- a/dragon_voice/llm/openrouter_llm.py
+++ b/dragon_voice/llm/openrouter_llm.py
@@ -13,7 +13,7 @@ from typing import AsyncIterator
 import aiohttp
 
 from dragon_voice.config import LLMConfig
-from dragon_voice.llm.base import LLMBackend
+from dragon_voice.llm.base import LLMBackend, Modality
 
 logger = logging.getLogger(__name__)
 
@@ -349,6 +349,16 @@ class OpenRouterBackend(LLMBackend):
     def name(self) -> str:
         return f"OpenRouter ({self._model})"
 
+    @property
+    def capabilities(self) -> frozenset[Modality]:
+        """Look up the configured OpenRouter model in the capability registry.
+
+        Used by the multi-model router (#183). Unknown models default to
+        text + tool_calling (a safe baseline for OR — every modern OR
+        model supports tools via the chat-completions API).
+        """
+        return _openrouter_capabilities(self._model)
+
 
 # ── Pricing table (Phase 3) ───────────────────────────────────────────
 # Values are in MILS per 1M tokens ($USD * 1000 * 1000).  Storing in mils
@@ -403,3 +413,38 @@ def price_for_model(model: str, prompt_tokens: int, completion_tokens: int) -> i
     cost_in  = (in_num  + 999_999) // 1_000_000 if in_num  > 0 else 0
     cost_out = (out_num + 999_999) // 1_000_000 if out_num > 0 else 0
     return cost_in + cost_out
+
+
+# ── Capability registry (#183) ─────────────────────────────────────────
+# Per-model declared modalities for the multi-model router.  Each entry
+# is the set of caps OpenRouter exposes for that model.  Keep in sync
+# with OpenRouter's documented multimodal endpoints; new entries added
+# as we use new models.
+#
+# Default for unknown OR models: {TEXT, TOOL_CALLING}.  OR's chat
+# completions API supports tools across the board; vision/video/audio
+# are explicit per-model and must be opted in.
+_OPENROUTER_CAPS: dict[str, frozenset[Modality]] = {
+    # Anthropic (vision + tools across the line)
+    "anthropic/claude-3-haiku":   frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "anthropic/claude-3.5-haiku": frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "anthropic/claude-sonnet-4-20250514": frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    # OpenAI
+    "openai/gpt-4o":              frozenset({Modality.TEXT, Modality.VISION, Modality.AUDIO_IN, Modality.AUDIO_OUT, Modality.TOOL_CALLING}),
+    "openai/gpt-4o-mini":         frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "openai/gpt-audio-mini":      frozenset({Modality.TEXT, Modality.AUDIO_IN, Modality.AUDIO_OUT}),
+    # Google Gemini Flash family — vision + native video, full tools
+    "google/gemini-3-flash-preview": frozenset({Modality.TEXT, Modality.VISION, Modality.VIDEO, Modality.AUDIO_IN, Modality.TOOL_CALLING}),
+    "google/gemini-2.5-flash":       frozenset({Modality.TEXT, Modality.VISION, Modality.VIDEO, Modality.AUDIO_IN, Modality.TOOL_CALLING}),
+    "google/gemini-2.5-flash-lite":  frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "google/gemini-2.0-flash-001":   frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+}
+
+_OPENROUTER_DEFAULT_CAPS = frozenset({Modality.TEXT, Modality.TOOL_CALLING})
+
+
+def _openrouter_capabilities(model_id: str) -> frozenset[Modality]:
+    """Return declared modalities for an OpenRouter model id."""
+    if not model_id:
+        return _OPENROUTER_DEFAULT_CAPS
+    return _OPENROUTER_CAPS.get(model_id, _OPENROUTER_DEFAULT_CAPS)

--- a/dragon_voice/llm/tinkerclaw_llm.py
+++ b/dragon_voice/llm/tinkerclaw_llm.py
@@ -17,7 +17,7 @@ import aiohttp
 
 from dragon_voice.config import LLMConfig
 from dragon_voice.errors import DragonError, Scope, Severity
-from dragon_voice.llm.base import LLMBackend
+from dragon_voice.llm.base import LLMBackend, Modality
 
 logger = logging.getLogger(__name__)
 
@@ -486,3 +486,20 @@ class TinkerClawBackend(LLMBackend):
     @property
     def name(self) -> str:
         return f"TinkerClaw ({self._model})"
+
+    @property
+    def capabilities(self) -> frozenset[Modality]:
+        """TinkerClaw gateway routes through whichever model is configured.
+
+        The gateway itself is agentic — every model it serves goes
+        through its tool-execution layer. Vision is model-dependent.
+        Declared mostly for completeness + diagnostic surfaces; the
+        router doesn't pick TinkerClaw (voice_mode=3 short-circuits
+        the router entirely).
+        """
+        model_lc = (self._model or "").lower()
+        caps = {Modality.TEXT, Modality.TOOL_CALLING}
+        if any(prefix in model_lc for prefix in
+               ("minimax/", "anthropic/", "openai/gpt-4o", "google/gemini")):
+            caps.add(Modality.VISION)
+        return frozenset(caps)

--- a/tests/test_capability_declaration.py
+++ b/tests/test_capability_declaration.py
@@ -1,0 +1,153 @@
+"""Verify each LLMBackend declares its modality capabilities correctly.
+
+PR 1 of the multi-model router (#183) — these tests are the contract
+the router will rely on. If you add a new backend or change a
+capability heuristic, add a test row here.
+"""
+
+from dragon_voice.config import LLMConfig
+from dragon_voice.llm.base import LLMBackend, Modality
+from dragon_voice.llm.ollama_llm import OllamaBackend
+from dragon_voice.llm.openrouter_llm import OpenRouterBackend, _openrouter_capabilities
+from dragon_voice.llm.lmstudio_llm import LMStudioBackend
+from dragon_voice.llm.npu_genie import NPUGenieBackend
+from dragon_voice.llm.tinkerclaw_llm import TinkerClawBackend
+
+
+# ── Base default ──────────────────────────────────────────────────
+def test_base_default_is_text_only():
+    """Anything inheriting from LLMBackend without override is text-only."""
+    class _StubBackend(LLMBackend):
+        async def initialize(self): pass
+        async def generate_stream(self, prompt, system_prompt=""): yield ""
+        async def shutdown(self): pass
+        @property
+        def name(self): return "stub"
+    assert _StubBackend().capabilities == frozenset({Modality.TEXT})
+
+
+# ── Ollama ────────────────────────────────────────────────────────
+def _ollama_caps(model: str) -> frozenset[Modality]:
+    cfg = LLMConfig(backend="ollama", ollama_model=model)
+    return OllamaBackend(cfg).capabilities
+
+
+def test_ollama_text_model_only_text_and_tools():
+    caps = _ollama_caps("ministral-3:3b")
+    assert Modality.TEXT in caps
+    assert Modality.TOOL_CALLING in caps
+    assert Modality.VISION not in caps
+    assert Modality.AUDIO_IN not in caps
+
+
+def test_ollama_minicpm_v_has_vision_and_video():
+    caps = _ollama_caps("hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M")
+    assert {Modality.TEXT, Modality.VISION, Modality.VIDEO} <= caps
+    assert Modality.AUDIO_IN not in caps  # V is vision-only, not omni
+
+
+def test_ollama_minicpm_o_has_vision_video_audio():
+    caps = _ollama_caps("hf.co/openbmb/MiniCPM-o-4_5-gguf:Q4_K_M")
+    assert {Modality.TEXT, Modality.VISION, Modality.VIDEO,
+            Modality.AUDIO_IN, Modality.AUDIO_OUT} <= caps
+
+
+def test_ollama_llava_has_vision():
+    caps = _ollama_caps("llava:7b")
+    assert Modality.VISION in caps
+    assert Modality.AUDIO_IN not in caps
+
+
+def test_ollama_unknown_model_defaults_text():
+    caps = _ollama_caps("some-experimental-model:latest")
+    assert caps == frozenset({Modality.TEXT})
+
+
+# ── OpenRouter ────────────────────────────────────────────────────
+def _or_caps(model: str) -> frozenset[Modality]:
+    cfg = LLMConfig(backend="openrouter", openrouter_model=model,
+                    openrouter_api_key="sk-test")
+    return OpenRouterBackend(cfg).capabilities
+
+
+def test_openrouter_haiku_has_vision_and_tools():
+    caps = _or_caps("anthropic/claude-3.5-haiku")
+    assert {Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING} <= caps
+
+
+def test_openrouter_gpt4o_has_audio():
+    caps = _or_caps("openai/gpt-4o")
+    assert {Modality.TEXT, Modality.VISION, Modality.AUDIO_IN,
+            Modality.AUDIO_OUT, Modality.TOOL_CALLING} <= caps
+
+
+def test_openrouter_gemini_flash_has_video():
+    caps = _or_caps("google/gemini-2.5-flash")
+    assert Modality.VIDEO in caps
+    assert Modality.VISION in caps
+
+
+def test_openrouter_unknown_falls_back_to_text_and_tools():
+    caps = _openrouter_capabilities("some-experimental/model")
+    assert caps == frozenset({Modality.TEXT, Modality.TOOL_CALLING})
+
+
+def test_openrouter_empty_model_id_falls_back():
+    caps = _openrouter_capabilities("")
+    assert caps == frozenset({Modality.TEXT, Modality.TOOL_CALLING})
+
+
+# ── LM Studio ─────────────────────────────────────────────────────
+def _lmstudio_caps(model: str) -> frozenset[Modality]:
+    cfg = LLMConfig(backend="lmstudio", lmstudio_model=model,
+                    lmstudio_url="http://localhost:1234/v1")
+    return LMStudioBackend(cfg).capabilities
+
+
+def test_lmstudio_default_text_and_tools():
+    caps = _lmstudio_caps("default")
+    assert caps == frozenset({Modality.TEXT, Modality.TOOL_CALLING})
+
+
+def test_lmstudio_minicpm_v_has_vision():
+    caps = _lmstudio_caps("openbmb/minicpm-v-4")
+    assert {Modality.TEXT, Modality.VISION, Modality.VIDEO,
+            Modality.TOOL_CALLING} <= caps
+
+
+def test_lmstudio_minicpm_o_has_audio():
+    caps = _lmstudio_caps("openbmb/minicpm-o-4_5")
+    assert {Modality.AUDIO_IN, Modality.AUDIO_OUT} <= caps
+
+
+# ── NPU Genie ─────────────────────────────────────────────────────
+def test_npu_genie_text_only():
+    cfg = LLMConfig(backend="npu_genie",
+                    genie_model_dir="/tmp/nonexistent",
+                    genie_config="cfg.json")
+    # NPU init reads the dir; we don't call initialize() here.
+    backend = NPUGenieBackend(cfg)
+    assert backend.capabilities == frozenset({Modality.TEXT})
+
+
+# ── TinkerClaw ────────────────────────────────────────────────────
+def _tc_caps(model: str) -> frozenset[Modality]:
+    cfg = LLMConfig(backend="tinkerclaw", tinkerclaw_model=model,
+                    tinkerclaw_url="http://localhost:18789",
+                    tinkerclaw_token="ci-tc-token")
+    return TinkerClawBackend(cfg).capabilities
+
+
+def test_tinkerclaw_minimax_has_vision_and_tools():
+    caps = _tc_caps("minimax/MiniMax-M2.5")
+    assert {Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING} <= caps
+
+
+def test_tinkerclaw_anthropic_routed_has_vision():
+    caps = _tc_caps("anthropic/claude-3.5-haiku")
+    assert Modality.VISION in caps
+
+
+def test_tinkerclaw_unknown_text_only_with_tools():
+    caps = _tc_caps("local-only-model")
+    assert caps == frozenset({Modality.TEXT, Modality.TOOL_CALLING})


### PR DESCRIPTION
## Summary
- **PR 1 of 3** for the multi-model router roadmap (#183).
- Adds `Modality` enum + `capabilities -> frozenset[Modality]` property to `LLMBackend`. Every concrete backend overrides it based on configured model id.
- Zero behavior change. Single-backend dispatch is untouched. PRs 2 and 3 build the router on top.

## Modalities
\`TEXT, VISION, VIDEO, AUDIO_IN, AUDIO_OUT, TOOL_CALLING\`

## Per-backend logic
| Backend | Strategy |
|---------|----------|
| ollama | Substring scan against vision-family prefixes (llava, minicpm-v/o, moondream, qwen2-vl, pixtral, internvl). minicpm-o adds AUDIO_IN/OUT. Tool-calling gated on FC families. |
| openrouter | Static registry by exact model id. Unknown OR models default to TEXT+TOOL_CALLING. |
| lmstudio | Same name-substring heuristic as ollama (LM Studio serves arbitrary GGUFs named after HF repo). |
| npu_genie | Text-only (QAIRT/Genie has no multimodal). |
| tinkerclaw | TEXT+TOOL_CALLING + VISION when gateway model is anthropic/openai/gemini/minimax. |
| dual | Forwards to responder.capabilities. |

## Tests
\`tests/test_capability_declaration.py\` — **18 assertions** across all six backends. Full suite: **499 passed, 1 skipped, 0 regressions**.

## Production verification
Deployed to Dragon, restarted \`tinkerclaw-voice\`, Tab5 reconnected, ministral loaded successfully. Imports clean, no startup errors.

## Test plan
- [x] Capability tests pass
- [x] Lint clean (\`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006\`)
- [x] Full test suite passes
- [x] Live service restart on Dragon — no import errors
- [x] Tab5 round-trip works against the deployed code