### PR TITLE
feat(llm): refresh OpenRouter model registry to live 2026-04-27 catalog (refs #183)

### DIFF
--- a/dragon_voice/config.yaml
+++ b/dragon_voice/config.yaml
@@ -72,6 +72,49 @@ llm:
   dual_responder_backend: ""
   dual_responder_model: "ministral-3:3b"
 
+  # ── Multi-model router (#183) — opt-in by setting backend: "router" above ──
+  # Capability-aware fleet: each entry declares its modalities; router picks
+  # per-turn based on the message's required caps + the active voice_mode tier.
+  # See dragon_voice/llm/router.py for the routing rules.  Default empty list
+  # leaves single-backend dispatch unchanged.
+  #
+  # Recommended fleet (verified live against OpenRouter 2026-04-27).
+  # To enable: change `backend:` above to `"router"`, uncomment the block
+  # below, and ensure your daily spend cap (Tab5 NVS `cap_mils`) is sized
+  # for the cloud-tier traffic you expect.
+  fleet: []
+  # fleet:
+  #   # ── Local tier ──
+  #   - {id: ministral,    backend: ollama,     model_id: "ministral-3:3b",
+  #      caps: [text, tool_calling],          tier: local, priority: 0,  keep_alive_s: 600}
+  #   - {id: minicpm_v4,   backend: ollama,
+  #      model_id: "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M",
+  #      caps: [text, vision, video],         tier: local, priority: 10, keep_alive_s: 120}
+  #   # ── Cloud tier ──
+  #   # Cheap text + tools default — DeepSeek V4 Flash ($0.14/$0.28)
+  #   - {id: ds_v4_flash,  backend: openrouter, model_id: "deepseek/deepseek-v4-flash",
+  #      caps: [text, tool_calling],          tier: cloud, priority: 0}
+  #   # Cheap multimodal default — Qwen 3.6 Flash, 1M ctx ($0.25/$1.50)
+  #   - {id: qwen36_flash, backend: openrouter, model_id: "qwen/qwen3.6-flash",
+  #      caps: [text, vision, tool_calling],  tier: cloud, priority: 5}
+  #   # Native video — Gemini 3 Flash Preview ($0.50/$3.00)
+  #   - {id: gemini_flash, backend: openrouter, model_id: "google/gemini-3-flash-preview",
+  #      caps: [text, vision, video, audio_in, tool_calling],
+  #                                           tier: cloud, priority: 8}
+  #   # Quality vision + tool chains — Sonnet 4.6 ($3/$15)
+  #   - {id: sonnet_46,    backend: openrouter, model_id: "anthropic/claude-sonnet-4.6",
+  #      caps: [text, vision, tool_calling],  tier: cloud, priority: 12}
+  #   # Native multimodal frontier — Gemini 3.1 Pro Preview ($2/$12)
+  #   - {id: gemini_pro,   backend: openrouter, model_id: "google/gemini-3.1-pro-preview",
+  #      caps: [text, vision, video, audio_in, tool_calling],
+  #                                           tier: cloud, priority: 18}
+  #   # Top-tier agentic — Opus 4.7 ($5/$25)
+  #   - {id: opus_47,      backend: openrouter, model_id: "anthropic/claude-opus-4.7",
+  #      caps: [text, vision, tool_calling],  tier: cloud, priority: 25}
+  #   # Frontier — GPT-5.5 ($5/$30)
+  #   - {id: gpt_55,       backend: openrouter, model_id: "openai/gpt-5.5",
+  #      caps: [text, vision, tool_calling],  tier: cloud, priority: 30}
+
   system_prompt: "You are Tinker, a helpful AI assistant. Reply in 1-2 sentences maximum. Be concise. Never simulate user responses. Never generate text after your answer. Stop immediately after answering."
   max_tokens: 256
   temperature: 0.7

--- a/dragon_voice/llm/openrouter_llm.py
+++ b/dragon_voice/llm/openrouter_llm.py
@@ -366,25 +366,68 @@ class OpenRouterBackend(LLMBackend):
 # token_count / 1_000_000 gives cost in mils.  Display side (Tab5) divides
 # by 1000 for cents or 100000 for dollars.
 #
-# Prices match OpenRouter's listed rates as of April 2026.  Update in one
-# place when they change.  Unknown models fall through to a conservative
-# default so a pricing surprise never zeroes out the receipt.
+# Prices match OpenRouter's listed rates as of 2026-04-27 (verified via
+# the live /api/v1/models endpoint).  Update in one place when they
+# change.  Unknown models fall through to a conservative default so a
+# pricing surprise never zeroes out the receipt.
 _PRICING_MILS_PER_M = {
-    # OpenAI
-    "openai/gpt-4o":             {"in":   2500000, "out":  10000000},
-    "openai/gpt-4o-mini":        {"in":    150000, "out":    600000},
-    "openai/gpt-audio-mini":     {"in":    300000, "out":   1200000},
-    # Anthropic
+    # ── OpenAI ─────────────────────────────────────────────────────
+    "openai/gpt-4o":              {"in":  2500000, "out":  10000000},
+    "openai/gpt-4o-mini":         {"in":   150000, "out":    600000},
+    "openai/gpt-audio-mini":      {"in":   300000, "out":   1200000},
+    "openai/gpt-5.5":             {"in":  5000000, "out":  30000000},  # Apr 24
+    "openai/gpt-5.5-pro":         {"in": 30000000, "out": 180000000},
+    "openai/gpt-5.4":             {"in":  2500000, "out":  15000000},
+    "openai/gpt-5.4-mini":        {"in":   750000, "out":   4500000},
+    "openai/gpt-5.4-nano":        {"in":   200000, "out":   1250000},
+    # ── Anthropic ──────────────────────────────────────────────────
     "anthropic/claude-sonnet-4-20250514": {"in": 3000000, "out": 15000000},
-    "anthropic/claude-3-haiku":  {"in":    250000, "out":   1250000},
-    "anthropic/claude-3.5-haiku":{"in":    800000, "out":   4000000},
-    # Google / Gemini Flash family (2026-04-20 OpenRouter listing)
-    "google/gemini-3-flash-preview":   {"in":  500000, "out": 3000000},
-    "google/gemini-2.5-flash":         {"in":  300000, "out": 2500000},
-    "google/gemini-2.5-flash-lite":    {"in":  100000, "out":  400000},
-    "google/gemini-2.0-flash-001":     {"in":  100000, "out":  400000},
+    "anthropic/claude-3-haiku":   {"in":   250000, "out":   1250000},
+    "anthropic/claude-3.5-haiku": {"in":   800000, "out":   4000000},
+    "anthropic/claude-haiku-4.5": {"in":  1000000, "out":   5000000},  # Oct 15
+    "anthropic/claude-sonnet-4.5":{"in":  3000000, "out":  15000000},  # Sep 29
+    "anthropic/claude-sonnet-4.6":{"in":  3000000, "out":  15000000},  # Feb 17
+    "anthropic/claude-opus-4.5":  {"in":  5000000, "out":  25000000},
+    "anthropic/claude-opus-4.6":  {"in":  5000000, "out":  25000000},
+    "anthropic/claude-opus-4.7":  {"in":  5000000, "out":  25000000},  # Apr 16
+    # ── Google ─────────────────────────────────────────────────────
+    "google/gemini-3-flash-preview":      {"in":  500000, "out":  3000000},  # Dec 17
+    "google/gemini-3.1-pro-preview":      {"in": 2000000, "out": 12000000},  # Feb 19
+    "google/gemini-3.1-flash-lite-preview":{"in": 250000, "out":  1500000},
+    "google/gemini-2.5-flash":            {"in":  300000, "out":  2500000},
+    "google/gemini-2.5-flash-lite":       {"in":  100000, "out":   400000},
+    "google/gemini-2.0-flash-001":        {"in":  100000, "out":   400000},
+    "google/gemma-4-26b-a4b-it":          {"in":   60000, "out":   330000},  # Apr 3
+    "google/gemma-4-31b-it":              {"in":  130000, "out":   380000},  # Apr 2
+    # ── DeepSeek ───────────────────────────────────────────────────
+    "deepseek/deepseek-v3.2":     {"in":   250000, "out":    380000},
+    "deepseek/deepseek-v4-flash": {"in":   140000, "out":    280000},  # Apr 24
+    "deepseek/deepseek-v4-pro":   {"in":   430000, "out":    870000},  # Apr 24
+    "deepseek/deepseek-r1":       {"in":   700000, "out":   2500000},
+    # ── Qwen 3.5 / 3.6 family ──────────────────────────────────────
+    "qwen/qwen3.6-flash":         {"in":   250000, "out":  1500000},  # Apr 27 (released today)
+    "qwen/qwen3.6-27b":           {"in":   500000, "out":  2000000},
+    "qwen/qwen3.6-35b-a3b":       {"in":   160000, "out":   970000},
+    "qwen/qwen3.6-max-preview":   {"in":  1300000, "out":  7800000},
+    "qwen/qwen3.6-plus":          {"in":   330000, "out":  1950000},
+    "qwen/qwen3.5-plus-20260420": {"in":   400000, "out":  2400000},
+    "qwen/qwen3.5-flash-02-23":   {"in":    70000, "out":   260000},
+    # ── Moonshot / Kimi ────────────────────────────────────────────
+    "moonshotai/kimi-k2.6":       {"in":   740000, "out":  4660000},  # Apr 20
+    "moonshotai/kimi-k2.5":       {"in":   440000, "out":  2000000},
+    # ── x-AI Grok ──────────────────────────────────────────────────
+    "x-ai/grok-4.20":             {"in":  2000000, "out":  6000000},
+    "x-ai/grok-4.20-multi-agent": {"in":  2000000, "out":  6000000},
+    "x-ai/grok-4.1-fast":         {"in":   200000, "out":   500000},
+    # ── Z.ai GLM ───────────────────────────────────────────────────
+    "z-ai/glm-5.1":               {"in":  1050000, "out":  3500000},
+    "z-ai/glm-5v-turbo":          {"in":  1200000, "out":  4000000},
+    "z-ai/glm-4.7-flash":         {"in":    60000, "out":   400000},
+    # ── Xiaomi MiMo ────────────────────────────────────────────────
+    "xiaomi/mimo-v2.5":           {"in":   400000, "out":  2000000},
+    "xiaomi/mimo-v2.5-pro":       {"in":  1000000, "out":  3000000},
     # Fallback for anything unknown -- $2/$8 per M tokens, slightly high on purpose
-    "_default":                  {"in":   2000000, "out":   8000000},
+    "_default":                   {"in":  2000000, "out":  8000000},
 }
 
 
@@ -425,19 +468,65 @@ def price_for_model(model: str, prompt_tokens: int, completion_tokens: int) -> i
 # completions API supports tools across the board; vision/video/audio
 # are explicit per-model and must be opted in.
 _OPENROUTER_CAPS: dict[str, frozenset[Modality]] = {
-    # Anthropic (vision + tools across the line)
-    "anthropic/claude-3-haiku":   frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
-    "anthropic/claude-3.5-haiku": frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    # ── Anthropic ────────────────────────────────────────────────
+    # Note: claude-3.5-haiku is technically vision-capable per the
+    # Anthropic route, but OR's Bedrock route rejects images.  Until
+    # OR adds a way to pin the route, we conservatively declare it
+    # text-only so the router doesn't pick it for vision turns.
+    "anthropic/claude-3.5-haiku":         frozenset({Modality.TEXT, Modality.TOOL_CALLING}),
+    "anthropic/claude-3-haiku":           frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "anthropic/claude-haiku-4.5":         frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),  # Oct 15
     "anthropic/claude-sonnet-4-20250514": frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
-    # OpenAI
-    "openai/gpt-4o":              frozenset({Modality.TEXT, Modality.VISION, Modality.AUDIO_IN, Modality.AUDIO_OUT, Modality.TOOL_CALLING}),
-    "openai/gpt-4o-mini":         frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
-    "openai/gpt-audio-mini":      frozenset({Modality.TEXT, Modality.AUDIO_IN, Modality.AUDIO_OUT}),
-    # Google Gemini Flash family — vision + native video, full tools
-    "google/gemini-3-flash-preview": frozenset({Modality.TEXT, Modality.VISION, Modality.VIDEO, Modality.AUDIO_IN, Modality.TOOL_CALLING}),
-    "google/gemini-2.5-flash":       frozenset({Modality.TEXT, Modality.VISION, Modality.VIDEO, Modality.AUDIO_IN, Modality.TOOL_CALLING}),
-    "google/gemini-2.5-flash-lite":  frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
-    "google/gemini-2.0-flash-001":   frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "anthropic/claude-sonnet-4.5":        frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),  # Sep 29
+    "anthropic/claude-sonnet-4.6":        frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),  # Feb 17
+    "anthropic/claude-opus-4.5":          frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "anthropic/claude-opus-4.6":          frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "anthropic/claude-opus-4.7":          frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),  # Apr 16
+    # ── OpenAI ───────────────────────────────────────────────────
+    "openai/gpt-4o":                      frozenset({Modality.TEXT, Modality.VISION, Modality.AUDIO_IN, Modality.AUDIO_OUT, Modality.TOOL_CALLING}),
+    "openai/gpt-4o-mini":                 frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "openai/gpt-audio-mini":              frozenset({Modality.TEXT, Modality.AUDIO_IN, Modality.AUDIO_OUT}),
+    "openai/gpt-5.4":                     frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "openai/gpt-5.4-mini":                frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "openai/gpt-5.4-nano":                frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "openai/gpt-5.5":                     frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),  # Apr 24
+    "openai/gpt-5.5-pro":                 frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    # ── Google Gemini family — native video + audio_in on 3.x ──
+    "google/gemini-3-flash-preview":      frozenset({Modality.TEXT, Modality.VISION, Modality.VIDEO, Modality.AUDIO_IN, Modality.TOOL_CALLING}),
+    "google/gemini-3.1-pro-preview":      frozenset({Modality.TEXT, Modality.VISION, Modality.VIDEO, Modality.AUDIO_IN, Modality.TOOL_CALLING}),
+    "google/gemini-3.1-flash-lite-preview": frozenset({Modality.TEXT, Modality.VISION, Modality.VIDEO, Modality.AUDIO_IN, Modality.TOOL_CALLING}),
+    "google/gemini-2.5-flash":            frozenset({Modality.TEXT, Modality.VISION, Modality.VIDEO, Modality.AUDIO_IN, Modality.TOOL_CALLING}),
+    "google/gemini-2.5-flash-lite":       frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "google/gemini-2.0-flash-001":        frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    # Gemma open-weights (vision capable since Gemma 3)
+    "google/gemma-4-26b-a4b-it":          frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "google/gemma-4-31b-it":              frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    # ── DeepSeek (text-only across the line) ────────────────────
+    "deepseek/deepseek-v3.2":             frozenset({Modality.TEXT, Modality.TOOL_CALLING}),
+    "deepseek/deepseek-v4-flash":         frozenset({Modality.TEXT, Modality.TOOL_CALLING}),  # Apr 24
+    "deepseek/deepseek-v4-pro":           frozenset({Modality.TEXT, Modality.TOOL_CALLING}),  # Apr 24
+    "deepseek/deepseek-r1":               frozenset({Modality.TEXT, Modality.TOOL_CALLING}),
+    # ── Qwen 3.5 / 3.6 — multimodal across most of the line ────
+    "qwen/qwen3.6-flash":                 frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),  # Apr 27
+    "qwen/qwen3.6-27b":                   frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "qwen/qwen3.6-35b-a3b":               frozenset({Modality.TEXT, Modality.VISION}),  # vision but no tools per OR meta
+    "qwen/qwen3.6-max-preview":           frozenset({Modality.TEXT, Modality.TOOL_CALLING}),  # text+tools, no vision per OR meta
+    "qwen/qwen3.6-plus":                  frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "qwen/qwen3.5-plus-20260420":         frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "qwen/qwen3.5-flash-02-23":           frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    # ── Moonshot Kimi ───────────────────────────────────────────
+    "moonshotai/kimi-k2.6":               frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "moonshotai/kimi-k2.5":               frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    # ── x-AI Grok ───────────────────────────────────────────────
+    "x-ai/grok-4.20":                     frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "x-ai/grok-4.1-fast":                 frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    # ── Z.ai GLM ────────────────────────────────────────────────
+    "z-ai/glm-5.1":                       frozenset({Modality.TEXT, Modality.TOOL_CALLING}),
+    "z-ai/glm-5v-turbo":                  frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "z-ai/glm-4.7-flash":                 frozenset({Modality.TEXT, Modality.TOOL_CALLING}),
+    # ── Xiaomi MiMo ─────────────────────────────────────────────
+    "xiaomi/mimo-v2.5":                   frozenset({Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING}),
+    "xiaomi/mimo-v2.5-pro":               frozenset({Modality.TEXT, Modality.TOOL_CALLING}),
 }
 
 _OPENROUTER_DEFAULT_CAPS = frozenset({Modality.TEXT, Modality.TOOL_CALLING})

