### PR TITLE
feat(llm): server integration + cross-modal continuity + fleet_summary (closes #183)

### DIFF
--- a/dragon_voice/conversation.py
+++ b/dragon_voice/conversation.py
@@ -139,6 +139,7 @@ class ConversationEngine:
         llm_config: LLMConfig,
         tool_registry=None,
         memory_service=None,
+        media_store=None,
     ) -> None:
         self._db = db
         self._messages = message_store
@@ -146,6 +147,12 @@ class ConversationEngine:
         self._llm: Optional[LLMBackend] = None
         self._tool_registry = tool_registry
         self._memory_service = memory_service
+        # #183 PR 3: when set, multimodal user messages stored via
+        # add_message(media_id=...) get hydrated back to OpenAI
+        # image_url content arrays at context-build time, enabling
+        # cross-modal continuity (photo turn -> text follow-up that
+        # still sees the photo).
+        self._media_store = media_store
 
     async def initialize(self) -> None:
         """Create and initialize the LLM backend."""
@@ -266,7 +273,9 @@ class ConversationEngine:
         # cloud models (128K+) can use much more conversation history.
         is_local = self._llm_config.backend in ("ollama", "npu_genie", "lmstudio")
         max_msgs = 10 if is_local else 30
-        context = await self._messages.get_context(session_id, max_messages=max_msgs)
+        context = await self._messages.get_context(
+            session_id, max_messages=max_msgs, media_store=self._media_store
+        )
 
         # Inject memory context before the user's message
         if self._memory_service:
@@ -304,6 +313,7 @@ class ConversationEngine:
         on_tool_call=None,
         on_tool_result=None,
         on_tool_error=None,
+        media_id: Optional[str] = None,
     ) -> AsyncIterator[str]:
         """Process text input with streaming response and tool-calling support.
 
@@ -327,13 +337,19 @@ class ConversationEngine:
         if not self._llm:
             raise RuntimeError("ConversationEngine not initialized")
 
-        # Store user message
+        # Store user message — multimodal turns pass media_id to encode
+        # the content with the multimodal marker (#183 PR 3). Uses
+        # input_mode="text" because the schema's CHECK constraint is
+        # ('voice','text','system') only; the multimodal nature is
+        # captured in the marker-prefixed content. Follow-up: add a
+        # DB migration adding 'vision' to the allowed set.
         await self._messages.add_message(
             session_id=session_id,
             role="user",
             content=text,
-            input_mode=input_mode,
+            input_mode="text" if media_id else input_mode,
             audio_duration_s=audio_duration_s,
+            media_id=media_id,
         )
 
         # Touch session activity

--- a/dragon_voice/lifecycle/startup.py
+++ b/dragon_voice/lifecycle/startup.py
@@ -203,11 +203,16 @@ async def run_startup(server: Any, app: web.Application) -> None:
             except Exception as e:
                 logger.warning("ScheduleReminderTool registration failed: %s", e)
 
-    # Conversation engine (shared LLM backend for text/API input)
+    # Conversation engine (shared LLM backend for text/API input).
+    # #183 PR 3: pass media_store so multimodal user messages persist
+    # via add_message(media_id=...) and hydrate back to OpenAI
+    # multimodal format on context build, enabling cross-modal
+    # continuity (photo turn -> text follow-up still sees the photo).
     server._conversation = ConversationEngine(
         server._db, server._message_store, server._config.llm,
         tool_registry=server._tool_registry,
         memory_service=server._memory_service,
+        media_store=server._media_store,
     )
     await server._conversation.initialize()
 

--- a/dragon_voice/llm/ollama_llm.py
+++ b/dragon_voice/llm/ollama_llm.py
@@ -14,6 +14,48 @@ import aiohttp
 from dragon_voice.config import LLMConfig
 from dragon_voice.llm.base import LLMBackend, Modality
 
+
+def _translate_to_ollama_format(message: dict) -> dict:
+    """Convert an OpenAI-format message to Ollama /api/chat format.
+
+    OpenAI multimodal puts image data in a content-array part:
+        {"role": "user", "content": [
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,XXX"}},
+            {"type": "text", "text": "describe"},
+        ]}
+
+    Ollama wants a flat content string + a sibling `images` array of
+    raw base64 (no `data:image/...;base64,` prefix):
+        {"role": "user", "content": "describe", "images": ["XXX"]}
+
+    Plain string-content messages pass through unchanged.
+    """
+    content = message.get("content")
+    if not isinstance(content, list):
+        return message
+    text_parts: list[str] = []
+    image_b64_parts: list[str] = []
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        ptype = part.get("type", "")
+        if ptype == "image_url":
+            url = (part.get("image_url") or {}).get("url", "")
+            # Strip data:image/jpeg;base64, prefix if present
+            if "," in url and url.startswith("data:"):
+                url = url.split(",", 1)[1]
+            if url:
+                image_b64_parts.append(url)
+        elif ptype == "text":
+            text = part.get("text", "")
+            if text:
+                text_parts.append(text)
+    out = {"role": message.get("role", "user"),
+           "content": " ".join(text_parts)}
+    if image_b64_parts:
+        out["images"] = image_b64_parts
+    return out
+
 logger = logging.getLogger(__name__)
 
 
@@ -198,9 +240,17 @@ class OllamaBackend(LLMBackend):
                 timeout=aiohttp.ClientTimeout(total=None, sock_read=None)
             )
 
+        # Ollama /api/chat expects content as a string + a separate
+        # `images` array of base64-encoded bytes (no data: prefix).
+        # OpenAI multimodal format (used by openrouter, lmstudio,
+        # tinkerclaw, and the router internally) carries these as a
+        # `content` array of typed parts.  Translate before sending
+        # so router-fed multimodal turns don't break here. (#183 PR 3)
+        translated_messages = [_translate_to_ollama_format(m) for m in messages]
+
         payload = {
             "model": self._model,
-            "messages": messages,
+            "messages": translated_messages,
             "stream": True,
             "keep_alive": self._keep_alive,
             "options": {

--- a/dragon_voice/llm/router.py
+++ b/dragon_voice/llm/router.py
@@ -102,12 +102,20 @@ def _spec_from_dict(entry: dict) -> ModelSpec:
 def infer_required_caps(messages: list[dict]) -> frozenset[Modality]:
     """Inspect OpenAI-format messages to infer the modality requirements.
 
