### PR TITLE
docs: cover the multi-model router + 2026-04 OpenRouter catalog refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ A file is too big when it has more than one *reason to change*.  Before extracti
 - **SSH:** `ssh radxa@192.168.1.91  # password in ~/.ssh/config or use key auth`
 - **OS:** Ubuntu (Dragon Q6A — Qualcomm QCS6490, ARM64)
 - **Connection:** Ethernet only (WiFi disabled). Static IP on enp1s0.
-- **Services stripped:** gdm3, snapd, ollama, nanobot masked. Only tinkerclaw-voice, tinkerclaw-dashboard, tinkerclaw-ngrok run.
+- **Services stripped:** gdm3, snapd, nanobot, rustdesk, fwupd masked.  Active services: tinkerclaw-voice, tinkerclaw-dashboard, tinkerclaw-ngrok, **ollama** (active for embeddings + Local-mode LLM inference; was previously masked but unmasked when the multi-model router landed in #185).
 
 ## Service Map
 | Service | Port | SystemD Unit | Description |
@@ -129,12 +129,136 @@ Tab5 sends `{"type":"config_update","voice_mode":0|1|2|3,"llm_model":"..."}`. Dr
 - **Auto-Fallback:** If cloud STT/TTS fails (timeout, API error), pipeline auto-falls back to local (Moonshine/Piper) for that request AND sends `config_update` with `error` field to Tab5 → auto-reverts to Local mode.
 - **Backward compat:** Old `cloud_mode` boolean still accepted (maps to voice_mode 0 or 2).
 - **Config fields:** `LLMConfig.local_backend` (remembers original for fallback), `LLMConfig.openrouter_model` (user-selectable).
-- **Valid backends:** STT: `moonshine`, `whisper_cpp`, `vosk`, `openrouter`. TTS: `piper`, `kokoro`, `edge_tts`, `openrouter`. LLM: `ollama`, `npu_genie`, `openrouter`, `lmstudio`, `tinkerclaw`.
+- **Valid backends:** STT: `moonshine`, `whisper_cpp`, `vosk`, `openrouter`. TTS: `piper`, `kokoro`, `edge_tts`, `openrouter`. LLM: `ollama`, `npu_genie`, `openrouter`, `lmstudio`, `tinkerclaw`, `dual`, `router` (#183).
 - **Mode-aware system prompts:** Each voice mode sets a different system prompt length — Local (concise, 128 tokens), Hybrid (medium, 256 tokens), Cloud (rich, 512 tokens). This keeps local model context tight while giving cloud models room for nuanced instructions.
 - **Mode-aware pipeline timeouts:** Local mode = 300s (5 min) for tool-calling chains on slow local models. Cloud mode = 60s (1 min). TinkerClaw mode = 180s (3 min, tool execution gaps). Timeouts configured per voice mode in pipeline.py.
 - **Session system_prompt updated on mode switch:** When voice_mode changes, the session's `system_prompt` is updated in the DB immediately so the conversation engine picks it up on the next turn.
 - **Pipeline init resets to local defaults on reconnect:** When a device reconnects, the pipeline is re-initialized with local defaults (voice_mode 0) regardless of the previous session's mode. The client must re-send `config_update` to restore cloud mode.
 - **Per-connection config (deep copy):** Each WebSocket connection gets a deep copy of the global config via `copy.deepcopy()`. This prevents one device's config_update (e.g., switching to cloud mode) from corrupting another device's pipeline config. Without deep copy, two Tab5s connected simultaneously would share the same mutable config object.
+
+## Multi-Model Router (#183, April 2026)
+
+**The single voice-mode-picks-one-backend assumption is gone.** Dragon now supports a *fleet* of LLM backends declared in `LLMConfig.fleet`, with a `CapabilityAwareRouter` that picks per-turn based on the modalities present in the message and the active voice_mode tier.
+
+The router is opt-in: keep `backend: "ollama"` (or any single backend) and behavior is identical to today. Set `backend: "router"` and populate `fleet` to activate.
+
+### Capability declarations
+Every `LLMBackend` subclass declares a frozenset of `Modality` values via the `capabilities` property.  See `dragon_voice/llm/base.py`.
+
+| Modality | Used when |
+|----------|-----------|
+| `TEXT` | Always required |
+| `VISION` | Message content has `{"type":"image_url"}` |
+| `VIDEO` | Message content has `{"type":"video_url"}` |
+| `AUDIO_IN` | Message content has `{"type":"input_audio"}` |
+| `AUDIO_OUT` | Backend can emit audio responses |
+| `TOOL_CALLING` | Backend trained for function-calling (informational; *not* a router gate) |
+
+Per-backend declaration logic:
+- **ollama** — substring scan of model id (vision: `llava`, `minicpm-v`, `minicpm-o`, `moondream`, `qwen2-vl`, `pixtral`, `internvl`; audio: `minicpm-o`; tools: known FC families).
+- **openrouter** — static registry in `_OPENROUTER_CAPS` (`openrouter_llm.py`). 35 models tracked as of 2026-04-27 (see PR #187). Unknown models default to `{TEXT, TOOL_CALLING}`.
+- **lmstudio** — same name-substring heuristic as ollama (LM Studio serves arbitrary GGUFs).
+- **npu_genie** — text-only (QAIRT has no vision support).
+- **tinkerclaw** — TEXT+TOOL_CALLING + VISION when gateway model is `anthropic/`, `openai/gpt-4o`, `google/gemini`, `minimax/`.
+- **dual** — forwards to responder's caps (responder is the backend whose tokens reach the user).
+
+### Tier policy from voice_mode
+```
+TIER_FOR_MODE = {
+    0: {"local"},          # Local
+    1: {"local"},          # Hybrid (LLM stays local; STT/TTS go cloud — unchanged)
+    2: {"cloud", "lan"},   # Full Cloud (LAN tier eligible — e.g., LM Studio on workstation)
+    3: None,               # TinkerClaw — bypass router, gateway picks
+}
+```
+
+### Routing rule
+```python
+def choose(required_caps, voice_mode):
+    tier_filter = TIER_FOR_MODE[voice_mode]
+    if tier_filter is None:
+        return None  # tinkerclaw mode — router not used
+    candidates = [m for m in fleet
+                  if required_caps <= m.capabilities
+                  and m.tier in tier_filter]
+    return min(candidates, key=lambda m: m.priority) if candidates else None
+```
+
+Lowest priority wins. `infer_required_caps(messages)` walks OpenAI-format content arrays — image_url → +VISION, video_url → +VIDEO, input_audio → +AUDIO_IN. TOOL_CALLING is intentionally NOT inferred (would gate vision turns from picking MiniCPM-V which lacks tools); tool detection happens at runtime when the model emits a tool marker.
+
+### Fleet config example
+Drop into `dragon_voice/config.yaml`. Verified live against OpenRouter 2026-04-27.
+
+```yaml
+llm:
+  backend: "router"
+  fleet:
+    # ── Local tier ──
+    - {id: ministral,    backend: ollama,     model_id: "ministral-3:3b",
+       caps: [text, tool_calling],          tier: local, priority: 0,  keep_alive_s: 600}
+    - {id: minicpm_v4,   backend: ollama,
+       model_id: "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M",
+       caps: [text, vision, video],         tier: local, priority: 10, keep_alive_s: 120}
+    # ── Cloud tier ──
+    - {id: ds_v4_flash,  backend: openrouter, model_id: "deepseek/deepseek-v4-flash",
+       caps: [text, tool_calling],          tier: cloud, priority: 0}      # cheapest text+tools
+    - {id: qwen36_flash, backend: openrouter, model_id: "qwen/qwen3.6-flash",
+       caps: [text, vision, tool_calling],  tier: cloud, priority: 5}      # cheapest multimodal
+    - {id: gemini_flash, backend: openrouter, model_id: "google/gemini-3-flash-preview",
+       caps: [text, vision, video, audio_in, tool_calling],
+                                            tier: cloud, priority: 8}      # native video
+    - {id: sonnet_46,    backend: openrouter, model_id: "anthropic/claude-sonnet-4.6",
+       caps: [text, vision, tool_calling],  tier: cloud, priority: 12}     # quality vision
+    - {id: gemini_pro,   backend: openrouter, model_id: "google/gemini-3.1-pro-preview",
+       caps: [text, vision, video, audio_in, tool_calling],
+                                            tier: cloud, priority: 18}     # frontier multimodal
+    - {id: opus_47,      backend: openrouter, model_id: "anthropic/claude-opus-4.7",
+       caps: [text, vision, tool_calling],  tier: cloud, priority: 25}     # premium agentic
+    - {id: gpt_55,       backend: openrouter, model_id: "openai/gpt-5.5",
+       caps: [text, vision, tool_calling],  tier: cloud, priority: 30}     # frontier
+```
+
+### How the router behaves
+- **Local mode, text turn:** picks `ministral` (priority 0).
+- **Local mode, vision turn (photo):** picks `minicpm_v4` (only local-tier vision-capable).
+- **Cloud mode, text turn:** picks `ds_v4_flash` ($0.14/$0.28 per M, 7× cheaper than Sonnet for plain chat).
+- **Cloud mode, vision turn:** picks `qwen36_flash` ($0.25/$1.50, 1M context).
+- **Cloud mode, video turn (.MJP from Tab5):** picks `gemini_flash` (only cloud-tier with VIDEO at priority ≤ 18).
+- **Voice-mode swap (e.g. Local → Cloud):** router calls `set_voice_mode(2)` — no backend recreate, instantiated sub-backends survive the switch.
+
+### `fleet_summary` in protocol
+When the router is active, `session_start.config` and `config_update` ACK include a per-modality summary so Tab5 can light up vision/video/audio capability chips dynamically:
+```json
+{
+  "type": "session_start",
+  "config": {
+    ...,
+    "fleet_summary": {
+      "text":     "ministral-3:3b",
+      "vision":   "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M",
+      "video":    "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M",
+      "audio_in": null,
+      "audio_out": null,
+      "tool_calling": "ministral-3:3b"
+    }
+  }
+}
+```
+Tab5 firmware can ignore `fleet_summary` (legacy `vision_capability` event keeps firing for backward compat).
+
+### Cross-modal continuity
+`_handle_user_media` no longer bypasses ConversationEngine. Multimodal user messages persist via `MessageStore.add_message(media_id=...)` with a `__mm__:` JSON marker. `get_context(media_store=...)` hydrates them back to OpenAI `image_url` content arrays on context build. **Result: send a photo, then ask "what color was the chair?" — the text follow-up turn still sees the photo.**
+
+`OllamaBackend.generate_stream_with_messages` translates OpenAI-format multimodal content arrays to Ollama's flat `content + images` format. Without this, router-fed vision turns failed with `json: cannot unmarshal array into Go struct field`.
+
+### Files
+- `dragon_voice/llm/router.py` — `CapabilityAwareRouter`, `ModelSpec`, `TIER_FOR_MODE`, `infer_required_caps()`, `summarize()`
+- `dragon_voice/llm/base.py` — `Modality` enum + `LLMBackend.capabilities` default
+- `dragon_voice/llm/openrouter_llm.py` — `_OPENROUTER_CAPS` + `_PRICING_MILS_PER_M` registries (35 models, last sync 2026-04-27)
+- `dragon_voice/messages.py` — multimodal marker encode/decode
+- `tests/test_router_routing.py` — 29 routing-rule assertions
+- `tests/test_capability_declaration.py` — 31 per-backend cap assertions
+- `tests/test_multimodal_persistence.py` — 14 marker + hydration tests
 
 ## TinkerClaw Integration (Optional Sidecar)
 
@@ -161,6 +285,22 @@ Dragon renders rich content (code blocks, markdown tables, image URLs) from LLM 
 - **Protocol messages (Tab5 → Dragon):** `user_media` (camera photo for multimodal LLM). See `docs/protocol.md`.
 - **Dependencies:** Pillow (existing), Pygments>=2.17.0 (new — syntax highlighting). System font `fonts-dejavu-core` required on Dragon for Pygments.
 - **Both code paths:** Media detection runs in both ConvEngine and TinkerClaw (voice_mode 3) paths, inside the WS voice handler in `dragon_voice/server.py`. The TinkerClaw path has an early `return` — media detection is placed before it.
+
+## Video Relay + Web Call Client (April 2026)
+
+Tab5 ↔ Dragon ↔ (Tab5 or web) two-way video + audio calls. Dragon is a dumb fan-out relay — no transcoding.
+
+- **Module:** `dragon_voice/video_upstream.py` — receives `VID0`-tagged binary frames from one connected Tab5 and **broadcasts verbatim to all OTHER connected clients**. Same fan-out applies to `AUD0`-tagged frames in the call audio path. No re-encode, no buffering beyond the WS write queue.
+- **Wire format (see `docs/protocol.md` §18):** `"VID0"` (4 bytes) + `len_be` (4 bytes BE u32) + JPEG payload. `"AUD0"` (4 bytes) + `len_be` + raw 16 kHz mono int16 PCM. Untagged binary frames are still mic-PCM bound for STT.
+- **`POST /api/video/inject`** — debug endpoint that pushes a JPEG into the relay as if it had come from a Tab5; useful for testing the Tab5 downlink decode path without a second device. Bearer-auth.
+- **`/call`** — serves `dragon_voice/static/call.html`, a minimal browser call client (HTML + JS, `getUserMedia` for camera + mic, Web Audio API for 16 kHz PCM capture and playback). The web client is just another participant on the relay — Dragon doesn't know or care it's a browser. Shipped in #180 (video) + #181 (audio).
+- **Audio in calls:** Web client captures 16 kHz mono PCM via Web Audio, wraps with `AUD0`, and plays inbound `AUD0` frames back through an `AudioBufferSourceNode` chain.
+
+## OPUS Audio Codec (April 2026 — partial)
+
+- **Capability negotiation works end-to-end** (TinkerBox #174 + TinkerTab #263/#265): Tab5's `register` frame advertises codec capabilities; Dragon responds in `session_start.config` with the negotiated codec.
+- **Decoder ready** for Phase 2B Dragon→Tab5 OPUS TTS — Tab5 can decode OPUS frames if Dragon emits them.
+- **Encoder BROKEN on Tab5** — SILK NSQ crash on ESP32-P4 mid-encode. Encoder is gated OFF in TinkerTab `voice_codec.h` pending TinkerTab #264 root-cause. Don't enable the OPUS uplink path until #264 closes.
 
 ## OTA Firmware Endpoints
 Dragon serves firmware updates for Tab5 via two endpoints:
@@ -502,7 +642,18 @@ dragon_voice/         — Voice pipeline package (port 3502)
     note_tool.py      — NoteTool (registered after NotesService)
   stt/                — STT backends (moonshine, whisper_cpp, vosk, openrouter)
   tts/                — TTS backends (piper, kokoro, edge_tts, openrouter)
-  llm/                — LLM backends (ollama, openrouter, lmstudio, npu_genie, tinkerclaw)
+  llm/                — LLM backends + multi-model router (#183-#187)
+    base.py             — LLMBackend ABC + Modality enum + capabilities default
+    router.py           — CapabilityAwareRouter, ModelSpec, TIER_FOR_MODE,
+                          infer_required_caps, summarize.  Opt-in via
+                          backend: "router" + a populated fleet[].
+    ollama_llm.py       — Ollama (multimodal-aware translator added in #186)
+    openrouter_llm.py   — OpenRouter + _OPENROUTER_CAPS (35 models, sync 2026-04-27)
+                          + _PRICING_MILS_PER_M (matched 1:1 with caps registry)
+    lmstudio_llm.py     — Local OpenAI-compatible server (LAN tier in fleet)
+    npu_genie.py        — QAIRT/Genie (text-only, ~8 tok/s on QCS6490 HTP)
+    tinkerclaw_llm.py   — TinkerClaw gateway adapter (voice_mode=3)
+    dual.py             — Two-backend picker+responder (predates router)
   notes/              — Notes module (CRUD + search + audio ingestion)
   media/              — Rich media rendering package
     __init__.py       — Package exports (MediaStore, MediaPipeline)

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -718,3 +718,40 @@ sequentially across the whole file (don't restart per section).
   1. **`asyncio.wait_for` timeouts are user-perception budgets — calibrate them to "the user has already given up" not "the network might recover".**  15 s in a real-time voice pipeline is forever.
   2. **Lazy-init on the critical path is the same anti-pattern as cold caches in HTTP servers.**  If a fallback exists, prewarm it the moment the primary becomes "this might fail" — for STT, that's the swap into a cloud backend.
   3. **Every multi-second wait in a synchronous user path needs a paired progress emit.**  "No signal" is worse UX than "negative signal" — Tab5 can render a transient toast for "Cloud STT slow", but it can't render anything from silence.
+
+### 90. OpenAI multimodal `content` array sent to Ollama hits a 400 unmarshal error
+- **Date:** 2026-04-27
+- **Symptom:** First end-to-end test of the multi-model router with MiniCPM-V on Dragon: router correctly picked the vision model, lazy-instantiated the backend, but every vision turn returned `[Ollama error: 400]`. Server log: `Ollama error 400: {"error":"json: cannot unmarshal array into Go struct field ChatRequest.messages.content of type string"}`.
+- **Root Cause:** The `messages` list our caller sends is OpenAI multimodal format — `{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:..."}},{"type":"text","text":"..."}]}` (a content *array* of typed parts).  Ollama's `/api/chat` expects a flat `content` *string* + a sibling `images: [base64]` array (raw bytes, no `data:` prefix).  Three other backends (openrouter, lmstudio, tinkerclaw) all natively accept the OpenAI shape; OllamaBackend was passing the multimodal messages straight through to Ollama, which JSON-rejected them.
+- **Fix:** Added `_translate_to_ollama_format(message)` in `dragon_voice/llm/ollama_llm.py` that walks any list-typed `content`, extracts `image_url` URLs (strips the `data:image/jpeg;base64,` prefix if present), collects `text` parts into a flat string, and emits `{"role":..., "content": "<joined text>", "images": ["<base64>", ...]}`.  Plain string-content messages pass through unchanged.  Translation runs on every `messages[]` element before the request body is built.
+- **Prevention:**
+  1. **Every backend that claims `Modality.VISION` must accept the canonical OpenAI multimodal content-array shape OR translate from it.**  The router emits one canonical format (#183); each backend either matches that format natively or owns the translation.
+  2. **Vision capability declaration is a contract, not a hint.**  If `OllamaBackend.capabilities` returns `{VISION}` for a vision-trained model, the backend must successfully serve a vision turn — not 400.  The new `tests/test_router_routing.py` covers routing logic; vision-actually-works integration is exercised by `tests/e2e/runner.py story_full` (Tab5 photo → /api/media/upload → router → MiniCPM-V → reply).
+
+### 91. Long-poll on ESP-IDF httpd is a footgun (PANIC under sustained load)
+- **Date:** 2026-04-27
+- **Symptom:** Tab5 e2e harness ran a `story_smoke` scenario with the experimental `?block_until=&timeout_ms=` long-poll variant of `/events`. Smoke completed but Tab5 became unreachable on the next run. `GET /info` after watchdog reset returned `"reset_reason":"PANIC"`.
+- **Root Cause:** ESP-IDF httpd is single-task by design — one `httpd_task` services all connections via `select()`. When the long-poll handler `vTaskDelay`s waiting for a matching event, all other requests queue behind it. Worse, the experimental implementation re-allocated the cJSON events array on every 200 ms iteration of the wait loop. Across a multi-minute test run, the per-iteration alloc/free churn (or possibly the `cJSON` walks themselves) accumulated heap fragmentation that eventually pushed the device into PANIC.
+- **Fix:** Reverted the long-poll feature entirely. `GET /events?since=N` stays instant-return only. Documented the caveat in `debug_server.c` so the next person who reaches for "but long-poll would be nice" sees the prior art. Harness in `tests/e2e/driver.py` falls back to 250 ms polling — burns more HTTP round-trips but doesn't risk the device.
+- **Prevention:**
+  1. **Single-thread http servers cannot host long-poll handlers.**  vTaskDelay inside a request handler is equivalent to taking the whole server offline for the duration.  If you need push-style notification, use a different transport (a dedicated WebSocket on a separate task, server-sent events with a per-request task spawned via `httpd_queue_work`, or just tell the client to poll faster).
+  2. **Per-iteration heap allocation in tight loops on embedded devices is suspicious.**  Even if each iteration is balanced (alloc + free), the TLSF heap can fragment.  Allocate-once + reuse, or batch the work outside the loop.
+  3. **"Reverted" is a valid commit message body.**  Documenting *why* a feature was removed (with the reset_reason and the timing) saves the next contributor from re-implementing it the same way.
+
+### 92. Diagnostic side-snapshots steal events from the cursor that subsequent waiters need
+- **Date:** 2026-04-27
+- **Symptom:** Tab5 e2e harness's `await_event("camera.capture", timeout_s=10)` failed even though `/screenshot` clearly showed "Photo saved!" toast (event obviously fired).  Direct `/events?since=0` query confirmed `camera.capture` was in the ring.
+- **Root Cause:** `Tab5Driver.events()` advances `_last_event_ms` to the latest event's timestamp on every call, so the next call only returns *newer* events.  The scenario runner's per-step diagnostic block called `events(since_ms=events_before)` to capture what fired during the step — and inadvertently advanced the cursor *past* the events it captured.  The next step's `await_event` started polling from a cursor that was already in the future relative to the events it was looking for.
+- **Fix:** Added `peek=True` parameter to `events()`.  When `peek=True`, the cursor doesn't advance.  The scenario runner's diagnostic snapshot uses `peek=True`; explicit await calls still advance the cursor.
+- **Prevention:**
+  1. **Stateful side effects in "read" methods are easy to write and hard to debug.**  Whenever a read advances a cursor, give callers an opt-out for the side effect.
+  2. **Diagnostic plumbing should never compete with primary control plumbing.**  Capturing "what happened" for a report is observation; consuming events for routing is action.  Separate the two.
+
+### 93. claude-3.5-haiku via OpenRouter's Bedrock route rejects images at runtime
+- **Date:** 2026-04-27
+- **Symptom:** Router correctly picked `anthropic/claude-3.5-haiku` for a vision turn in cloud mode (the registry declared it vision-capable per Anthropic's published specs).  OpenRouter returned: `{"error":{"code":400,"metadata":{"raw":"{\"message\":\"'claude-3-5-haiku-20241022' does not support image input.\"}","provider_name":"Amazon Bedrock"}}}`.
+- **Root Cause:** OpenRouter brokers the same model across multiple providers (Anthropic-direct, Amazon Bedrock, Google Vertex, etc.). Bedrock's claude-3.5-haiku endpoint is text-only even though Anthropic's native endpoint serves images. Our capability registry was based on the Anthropic-native truth — wrong for the Bedrock route OpenRouter happened to pick.
+- **Fix:** Downgraded `anthropic/claude-3.5-haiku` to `{TEXT, TOOL_CALLING}` in `_OPENROUTER_CAPS` (PR #187). Vision-capable cheap-tier alternatives in the curated fleet: `qwen/qwen3.6-flash` ($0.25/$1.50, 1M ctx) and `google/gemini-3-flash-preview` ($0.50/$3, native video).
+- **Prevention:**
+  1. **OpenRouter capability declarations should be based on the route OR is most likely to pick, not the model's published native capabilities.**  When in doubt, conservatively declare text-only and let the user opt back in.
+  2. **Add an integration test that hits each declared-vision-capable OR model with a tiny test image** — would have caught the Bedrock mismatch before the e2e harness did.  Parking this as a follow-up.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -30,6 +30,9 @@ This document defines the WebSocket protocol between **Tab5** (ESP32-P4 thin cli
 14. [config_update Backward Compatibility](#14-config_update-backward-compatibility)
 15. [Rich Media Messages](#15-rich-media-messages)
 16. [Message Reference](#16-message-reference)
+17. [Widget Platform Messages](#17-widget-platform-messages-v1-april-2026)
+18. [Video + Call Audio](#18-video--call-audio-april-2026)
+19. [Progress Event Bus](#19-progress-event-bus-β-arch-april-2026)
 
 ---
 
@@ -154,10 +157,18 @@ Sent immediately after registration is processed and the pipeline is fully initi
   "config": {
     "stt": "moonshine",
     "tts": "piper",
-    "llm": "npu_genie",
+    "llm": "router",
     "tts_sample_rate": 22050,
     "response_mode": "match_input",
-    "system_prompt": "You are Tinker..."
+    "system_prompt": "You are Tinker...",
+    "fleet_summary": {
+      "text":         "ministral-3:3b",
+      "vision":       "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M",
+      "video":        "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M",
+      "audio_in":     null,
+      "audio_out":    null,
+      "tool_calling": "ministral-3:3b"
+    }
   }
 }
 ```
@@ -170,6 +181,7 @@ Sent immediately after registration is processed and the pipeline is fully initi
 | `resumed` | bool | `true` if this is a resumed session with existing history. |
 | `message_count` | int | Number of messages in the resumed session (`0` for new). |
 | `config` | object | Active backend configuration for this session. |
+| `config.fleet_summary` | object\|null | **(#186, present only when `llm == "router"`)** Per-modality model_id the router would currently pick at the active voice_mode tier.  Keys are `Modality` values (text, vision, video, audio_in, audio_out, tool_calling). Value is the chosen model_id or `null` if no fleet entry has that capability in the current tier. Tab5 firmware can ignore this field — the legacy `vision_capability` event keeps firing for backward compat. New firmware can use it to light up dynamic capability chips. Re-sent on every `config_update` ACK after a voice_mode change. |
 
 **When sent:** After Dragon finishes initializing the pipeline (may take several seconds on first connect as models load).
 
@@ -1611,7 +1623,30 @@ widget_card is its superset (adds action).
 
 ---
 
-## 18. Progress Event Bus (β-arch, April 2026)
+## 18. Video + Call Audio (April 2026)
+
+Two-way video calls between Tab5, Dragon, and a browser client. Dragon is a verbatim broadcast relay — no transcode, no buffering beyond the WS write queue.
+
+Wire framing for both directions:
+
+| Magic (4 bytes ASCII) | Length (4 bytes BE u32) | Payload |
+|-----------------------|--------------------------|---------|
+| `VID0`                | `len`                    | JPEG frame (Tab5 HW JPEG encoder, web `getUserMedia` MediaRecorder, or `/api/video/inject`) |
+| `AUD0`                | `len`                    | Raw 16 kHz mono int16 PCM (Tab5 mic in `VOICE_MODE_CALL`, web Web Audio capture) |
+
+Untagged binary frames remain raw mic PCM bound for STT (existing §3.2 behaviour) — the magic tag is what disambiguates.
+
+**Relay model:** A frame received from one connection is forwarded byte-for-byte to all OTHER connections (sender excluded). Implemented in `dragon_voice/video_upstream.py`.
+
+**Endpoints:**
+- `POST /api/video/inject` — debug push of a JPEG into the relay (bearer-auth)
+- `GET /call` — serves `dragon_voice/static/call.html`, the browser call client
+
+**Tab5 atomic helpers:** `voice_video_start_call()` / `voice_video_end_call()` flip `VOICE_MODE_CALL`, open/close the camera, and show/hide the video pane in one call.
+
+---
+
+## 19. Progress Event Bus (β-arch, April 2026)
 
 **Added with the β-arch refactor (TinkerBox PR #N, issue #123).** A unified `progress` channel that supersedes the per-phase ad-hoc events introduced by Phase 2 (`dictation_postprocessing`, `tool_call`/`tool_result`, etc.).  The vision: one Tab5 renderer for all in-flight signals; new progress phases plug in for free without protocol churn.
 

--- a/docs/router-cookbook.md
+++ b/docs/router-cookbook.md
@@ -1,0 +1,146 @@
+# Multi-Model Router Cookbook
+
+Copy-paste fleets for common routing patterns. Drop into `dragon_voice/config.yaml` under `llm:` and set `backend: "router"`.
+
+All `model_id` strings verified live against OpenRouter on 2026-04-27. Pricing shown is in $/M tokens (input/output).
+
+---
+
+## 1. Default Recommended Fleet
+
+The all-purpose fleet shipped as the canonical example in `config.yaml`. Cheap defaults for both text and multimodal, premium options on standby for hard turns.
+
+```yaml
+llm:
+  backend: "router"
+  fleet:
+    # Local tier
+    - {id: ministral,   backend: ollama, model_id: "ministral-3:3b",
+       caps: [text, tool_calling],          tier: local, priority: 0,  keep_alive_s: 600}
+    - {id: minicpm_v4,  backend: ollama,
+       model_id: "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M",
+       caps: [text, vision, video],         tier: local, priority: 10, keep_alive_s: 120}
+    # Cloud tier
+    - {id: ds_v4_flash,  backend: openrouter, model_id: "deepseek/deepseek-v4-flash",
+       caps: [text, tool_calling],          tier: cloud, priority: 0}      # $0.14/$0.28
+    - {id: qwen36_flash, backend: openrouter, model_id: "qwen/qwen3.6-flash",
+       caps: [text, vision, tool_calling],  tier: cloud, priority: 5}      # $0.25/$1.50
+    - {id: gemini_flash, backend: openrouter, model_id: "google/gemini-3-flash-preview",
+       caps: [text, vision, video, audio_in, tool_calling],
+                                            tier: cloud, priority: 8}      # $0.50/$3
+    - {id: sonnet_46,    backend: openrouter, model_id: "anthropic/claude-sonnet-4.6",
+       caps: [text, vision, tool_calling],  tier: cloud, priority: 12}     # $3/$15
+    - {id: gemini_pro,   backend: openrouter, model_id: "google/gemini-3.1-pro-preview",
+       caps: [text, vision, video, audio_in, tool_calling],
+                                            tier: cloud, priority: 18}     # $2/$12
+    - {id: opus_47,      backend: openrouter, model_id: "anthropic/claude-opus-4.7",
+       caps: [text, vision, tool_calling],  tier: cloud, priority: 25}     # $5/$25
+    - {id: gpt_55,       backend: openrouter, model_id: "openai/gpt-5.5",
+       caps: [text, vision, tool_calling],  tier: cloud, priority: 30}     # $5/$30
+```
+
+**Behavior:**
+- Local text → `ministral` (always resident, 10-min keepalive)
+- Local vision → `minicpm_v4` (loads on first photo, evicts after 2-min idle)
+- Cloud text → `ds_v4_flash` (cheapest)
+- Cloud vision → `qwen36_flash`
+- Cloud video → `gemini_flash` (only ≤ priority 18 cloud entry with VIDEO)
+
+---
+
+## 2. "Cheapskate" — Sub-$0.50/M everything
+
+Maximum cost optimization. Sacrifices quality for spend.
+
+```yaml
+llm:
+  backend: "router"
+  fleet:
+    - {id: ds_v4_flash,  backend: openrouter, model_id: "deepseek/deepseek-v4-flash",
+       caps: [text, tool_calling],          tier: cloud, priority: 0}
+    - {id: qwen35_flash, backend: openrouter, model_id: "qwen/qwen3.5-flash-02-23",
+       caps: [text, vision, tool_calling],  tier: cloud, priority: 5}      # $0.07/$0.26 (!)
+    - {id: gemma_4_26b,  backend: openrouter, model_id: "google/gemma-4-26b-a4b-it",
+       caps: [text, vision, tool_calling],  tier: cloud, priority: 8}      # $0.06/$0.33
+    - {id: glm_4_7,      backend: openrouter, model_id: "z-ai/glm-4.7-flash",
+       caps: [text, tool_calling],          tier: cloud, priority: 3}      # $0.06/$0.40
+```
+
+Best for: high-volume background tasks, agentic chains where one bad reply isn't catastrophic.
+
+---
+
+## 3. "Top Tier Only" — Frontier on every turn
+
+For when latency + cost don't matter and you want the best answer every time.
+
+```yaml
+llm:
+  backend: "router"
+  fleet:
+    - {id: opus_47,    backend: openrouter, model_id: "anthropic/claude-opus-4.7",
+       caps: [text, vision, tool_calling],  tier: cloud, priority: 0}
+    - {id: gpt_55,     backend: openrouter, model_id: "openai/gpt-5.5",
+       caps: [text, vision, tool_calling],  tier: cloud, priority: 5}
+    - {id: gemini_pro, backend: openrouter, model_id: "google/gemini-3.1-pro-preview",
+       caps: [text, vision, video, audio_in, tool_calling],
+                                            tier: cloud, priority: 10}
+```
+
+Default ($5–30/M output) is fine — but watch the daily cap. Bump Tab5 NVS `cap_mils` to 2000000 ($20/day) before flipping this on or auto-downgrade will kick in fast.
+
+---
+
+## 4. "Local with Cloud Vision Fallback"
+
+Hybrid pattern that lets Local mode borrow a cloud vision model when the local one isn't loaded or fails. Currently NOT supported by the router (tier filter is hard) — file as a follow-up issue if you want it. Workaround: stay in Local mode for text, manually flip to Cloud when you tap the camera.
+
+---
+
+## 5. "DGX Workstation Acceleration"
+
+Run heavy multimodal models on a workstation/DGX via LM Studio's OpenAI-compatible API; Dragon stays text-fast.
+
+```yaml
+llm:
+  backend: "router"
+  fleet:
+    # Local tier (Dragon Q6A)
+    - {id: ministral, backend: ollama, model_id: "ministral-3:3b",
+       caps: [text, tool_calling],     tier: local, priority: 0}
+    # LAN tier (DGX/workstation running LM Studio on port 1234)
+    - {id: dgx_minicpm_o, backend: lmstudio,
+       model_id: "openbmb/minicpm-o-4.5",
+       caps: [text, vision, video, audio_in, audio_out, tool_calling],
+       tier: lan, priority: 5,
+       lmstudio_url: "http://workstation.local:1234/v1"}
+    # Cloud tier (fallback)
+    - {id: ds_v4_flash, backend: openrouter, model_id: "deepseek/deepseek-v4-flash",
+       caps: [text, tool_calling],     tier: cloud, priority: 0}
+```
+
+Vision turns in Cloud mode route to `dgx_minicpm_o` (priority 5 < cloud entries) — fast inference on DGX hardware, zero per-token cost, no internet round-trip.
+
+---
+
+## Tuning notes
+
+- **`keep_alive_s`** is passed to ollama as the `keep_alive` parameter. Set high (600+ s) for the always-resident text model and low (60-120 s) for the heavy multimodal model so RAM isn't wasted between bursts.
+- **`priority`** is just an integer — lower wins. Use gaps (0, 5, 10, 15, ...) so you can insert new models without renumbering.
+- **`tier`** must be one of `local`, `cloud`, `lan`. Custom tier strings are a follow-up if needed.
+- **Removing the router** is just `backend: "ollama"` (or whatever single backend). Empty `fleet: []` is fine in that mode — router code never runs.
+- **Cost cap is enforced device-side** via Tab5 NVS `cap_mils`. Default $1/day. The router doesn't itself track spend; it asks `price_for_model()` after each turn and sums into the daily counter. Auto-downgrade fires when exceeded → `voice_mode=0` (Local).
+
+## Adding a new OpenRouter model
+
+1. Add to `_OPENROUTER_CAPS` in `dragon_voice/llm/openrouter_llm.py` with the right `frozenset({Modality.TEXT, ...})`.
+2. Add the same entry to `_PRICING_MILS_PER_M` (the registry-completeness test catches drift).
+3. Add a fleet entry in your `config.yaml` under `llm.fleet`.
+4. Restart `tinkerclaw-voice`. Router picks up the new entry on next session_start.
+
+## Troubleshooting
+
+- **Router is configured but the wrong model fires:** check `infer_required_caps(messages)` (see `tests/test_router_routing.py`) — TOOL_CALLING is intentionally NOT inferred from system-prompt content; it's a bonus, not a gate.
+- **`router: no fleet model satisfies …`:** the modality combo isn't covered in the active tier. Either expand the fleet or switch tier (voice_mode).
+- **Model ID gets a 400 from OpenRouter:** OR may have brokered to a route that doesn't support the modality your registry claimed (see LEARNINGS #93 about haiku-3.5 via Bedrock). Conservatively declare text-only; flip back when the route situation clarifies.
+- **Fleet summary in `session_start.config` is missing:** the router isn't active. Confirm `backend: "router"` in `config.yaml`.


### PR DESCRIPTION
## Summary
Documentation sweep tied to the 4 PRs that landed the multi-model router (#184/#185/#186/#187) and the OR registry refresh. Audit found the router was a major feature with **zero mention** in CLAUDE.md or the protocol spec.

## What's documented now
| File | What changed |
|------|--------------|
| **CLAUDE.md** | New H2 "Multi-Model Router" section (capability declarations, tier policy, choose rule, fleet example, cross-modal continuity, OllamaBackend translator, fleet_summary protocol). "valid_llm" includes `dual` + `router`. Service Map: corrected stale "ollama masked" claim. File Structure: expanded llm/ section with per-file descriptions. |
| **docs/protocol.md** | `session_start.config.fleet_summary` field documented + example updated. |
| **docs/router-cookbook.md (NEW)** | 5 fleet recipes (Default, Cheapskate sub-$0.50/M, Top-Tier, LAN/DGX, Local+Cloud Vision) + tuning notes + add-new-model runbook + troubleshooting. |
| **LEARNINGS.md** | 4 new entries (#90-#93): Ollama multimodal translator, ESP-IDF httpd long-poll PANIC, events cursor-stealing, claude-3.5-haiku Bedrock route surprise. |

## No code change
Pure docs. Existing tests unaffected (still 555 passing).
