### PR TITLE
feat(llm): CapabilityAwareRouter + fleet config schema (refs #183)

### DIFF
--- a/dragon_voice/config.py
+++ b/dragon_voice/config.py
@@ -123,6 +123,13 @@ class LLMConfig:
     dual_picker_model: str = "hf.co/Salesforce/xLAM-2-1b-fc-r-gguf:Q4_K_M"
     dual_responder_backend: str = ""
     dual_responder_model: str = "ministral-3:3b"
+    # Multi-model router (#183) fleet — when `backend == "router"`,
+    # this list defines the pool the router picks from per-turn.
+    # Each entry mirrors `ModelSpec` (defined in dragon_voice.llm.router
+    # to avoid an import cycle on this module).  Empty list + non-router
+    # backend selection = legacy single-backend dispatch (no behavior
+    # change).
+    fleet: list[dict] = field(default_factory=list)
 
 
 @dataclass
@@ -208,7 +215,7 @@ class VoiceConfig:
                 f"stt.backend must be one of {valid_stt}, got '{self.stt.backend}'"
             )
 
-        valid_llm = ("ollama", "openrouter", "lmstudio", "npu_genie", "tinkerclaw", "dual")
+        valid_llm = ("ollama", "openrouter", "lmstudio", "npu_genie", "tinkerclaw", "dual", "router")
         if self.llm.backend not in valid_llm:
             errors.append(
                 f"llm.backend must be one of {valid_llm}, got '{self.llm.backend}'"

--- a/dragon_voice/llm/__init__.py
+++ b/dragon_voice/llm/__init__.py
@@ -10,6 +10,7 @@ _BACKENDS = {
     "npu_genie": "dragon_voice.llm.npu_genie.NPUGenieBackend",
     "tinkerclaw": "dragon_voice.llm.tinkerclaw_llm.TinkerClawBackend",
     "dual": "dragon_voice.llm.dual.DualModelBackend",
+    "router": "dragon_voice.llm.router.CapabilityAwareRouter",
 }
 
 

--- a/dragon_voice/llm/router.py
+++ b/dragon_voice/llm/router.py
@@ -1,0 +1,312 @@
+"""Capability-aware multi-model router (#183).
+
+Holds a fleet of LLMBackend instances declared in `LLMConfig.fleet`,
+picks one per request based on the modalities present in the inbound
+messages and the active voice_mode tier policy.
+
+Lifecycle:
+- `__init__(config)` parses the fleet into `ModelSpec` records, stores
+  voice_mode (default 0 = local).
+- `initialize()` is a no-op — sub-backends are *lazily instantiated*
+  on first use to keep startup fast and avoid loading models that may
+  never be needed.
+- `generate_stream_with_messages(messages)` infers required caps from
+  the message content array, picks a spec via `choose()`, lazily
+  instantiates the sub-backend, and delegates token streaming.
+- `set_voice_mode(mode)` flips the tier policy without rebuilding the
+  fleet — instantiated backends survive the switch.
+- `shutdown()` closes every instantiated sub-backend.
+
+Threading: the router itself is single-task (each WS connection has
+its own deep-copied config and its own router instance), so per-call
+contention is not a concern.  Lazy instantiation uses an `asyncio.Lock`
+to keep parallel requests for the same uninstantiated backend from
+double-creating it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import logging
+from dataclasses import dataclass, field
+from typing import AsyncIterator, Iterable
+
+from dragon_voice.config import LLMConfig
+from dragon_voice.llm.base import LLMBackend, Modality
+
+logger = logging.getLogger(__name__)
+
+
+# ── Tier policy from voice_mode ────────────────────────────────────
+# voice_mode is the Tab5-side three-tier picker:
+#   0 = Local        — local-tier LLM (NPU/ollama/lmstudio if LAN)
+#   1 = Hybrid       — local LLM, cloud STT/TTS (LLM tier unchanged)
+#   2 = Full Cloud   — cloud + LAN tier eligible for routing
+#   3 = TinkerClaw   — gateway picks; router is not used
+TIER_FOR_MODE: dict[int, frozenset[str] | None] = {
+    0: frozenset({"local"}),
+    1: frozenset({"local"}),
+    2: frozenset({"cloud", "lan"}),
+    3: None,
+}
+
+
+@dataclass
+class ModelSpec:
+    """One entry in the router's fleet.
+
+    Mirrors the YAML schema in `LLMConfig.fleet`. Fields beyond the
+    core router contract (e.g. `lmstudio_url`) get folded into the
+    sub-backend's `LLMConfig` at instantiation time.
+    """
+
+    id: str                                # human-readable, e.g. "minicpm_v4"
+    backend: str                           # ollama/openrouter/lmstudio/npu_genie/tinkerclaw
+    model_id: str                          # the actual model identifier
+    capabilities: frozenset[Modality]      # declared modalities
+    tier: str                              # local | cloud | lan
+    priority: int = 0                      # lower = preferred
+    keep_alive_s: int = 120                # ollama keep_alive override
+    overrides: dict = field(default_factory=dict)  # extra cfg fields (lmstudio_url, etc.)
+
+
+def _spec_from_dict(entry: dict) -> ModelSpec:
+    """Parse a YAML-loaded dict into a ModelSpec, validating fields."""
+    if "id" not in entry or "backend" not in entry or "model_id" not in entry:
+        raise ValueError(
+            f"fleet entry missing required field (id/backend/model_id): {entry}"
+        )
+    raw_caps = entry.get("caps", entry.get("capabilities", ["text"]))
+    caps = frozenset(Modality(c) for c in raw_caps)
+    tier = entry.get("tier", "local")
+    if tier not in ("local", "cloud", "lan"):
+        raise ValueError(f"fleet entry tier must be local/cloud/lan: {entry}")
+    # Pull known core fields out; everything else becomes an override
+    # to splat into the sub-backend's LLMConfig.
+    KNOWN = {"id", "backend", "model_id", "caps", "capabilities",
+             "tier", "priority", "keep_alive_s"}
+    overrides = {k: v for k, v in entry.items() if k not in KNOWN}
+    return ModelSpec(
+        id=entry["id"],
+        backend=entry["backend"],
+        model_id=entry["model_id"],
+        capabilities=caps,
+        tier=tier,
+        priority=int(entry.get("priority", 0)),
+        keep_alive_s=int(entry.get("keep_alive_s", 120)),
+        overrides=overrides,
+    )
+
+
+def infer_required_caps(messages: list[dict]) -> frozenset[Modality]:
+    """Inspect OpenAI-format messages to infer the modality requirements.
+
+    - Image content (`type: image_url`) → +VISION
+    - Video content (`type: video_url`) → +VIDEO
+    - Audio content (`type: input_audio` or audio attachment) → +AUDIO_IN
+    - Tool definitions in the system prompt → +TOOL_CALLING (light heuristic;
+      the parser is tolerant so we set this conservatively whenever any
+      message mentions a tool call marker).
+    Always includes TEXT.
+    """
+    caps: set[Modality] = {Modality.TEXT}
+    for msg in messages or []:
+        content = msg.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                ptype = part.get("type", "")
+                if ptype == "image_url":
+                    caps.add(Modality.VISION)
+                elif ptype == "video_url":
+                    caps.add(Modality.VIDEO)
+                elif ptype == "input_audio" or ptype == "audio":
+                    caps.add(Modality.AUDIO_IN)
+        elif isinstance(content, str):
+            # Cheap heuristic: tool-call markers in system prompt mean
+            # the caller wants tool support.
+            if msg.get("role") == "system" and (
+                "<tool>" in content or "<tool_call>" in content
+            ):
+                caps.add(Modality.TOOL_CALLING)
+    return frozenset(caps)
+
+
+class CapabilityAwareRouter(LLMBackend):
+    """Pick one of N sub-backends per request based on capabilities + tier."""
+
+    def __init__(self, config: LLMConfig) -> None:
+        self._config = config
+        self._fleet: list[ModelSpec] = [
+            _spec_from_dict(e) for e in (config.fleet or [])
+        ]
+        if not self._fleet:
+            raise ValueError(
+                "CapabilityAwareRouter requires a non-empty `llm.fleet` — "
+                "either populate fleet[] or set backend to a single-model "
+                "value (ollama/openrouter/lmstudio/...)."
+            )
+        self._instances: dict[str, LLMBackend] = {}
+        self._instance_lock = asyncio.Lock()
+        self._voice_mode: int = 0
+        logger.info(
+            "Router initialized with %d models: %s",
+            len(self._fleet),
+            ", ".join(f"{s.id}({s.tier})" for s in self._fleet),
+        )
+
+    # ── LLMBackend abstract methods ──────────────────────────────
+    async def initialize(self) -> None:
+        """No-op — sub-backends initialise lazily on first use."""
+        return None
+
+    async def generate_stream(
+        self, prompt: str, system_prompt: str = ""
+    ) -> AsyncIterator[str]:
+        """Text-only fallback — wraps the single prompt and delegates."""
+        messages: list[dict] = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": prompt})
+        async for tok in self.generate_stream_with_messages(messages):
+            yield tok
+
+    async def generate_stream_with_messages(
+        self, messages: list[dict]
+    ) -> AsyncIterator[str]:
+        required = infer_required_caps(messages)
+        spec = self.choose(required, self._voice_mode)
+        if spec is None:
+            tier = TIER_FOR_MODE.get(self._voice_mode)
+            tier_str = ",".join(sorted(tier)) if tier else "tinkerclaw"
+            logger.error(
+                "router: no fleet model satisfies %s in tier=%s",
+                sorted(required), tier_str,
+            )
+            # Yield nothing; caller (server.py) will detect empty + emit
+            # the modality_unsupported error event.
+            return
+        backend = await self._ensure_instance(spec)
+        logger.info(
+            "router: chose %s for %s tier=%s",
+            spec.id, sorted(required), spec.tier,
+        )
+        async for tok in backend.generate_stream_with_messages(messages):
+            yield tok
+
+    async def shutdown(self) -> None:
+        for spec_id, backend in list(self._instances.items()):
+            try:
+                await backend.shutdown()
+            except Exception as e:  # noqa: BLE001
+                logger.warning("router: %s shutdown error: %s", spec_id, e)
+        self._instances.clear()
+
+    @property
+    def name(self) -> str:
+        return f"Router({len(self._fleet)} models, mode={self._voice_mode})"
+
+    @property
+    def capabilities(self) -> frozenset[Modality]:
+        """Union of the entire fleet's caps within the active tier.
+
+        This is what the rest of the server queries (e.g.
+        `_handle_user_media` checks `if Modality.VISION in llm.capabilities`).
+        Restricting to the current tier means a Local-mode connection
+        with no local vision model in fleet correctly reports VISION
+        unavailable, even if a cloud vision model exists in fleet.
+        """
+        tier = TIER_FOR_MODE.get(self._voice_mode)
+        if tier is None:
+            return frozenset()
+        union: set[Modality] = set()
+        for spec in self._fleet:
+            if spec.tier in tier:
+                union |= spec.capabilities
+        return frozenset(union)
+
+    # ── Router-specific surface ──────────────────────────────────
+    def choose(
+        self, required: Iterable[Modality], voice_mode: int
+    ) -> ModelSpec | None:
+        """Pick the lowest-priority spec satisfying caps + tier."""
+        tier = TIER_FOR_MODE.get(voice_mode)
+        if tier is None:
+            return None
+        req_set = frozenset(required)
+        candidates = [
+            s for s in self._fleet
+            if s.tier in tier and req_set <= s.capabilities
+        ]
+        if not candidates:
+            return None
+        return min(candidates, key=lambda s: s.priority)
+
+    def set_voice_mode(self, mode: int) -> None:
+        """Flip tier policy. Instantiated sub-backends survive."""
+        if mode != self._voice_mode:
+            logger.info(
+                "router: voice_mode %d -> %d (instantiated=%s)",
+                self._voice_mode, mode, sorted(self._instances.keys()),
+            )
+            self._voice_mode = mode
+
+    def summarize(self, voice_mode: int | None = None) -> dict[str, str | None]:
+        """For each modality, what model_id would the router pick?
+
+        Used by `_handle_register` and `_handle_config_update` to push
+        a `fleet_summary` to Tab5 so the firmware can light up the
+        right capability chips dynamically.
+        """
+        mode = self._voice_mode if voice_mode is None else voice_mode
+        out: dict[str, str | None] = {}
+        for modality in Modality:
+            spec = self.choose({Modality.TEXT, modality}
+                               if modality != Modality.TEXT else {Modality.TEXT}, mode)
+            out[modality.value] = spec.model_id if spec else None
+        return out
+
+    # ── Lazy instantiation ───────────────────────────────────────
+    async def _ensure_instance(self, spec: ModelSpec) -> LLMBackend:
+        if spec.id in self._instances:
+            return self._instances[spec.id]
+        async with self._instance_lock:
+            # Re-check after acquiring (another coroutine may have just
+            # created it).
+            if spec.id in self._instances:
+                return self._instances[spec.id]
+            logger.info("router: instantiating %s (backend=%s, model=%s)",
+                        spec.id, spec.backend, spec.model_id)
+            sub_config = self._build_sub_config(spec)
+            # Late import to avoid factory cycle
+            from dragon_voice.llm import create_llm
+            backend = create_llm(sub_config)
+            await backend.initialize()
+            self._instances[spec.id] = backend
+            return backend
+
+    def _build_sub_config(self, spec: ModelSpec) -> LLMConfig:
+        """Deep-copy parent config + overlay this spec's fields."""
+        sub = copy.deepcopy(self._config)
+        sub.backend = spec.backend
+        sub.fleet = []  # sub-backends are single-model, not routers
+        if spec.backend == "ollama":
+            sub.ollama_model = spec.model_id
+            sub.ollama_keep_alive = f"{spec.keep_alive_s}s"
+        elif spec.backend == "openrouter":
+            sub.openrouter_model = spec.model_id
+        elif spec.backend == "lmstudio":
+            sub.lmstudio_model = spec.model_id
+        elif spec.backend == "tinkerclaw":
+            sub.tinkerclaw_model = spec.model_id
+        elif spec.backend == "npu_genie":
+            # NPU model identity is baked into the dir/config files;
+            # treating spec.model_id as a label only.
+            pass
+        # Apply per-spec overrides (e.g. lmstudio_url for a LAN backend)
+        for k, v in spec.overrides.items():
+            if hasattr(sub, k):
+                setattr(sub, k, v)
+        return sub

--- a/tests/test_router_routing.py
+++ b/tests/test_router_routing.py
@@ -1,0 +1,329 @@
+"""CapabilityAwareRouter unit tests (#183 PR 2).
+
+Cover:
+- Spec parsing from YAML-style dicts
+- choose() picks lowest priority + tier filter + cap match
+- Voice mode -> tier policy
+- summarize() returns per-modality model_id picks
+- Lazy instantiation + shutdown propagation
+- Empty fleet rejected
+- generate_stream_with_messages infers caps from message content
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dragon_voice.config import LLMConfig
+from dragon_voice.llm.base import LLMBackend, Modality
+from dragon_voice.llm.router import (
+    CapabilityAwareRouter,
+    ModelSpec,
+    TIER_FOR_MODE,
+    _spec_from_dict,
+    infer_required_caps,
+)
+
+
+# ── Fleet fixture ─────────────────────────────────────────────────
+def _fleet_dict() -> list[dict]:
+    return [
+        # Local tier
+        {"id": "ministral", "backend": "ollama", "model_id": "ministral-3:3b",
+         "caps": ["text", "tool_calling"], "tier": "local", "priority": 0},
+        {"id": "minicpm_v4", "backend": "ollama",
+         "model_id": "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M",
+         "caps": ["text", "vision", "video"], "tier": "local", "priority": 10},
+        {"id": "minicpm_o45", "backend": "ollama",
+         "model_id": "hf.co/openbmb/MiniCPM-o-4_5-gguf:Q4_K_M",
+         "caps": ["text", "vision", "video", "audio_in", "audio_out"],
+         "tier": "local", "priority": 20},
+        # Cloud tier
+        {"id": "haiku", "backend": "openrouter",
+         "model_id": "anthropic/claude-3.5-haiku",
+         "caps": ["text", "vision", "tool_calling"],
+         "tier": "cloud", "priority": 5},
+        {"id": "gemini_video", "backend": "openrouter",
+         "model_id": "google/gemini-2.5-flash",
+         "caps": ["text", "vision", "video", "tool_calling"],
+         "tier": "cloud", "priority": 8},
+    ]
+
+
+def _router(extra_overrides: dict | None = None) -> CapabilityAwareRouter:
+    cfg = LLMConfig(backend="router", fleet=_fleet_dict())
+    if extra_overrides:
+        for k, v in extra_overrides.items():
+            setattr(cfg, k, v)
+    return CapabilityAwareRouter(cfg)
+
+
+# ── Spec parsing ──────────────────────────────────────────────────
+def test_spec_from_dict_minimal():
+    spec = _spec_from_dict({"id": "x", "backend": "ollama", "model_id": "m"})
+    assert spec.id == "x"
+    assert spec.tier == "local"
+    assert spec.priority == 0
+    assert spec.capabilities == frozenset({Modality.TEXT})
+
+
+def test_spec_from_dict_caps_alias():
+    """`caps` and `capabilities` both work as keys."""
+    a = _spec_from_dict({"id": "a", "backend": "ollama", "model_id": "m",
+                         "caps": ["text", "vision"]})
+    b = _spec_from_dict({"id": "b", "backend": "ollama", "model_id": "m",
+                         "capabilities": ["text", "vision"]})
+    assert a.capabilities == b.capabilities
+
+
+def test_spec_from_dict_overrides_for_lmstudio_url():
+    spec = _spec_from_dict({"id": "dgx", "backend": "lmstudio", "model_id": "x",
+                            "lmstudio_url": "http://workstation:1234/v1"})
+    assert spec.overrides["lmstudio_url"] == "http://workstation:1234/v1"
+
+
+def test_spec_from_dict_rejects_missing_required():
+    with pytest.raises(ValueError, match="missing required field"):
+        _spec_from_dict({"backend": "ollama"})
+
+
+def test_spec_from_dict_rejects_bad_tier():
+    with pytest.raises(ValueError, match="tier must be"):
+        _spec_from_dict({"id": "x", "backend": "ollama", "model_id": "m",
+                         "tier": "rogue"})
+
+
+# ── Router init ───────────────────────────────────────────────────
+def test_router_rejects_empty_fleet():
+    cfg = LLMConfig(backend="router", fleet=[])
+    with pytest.raises(ValueError, match="non-empty"):
+        CapabilityAwareRouter(cfg)
+
+
+def test_router_init_logs_fleet_summary():
+    r = _router()
+    assert len(r._fleet) == 5
+    assert r._voice_mode == 0
+
+
+# ── choose() ──────────────────────────────────────────────────────
+def test_choose_local_text_picks_ministral():
+    r = _router()
+    spec = r.choose({Modality.TEXT}, voice_mode=0)
+    assert spec.id == "ministral"
+
+
+def test_choose_local_vision_picks_minicpm_v4_not_o45():
+    """Lower priority wins — V4 (priority 10) beats o4.5 (priority 20)."""
+    r = _router()
+    spec = r.choose({Modality.TEXT, Modality.VISION}, voice_mode=0)
+    assert spec.id == "minicpm_v4"
+
+
+def test_choose_local_audio_picks_minicpm_o45():
+    """Only o4.5 declares audio in the local fleet."""
+    r = _router()
+    spec = r.choose({Modality.TEXT, Modality.AUDIO_IN}, voice_mode=0)
+    assert spec.id == "minicpm_o45"
+
+
+def test_choose_cloud_vision_picks_haiku_lowest_priority():
+    r = _router()
+    spec = r.choose({Modality.TEXT, Modality.VISION}, voice_mode=2)
+    assert spec.id == "haiku"
+
+
+def test_choose_cloud_video_picks_gemini():
+    """Video is only on gemini in the cloud fleet."""
+    r = _router()
+    spec = r.choose({Modality.TEXT, Modality.VIDEO}, voice_mode=2)
+    assert spec.id == "gemini_video"
+
+
+def test_choose_local_audio_in_cloud_mode_returns_none():
+    """Cloud fleet has no audio model; returns None."""
+    r = _router()
+    spec = r.choose({Modality.TEXT, Modality.AUDIO_IN}, voice_mode=2)
+    assert spec is None
+
+
+def test_choose_tinkerclaw_mode_returns_none():
+    """voice_mode=3 short-circuits the router."""
+    r = _router()
+    spec = r.choose({Modality.TEXT}, voice_mode=3)
+    assert spec is None
+
+
+def test_choose_hybrid_uses_local_tier():
+    """Hybrid (mode 1) keeps LLM local."""
+    r = _router()
+    spec = r.choose({Modality.TEXT}, voice_mode=1)
+    assert spec.id == "ministral"
+    assert spec.tier == "local"
+
+
+# ── set_voice_mode ────────────────────────────────────────────────
+def test_set_voice_mode_changes_routing():
+    r = _router()
+    spec0 = r.choose({Modality.TEXT, Modality.VISION}, voice_mode=0)
+    r.set_voice_mode(2)
+    spec2 = r.choose({Modality.TEXT, Modality.VISION}, voice_mode=2)
+    assert spec0.id == "minicpm_v4"
+    assert spec2.id == "haiku"
+
+
+# ── capabilities (tier-restricted union) ──────────────────────────
+def test_capabilities_local_mode_union():
+    r = _router()
+    assert Modality.VISION in r.capabilities
+    assert Modality.AUDIO_IN in r.capabilities  # minicpm_o45 has it
+
+
+def test_capabilities_cloud_mode_no_audio():
+    r = _router()
+    r.set_voice_mode(2)
+    assert Modality.VISION in r.capabilities
+    assert Modality.VIDEO in r.capabilities      # gemini_video has it
+    assert Modality.AUDIO_IN not in r.capabilities  # cloud fleet has no audio
+
+
+def test_capabilities_tinkerclaw_mode_empty():
+    r = _router()
+    r.set_voice_mode(3)
+    assert r.capabilities == frozenset()
+
+
+# ── summarize() ───────────────────────────────────────────────────
+def test_summarize_local_mode():
+    r = _router()
+    summary = r.summarize(voice_mode=0)
+    assert summary["text"] == "ministral-3:3b"
+    assert summary["vision"] == "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M"
+    assert summary["audio_in"] == "hf.co/openbmb/MiniCPM-o-4_5-gguf:Q4_K_M"
+
+
+def test_summarize_cloud_mode():
+    r = _router()
+    summary = r.summarize(voice_mode=2)
+    # Lowest-priority text-capable cloud model is haiku (priority 5)
+    assert summary["text"] == "anthropic/claude-3.5-haiku"
+    assert summary["vision"] == "anthropic/claude-3.5-haiku"
+    assert summary["video"] == "google/gemini-2.5-flash"
+    assert summary["audio_in"] is None  # no cloud audio in fleet
+
+
+# ── infer_required_caps() ─────────────────────────────────────────
+def test_infer_text_only():
+    msgs = [{"role": "user", "content": "hello"}]
+    assert infer_required_caps(msgs) == frozenset({Modality.TEXT})
+
+
+def test_infer_vision_from_image_url():
+    msgs = [{"role": "user", "content": [
+        {"type": "image_url", "image_url": {"url": "data:..."}},
+        {"type": "text", "text": "describe"},
+    ]}]
+    caps = infer_required_caps(msgs)
+    assert Modality.VISION in caps
+    assert Modality.TEXT in caps
+
+
+def test_infer_video_from_video_url():
+    msgs = [{"role": "user", "content": [
+        {"type": "video_url", "video_url": {"url": "x"}},
+        {"type": "text", "text": "describe"},
+    ]}]
+    assert Modality.VIDEO in infer_required_caps(msgs)
+
+
+def test_infer_audio_from_input_audio():
+    msgs = [{"role": "user", "content": [
+        {"type": "input_audio", "input_audio": {"data": "x"}},
+    ]}]
+    assert Modality.AUDIO_IN in infer_required_caps(msgs)
+
+
+# ── Lazy instantiation + delegate (mocked) ────────────────────────
+class _FakeBackend(LLMBackend):
+    def __init__(self, *a, tokens=("a", "b"), **kw):
+        self.tokens = tokens
+        self.initialized = False
+        self.shutdown_called = False
+
+    async def initialize(self):
+        self.initialized = True
+
+    async def generate_stream(self, prompt, system_prompt=""):
+        for t in self.tokens:
+            yield t
+
+    async def generate_stream_with_messages(self, messages):
+        for t in self.tokens:
+            yield t
+
+    async def shutdown(self):
+        self.shutdown_called = True
+
+    @property
+    def name(self):
+        return "fake"
+
+
+@pytest.mark.asyncio
+async def test_lazy_instantiation_and_delegate():
+    """First request instantiates the picked backend; second reuses it."""
+    r = _router()
+    fakes_created: list[_FakeBackend] = []
+    def _create(_cfg):
+        fb = _FakeBackend()
+        fakes_created.append(fb)
+        return fb
+    with patch("dragon_voice.llm.create_llm", side_effect=_create):
+        msgs = [{"role": "user", "content": "hi"}]
+        out1 = [t async for t in r.generate_stream_with_messages(msgs)]
+        out2 = [t async for t in r.generate_stream_with_messages(msgs)]
+    assert out1 == ["a", "b"]
+    assert out2 == ["a", "b"]
+    assert len(fakes_created) == 1  # reuse on second call
+    assert fakes_created[0].initialized is True
+
+
+@pytest.mark.asyncio
+async def test_shutdown_propagates_to_all_instances():
+    r = _router()
+    fakes: list[_FakeBackend] = []
+    def _create(_cfg):
+        fb = _FakeBackend()
+        fakes.append(fb)
+        return fb
+    with patch("dragon_voice.llm.create_llm", side_effect=_create):
+        # Force two different specs to instantiate
+        msgs_text = [{"role": "user", "content": "hi"}]  # → ministral
+        msgs_vision = [{"role": "user", "content": [
+            {"type": "image_url", "image_url": {"url": "data:..."}},
+            {"type": "text", "text": "?"},
+        ]}]  # → minicpm_v4
+        async for _ in r.generate_stream_with_messages(msgs_text): pass
+        async for _ in r.generate_stream_with_messages(msgs_vision): pass
+    assert len(fakes) == 2
+    await r.shutdown()
+    assert all(f.shutdown_called for f in fakes)
+
+
+@pytest.mark.asyncio
+async def test_no_match_yields_nothing():
+    """Audio request in cloud-only fleet → empty stream (caller emits error)."""
+    r = _router()
+    r.set_voice_mode(2)  # cloud — no audio model
+    msgs = [{"role": "user", "content": [
+        {"type": "input_audio", "input_audio": {"data": "x"}},
+    ]}]
+    out = [t async for t in r.generate_stream_with_messages(msgs)]
+    assert out == []
+
+
+# ── Tier policy ───────────────────────────────────────────────────
+def test_tier_policy_table_complete():
+    """Every Tab5 voice_mode (0..3) must have a tier policy."""
+    for mode in (0, 1, 2, 3):
+        assert mode in TIER_FOR_MODE


### PR DESCRIPTION
## Summary
- **PR 2 of 3** for the multi-model router roadmap (#183).
- Adds `CapabilityAwareRouter` (itself an `LLMBackend`) + `ModelSpec` dataclass + fleet schema in `LLMConfig.fleet`.
- Server-side wiring (`_handle_user_media` + cross-modal continuity + `fleet_summary` push) lands in PR 3.

## Why
Today the server creates one `LLMBackend` per voice-mode swap. With this PR, configuring `backend: \"router\"` lets that single \"backend\" actually be a fleet of N models that the router picks from per-turn based on the modalities present in the message and the active tier policy.

## What changed
| Area | Change |
|------|--------|
| `dragon_voice/llm/router.py` | NEW — `CapabilityAwareRouter`, `ModelSpec`, `TIER_FOR_MODE`, `infer_required_caps()` |
| `dragon_voice/llm/__init__.py` | Add `\"router\"` factory entry |
| `dragon_voice/config.py` | `LLMConfig.fleet: list[dict]` + add `\"router\"` to `valid_llm` validator tuple |

## Architecture
- **Tier policy:** `voice_mode` 0/1 → `{local}`, 2 → `{cloud, lan}`, 3 → router bypassed (TinkerClaw gateway picks)
- **`choose(required_caps, voice_mode)`:** lowest-priority spec satisfying caps + tier
- **`infer_required_caps(messages)`:** walks OpenAI-format content arrays (image_url → +VISION, video_url → +VIDEO, input_audio → +AUDIO_IN)
- **Lazy instantiation:** sub-backends created on first use; `keep_alive_s` passed to ollama so unused models evict
- **`set_voice_mode(mode)`:** flips tier policy without rebuilding fleet — instantiated sub-backends survive
- **`summarize(voice_mode)`:** returns per-modality model_id the router would pick — used by PR 3 to push `fleet_summary` to Tab5

## Backward compat
`LLMConfig.fleet` defaults to `[]`. Until a deployment sets `backend: \"router\"`, behavior is identical to today.

## Tests
\`tests/test_router_routing.py\` — **29 assertions** covering: spec parsing, choose() across tier×capability matrix, voice_mode flips, summarize(), capabilities tier-restricted union, infer_required_caps, lazy instantiation (mocked), shutdown propagation, empty-fleet rejection, TinkerClaw bypass.

Full suite: **528 passed (+29), 1 skipped, 0 regressions**.

## Production verification
Deployed to Dragon, restarted \`tinkerclaw-voice\` with default single-backend config — service boots cleanly. Router code is in tree but inactive until config opt-in.

## Test plan
- [x] Router unit tests pass
- [x] Lint clean
- [x] Full test suite passes (no regressions)
- [x] Service restart on Dragon — no import errors