--- a/tests/test_capability_declaration.py
+++ b/tests/test_capability_declaration.py
@@ -70,8 +70,11 @@ def _or_caps(model: str) -> frozenset[Modality]:
     return OpenRouterBackend(cfg).capabilities
 
 
-def test_openrouter_haiku_has_vision_and_tools():
-    caps = _or_caps("anthropic/claude-3.5-haiku")
+def test_openrouter_haiku_3_has_vision_and_tools():
+    """Haiku 3.0 (older route) actually serves images cleanly.
+    See test_openrouter_haiku_35_is_text_only_due_to_bedrock_route below
+    for why 3.5 is treated text-only."""
+    caps = _or_caps("anthropic/claude-3-haiku")
     assert {Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING} <= caps
 
 
@@ -95,6 +98,88 @@ def test_openrouter_unknown_falls_back_to_text_and_tools():
 def test_openrouter_empty_model_id_falls_back():
     caps = _openrouter_capabilities("")
     assert caps == frozenset({Modality.TEXT, Modality.TOOL_CALLING})
+
+
+# ── 2026-04-27 fleet (verified live) ──────────────────────────────
+def test_openrouter_haiku_35_is_text_only_due_to_bedrock_route():
+    """Haiku 3.5 via OR's Bedrock route rejects images — declare text-only."""
+    caps = _or_caps("anthropic/claude-3.5-haiku")
+    assert Modality.VISION not in caps
+    assert Modality.TEXT in caps
+    assert Modality.TOOL_CALLING in caps
+
+
+def test_openrouter_sonnet_46_has_vision_and_tools():
+    caps = _or_caps("anthropic/claude-sonnet-4.6")
+    assert {Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING} <= caps
+
+
+def test_openrouter_haiku_45_has_vision():
+    caps = _or_caps("anthropic/claude-haiku-4.5")
+    assert Modality.VISION in caps
+
+
+def test_openrouter_opus_47_has_vision():
+    caps = _or_caps("anthropic/claude-opus-4.7")
+    assert Modality.VISION in caps
+
+
+def test_openrouter_gpt_55_has_vision():
+    caps = _or_caps("openai/gpt-5.5")
+    assert {Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING} <= caps
+
+
+def test_openrouter_gemini_3_flash_preview_has_video_and_audio():
+    caps = _or_caps("google/gemini-3-flash-preview")
+    assert {Modality.VISION, Modality.VIDEO, Modality.AUDIO_IN} <= caps
+
+
+def test_openrouter_gemini_31_pro_preview_has_video():
+    caps = _or_caps("google/gemini-3.1-pro-preview")
+    assert Modality.VIDEO in caps
+
+
+def test_openrouter_deepseek_v4_pro_text_only():
+    """DeepSeek V4 line is text-only across the board (no vision support)."""
+    caps = _or_caps("deepseek/deepseek-v4-pro")
+    assert Modality.VISION not in caps
+    assert Modality.TEXT in caps
+
+
+def test_openrouter_deepseek_v4_flash_text_only():
+    caps = _or_caps("deepseek/deepseek-v4-flash")
+    assert Modality.VISION not in caps
+
+
+def test_openrouter_qwen_36_flash_has_vision():
+    """Qwen 3.6 Flash (released 2026-04-27) — multimodal sleeper pick."""
+    caps = _or_caps("qwen/qwen3.6-flash")
+    assert {Modality.TEXT, Modality.VISION, Modality.TOOL_CALLING} <= caps
+
+
+def test_openrouter_kimi_k26_has_vision():
+    caps = _or_caps("moonshotai/kimi-k2.6")
+    assert Modality.VISION in caps
+
+
+def test_openrouter_grok_420_has_vision():
+    caps = _or_caps("x-ai/grok-4.20")
+    assert Modality.VISION in caps
+
+
+# ── Pricing registry (verified live 2026-04-27) ──────────────────
+def test_pricing_registry_has_all_caps_models():
+    """Every model in _OPENROUTER_CAPS should also be in pricing.
+
+    Catches the silent-undercount bug where adding a cap entry without
+    a matching pricing entry falls through to `_default` rates and
+    misreports daily spend.
+    """
+    from dragon_voice.llm.openrouter_llm import (
+        _OPENROUTER_CAPS, _PRICING_MILS_PER_M,
+    )
+    missing = [m for m in _OPENROUTER_CAPS if m not in _PRICING_MILS_PER_M]
+    assert not missing, f"Models in caps but missing pricing: {missing}"
 
 
 # ── LM Studio ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Pulled the live OpenRouter \`/api/v1/models\` endpoint and synced both \`_OPENROUTER_CAPS\` and \`_PRICING_MILS_PER_M\` to current reality. Yesterday's PR #186 cited some stale models (sonnet-4.5 vs the newer 4.6, gpt-5.4 vs gpt-5.5 from Apr 24) and missed the brand-new Qwen 3.6 family that dropped today.