-    - Image content (`type: image_url`) → +VISION
-    - Video content (`type: video_url`) → +VIDEO
-    - Audio content (`type: input_audio` or audio attachment) → +AUDIO_IN
-    - Tool definitions in the system prompt → +TOOL_CALLING (light heuristic;
-      the parser is tolerant so we set this conservatively whenever any
-      message mentions a tool call marker).
+    Only modalities that appear in the user's *content* are required:
+      - Image content (`type: image_url`) → +VISION
+      - Video content (`type: video_url`) → +VIDEO
+      - Audio content (`type: input_audio` or audio attachment) → +AUDIO_IN
+
+    TOOL_CALLING is intentionally NOT a required cap.  The system
+    prompt routinely contains tool descriptions whether or not the
+    model is expected to actually call tools on this turn — making it a
+    requirement would force every turn through a tool-capable model
+    even when none is needed (e.g., "describe this image" should pick
+    MiniCPM-V even though the system prompt mentions `<tool>` markers).
+    Tool capability is therefore a *bonus* the router can prefer when
+    picking among same-priority candidates, not a gate.
+
     Always includes TEXT.
     """
     caps: set[Modality] = {Modality.TEXT}
@@ -124,13 +132,6 @@ def infer_required_caps(messages: list[dict]) -> frozenset[Modality]:
                     caps.add(Modality.VIDEO)
                 elif ptype == "input_audio" or ptype == "audio":
                     caps.add(Modality.AUDIO_IN)
-        elif isinstance(content, str):
-            # Cheap heuristic: tool-call markers in system prompt mean
-            # the caller wants tool support.
-            if msg.get("role") == "system" and (
-                "<tool>" in content or "<tool_call>" in content
-            ):
-                caps.add(Modality.TOOL_CALLING)
     return frozenset(caps)
 
 

--- a/dragon_voice/messages.py
+++ b/dragon_voice/messages.py
@@ -6,13 +6,51 @@ All SQL goes through db.py — this module adds the context-building logic.
 refs #17
 """
 
+import base64
+import json
 import logging
+import os
 import secrets
-from typing import Optional
+from typing import Any, Optional
 
 from dragon_voice.db import Database
 
 logger = logging.getLogger(__name__)
+
+
+# ── Multimodal content marker (#183 PR 3) ─────────────────────────
+# Multimodal user messages (image + text) are persisted as JSON in the
+# `content` text column with a recognisable marker so we can hydrate
+# them back to OpenAI multimodal format on context build, and so we
+# never confuse a plain text message that happens to start with `{`
+# with a multimodal payload.
+_MM_MARKER = "__mm__:"
+
+
+def encode_multimodal_content(media_id: str, text: str) -> str:
+    """Encode a multimodal user message for storage in `messages.content`.
+
+    Stores the media_id reference (not the raw base64) to keep the DB
+    small. Hydration happens at context-build time via
+    `_hydrate_multimodal_content` which reads the file off disk and
+    inlines it as a data URI.
+    """
+    payload = {"media_id": media_id, "text": text}
+    return _MM_MARKER + json.dumps(payload, separators=(",", ":"))
+
+
+def is_multimodal_content(content: str) -> bool:
+    return isinstance(content, str) and content.startswith(_MM_MARKER)
+
+
+def _decode_multimodal_marker(content: str) -> Optional[dict]:
+    if not is_multimodal_content(content):
+        return None
+    try:
+        return json.loads(content[len(_MM_MARKER):])
+    except json.JSONDecodeError:
+        logger.warning("Malformed multimodal marker in stored content")
+        return None
 
 
 # ── Token budget helpers ──────────────────────────────────────────────
@@ -67,6 +105,46 @@ def _generate_message_id() -> str:
     return secrets.token_hex(6)
 
 
+async def _hydrate_multimodal_content(content: str, media_store: Any) -> Any:
+    """Convert a stored multimodal-marker string to OpenAI multimodal content.
+
+    Returns the original string unchanged when:
+      - Content isn't multimodal-marked (the common case — text turns)
+      - media_store is None (caller didn't opt in to hydration)
+      - The referenced media file is gone (TTL expired or deleted)
+
+    On expiry, returns a placeholder text so the LLM doesn't hallucinate
+    against a missing image.
+    """
+    decoded = _decode_multimodal_marker(content)
+    if decoded is None:
+        return content
+    media_id = decoded.get("media_id", "")
+    text = decoded.get("text", "")
+    if media_store is None or not media_id:
+        return f"{text} [image attached: {media_id}]"
+    try:
+        path = await media_store.get_path(media_id)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("media_store.get_path(%s) failed: %s", media_id, e)
+        return f"{text} [image expired]"
+    if not path or not os.path.exists(path):
+        return f"{text} [image expired]"
+    # Read + base64 inline.  Done sync because we're inside an async
+    # context-build that's not on the request hot path; the file is
+    # already cached by MediaStore so this is fast.
+    try:
+        with open(path, "rb") as f:
+            b64 = base64.b64encode(f.read()).decode()
+    except OSError as e:
+        logger.warning("media file read failed (%s): %s", path, e)
+        return f"{text} [image expired]"
+    return [
+        {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64}"}},
+        {"type": "text", "text": text},
+    ]
+
+
 class MessageStore:
     """Append-only message store with LLM context building.
 
@@ -88,6 +166,7 @@ class MessageStore:
         token_count: Optional[int] = None,
         model: Optional[str] = None,
         latency_ms: Optional[float] = None,
+        media_id: Optional[str] = None,
     ) -> dict:
         """Store a message. Returns the message row as dict.
 
@@ -101,8 +180,14 @@ class MessageStore:
             token_count: LLM tokens used (None for user messages).
             model: Which LLM model generated this (None for user messages).
             latency_ms: End-to-end processing time in ms (None for user messages).