## What's now in the registry
- **Anthropic:** sonnet-4.5/4.6, haiku-4.5, opus-4.5/4.6/4.7. **claude-3.5-haiku downgraded to text-only** because OR's Bedrock route rejects images.
- **OpenAI:** gpt-5.5, gpt-5.5-pro (Apr 24), gpt-5.4 family
- **Google:** gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.1-flash-lite, gemma-4 (vision + native video where applicable)
- **DeepSeek:** v4-flash, v4-pro, v3.2, r1 (all text-only)
- **Qwen 3.6 family:** flash, 27b, plus, max-preview, 35b-a3b (released today)
- **Moonshot Kimi K2.6, x-AI Grok 4.20, Z-ai GLM 5.x, Xiaomi MiMo 2.5**

## Why this matters
1. **Vision actually works** — old code declared Haiku 3.5 vision-capable, but OR's Bedrock route rejects images (bug surfaced in PR #186 e2e logs). Router now correctly skips it for vision turns.
2. **Spend tracking is accurate** — every registered model has a matching pricing entry. New test guards against future drift between caps and pricing tables.
3. **Cheaper defaults available** — DeepSeek V4 Flash ($0.14/$0.28) replaces Haiku 3.5 ($0.80/$4) as the cheap text+tools pick. Qwen 3.6 Flash ($0.25/$1.50, 1M ctx) is the new cheap multimodal default.

## Updated example fleet
Commented-out fleet in \`config.yaml\` updated to use the corrected models. Opt-in via \`backend: \"router\"\`.

## Tests
13 new assertions in \`test_capability_declaration.py\` covering the fresh model IDs + a registry-completeness check (every cap entry must have a pricing entry).

Full suite: **555 passed (+13), 1 skipped, 0 regressions**.

## Production verification
Deployed to Dragon, restarted \`tinkerclaw-voice\`, service boots cleanly with the expanded registry. No production behavior change — fleet remains opt-in.

## Test plan
- [x] All new tests pass
- [x] Lint clean
- [x] Full test suite passes
- [x] Service restart on Dragon
- [x] Pricing table covers every cap entry (registry completeness test)