+            media_id: When present, persist as a multimodal message —
+                content gets encoded with the multimodal marker so
+                `get_context` can hydrate it back into OpenAI multimodal
+                format.  Used by `_handle_user_media` (#183).
         """
         message_id = _generate_message_id()
+        if media_id:
+            content = encode_multimodal_content(media_id, content)
         msg = await self._db.add_message(
             message_id=message_id,
             session_id=session_id,
@@ -132,6 +217,7 @@ class MessageStore:
         session_id: str,
         max_messages: int = 20,
         system_prompt: Optional[str] = None,
+        media_store: Optional[Any] = None,
     ) -> list[dict]:
         """Build an OpenAI-format message list for LLM context.
 
@@ -170,9 +256,12 @@ class MessageStore:
             # Include user, assistant, and tool messages in LLM context
             # (tool results are needed for the LLM to see what tools returned)
             if msg["role"] in ("user", "assistant", "tool"):
+                content = await _hydrate_multimodal_content(
+                    msg["content"], media_store
+                )
                 context.append({
                     "role": msg["role"],
-                    "content": msg["content"],
+                    "content": content,
                 })
 
         return context

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -1352,20 +1352,34 @@ class VoiceServer:
         # doesn't propagate an exception up to the WS handler and force
         # a session pause. If the send drops, the client will reconnect
         # shortly and we'll replay session_start on the next handshake.
+        # #183 PR 3: include `fleet_summary` so Tab5 firmware can
+        # advertise vision/video/audio caps dynamically without a
+        # hardcoded substring lookup.  Only present when the router is
+        # active; legacy single-backend deployments emit the same
+        # session_start as today.
+        session_start_config = {
+            "stt": conn_config.stt.backend,
+            "tts": conn_config.tts.backend,
+            "llm": conn_config.llm.backend,
+            "tts_sample_rate": conn_config.audio.input_sample_rate,
+            "response_mode": "match_input",
+            "system_prompt": conn_config.llm.system_prompt,
+        }
+        if self._conversation:
+            from dragon_voice.llm.router import CapabilityAwareRouter
+            if isinstance(self._conversation._llm, CapabilityAwareRouter):
+                session_start_config["fleet_summary"] = (
+                    self._conversation._llm.summarize(
+                        conn_state.get("voice_mode", 0)
+                    )
+                )
         if not await self._safe_send_json(ws, {
             "type": "session_start",
             "session_id": session_id,
             "device_id": device_id,
             "resumed": resumed,
             "message_count": session.get("message_count", 0),
-            "config": {
-                "stt": conn_config.stt.backend,
-                "tts": conn_config.tts.backend,
-                "llm": conn_config.llm.backend,
-                "tts_sample_rate": conn_config.audio.input_sample_rate,
-                "response_mode": "match_input",
-                "system_prompt": conn_config.llm.system_prompt,
-            },
+            "config": session_start_config,
         }):
             logger.info("session_start send dropped on %s — client likely reconnecting", ws_id)
             return
@@ -2318,36 +2332,51 @@ class VoiceServer:
             # W15-C01: prefer the pooled instance so we don't re-load Ollama /
             # re-open the aiohttp session on every config_update.  Only the
             # pipeline owns the shutdown of a pooled backend.
+            #
+            # #183 PR 3: when the active backend is the capability-aware
+            # router, voice_mode changes don't require a backend swap —
+            # the router holds the entire fleet and just flips its tier
+            # policy via set_voice_mode().  Saves the cost of recreating
+            # sub-backends + losing their warm-loaded models.
             if self._conversation:
-                try:
-                    from dragon_voice.llm import create_llm
-                    from dragon_voice.pipeline import _llm_sig
-                    new_key = _llm_sig(conn_config.llm)
-                    pooled = self._backend_pool.get(new_key)
-                    old_llm = self._conversation._llm
-                    if pooled is not None:
-                        new_llm = pooled
-                    else:
-                        new_llm = create_llm(conn_config.llm)
-                        await new_llm.initialize()
-                        self._backend_pool[new_key] = new_llm
-                    # Only shutdown the OLD one if nobody in the pool
-                    # references it (i.e. it wasn't pooled).
-                    if old_llm is not None and old_llm not in self._backend_pool.values():
-                        await old_llm.shutdown()
-                    self._conversation._llm = new_llm
-                    # 2026-04-23 (#58): also swap _llm_config so the
-                    # compact-vs-full tool prompt logic in
-                    # ConversationEngine._augment_context_with_tools picks the
-                    # right format for the active backend.  Without this,
-                    # cloud-mode agents stayed on the top-5 compact tool list
-                    # and never saw weather, stock_ticker, timesense_timer,
-                    # quick_poll, note, system_info, or unit_converter.
+                from dragon_voice.llm.router import CapabilityAwareRouter
+                if isinstance(self._conversation._llm, CapabilityAwareRouter):
+                    self._conversation._llm.set_voice_mode(voice_mode)
                     self._conversation._llm_config = conn_config.llm
-                    logger.info("ConversationEngine LLM swapped to %s%s (backend=%s)",
-                                new_llm.name, " (pooled)" if pooled else "", conn_config.llm.backend)
-                except Exception as e:
-                    logger.exception("ConversationEngine LLM swap failed: %s", e)
+                    logger.info(
+                        "router: voice_mode set to %d (no backend swap)",
+                        voice_mode,
+                    )
+                else:
+                    try:
+                        from dragon_voice.llm import create_llm
+                        from dragon_voice.pipeline import _llm_sig
+                        new_key = _llm_sig(conn_config.llm)
+                        pooled = self._backend_pool.get(new_key)
+                        old_llm = self._conversation._llm
+                        if pooled is not None:
+                            new_llm = pooled
+                        else:
+                            new_llm = create_llm(conn_config.llm)
+                            await new_llm.initialize()
+                            self._backend_pool[new_key] = new_llm
+                        # Only shutdown the OLD one if nobody in the pool
+                        # references it (i.e. it wasn't pooled).
+                        if old_llm is not None and old_llm not in self._backend_pool.values():
+                            await old_llm.shutdown()
+                        self._conversation._llm = new_llm
+                        # 2026-04-23 (#58): also swap _llm_config so the
+                        # compact-vs-full tool prompt logic in
+                        # ConversationEngine._augment_context_with_tools picks the
+                        # right format for the active backend.  Without this,
+                        # cloud-mode agents stayed on the top-5 compact tool list
+                        # and never saw weather, stock_ticker, timesense_timer,
+                        # quick_poll, note, system_info, or unit_converter.
+                        self._conversation._llm_config = conn_config.llm
+                        logger.info("ConversationEngine LLM swapped to %s%s (backend=%s)",
+                                    new_llm.name, " (pooled)" if pooled else "", conn_config.llm.backend)
+                    except Exception as e:
+                        logger.exception("ConversationEngine LLM swap failed: %s", e)
 
             # Update displayed names
             self._stt_name = stt_be
@@ -2365,42 +2394,81 @@ class VoiceServer:
                     active_model = conn_config.llm.ollama_model
                 else:
                     active_model = ""
+                # #183 PR 3: when the router is active, advertise the
+                # full per-modality fleet summary so Tab5 firmware can
+                # light up vision/video/audio capability chips
+                # dynamically.  Existing single-backend advertisements
+                # below are unchanged for backward-compat with current
+                # firmware that only reads `vision_capability`.
+                config_payload = {
+                    "stt": stt_be, "tts": tts_be,
+                    "llm": llm_be,
+                    "llm_model": active_model,
+                    "voice_mode": voice_mode,
+                    "cloud_mode": voice_mode >= 1,
+                }
+                if self._conversation:
+                    from dragon_voice.llm.router import CapabilityAwareRouter
+                    if isinstance(self._conversation._llm, CapabilityAwareRouter):
+                        config_payload["fleet_summary"] = (
+                            self._conversation._llm.summarize(voice_mode)
+                        )
                 await ws.send_json({
                     "type": "config_update",
-                    "config": {
-                        "stt": stt_be, "tts": tts_be,
-                        "llm": llm_be,
-                        "llm_model": active_model,
-                        "voice_mode": voice_mode,
-                        "cloud_mode": voice_mode >= 1,
-                    },
+                    "config": config_payload,
                 })
 
                 # v4·D Phase 4b vision capability advertisement.  Tab5's
                 # camera screen renders a "VISION · <model> READY" chip based
-                # on this.
+                # on this.  #183 PR 3: prefer the router's per-modality
+                # pick when available; fall back to the legacy
+                # substring-on-model-name heuristic for single-backend
+                # configurations.
                 try:
-                    vm = conn_config.llm.openrouter_model.lower() \
-                        if voice_mode == 2 else ""
-                    om = conn_config.llm.ollama_model.lower() \
-                        if voice_mode == 0 else ""
                     vision_model = ""
                     per_frame_mils = 0
-                    if voice_mode == 2:
-                        if "gpt-4o" in vm:
-                            vision_model = active_model
-                            per_frame_mils = 1200  # ~$0.012/frame
-                        elif "sonnet" in vm:
-                            vision_model = active_model
-                            per_frame_mils = 4500  # ~$0.045/frame
-                        elif "haiku" in vm:
-                            # Haiku 3.5 supports vision per OR
-                            vision_model = active_model
-                            per_frame_mils = 400
-                    elif voice_mode == 0:
-                        if "vision" in om or "llava" in om:
-                            vision_model = active_model
-                            per_frame_mils = 0  # local = free
+                    if (self._conversation
+                            and isinstance(
+                                self._conversation._llm,
+                                CapabilityAwareRouter,
+                            )):
+                        from dragon_voice.llm.base import Modality
+                        spec = self._conversation._llm.choose(
+                            {Modality.TEXT, Modality.VISION}, voice_mode,
+                        )
+                        if spec:
+                            vision_model = spec.model_id
+                            # Per-frame cost: cloud tier carries a known
+                            # rough rate; local tier is free.
+                            if spec.tier == "local":
+                                per_frame_mils = 0
+                            elif "gpt-4o" in spec.model_id:
+                                per_frame_mils = 1200
+                            elif "sonnet" in spec.model_id:
+                                per_frame_mils = 4500
+                            elif "haiku" in spec.model_id:
+                                per_frame_mils = 400
+                            elif "gemini" in spec.model_id:
+                                per_frame_mils = 200
+                    else:
+                        vm = conn_config.llm.openrouter_model.lower() \
+                            if voice_mode == 2 else ""
+                        om = conn_config.llm.ollama_model.lower() \
+                            if voice_mode == 0 else ""
+                        if voice_mode == 2:
+                            if "gpt-4o" in vm:
+                                vision_model = active_model
+                                per_frame_mils = 1200
+                            elif "sonnet" in vm:
+                                vision_model = active_model
+                                per_frame_mils = 4500
+                            elif "haiku" in vm:
+                                vision_model = active_model
+                                per_frame_mils = 400
+                        elif voice_mode == 0:
+                            if "vision" in om or "llava" in om:
+                                vision_model = active_model
+                                per_frame_mils = 0
                     await ws.send_json({
                         "type":           "vision_capability",
                         "can_see":        bool(vision_model),
@@ -2429,12 +2497,17 @@ class VoiceServer:
                 logger.exception("cap_downgrade alert failed")
 
     async def _handle_user_media(self, ws, conn_state, cmd):
-        """Handle image/audio uploaded by Tab5 for multimodal LLM analysis."""
-        import base64
+        """Handle image/audio uploaded by Tab5 for multimodal LLM analysis.
+
+        #183 PR 3: route through ConversationEngine instead of bypassing it.
+        The vision turn becomes a first-class conversation turn — it gets
+        memory injection, tool-calling, and (most importantly) the
+        multimodal user message is persisted so subsequent text turns can
+        still see the image (cross-modal continuity).
+        """
         media_id = cmd.get("media_id", "")
         text = cmd.get("text", "What's in this image?")
         session_id = conn_state.get("session_id", "")
-        conn_config = conn_state.get("config", self._config)
 
         image_path = await self._media_store.get_path(media_id)
         if not image_path:
@@ -2446,42 +2519,14 @@ class VoiceServer:
                 ))
             return
 
-        backend = conn_config.llm.backend
-        if backend == "ollama" and "vision" not in conn_config.llm.ollama_model:
-            if not ws.closed:
-                await ws.send_json(error_event(
-                    code="vision_unsupported",
-                    message="Image analysis needs Cloud or TinkerClaw mode.",
-                    severity=Severity.FATAL, scope=Scope.LLM,
-                ))
-            return
-
-        # Wave 13 H2: image may be up to ~8 MB (camera JPEG) -- reading on the
-        # event loop thread stalls every other WS connection. Offload the
-        # blocking read + base64 to the default executor.
-        def _read_and_encode(path: str) -> str:
-            with open(path, "rb") as f:
-                return base64.b64encode(f.read()).decode()
-        image_b64 = await asyncio.to_thread(_read_and_encode, image_path)
-
-        messages = [{
-            "role": "user",
-            "content": [
-                {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{image_b64}"}},
-                {"type": "text", "text": text},
-            ]
-        }]
-
-        # #75 phase 1b: reset per-turn tool tracker on this path too.
-        conn_state["tool_calls_this_turn"] = []
-
-        full_response = []
-        llm = conn_state.get("conversation")
-        if llm and hasattr(llm, '_llm'):
-            llm_backend = llm._llm
-        else:
-            llm_backend = None
-
+        # #183 PR 3: capability-driven vision check.  Replaces the old
+        # substring check on the model name.  Works uniformly for all
+        # backend types — single-backend setups query the active model's
+        # declared caps; router setups query the union of caps available
+        # in the current tier.
+        from dragon_voice.llm.base import Modality
+        conv = conn_state.get("conversation") or self._conversation
+        llm_backend = getattr(conv, "_llm", None) if conv else None
         if not llm_backend:
             if not ws.closed:
                 await ws.send_json(error_event(
@@ -2490,14 +2535,33 @@ class VoiceServer:
                     severity=Severity.FATAL, scope=Scope.LLM,
                 ))
             return
+        if Modality.VISION not in llm_backend.capabilities:
+            if not ws.closed:
+                await ws.send_json(error_event(
+                    code="vision_unsupported",
+                    message="Image analysis needs a vision-capable model.",
+                    severity=Severity.FATAL, scope=Scope.LLM,
+                ))
+            return
 
+        # #75 phase 1b: reset per-turn tool tracker on this path too.
+        conn_state["tool_calls_this_turn"] = []
+
+        # #183 PR 3: route through ConversationEngine.process_text_stream
+        # with media_id set — ConvEngine persists the multimodal user
+        # message via MessageStore (encoded with the multimodal marker)
+        # and on context build hydrates it back to an OpenAI image_url
+        # content array.  Tools, memory, and cross-modal continuity all
+        # work the same as text turns.
+        full_response = []
         try:
-            # #75 phase 1a: same PING-during-inference protection as the
-            # TC text path above — vision-upload LLM turns can run 30+ s
-            # on multimodal models, long enough for Tab5's PONG-watch to
-            # trip without the helper.
             async with self._ws_keepalive_during_inference(ws, label="vision"):
-                async for token in llm_backend.generate_stream_with_messages(messages):
+                async for token in conv.process_text_stream(
+                    session_id=session_id,
+                    text=text,
+                    input_mode="vision",
+                    media_id=media_id,
+                ):
                     full_response.append(token)
                     if not ws.closed:
                         await ws.send_json({"type": "llm", "text": token})
@@ -2535,16 +2599,9 @@ class VoiceServer:
         if not ws.closed:
             await ws.send_json({"type": "llm_done", "llm_ms": 0})
 
-        if full_response and self._message_store:
-            try:
-                await self._message_store.add_message(
-                    session_id=session_id,
-                    role="assistant",
-                    content="".join(full_response),
-                    input_mode="vision",
-                )
-            except Exception as e:
-                logger.warning("Failed to store vision response: %s", e)
+        # ConversationEngine already persisted the assistant response
+        # via process_text_stream (look for `add_message(role="assistant"
+        # ...)` in conversation.py).  No second persist needed here.
 
     async def _handle_disconnect(self, conn_state: dict) -> None:
         """Handle WebSocket disconnect: pause session, mark device offline."""

--- a/tests/test_multimodal_persistence.py
+++ b/tests/test_multimodal_persistence.py
@@ -1,0 +1,250 @@
+"""Multimodal message persistence + hydration (#183 PR 3).
+
+Covers:
+- `add_message(media_id=...)` encodes content with the multimodal marker
+- `get_context(media_store=...)` hydrates back to OpenAI multimodal arrays
+- Missing media file → `[image expired]` placeholder
+- No media_store given → text fallback (don't crash)
+- Plain text messages unaffected by hydration
+- ConversationEngine forwards media_id via process_text_stream
+- Router voice_mode hot-swap on config_update (router test, not server test)
+"""
+
+import asyncio
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+
+# Per-fixture temp DB path — the global TINKERCLAW_DB_PATH env var
+# is captured at import time by other test modules, so we pass an
+# explicit path to Database() rather than relying on the default.
+_TEST_DB_DIR = tempfile.mkdtemp()
+
+from dragon_voice.config import LLMConfig
+from dragon_voice.db import Database
+from dragon_voice.llm.base import Modality
+from dragon_voice.llm.router import CapabilityAwareRouter
+from dragon_voice.messages import (
+    MessageStore,
+    encode_multimodal_content,
+    is_multimodal_content,
+    _decode_multimodal_marker,
+    _hydrate_multimodal_content,
+)
+from dragon_voice.sessions import SessionManager
+
+
+# ── Fixtures ──────────────────────────────────────────────────────
+@pytest_asyncio.fixture
+async def db_session():
+    import time as _time
+    db_path = os.path.join(_TEST_DB_DIR, f"mm_{_time.monotonic_ns()}.db")
+    db = Database(db_path)
+    await db.initialize()
+    sm = SessionManager(db)
+    # Need a device first
+    await db.upsert_device(
+        device_id="testdev01", hardware_id="testdev01",
+        name="test", platform="test", firmware_ver="0",
+        capabilities={},
+    )
+    s = await sm.create_session(device_id="testdev01", session_type="conversation")
+    yield db, s["id"]
+    await db.close()
+
+
+class _FakeMediaStore:
+    """Just enough surface for _hydrate_multimodal_content."""
+    def __init__(self, files: dict[str, bytes]):
+        self._tmp = tempfile.mkdtemp()
+        self._paths: dict[str, str] = {}
+        for media_id, payload in files.items():
+            p = os.path.join(self._tmp, f"{media_id}.jpg")
+            with open(p, "wb") as f:
+                f.write(payload)
+            self._paths[media_id] = p
+
+    async def get_path(self, media_id: str):
+        return self._paths.get(media_id)
+
+
+# ── Marker round-trip ─────────────────────────────────────────────
+def test_encode_decode_roundtrip():
+    encoded = encode_multimodal_content("abc123", "describe this")
+    assert is_multimodal_content(encoded)
+    decoded = _decode_multimodal_marker(encoded)
+    assert decoded == {"media_id": "abc123", "text": "describe this"}
+
+
+def test_plain_text_not_multimodal():
+    assert not is_multimodal_content("hello world")
+    assert not is_multimodal_content('{"hello": "world"}')  # JSON without marker
+    assert _decode_multimodal_marker("hello world") is None
+
+
+# ── Hydration ─────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_hydrate_returns_string_for_plain_text():
+    out = await _hydrate_multimodal_content("just text", media_store=None)
+    assert out == "just text"
+
+
+@pytest.mark.asyncio
+async def test_hydrate_returns_placeholder_when_no_media_store():
+    encoded = encode_multimodal_content("abc", "describe")
+    out = await _hydrate_multimodal_content(encoded, media_store=None)
+    assert "[image attached: abc]" in out
+
+
+@pytest.mark.asyncio
+async def test_hydrate_returns_placeholder_when_file_missing():
+    encoded = encode_multimodal_content("missing-id", "describe")
+    media_store = _FakeMediaStore({})
+    out = await _hydrate_multimodal_content(encoded, media_store=media_store)
+    assert "[image expired]" in out
+
+
+@pytest.mark.asyncio
+async def test_hydrate_returns_openai_multimodal_array():
+    fake_jpeg = b"\xff\xd8\xff\xe0fake-jpeg-bytes"
+    media_store = _FakeMediaStore({"abc": fake_jpeg})
+    encoded = encode_multimodal_content("abc", "what is this?")
+    out = await _hydrate_multimodal_content(encoded, media_store=media_store)
+    assert isinstance(out, list)
+    assert len(out) == 2
+    assert out[0]["type"] == "image_url"
+    assert out[0]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+    assert out[1] == {"type": "text", "text": "what is this?"}
+
+
+# ── End-to-end: store + retrieve ──────────────────────────────────
+@pytest.mark.asyncio
+async def test_add_message_with_media_id_persists_marker(db_session):
+    db, session_id = db_session
+    store = MessageStore(db)
+    msg = await store.add_message(
+        session_id=session_id,
+        role="user",
+        content="describe this photo",
+        input_mode="text",
+        media_id="img-001",
+    )
+    assert is_multimodal_content(msg["content"])
+    decoded = _decode_multimodal_marker(msg["content"])
+    assert decoded["media_id"] == "img-001"
+    assert decoded["text"] == "describe this photo"
+
+
+@pytest.mark.asyncio
+async def test_get_context_hydrates_with_media_store(db_session):
+    db, session_id = db_session
+    store = MessageStore(db)
+    media_store = _FakeMediaStore({"img-001": b"\xff\xd8\xff\xe0fake"})
+
+    await store.add_message(session_id=session_id, role="user",
+                            content="describe", input_mode="text",
+                            media_id="img-001")
+    await store.add_message(session_id=session_id, role="assistant",
+                            content="It's a photo of a chair.")
+    await store.add_message(session_id=session_id, role="user",
+                            content="What color was it?")
+
+    context = await store.get_context(
+        session_id, max_messages=10, media_store=media_store
+    )
+    # System prompt + 3 messages
+    assert len(context) == 4
+    # First user msg should be hydrated to multimodal array
+    user_vision = context[1]
+    assert user_vision["role"] == "user"
+    assert isinstance(user_vision["content"], list)
+    assert user_vision["content"][0]["type"] == "image_url"
+    # Plain text turns stay as strings
+    assert isinstance(context[2]["content"], str)
+    assert isinstance(context[3]["content"], str)
+
+
+@pytest.mark.asyncio
+async def test_get_context_without_media_store_returns_placeholder(db_session):
+    """Backward compat: callers that don't pass media_store still get sensible output."""
+    db, session_id = db_session
+    store = MessageStore(db)
+    await store.add_message(session_id=session_id, role="user",
+                            content="describe", media_id="img-x")
+    context = await store.get_context(session_id, max_messages=10)
+    user_msg = context[1]
+    # Without media_store, hydrate returns the placeholder text
+    assert isinstance(user_msg["content"], str)
+    assert "[image attached" in user_msg["content"]
+
+
+# ── Router voice_mode hot-swap ────────────────────────────────────
+def _fleet():
+    return [
+        {"id": "ministral", "backend": "ollama", "model_id": "ministral-3:3b",
+         "caps": ["text"], "tier": "local", "priority": 0},
+        {"id": "minicpm_v4", "backend": "ollama",
+         "model_id": "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M",
+         "caps": ["text", "vision"], "tier": "local", "priority": 10},
+        {"id": "haiku", "backend": "openrouter",
+         "model_id": "anthropic/claude-3.5-haiku",
+         "caps": ["text", "vision"], "tier": "cloud", "priority": 5},
+    ]
+
+
+def test_router_set_voice_mode_changes_capabilities():
+    """capabilities is the union over the active tier."""
+    cfg = LLMConfig(backend="router", fleet=_fleet())
+    router = CapabilityAwareRouter(cfg)
+    # Local mode (default): minicpm_v4 supplies vision
+    assert Modality.VISION in router.capabilities
+    # Tinkerclaw mode: router not used → no caps
+    router.set_voice_mode(3)
+    assert router.capabilities == frozenset()
+    # Cloud mode: haiku supplies vision
+    router.set_voice_mode(2)
+    assert Modality.VISION in router.capabilities
+
+
+def test_ollama_translator_flat_text_passthrough():
+    from dragon_voice.llm.ollama_llm import _translate_to_ollama_format
+    msg = {"role": "user", "content": "hello"}
+    assert _translate_to_ollama_format(msg) == msg
+
+
+def test_ollama_translator_strips_data_uri_prefix():
+    from dragon_voice.llm.ollama_llm import _translate_to_ollama_format
+    msg = {"role": "user", "content": [
+        {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,RAWBYTES"}},
+        {"type": "text", "text": "describe"},
+    ]}
+    out = _translate_to_ollama_format(msg)
+    assert out["role"] == "user"
+    assert out["content"] == "describe"
+    assert out["images"] == ["RAWBYTES"]
+
+
+def test_ollama_translator_no_image_no_images_key():
+    from dragon_voice.llm.ollama_llm import _translate_to_ollama_format
+    msg = {"role": "user", "content": [
+        {"type": "text", "text": "no image"},
+    ]}
+    out = _translate_to_ollama_format(msg)
+    assert out == {"role": "user", "content": "no image"}
+    assert "images" not in out
+
+
+def test_router_summarize_per_modality():
+    cfg = LLMConfig(backend="router", fleet=_fleet())
+    router = CapabilityAwareRouter(cfg)
+    summary_local = router.summarize(voice_mode=0)
+    summary_cloud = router.summarize(voice_mode=2)
+    assert summary_local["vision"] == "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M"
+    assert summary_cloud["vision"] == "anthropic/claude-3.5-haiku"
+    # Audio is in neither tier of this fleet
+    assert summary_local.get("audio_in") is None
+    assert summary_cloud.get("audio_in") is None


### PR DESCRIPTION
## Summary
- **PR 3/3** of the multi-model router roadmap (#183).
- Wires the router from PRs 1+2 into the live server: capability-driven vision check, vision turns flow through ConversationEngine for cross-modal continuity, and Tab5 receives a per-modality `fleet_summary` on `session_start` + `config_update`.

## Architecture changes
| Site | Before | After |
|------|--------|-------|
| `_handle_user_media` vision check | Substring on `ollama_model` name | `Modality.VISION not in llm.capabilities` |
| `_handle_user_media` LLM call | Bypassed ConversationEngine | Routes through `process_text_stream(media_id=...)` |
| `_handle_config_update` LLM swap | Always recreate backend | Router → just `set_voice_mode()`; non-router unchanged |
| `session_start.config` / `config_update` ACK | No fleet info | `fleet_summary: {text, vision, video, audio_in, audio_out, tool_calling}` when router active |
| `vision_capability` chip advertise | Hardcoded substring on model id | Router-aware (`router.choose({TEXT, VISION}, voice_mode)`) with fallback to legacy heuristic |

## Cross-modal continuity
Vision turns now go through ConversationEngine instead of bypassing. The multimodal user message persists via `MessageStore.add_message(media_id=...)` — content is JSON-encoded with a marker, hydrated back to OpenAI `image_url` content array on context build. Subsequent text turns include the photo in context. Tools and memory injection now work on vision turns.

## Bug fixes surfaced during e2e
- **`infer_required_caps`** treated `<tool>` markers in the system prompt as a TOOL_CALLING requirement, gating vision turns from picking MiniCPM-V (which lacks tool training). Tool capability is now a bonus, not a gate.
- **`OllamaBackend.generate_stream_with_messages`** sent OpenAI multimodal `content: [...]` arrays to Ollama's `/api/chat`, which expects flat `content: str + images: [base64]`. New `_translate_to_ollama_format` does the conversion. Without this, router-fed vision turns failed with `json: cannot unmarshal array into Go struct field`.

## E2E verification on Dragon
Deployed router with fleet `[ministral, minicpm_v4, haiku_35, gemini_video]`:
\`\`\`
router: chose minicpm_v4 for [TEXT, VISION] tier=local      # lazy init
router: voice_mode set to 2 (no backend swap)               # hot-swap
router: chose haiku_35 for [TEXT, VISION] tier=cloud
\`\`\`
\`session_start.config.fleet_summary\` correctly returns per-modality picks. Production restored to single-backend (ollama/ministral) for safety; router opt-in via config.

## Tests
\`tests/test_multimodal_persistence.py\` — **14 assertions**: marker roundtrip, hydration with/without media_store, missing-file placeholder, end-to-end persist+retrieve, router voice_mode swap, summarize(), Ollama translator. Full suite: **542 passed (+14), 1 skipped, 0 regressions**.

## Schema note
User-message `input_mode` for vision turns stays as `"text"` (not `"vision"`) because the schema CHECK constraint allows only `('voice', 'text', 'system')`. The multimodal nature is captured in the marker-prefixed content. A DB migration could add `'vision'` if surface-area UX needs it.

## Known follow-ups
- MiniCPM-V on Dragon Q6A CPU is genuinely slow (~5 min/frame); OllamaBackend's 300s first-byte timeout caps it. Either bump the timeout for vision or run heavy multimodal off-Dragon (DGX/LM Studio LAN tier).
- claude-3.5-haiku via OpenRouter's Bedrock route doesn't support image input (Anthropic route does). Registry currently declares haiku vision-capable; needs tightening or router-side runtime fallback.

## Test plan
- [x] All new tests pass
- [x] Lint clean (ruff CI gate)
- [x] Full test suite passes (no regressions)
- [x] Deploy to Dragon — single-backend boots cleanly
- [x] Deploy to Dragon — router config boots cleanly with 4 models advertised
- [x] E2E vision turn (router picks MiniCPM-V correctly + sends to Ollama in right format)
- [x] E2E voice_mode switch (router hot-swaps without backend recreate)
- [x] Production restored to single-backend