### PR TITLE
docs: world-class onboarding — ARCHITECTURE + 3 flow traces + GLOSSARY

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # TinkerBox — Dragon Server Stack (THE BRAIN)
 
+> **Trying to understand what this project IS rather than how to operate it?** Read [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) first — system overview, component diagram, data flows. This file is the *runbook* (deploy, debug, restart, monitor); ARCHITECTURE.md is the *map*.  [`GLOSSARY.md`](GLOSSARY.md) covers any unfamiliar terms.
+
 ## Active investigations — READ FIRST before related work
 
 - **UX-gap remediation (2026-04-25)** → see [`docs/UX-GAPS.md`](docs/UX-GAPS.md)

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,217 @@
+# TinkerClaw Glossary
+
+> Single-line definitions for terms that appear across both repos
+> (TinkerBox = Dragon brain, TinkerTab = Tab5 firmware).  When a term
+> means something different in another context, the link points at the
+> code or doc where the canonical definition lives.
+
+## A
+
+**`add_message`** — `MessageStore.add_message(session_id, role, content, …)` in [`messages.py`](dragon_voice/messages.py). Appends one message to the session log. Optional `media_id` parameter encodes a multimodal user message via the `__mm__:` content marker. Append-only; messages never mutate.
+
+**Agentic pipeline** — Dragon's tool-calling loop. LLM emits `<tool>NAME</tool><args>{...}</args>` markers; [`tools/registry.py`](dragon_voice/tools/registry.py) parses them, executes the matching `Tool`, injects the result back into the conversation, and re-prompts the LLM. Capped at `MAX_TOOL_CALLS=3` per turn.
+
+**`AUD0`** — 4-byte ASCII magic prefix on a binary WS frame indicating it's call audio (raw 16 kHz mono int16 PCM), not mic-PCM-bound-for-STT. See [`flows/video-call.md`](docs/flows/video-call.md).
+
+**`auth_tok`** — Tab5 NVS key holding the 32-char hex bearer token for the Tab5 firmware's debug HTTP server (port 8080). Auto-generated on first boot, persists across reboots. Different from `DRAGON_API_TOKEN`, which gates Dragon's `/api/*` REST endpoints.
+
+## B
+
+**Backend pool** — Dragon's process-wide cache of warm `LLMBackend` instances keyed by config signature (see `pipeline._llm_sig`). Avoids re-loading Ollama models on every connection's `config_update`. Owned by `VoiceServer._backend_pool`.
+
+**β-arch (beta-arch)** — issue [#123](https://github.com/lorcan35/TinkerBox/issues/123). Unified `progress` event bus that supersedes per-phase ad-hoc events (`tool_call`, `dictation_postprocessing`, etc.). Migration is incremental — `progress_bus_emit_legacy: true` keeps double-emitting for backwards-compat with current Tab5.
+
+## C
+
+**Capability** / **`Modality`** — One of `TEXT`, `VISION`, `VIDEO`, `AUDIO_IN`, `AUDIO_OUT`, `TOOL_CALLING`. Each `LLMBackend` declares a `frozenset[Modality]` via the `capabilities` property; the router uses these to pick a backend per turn. See [`llm/base.py`](dragon_voice/llm/base.py) and [`flows/vision-turn.md`](docs/flows/vision-turn.md).
+
+**`CapabilityAwareRouter`** — The router itself. Implements `LLMBackend` so it slots into ConvEngine like any single-model backend. Holds N sub-backends, picks per call based on inferred caps + tier policy. Lazy-instantiates sub-backends. See [`llm/router.py`](dragon_voice/llm/router.py) and [`docs/router-cookbook.md`](docs/router-cookbook.md).
+
+**`cap_mils`** — Tab5 NVS key holding daily LLM-spend cap in mils (1/1000 ¢). Default 100000 (= $1.00/day). When `spent_mils` exceeds this on a Cloud-mode turn, Tab5 auto-downgrades to Local mode and announces `cap_downgrade` via `config_update`.
+
+**`cam_rot`** — Tab5 NVS key (uint8 0..3) holding camera rotation in 90° steps (0=none, 1=90°CW, 2=180°, 3=270°CW). Applied in software after V4L2 capture before display, photo save, and video record. Settings dropdown + an in-viewfinder "Rot" button writes the key.
+
+**Cloud mode** — `voice_mode = 2`. STT, LLM, TTS all go through OpenRouter (LLM is router-picked). 3-6 s/turn typical. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) "The four modes."
+
+**Compact tool format** — When the active LLM is a small local model (e.g., ministral-3:3b), the system prompt uses an abbreviated XML tool listing instead of full OpenAI-style function definitions. Saves context tokens; see [`tools/registry.py: format_for_llm(compact=True)`](dragon_voice/tools/registry.py).
+
+**`config_update`** — WS message Tab5 sends to swap `voice_mode` and/or `llm_model`. Dragon hot-swaps the relevant backends (or, if router-active, just calls `set_voice_mode`). Per-connection deep-copy of config means two Tab5s on the same Dragon can be in different modes simultaneously. Confirmed back to Tab5 via the same message type with the applied config.
+
+**ConversationEngine** — [`dragon_voice/conversation.py`](dragon_voice/conversation.py). The orchestrator for a multi-turn LLM conversation with memory + tools + history. Entry point: `process_text_stream(session_id, text, media_id=None, ...)`. Voice turns, text turns, and (post-#186) vision turns all converge here.
+
+**Cross-modal continuity** — Property guaranteed by PR #186: a vision turn persists the user's photo into `messages` table via the multimodal-marker encoding; subsequent text turns load it back hydrated to OpenAI `image_url` content arrays via `MessageStore.get_context(media_store=…)`. Means "send a photo, then ask follow-up text" works.
+
+## D
+
+**Device** — A registered hardware client (Tab5 instances, browser at `/call`, etc.). Persists in `devices` table. Identified by stable `device_id` (Tab5 uses MAC). Survives reboots; sessions belong to devices.
+
+**Dictation mode** — Long-form voice recording. Tab5 sends `{"type":"start","mode":"dictate"}`. Dragon emits `stt_partial` events as you speak. Auto-stops after 5 s of silence (`DICTATION_AUTO_STOP_FRAMES=250`). Post-processing runs the transcript through the LLM to generate a title + summary, returned via `dictation_summary`.
+
+**Dragon** — The brain of TinkerClaw. Snapdragon QCS6490 ARM SBC running Ubuntu + the `dragon_voice` Python service on port 3502. Hosts STT, LLM (router-fronted), TTS, embeddings, conversation engine, tools, memory, dashboard, OTA. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+
+**`DRAGON_API_TOKEN`** — Bearer token for Dragon's `/api/*` REST surface. Lives in `/home/radxa/.env` (loaded by systemd `EnvironmentFile=`). Different from Tab5's `auth_tok` (which gates the Tab5 firmware debug server on port 8080).
+
+**Dual** — Old two-backend orchestration (`backend: "dual"`). Picker model emits a tool call; responder model writes the user-visible reply. Predates the multi-model router. Still supported but the router (`backend: "router"`) is more general.
+
+## E
+
+**Embedding model** — `nomic-embed-text` running locally via Ollama. 768-dimensional vectors. Used for memory facts + document chunks + RAG search. See `MemoryService`.
+
+**Empty-reply guard** — [`tools/response_wrap.py: synthesize_wrap`](dragon_voice/tools/response_wrap.py). When an FC-trained model emits a tool call but no user-visible text, this synthesizes a one-line natural-language ack from the tool result so the user doesn't see silence. Triggered by `looks_like_useful_text(response) == False` AND at least one tool fired.
+
+**`/events` ring** — Tab5 firmware-side observability. Ring buffer of 256 events with `kind` + `detail` + `ms` (uptime). Populated by `tab5_debug_obs_event()` calls at key sites; queried via `GET /events?since=<ms>`. Used by the e2e harness to know when state changed.
+
+## F
+
+**Fleet** — `LLMConfig.fleet: list[ModelSpec]` in [`config.py`](dragon_voice/config.py). The list of LLM backends the router can pick from. Each spec declares `id`, `backend`, `model_id`, `caps`, `tier`, `priority`, `keep_alive_s`. Empty list + non-`router` backend = legacy single-backend dispatch.
+
+**`fleet_summary`** — Dragon → Tab5 protocol field on `session_start.config` and `config_update` ACK. `dict[Modality, model_id | null]` — the model the router would currently pick per modality at the active tier. Lets Tab5 firmware light up dynamic capability chips. Only present when `llm == "router"`.
+
+**FreeRTOS** — Tab5's RTOS. Tasks, mutexes, semaphores, queues. Most Tab5 firmware concurrency is FreeRTOS-task-based (one task per long-running concern: WS RX, mic capture, video stream, etc.). Stack allocations are tight on the dual-core RISC-V; PSRAM-stack tasks via `xTaskCreatePinnedToCoreWithCaps`.
+
+**Full Cloud** → see **Cloud mode**.
+
+## G
+
+**Genie** → see **NPU Genie**.
+
+**Glyph OS** — Internal codename for the Tab5 visual design language. Currently v4·C ("Ambient Canvas"). v3 designs (`stitch-designs/v3/`) are local-only design exploration; never committed to the repo.
+
+## H
+
+**Hybrid mode** — `voice_mode = 1`. STT and TTS go cloud (OpenRouter `gpt-audio-mini`); LLM stays local (ollama). Best dollar-per-turn for a snappy assistant. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+
+## I
+
+**`infer_required_caps`** — [`router.py`](dragon_voice/llm/router.py) function. Walks an OpenAI-format `messages` list, infers what `Modality` set the request needs: image_url → +VISION, video_url → +VIDEO, input_audio → +AUDIO_IN. Always includes TEXT. **Does NOT** infer TOOL_CALLING — see PR #186 for why (would gate vision turns from picking MiniCPM-V which lacks tools).
+
+**`input_mode`** — `messages.input_mode` column. CHECK constraint allows `'voice' | 'text' | 'system'`. Vision turns use `'text'` because the multimodal-ness lives in the content marker, not the input_mode. A migration to add `'vision'` is documented but not shipped.
+
+## L
+
+**LAN tier** — Router tier for backends running on the same LAN as Dragon, like a workstation hosting LM Studio. Eligible in voice_mode 2 (Cloud) alongside the cloud tier. Lets you run heavy multimodal models off-Dragon at zero per-token cost.
+
+**`LLMBackend`** — Abstract base in [`llm/base.py`](dragon_voice/llm/base.py). Six concrete subclasses (ollama, openrouter, lmstudio, npu_genie, tinkerclaw, dual) plus the router (which IS-A LLMBackend, holding N sub-backends). All implement `generate_stream(prompt)` (legacy) and `generate_stream_with_messages(messages)` (multimodal-aware).
+
+**`llm_done`** — WS message Dragon sends after the final LLM token of a turn streams. Carries `llm_ms` (latency). Tab5's debug-obs system also fires a `chat.llm_done` event here for the e2e harness.
+
+**Local mode** — `voice_mode = 0`. STT (Moonshine), LLM (ollama or NPU), TTS (Piper) all on Dragon. Privacy-first; slow on Q6A CPU (~60-90 s/turn for ministral-3:3b). The default.
+
+**Long-press** — Tab5 touch event. The `/touch` debug endpoint accepts `action:"long_press"` with `duration_ms` 500-5000. LVGL fires `LV_EVENT_LONG_PRESSED` at 400 ms by default.
+
+## M
+
+**MCP** — Model Context Protocol. Anthropic's tool/resource discovery protocol. Dragon ships an MCP client + bridge in [`dragon_voice/mcp/`](dragon_voice/mcp/) that registers external MCP servers as Dragon tools.
+
+**MediaStore** — [`dragon_voice/media/store.py`](dragon_voice/media/store.py). Disk-backed (`/home/radxa/media/`) blob store for rich media. 24h TTL with hourly cleanup. 500 MB cap. Files named `<sha256>.jpg`. Both Dragon-rendered media (Pygments code, Pillow tables) and Tab5-uploaded camera photos live here.
+
+**MediaPipeline** — [`dragon_voice/media/pipeline.py`](dragon_voice/media/pipeline.py). After an LLM turn finishes, scans the response for code blocks / tables / image URLs and renders them as JPEG via Pygments + Pillow. Up to 3 media items per response. Strips the rendered content from the text via `text_update`.
+
+**Memory facts** — Persisted user-or-LLM-stated facts in `memory_facts` table. Embedded with `nomic-embed-text` (768-dim). Auto-recalled before every LLM call via cosine similarity against the user's query. Stored via `remember` tool, retrieved via `recall` tool, browsed via dashboard's Memory tab.
+
+**`messages` table** — Append-only log of every conversation message. `(id, session_id, role, content, input_mode, created_at, model, latency_ms, ...)`. Multimodal user messages encode the photo reference into `content` via the `__mm__:` marker prefix.
+
+**ministral-3:3b** — Default Local-mode LLM model. 2.8 GB. ~65 s median per turn on Dragon Q6A. Selected from the 11-model gauntlet documented in [`docs/historical/AUDIT-WAVE-14.md`](docs/historical/AUDIT-WAVE-14.md). Best correct-tool-fire rate (7/10) of all sub-4B models tested; only sub-4B model that fits Tab5's WS keepalive ceiling and does non-trivial math correctly.
+
+**Modality** → see **Capability**.
+
+**Moonshine** — STT model running on Dragon CPU. `medium-streaming-en` quantized variant via `moonshine_voice` package. ~400-800 ms for 2-second utterances on Q6A.
+
+**Multimodal marker** — `__mm__:` prefix on `messages.content`. Indicates the row is a JSON-encoded `{media_id, text}` pair, not plain text. `_hydrate_multimodal_content` in [`messages.py`](dragon_voice/messages.py) decodes it back into the OpenAI multimodal content-array format at context-build time.
+
+## N
+
+**ngrok** — Tunnels Dragon's local services to public domains: `tinkerclaw-voice.ngrok.dev` (port 3502), `tinkerclaw-dashboard.ngrok.dev` (3500), `tinkerclaw-gateway.ngrok.dev` (18789). Single systemd unit `tinkerclaw-ngrok.service` maintains all three. Tab5 firmware tries LAN first then ngrok fallback, so the device works off-network.
+
+**`nomic-embed-text`** — 768-dim embedding model running via Ollama. Used everywhere — memory facts, document chunks, search queries.
+
+**NPU Genie** — Qualcomm QAIRT-based LLM inference path on Dragon's Hexagon V68 NPU. Currently runs Llama 3.2 1B at ~8 tok/s. Text-only (no vision support). Setup in [`docs/npu-setup.md`](docs/npu-setup.md). Backend ID `"npu_genie"`.
+
+**NVS** — Tab5's non-volatile storage. ESP-IDF flash partition holding key-value settings. See TinkerTab `CLAUDE.md` "NVS Settings Keys" for the full table.
+
+## O
+
+**OPUS** — Audio codec for the WS streaming path. Capability negotiation works end-to-end (PR #174 / TinkerTab #263/#265). Decoder ready on Tab5; **encoder gated OFF** in `voice_codec.h` pending TinkerTab #264 — SILK NSQ crashes mid-frame on ESP32-P4. Don't enable uplink until #264 closes.
+
+## P
+
+**`peek=True`** — Parameter on `Tab5Driver.events()` in the e2e harness. When True, returns events without advancing the global cursor. Used by diagnostic snapshots so they don't steal events that subsequent `await_event` calls need. See LEARNINGS #92.
+
+**Piper** — TTS engine on Dragon CPU. `en_US-lessac-medium` voice. Outputs 22 050 Hz mono int16 PCM, resampled to 16 kHz before sending to Tab5. ~real-time (1× factor).
+
+**Priority** (router) — `ModelSpec.priority` int. Lower wins. Use gaps (0, 5, 10, 15) so new models can slot in without renumbering. Across same-tier same-cap candidates, the lowest-priority spec is chosen.
+
+**Pause / resume** — Session lifecycle states. WS connection drops → session goes `paused`. Reconnect → session resumes (server replays last 20 messages so chat overlay rehydrates). Pause-aged-out sessions (default 30 days, `paused_session_retention_days`) become `ended`.
+
+## R
+
+**RAG** — Retrieval-augmented generation. Memory facts + document chunks are retrieved via cosine similarity against the user's query, then injected into the system prompt before the LLM call. See `MemoryService.get_relevant_context`.
+
+**Relay** — Dragon's role in a video call. **Dumb fan-out broadcast**: receives `VID0` or `AUD0` binary frames from one connection and forwards them verbatim to all others. No transcoding, no buffering beyond the WS write queue. See [`flows/video-call.md`](docs/flows/video-call.md).
+
+**Router** → see **`CapabilityAwareRouter`**.
+
+## S
+
+**Session** — A multi-turn conversation. Belongs to a device. `id, device_id, type:"conversation"|"recording", system_prompt, status:"active|paused|ended", created_at, last_active_at, message_count`. Survives WS reconnect (within the pause window).
+
+**`session_start`** — First substantive Dragon → Tab5 message after `register`. Carries `session_id`, `resumed`, `message_count`, and a `config` blob (incl. `fleet_summary` when router is active). Tab5 transitions from CONNECTING to READY here.
+
+**`set_voice_mode`** — Method on `CapabilityAwareRouter`. Flips the tier policy without rebuilding the fleet. Instantiated sub-backends survive — saves the cost of re-loading models on every voice-mode change.
+
+**Skill** — User-facing pluggable feature on Dragon. Currently scaffolded — see [`docs/SKILL_AUTHORING.md`](docs/SKILL_AUTHORING.md) and TinkerTab's [`docs/WIDGETS.md`](https://github.com/lorcan35/TinkerTab/blob/main/docs/WIDGETS.md). Skills emit *widgets* (live, card, list, chart, media, prompt) into Tab5 surface slots. Time Sense (Pomodoro) is the reference skill.
+
+**`spent_mils`** / **`spent_day`** — Tab5 NVS keys tracking today's cumulative LLM spend in mils. Resets when `spent_day` rolls past local midnight. Compared against `cap_mils` to trigger auto-downgrade.
+
+**Surface** — Tab5 widget abstraction. Six surface types: live (one at a time, full home-card), card (transient), list (5 items max), chart (12 points max), media, prompt (3 choices max). Skills emit widget state via WS; Tab5 renders opinionatedly using v4·C theme tokens.
+
+## T
+
+**Tab5** — The face of TinkerClaw. M5Stack Tab5 (ESP32-P4) running native LVGL UI. Thin client — owns LVGL UI + mic/speaker/camera/touch + WiFi + NVS, sends/receives over WS to Dragon. See [TinkerTab](https://github.com/lorcan35/TinkerTab) repo.
+
+**`tab5_lv_async_call`** — `void tab5_lv_async_call(lv_async_cb_t cb, void *arg)` in TinkerTab's [`main/ui_core.{c,h}`](https://github.com/lorcan35/TinkerTab/blob/main/main/ui_core.c). Wrapper around LVGL's `lv_async_call` that takes the LVGL recursive mutex first. **Always use this**, never the LVGL primitive directly — `lv_async_call` is NOT thread-safe (does `lv_malloc` + `lv_timer_create` against unprotected TLSF; #257/#259 closed the long-residual stability class with this).
+
+**`task_worker`** — Shared FreeRTOS job queue on Tab5 ([`task_worker.{c,h}`](https://github.com/lorcan35/TinkerTab/blob/main/main/task_worker.c)). 16 KB stack on PSRAM. Long-running uploads / downloads / etc. enqueue here instead of spawning per-action tasks (which leaked under load — see PR #285 for the persistent-task pattern).
+
+**Tier** — Router term for the deployment cohort of a model. One of `local`, `cloud`, `lan`. `TIER_FOR_MODE` maps voice_mode to the set of tiers the router will pick from. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+
+**TinkerClaw Gateway** — Optional sidecar agent runner on Dragon, port 18789 localhost. Activated by `voice_mode = 3`. Owns its own LLM choice + tool execution + browser automation. Dragon becomes an audio pipe in this mode (STT + TTS still local, but ConversationEngine + ToolRegistry + MemoryService are bypassed).
+
+**Tool-calling dialect** — Three accepted XML formats:
+1. *Legacy:* `<tool>NAME</tool><args>{json}</args>` (TinkerBox system-prompt format)
+2. *Standard:* `<tool_call>{"name":"...","arguments":{...}}</tool_call>` (industry-typical FC fine-tunes)
+3. *Bracketed-name:* `[NAME]{json}</NAME>` (xLAM quirk — gated on registered tool names)
+
+See [`tools/registry.py`](dragon_voice/tools/registry.py) module docstring.
+
+**TOOL_CALLING** (Modality) — Declared by backends trained for function-calling. Informational, NOT a router gate — would otherwise force every turn through a tool-capable model even when none is needed. Tool detection happens at runtime via the parser.
+
+## V
+
+**`VID0`** — 4-byte ASCII magic on a binary WS frame indicating it's a JPEG video frame for the call relay. See [`flows/video-call.md`](docs/flows/video-call.md).
+
+**Vision capability** event — Dragon → Tab5 `vision_capability` WS message. Tells Tab5 whether the active LLM (or fleet's tier-aware vision pick) can do vision, what the model id is, and the per-frame cost in mils. Drives the camera-screen capability chip. Pre-#186 this was substring-based; post-#186 it's capability-driven.
+
+**Voice mode** → see **Local mode**, **Hybrid mode**, **Cloud mode**, **TinkerClaw Gateway**.
+
+**`VOICE_MODE_CALL`** — Tab5-internal voice-pipeline state. Independent of `voice_mode` 0/1/2/3. When active: mic frames are wrapped with `AUD0` and broadcast to other call participants instead of being fed to STT. See [`flows/video-call.md`](docs/flows/video-call.md).
+
+## W
+
+**Wave audit** — Periodic systematic audit of the cross-stack codebase. Wave 13 closed in 2026-04-21 (16 C/H items merged). Wave 14 closed (see [`docs/historical/AUDIT-WAVE-14.md`](docs/historical/AUDIT-WAVE-14.md)). Wave 15 active ([`docs/AUDIT-WAVE-15.md`](docs/AUDIT-WAVE-15.md)).
+
+**Widget** — Skill-emitted state rendered by Tab5. Six types — live, card, list, chart, media, prompt. Skills never write layout; the widget vocabulary IS the layout contract. See TinkerTab's `docs/WIDGETS.md`.
+
+**WS** — WebSocket. Specifically `/ws/voice` on Dragon port 3502 — the single channel Tab5 uses for register / voice / chat / vision / video / tool events / config updates. See [`protocol.md`](docs/protocol.md).
+
+## Cross-references
+
+- **Operating runbook** (deploy, debug, restart, monitor): [`CLAUDE.md`](CLAUDE.md)
+- **System architecture**: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
+- **Wire format**: [`docs/protocol.md`](docs/protocol.md)
+- **Per-flow traces**: [`docs/flows/`](docs/flows/)
+- **Router fleet recipes**: [`docs/router-cookbook.md`](docs/router-cookbook.md)
+- **Skills + widgets**: [`docs/SKILL_AUTHORING.md`](docs/SKILL_AUTHORING.md)
+- **NPU setup**: [`docs/npu-setup.md`](docs/npu-setup.md)
+- **Lessons + gotchas**: [`LEARNINGS.md`](LEARNINGS.md)
+- **Closed audits**: [`docs/historical/`](docs/historical/)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 
 **The Brain of TinkerClaw** -- Dragon Q6A server stack for the TinkerClaw voice assistant platform.
 
+📚 **Docs:** [Architecture](docs/ARCHITECTURE.md) · [Protocol](docs/protocol.md) · [Router cookbook](docs/router-cookbook.md) · [Flows](docs/flows/) · [Glossary](GLOSSARY.md) · [Lessons](LEARNINGS.md) · [CLAUDE.md](CLAUDE.md) (runbook)
+
+> **First time here?** Start with [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — system overview, diagrams, where every piece fits.  Then pick a [flow trace](docs/flows/) for a concrete walk-through.
+
 TinkerBox runs on a Radxa Dragon Q6A (Qualcomm QCS6490, ARM64) and provides the
 complete AI pipeline for TinkerClaw devices: speech-to-text, language model
 inference, text-to-speech synthesis, multi-turn conversation management, session
-persistence, a REST API, browser streaming, and a web dashboard. The companion
+persistence, a REST API, and a web dashboard.  The companion
 [TinkerTab](https://github.com/lorcan35/TinkerTab) firmware (ESP32-P4 / M5Stack
 Tab5) is a thin client -- it captures audio and displays results, but all
 intelligence lives here.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,314 @@
+# TinkerClaw — Architecture
+
+> **Start here if you've never seen this project before.** This doc is
+> the canonical answer to "what is TinkerClaw, what runs where, and
+> how do the pieces talk to each other?"  Pair it with
+> [`protocol.md`](protocol.md) (the wire format) and the per-flow
+> traces in [`flows/`](flows/) once you want code-level detail.
+
+## Elevator pitch
+
+TinkerClaw is a privacy-conscious voice assistant + skills platform
+that runs entirely on hardware you own.  The user-facing device is
+**Tab5** — a 5-inch portrait touchscreen that's the "face" of the
+system.  All intelligence lives on **Dragon** — a 12-core ARM SBC
+sitting somewhere on your LAN that runs speech-to-text, large-
+language-model inference, text-to-speech, and a tool/skill registry.
+A third optional layer, **TinkerClaw Gateway**, hosts the agentic
+sidecar that runs longer autonomous workflows.
+
+Tab5 is a thin client.  Dragon is the brain.  The two halves talk
+over a single WebSocket connection on the LAN, with an ngrok tunnel
+fallback when remote.  Cloud LLMs (Claude, GPT, Gemini, DeepSeek,
+Qwen, Kimi, Grok…) are a per-session opt-in via a multi-model router
+that picks per-modality per-tier — a vision turn can hit MiniCPM-V
+locally while a text turn stays on the cheap cloud DeepSeek.
+
+The product is *voice-first*: the original CDP-browser-streaming
+prototype was retired in PR
+[#155](https://github.com/lorcan35/TinkerTab/pull/155).  The user's
+voice → Dragon's intelligence → response back to user is the loop the
+whole system optimises for.
+
+## The three pieces
+
+```mermaid
+graph LR
+    User((👤 User)) -->|speaks, taps, looks| Tab5
+    Tab5 <-->|WebSocket port 3502<br/>VID0/AUD0/PCM frames| Dragon
+    Dragon -->|optional voice_mode=3<br/>localhost 18789| Gateway
+    Dragon -.->|optional cloud LLM<br/>via OpenRouter| Cloud[(☁ Cloud LLMs)]
+    Gateway -.-> Cloud
+
+    subgraph "Tab5 — the face (this repo: TinkerTab)"
+        Tab5
+    end
+    subgraph "Dragon Q6A — the brain (this repo: TinkerBox)"
+        Dragon
+        Gateway[TinkerClaw Gateway]
+    end
+```
+
+| Piece | Hardware | Software | Repo | Talks to |
+|-------|----------|----------|------|----------|
+| **Tab5** | M5Stack Tab5 — ESP32-P4 (RISC-V dual-core), 720x1280 IPS, MIPI-CSI camera, 4-mic + DAC, WiFi via ESP32-C5 hosted, 2 MB internal SRAM + 32 MB PSRAM, 16 MB flash, 6 Ah LiPo | C / ESP-IDF 5.5.2 + LVGL 9.2.2 native UI | [TinkerTab](https://github.com/lorcan35/TinkerTab) | Dragon (WS), human (mic/touch/screen/speaker/camera) |
+| **Dragon** | Radxa Q6A — Snapdragon QCS6490, 8-core Kryo (4×Cortex-A78 + 4×A55) + Adreno 643 + Hexagon V68 NPU (12 TOPS), 12 GB LPDDR5, 128 GB UFS, GbE | Python 3.12 + aiohttp + aiosqlite + Ollama + Moonshine STT + Piper TTS + nomic-embed-text + esp_video sentinel for skills | [TinkerBox](https://github.com/lorcan35/TinkerBox) (this repo) | Tab5 (WS), Cloud (HTTPS), TinkerClaw (HTTP localhost), web client at /call |
+| **TinkerClaw Gateway** | Same Dragon hardware, separate process | Node.js sidecar (TypeScript), agentic runtime, browser automation via CDP | [openclaw](https://github.com/lorcan35/openclaw) | Dragon (HTTP localhost), Cloud (HTTPS), browser/Playwright, channels (WhatsApp/Telegram/Slack/iMessage/etc.) |
+
+## The four modes
+
+Tab5 sends a `voice_mode` (0/1/2/3) on every config change.  Dragon
+hot-swaps STT/TTS/LLM backends based on it:
+
+| Mode | voice_mode | STT | LLM | TTS | When to use |
+|------|-----------|-----|-----|-----|-------------|
+| **Local** | 0 | Moonshine on Dragon CPU | Local — ollama (ministral-3:3b default) or NPU Genie (llama-3.2-1b @ ~8 tok/s) | Piper on Dragon CPU | Privacy-first, slow (60-90 s/turn on Q6A); the default |
+| **Hybrid** | 1 | OpenRouter `gpt-audio-mini` | Local (unchanged) | OpenRouter `gpt-audio-mini` | Fast STT/TTS, free LLM — best dollar-per-turn |
+| **Full Cloud** | 2 | OpenRouter `gpt-audio-mini` | OpenRouter (router-picked or `llm_model` override) | OpenRouter `gpt-audio-mini` | Latency + quality > privacy + cost; 3-6 s/turn |
+| **TinkerClaw** | 3 | Moonshine (or OR) | TinkerClaw Gateway (agent runner) | Piper (or OR) | Long-running autonomous tasks: code review, browser automation |
+
+Switching is hot — a deep-copied per-connection config means two Tab5s
+on the same Dragon can be in different modes simultaneously.  Cloud
+fallback to Local fires automatically when STT/TTS API errors out.
+
+## The router (per-modality LLM routing)
+
+When the LLM backend is `"router"` (opt-in, see `config.yaml` →
+`llm.fleet`), Dragon holds a *fleet* of LLM backends and picks per
+turn based on the modalities present in the message and the active
+voice_mode tier:
+
+```mermaid
+graph TD
+    Msg[Incoming message] --> Infer[infer_required_caps]
+    Infer -->|TEXT only| TextRoute{Tier}
+    Infer -->|TEXT+VISION| VisionRoute{Tier}
+    Infer -->|TEXT+VIDEO| VideoRoute{Tier}
+
+    TextRoute -->|local| Ministral[ministral-3:3b<br/>$0]
+    TextRoute -->|cloud| DSv4Flash[deepseek-v4-flash<br/>$0.14/$0.28]
+
+    VisionRoute -->|local| MiniCPM[minicpm-v-4<br/>$0]
+    VisionRoute -->|cloud| Qwen36[qwen3.6-flash<br/>$0.25/$1.50]
+
+    VideoRoute -->|local| MiniCPM
+    VideoRoute -->|cloud| GeminiFlash[gemini-3-flash-preview<br/>$0.50/$3]
+```
+
+Lowest priority wins.  Hot-swap on voice_mode change just flips tier
+policy — instantiated sub-backends survive.  Full architecture in
+[`router-cookbook.md`](router-cookbook.md).
+
+## Cross-repo data flows
+
+The four core flows on the system, with deep-dive traces in
+[`flows/`](flows/):
+
+| Flow | Tab5 trigger | Pipeline | Doc |
+|------|--------------|----------|-----|
+| **Voice turn** | Push-to-talk on home orb | mic → STT → ConvEngine → router → tools/memory → TTS → speaker | [`flows/voice-turn.md`](flows/voice-turn.md) |
+| **Text turn** | Chat input + Done key | text → ConvEngine → router → tools/memory → text+TTS | (variant of voice-turn — LLM path is identical) |
+| **Vision turn** | Camera screen → "Send photo" | JPEG upload → router (vision-capable model) → reply | [`flows/vision-turn.md`](flows/vision-turn.md) |
+| **Video call** | Nav sheet → Call tile | bidirectional VID0+AUD0 frames + browser client at `/call` | [`flows/video-call.md`](flows/video-call.md) |
+
+## Network topology
+
+```mermaid
+graph TB
+    Tab5[Tab5<br/>192.168.1.90]
+    DragonHost[Dragon Q6A<br/>192.168.1.91]
+
+    Tab5 -.->|/ws/voice<br/>main protocol| Voice
+    Tab5 -.->|REST: /api/media/upload,<br/>/api/ota/*| Voice
+    Browser((Browser<br/>anywhere on LAN)) -->|/call HTML+JS| Voice
+    DGX[Workstation<br/>LM Studio :1234] -.->|optional LAN tier<br/>fleet entry| Voice
+
+    subgraph DragonHost
+        Voice[tinkerclaw-voice<br/>:3502<br/>aiohttp]
+        Dashboard[tinkerclaw-dashboard<br/>:3500<br/>Web UI proxy]
+        Gateway[tinkerclaw-gateway<br/>:18789 localhost only]
+        Searx[searxng<br/>:8888 web_search backend]
+        Ollama[ollama<br/>:11434<br/>LLM + nomic-embed-text]
+    end
+
+    Voice -.->|ConversationEngine<br/>tool calls| Searx
+    Voice -.->|router → ollama backend| Ollama
+    Voice -.->|voice_mode=3| Gateway
+    Dashboard -->|/api/proxy/*<br/>aggregates state| Voice
+
+    NgrokExt[(public Internet<br/>via ngrok)] -->|tinkerclaw-voice.ngrok.dev| Voice
+    NgrokExt -.->|tinkerclaw-dashboard.ngrok.dev| Dashboard
+    NgrokExt -.->|tinkerclaw-gateway.ngrok.dev| Gateway
+```
+
+| Port | Service | Purpose | External |
+|------|---------|---------|----------|
+| 3500 | dashboard.py | Web UI (11-tab SPA) | via ngrok |
+| 3502 | dragon_voice (`-m dragon_voice`) | Voice WS + REST API + `/call` static | via ngrok |
+| 8080 | Tab5 firmware debug server | Remote control + e2e harness target | LAN-only |
+| 8888 | searxng | Self-hosted metasearch (web_search tool backend) | localhost |
+| 9222 | Chromium CDP | Browser automation target | localhost |
+| 11434 | ollama | LLM inference + embeddings | localhost |
+| 18789 | tinkerclaw-gateway | Agentic sidecar (voice_mode=3) | localhost |
+
+ngrok tunnels run as a single `tinkerclaw-ngrok.service`; the three
+public domains map 1:1 to the three local ports above.  Tab5 firmware
+tries the LAN address first then falls back to
+`wss://tinkerclaw-voice.ngrok.dev:443` so the device works off-network
+(travel, friend's house, etc.).  See
+[`telegram-bot.md`](telegram-bot.md) for the Telegram channel
+deployment as a fourth ngrok target.
+
+## Voice WebSocket protocol — at a glance
+
+The single most important contract on the system.  Full reference:
+[`protocol.md`](protocol.md).
+
+### Tab5 → Dragon (sending)
+
+| Type | Payload | When |
+|------|---------|------|
+| `register` | device_id, hardware_id, capabilities, session_id | First frame after WS connect |
+| `start` | optional `mode: "dictate"` | Begin streaming mic audio |
+| binary (untagged) | raw 16 kHz mono int16 PCM | Mic samples (≥30 ms chunks) |
+| binary `AUD0` + len + PCM | raw 16 kHz mono int16 PCM | Mic samples in **VOICE_MODE_CALL** (bypasses STT, broadcasts to other call participants) |
+| binary `VID0` + len + JPEG | JPEG frame from camera | Video uplink during call |
+| `stop` | (none) | End the speech turn → triggers STT |
+| `cancel` | (none) | Abort current LLM/TTS generation |
+| `text` | content | Skip STT, send text directly to LLM |
+| `config_update` | voice_mode, llm_model, reason | Mode swap |
+| `clear` | (none) | Reset conversation history |
+| `ping` | (none) | Keepalive during long inference |
+| `user_image` | media_id | Photo previously POSTed to `/api/media/upload` |
+| `user_media` | media_id, text | Vision turn (replaces `user_image` long-term) |
+
+### Dragon → Tab5 (receiving)
+
+| Type | Payload | When |
+|------|---------|------|
+| `session_start` | session_id, config (incl. `fleet_summary` if router active) | After `register` is processed |
+| `stt` / `stt_partial` | text | Transcript ready / partial during dictation |
+| `llm` | text token | Streaming LLM token |
+| `tool_call` / `tool_result` | tool name, args, result | Agentic activity |
+| `llm_done` | llm_ms | LLM stream complete |
+| `tts_start` / binary TTS / `tts_end` | 16 kHz mono PCM | Speak the response |
+| `media` / `card` / `audio_clip` / `text_update` | rendered rich content | Inline chat media |
+| `vision_capability` | can_see, model, per_frame_mils | Camera screen capability chip |
+| `progress` | phase, fields… | β-arch unified progress event bus (issue #123) |
+| `error` | code, severity, scope, message | Anything went wrong |
+| `pong` | (none) | Keepalive ack |
+| `config_update` | applied config (incl. `fleet_summary`) | Confirms mode swap |
+
+## Where the code lives
+
+The `dragon_voice` package on Dragon, decomposed in PR
+[#65](https://github.com/lorcan35/TinkerBox/pull/65):
+
+```
+dragon_voice/
+├── __main__.py        — `python3 -m dragon_voice` entry point
+├── server.py          — VoiceServer class + create_app + WS-voice handler family
+├── pipeline.py        — STT → LLM → TTS orchestration (VAD, dictation, post-process)
+├── conversation.py    — ConversationEngine: multi-turn + tool-calling + memory-augmented
+├── sessions.py        — SessionManager (create/resume/pause/end lifecycle)
+├── messages.py        — MessageStore (append-only, multimodal-aware context builder)
+├── memory.py          — MemoryService (facts + documents + RAG via nomic-embed-text)
+├── db.py              — Async SQLite (aiosqlite, WAL mode)
+├── config.py          — Config dataclasses (incl. ToolsConfig, MemoryConfig, fleet)
+├── config.yaml        — Default configuration
+│
+├── llm/               — Multi-model router + 6 backends (PRs #184-#188)
+│   ├── base.py        — LLMBackend ABC + Modality enum
+│   ├── router.py      — CapabilityAwareRouter (the new central piece)
+│   ├── ollama_llm.py  — Ollama (with OpenAI→Ollama multimodal translator)
+│   ├── openrouter_llm.py — OpenRouter (35-model capability + pricing registry)
+│   ├── lmstudio_llm.py   — LM Studio (LAN tier in fleet)
+│   ├── npu_genie.py   — Qualcomm QAIRT/Genie (text-only, ~8 tok/s)
+│   ├── tinkerclaw_llm.py — TinkerClaw gateway adapter (voice_mode=3)
+│   └── dual.py        — Picker+responder (predates router)
+│
+├── stt/               — moonshine, whisper_cpp, vosk, openrouter
+├── tts/               — piper, kokoro, edge_tts, openrouter
+├── notes/             — Notes CRUD + audio ingestion (separate sub-package)
+├── tools/             — ~15 tools (web_search, recall, datetime, weather, …)
+├── media/             — Rich-media renderer (Pygments, Pillow), MediaStore, URL signer
+├── surfaces/          — Tab5 widget abstraction (live/card/list/chart/media/prompt)
+├── mcp/               — Model Context Protocol client + bridge
+├── api/               — REST API package (53 endpoints)
+├── handlers/          — HTTP handlers (debug, status, config_api)
+├── lifecycle/         — startup, shutdown, monitors, purge
+└── middleware/        — auth, rate_limit, security_headers, cors
+```
+
+Companion files at repo root: `schema.sql` (11 tables: 6 foundation +
+3 memory + 2 scheduler), `dashboard.py` (port 3500 SPA), and
+`tests/` (556 unit tests + the live-Dragon e2e CLI runner).
+
+## Sessions, devices, and conversations
+
+| Concept | Lifetime | Survives | Stored in |
+|---------|----------|----------|-----------|
+| **WebSocket connection** | Until network blip | Reconnect → resume same session | (in-memory) |
+| **Session** | Until `paused`-aged-out (configurable, default 30 days) or explicitly ended | Reboot, reconnect, mode swap | `sessions` table |
+| **Device** | Forever (registered once) | Reboot, factory reset | `devices` table |
+| **Conversation** | == Session for new sessions; resumable across sessions if you re-attach | Append-only; messages never mutated | `messages` table (multimodal-aware via `__mm__:` content marker) |
+
+A device sends `register` with a stable `device_id` (Tab5 uses the
+hardware MAC).  If the device's `session_id` matches an active or
+recently-paused session, Dragon resumes it and replays the last 20
+messages so Tab5 chat can rehydrate without a REST round-trip.
+Otherwise a new session is created.  Multi-tab/multi-device users
+hit different sessions naturally.
+
+## Hardware: Dragon Q6A reference
+
+| Component | Spec | Notes |
+|-----------|------|-------|
+| SoC | Qualcomm QCS6490 | 4×Cortex-A78 @ 2.7 GHz + 4×Cortex-A55 @ 1.9 GHz |
+| RAM | 12 GB LPDDR5 | Effective ceiling for fleet is ~8 GB after OS + services |
+| NPU | Hexagon V68, 12 TOPS | QAIRT/Genie pipeline; Llama 3.2 1B at ~8 tok/s |
+| GPU | Adreno 643 | Currently unused for inference |
+| Storage | 128 GB UFS | `/home/radxa` lives here |
+| Network | 1 GbE on enp1s0 | Static IP 192.168.1.91; WiFi disabled |
+| OS | Ubuntu 22.04 ARM64 | Stripped: gdm3, snapd, nanobot, fwupd masked |
+| Power | 12 V / 3 A barrel | Sustained ~8 W idle, ~25 W under inference load |
+
+Voice pipeline RAM budget on a happy day:
+- aiohttp + dragon_voice baseline: ~600 MB
+- Moonshine medium STT: ~400 MB resident
+- Piper TTS: ~150 MB resident
+- ollama + ministral-3:3b: ~2.8 GB (model)
+- Free for cloud responses + media buffers + in-flight LLM contexts: ~7 GB
+
+Adding the multimodal models tightens this — `minicpm-v-4` (Q4_K_M) is
+~3.1 GB and `minicpm-o-4.5` would be ~5.5 GB.  The router's
+`keep_alive_s` parameter passes through to ollama so unused models
+evict promptly.
+
+## Why two repos?
+
+The repo split exists because the deploy targets are different:
+TinkerTab cross-compiles to ESP32-P4 with `idf.py` and flashes over
+USB, while TinkerBox is a Python service that `scp`s to Dragon and
+runs under systemd.  Versioning, CI, dependency footprint, and
+contributor expertise all want to be separate.
+
+The protocol contract in [`protocol.md`](protocol.md) is what
+guarantees they can evolve independently.  Tab5 firmware can ship a
+new feature behind a capability flag in the `register` frame; Dragon
+checks the flag before relying on it.
+
+## Where to go next
+
+Depending on what you're trying to do:
+
+| Goal | Read |
+|------|------|
+| Implement a Tab5-compatible client | [`protocol.md`](protocol.md) — full WS reference |
+| Trace one concrete request through the system | [`flows/voice-turn.md`](flows/voice-turn.md) (or `vision-turn.md`, `video-call.md`) |
+| Configure the LLM router fleet | [`router-cookbook.md`](router-cookbook.md) |
+| Author a skill that emits widgets | [`SKILL_AUTHORING.md`](SKILL_AUTHORING.md) + TinkerTab's [`docs/WIDGETS.md`](https://github.com/lorcan35/TinkerTab/blob/main/docs/WIDGETS.md) |
+| Set up the NPU LLM pipeline | [`npu-setup.md`](npu-setup.md) |
+| Look up an unfamiliar term | [`../GLOSSARY.md`](../GLOSSARY.md) |
+| Operate the running system | [`../CLAUDE.md`](../CLAUDE.md) — runbook (deploy, debug, restart, monitor) |
+| See past audits / progress trackers | [`historical/`](historical/) |

--- a/docs/flows/video-call.md
+++ b/docs/flows/video-call.md
@@ -1,0 +1,222 @@
+# Video Call — End-to-End Trace
+
+> Concrete walkthrough of a two-way video call between Tab5 and a
+> browser client at `/call`, with Dragon as a verbatim broadcast
+> relay.  No transcoding on Dragon — frames are forwarded byte-for-
+> byte to every other connected participant.
+
+## Setup
+
+- Tab5 at 192.168.1.90, voice WS connected.
+- Browser at any LAN device, opens `https://tinkerclaw-voice.ngrok.dev/call` (or `http://192.168.1.91:3502/call` on LAN).
+- Both client connections present in `_connections` on Dragon.
+
+## The architecture
+
+Dragon's role in a call is *deliberately stupid*: it receives `VID0`-tagged or `AUD0`-tagged binary frames from any connection and forwards them verbatim to all *other* connections (sender excluded). No transcoding, no re-encoding, no buffering beyond the WS write queue. This is the simplest thing that works and it scales naturally — adding a third participant is one more entry in the broadcast loop.
+
+```mermaid
+graph LR
+    Tab5A[Tab5 #1<br/>192.168.1.90]
+    Tab5B[Tab5 #2<br/>another device]
+    Browser[Browser at /call<br/>tinkerclaw-voice.ngrok.dev]
+    Inject[POST /api/video/inject<br/>debug endpoint]
+
+    subgraph "Dragon (relay only)"
+        Relay[VID0/AUD0<br/>broadcast]
+    end
+
+    Tab5A <-->|VID0+AUD0| Relay
+    Tab5B <-->|VID0+AUD0| Relay
+    Browser <-->|VID0+AUD0| Relay
+    Inject -->|test JPEG| Relay
+```
+
+## Wire format
+
+Tab5's video calling uses two binary-frame magic prefixes on the same WebSocket as voice:
+
+| Magic | Direction | Payload | Module |
+|-------|-----------|---------|--------|
+| `VID0` (4 bytes ASCII) + 4-byte BE u32 length + bytes | both | JPEG frame | TinkerTab `voice_video.{c,h}` ↔ TinkerBox `dragon_voice/video_upstream.py` |
+| `AUD0` (4 bytes ASCII) + 4-byte BE u32 length + bytes | both | raw 16 kHz mono int16 PCM | TinkerTab `voice.c` (VOICE_MODE_CALL path) ↔ same broadcaster |
+
+Untagged binary frames are still mic PCM bound for STT — the magic tag is what disambiguates. This means:
+- **Voice turn** (legacy): mic frames go to STT pipeline (no magic).
+- **Call** (`VOICE_MODE_CALL` enabled): mic frames are wrapped with `AUD0` and bypass STT entirely; video uplink is `VID0`-tagged JPEG.
+
+## Tab5 entry: `voice_video_start_call()`
+
+[`main/voice_video.h: voice_video_start_call(int fps)`](https://github.com/lorcan35/TinkerTab/blob/main/main/voice_video.h) is the atomic entry. Triggered by:
+- Nav sheet "Call" tile (`ui_nav_sheet.c`)
+- Debug endpoint `POST /video/call/start?fps=15`
+
+It does three things in order:
+1. Switch voice mode to `VOICE_MODE_CALL` — the persistent mic task ([`voice.c`](https://github.com/lorcan35/TinkerTab/blob/main/main/voice.c) ~line 2400) starts wrapping frames with `AUD0` instead of feeding STT.
+2. Open the camera if not already (the existing `tab5_camera_init`/`tab5_camera_capture` machinery from the camera screen).
+3. Show the in-call UI overlay ([`ui_video_pane.{c,h}`](https://github.com/lorcan35/TinkerTab/blob/main/main/ui_video_pane.c)) — fullscreen video pane with a 240×135 local-camera PIP in the corner and a red "End Call" pill at the bottom.
+
+Symmetric `voice_video_end_call()` reverses all three.
+
+## The trace
+
+```mermaid
+sequenceDiagram
+    participant U1 as 👤 User #1<br/>(on Tab5)
+    participant T as Tab5
+    participant D as Dragon (relay)
+    participant B as Browser at /call
+    participant U2 as 👤 User #2<br/>(at browser)
+
+    Note over T,B: Pre-call: both clients have voice WS open
+    U2->>B: Open https://...ngrok.dev/call<br/>Tap "Join call"
+    B->>D: WS connect (already auth'd)
+    B->>B: getUserMedia (camera+mic)<br/>MediaRecorder JPEG keyframes<br/>Web Audio 16 kHz mono capture
+
+    U1->>T: Tap nav sheet "Call" tile
+    T->>T: voice_video_start_call(fps=10)
+    Note over T: VOICE_MODE_CALL on<br/>Camera initialised<br/>ui_video_pane shown
+    T->>D: WS binary VID0 + len + JPEG (≥1 fps)
+    T->>D: WS binary AUD0 + len + 16kHz PCM (chunked)
+
+    Note over D: video_upstream.handle_binary
+    D->>B: WS binary VID0 + len + JPEG (relay)
+    D->>B: WS binary AUD0 + len + PCM (relay)
+    B->>U2: <video> draws the JPEG<br/>Web Audio plays back PCM
+
+    B->>D: WS binary VID0 + JPEG (browser→Tab5)
+    B->>D: WS binary AUD0 + PCM
+    D->>T: WS binary VID0 + JPEG (relay)
+    D->>T: WS binary AUD0 + PCM
+    T->>T: TJPGD decode → ui_video_pane canvas<br/>PCM → speaker
+
+    Note over T,B: ─── Hang up ───
+    U1->>T: Tap red "End Call" pill
+    T->>T: voice_video_end_call()
+    Note over T: VOICE_MODE_CALL off<br/>Camera closed<br/>Pane hidden
+    Note over D: T's WS connection still open<br/>but no longer in call
+    B->>U2: Browser sees no more frames
+    U2->>B: Tap "Leave"
+```
+
+### Tab5 → Dragon → Browser direction
+
+#### 1. Tab5 captures + JPEG-encodes
+[`voice_video.c: streaming_task`](https://github.com/lorcan35/TinkerTab/blob/main/main/voice_video.c) — persistent FreeRTOS task on Core 1. Idles on `s_event_sem` between calls; when a call is active, it captures a frame from the camera at the requested fps (default 10, max 10), applies `cam_rot` if non-zero, JPEG-encodes via the shared HW JPEG engine.
+
+The same encoder is shared with the camera-screen recording feature (#291); a mutex inside `voice_video.c` serializes concurrent uplink + record encodes since ESP32-P4 only has one HW JPEG engine.
+
+Output buffer is DMA-aligned via `jpeg_alloc_encoder_mem()`; the wire buffer (output + 8 byte header) is a separate plain PSRAM allocation since the WS-send path doesn't need DMA.
+
+#### 2. Tab5 wraps + sends VID0 frame
+[`voice_video.c: pack_wire_frame`](https://github.com/lorcan35/TinkerTab/blob/main/main/voice_video.c):
+```
+'V' 'I' 'D' '0'             // 4-byte magic
+[len >> 24] [len >> 16] [len >> 8] [len]   // 4-byte BE u32 length
+<JPEG bytes>                 // payload
+```
+
+`voice_ws_send_binary()` ships it. Each call connection's `aiohttp.WebSocketResponse` has an internal write queue; if the queue backs up (slow client), Tab5's send drops the frame rather than waiting. Better to drop than introduce variable lag.
+
+#### 3. Dragon dispatches to the broadcast handler
+[`dragon_voice/server.py:696+`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/server.py#L696) — the WS receive loop sniffs the first 4 bytes of every binary frame:
+```python
+if data[:4] == b"VID0":
+    handler.handle_binary(ws, conn_state, data)
+elif data[:4] == b"AUD0":
+    handler.handle_binary(ws, conn_state, data)
+else:
+    # legacy untagged → mic PCM → STT pipeline
+```
+
+The handler is [`video_upstream.py: VideoUpstreamHandler`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/video_upstream.py).
+
+#### 4. Verbatim broadcast
+[`video_upstream.py:105+`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/video_upstream.py#L105) iterates `_connections` and forwards the same `data` bytes to every connection that:
+- isn't the sender,
+- has its WS open,
+- isn't in a "muted" state (call_mute on Tab5 stops outbound AUD0 but doesn't affect VID0).
+
+No buffering beyond aiohttp's write queue. No re-encode. The JPEG that landed at Dragon is the JPEG that lands at every other client.
+
+#### 5. Browser receives + draws
+[`dragon_voice/static/call.html`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/static/call.html) — the call client. Maybe 200 lines of vanilla JS:
+- `ws = new WebSocket(...)` opened to the same `/ws/voice` endpoint.
+- `ws.onmessage` for binary frames: peek 4-byte magic → if VID0, slice off header, blob → object URL → set as `<video>` src OR draw onto a `<canvas>`. Object URLs are revoked promptly to avoid leaking.
+- For AUD0: decode the 16-bit PCM into a Float32Array, push into an `AudioBufferSourceNode` chain.
+
+The browser's outbound side captures via `getUserMedia({video, audio})` and:
+- Video: `MediaRecorder` produces JPEG keyframes (or `<canvas>` capture every N ms), wrapped with VID0 magic + length, sent as binary WS.
+- Audio: `AudioContext` + `ScriptProcessorNode` (or `AudioWorkletNode`) at 16 kHz mono Float32 → int16 conversion → AUD0-wrapped chunks.
+
+### Browser → Dragon → Tab5 direction
+
+Mirror image of the Tab5→Browser path. Browser sends VID0+AUD0 over its own WS connection; Dragon's broadcast handler picks it up and sends it to Tab5.
+
+#### 6. Tab5 decodes + renders
+[`voice_video.c: voice_video_on_downlink_frame`](https://github.com/lorcan35/TinkerTab/blob/main/main/voice_video.c) is the entry point Dragon's relay calls (via the WS receive callback in `voice.c`). 
+
+Step:
+- Verify the magic + length.
+- Allocate a slot for the JPEG payload (or reuse one from a pool).
+- Schedule `tab5_lv_async_call(decode_and_blit, slot)` to hop to the LVGL thread.
+- On the LVGL thread, TJPGD decodes the JPEG into the `ui_video_pane` canvas's PSRAM RGB565 buffer; `lv_obj_invalidate(canvas)` triggers the next render.
+
+For AUD0 frames: directly pushed into the playback ring buffer (same path as TTS playback) — feeds `esp_codec_dev_write()` to the ES8388 DAC, upsampled 1:3 from 16 kHz → 48 kHz I2S rate.
+
+The local-camera PIP in the corner is rendered separately by the streaming task — same `cam_rot` applies.
+
+## Endpoints
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /call` | Serves `static/call.html` (the browser client). The WS endpoint it connects to is the same `/ws/voice` everyone uses. |
+| `POST /api/video/inject` | Debug — pushes a JPEG into the relay as if it had come from a client. Bearer-auth. Useful for testing Tab5 downlink without a second device. |
+| `GET /video` (Tab5 debug) | Stats: frames sent/received, bytes, last JPEG size, pane state. |
+| `POST /video/call/start?fps=N` (Tab5 debug) | Atomic call-start (mode swap + camera open + pane show). |
+| `POST /video/call/end` (Tab5 debug) | Atomic call-end. |
+| `POST /call/mute` / `/call/unmute` (Tab5 debug) | Mic mute (uplink AUD0 stops; video continues). |
+| `POST /call/minimize` / `/call/restore` (Tab5 debug) | Pane minimize → PIP-only / restore to fullscreen. |
+| `GET /call/status` (Tab5 debug) | `{in_call, pane_visible, pane_minimized, video_stats}` snapshot. |
+
+## Latency + bandwidth
+
+| Hop | Typical |
+|-----|---------|
+| Camera capture + JPEG encode (Tab5) | ~50-100 ms per frame at 720p quality 30 |
+| Tab5 WS send | ~5-15 ms LAN, ~50-200 ms via ngrok |
+| Dragon relay forward | ~1-3 ms (no transcode) |
+| Browser receive + decode + paint | ~10-30 ms |
+| Total Tab5→Browser one-way | **~70-300 ms** depending on path |
+
+Bandwidth at 10 fps with 30-50 KB JPEG frames: ~3-5 Mbps each direction per stream. AUD0 at 16 kHz mono int16 = 32 KB/s = ~256 kbps each direction. Total per-call: ~6-10 Mbps both ways.
+
+## Where things go wrong
+
+| Symptom | Cause | Mitigation |
+|---------|-------|------------|
+| Tab5 video pane shows last-known frame frozen | Sender (browser/other Tab5) disconnected; broadcast loop has nothing to forward | Browser shows "Waiting for participant…" message; Tab5 pane just stops updating. End the call to recover. |
+| Audio underruns / gaps | Browser's `ScriptProcessorNode` not delivering frames fast enough (CPU contention) | Use `AudioWorkletNode` instead (cleaner threading); already on the roadmap. |
+| Tab5 mic uplink silent | `call_mute` was set; uplink AUD0 path short-circuits | Call `/call/unmute` or tap the mute button in the UI pane. |
+| `ngrok` path adds 200 ms latency | Free tier ngrok is in a US region | Use LAN address (192.168.1.91:3502) when both clients are local. |
+| Browser denies camera/mic | HTTPS context required for getUserMedia, and the user has to grant permission | Ngrok provides HTTPS automatically; for local LAN access need either HTTPS reverse proxy or use `localhost`. |
+| Frame drops under load | Tab5's HW JPEG engine + WS send queue can't keep up at 15 fps | Default fps is 10; reduce further if needed. The shared encoder mutex with the camera-record path can contend. |
+
+## OPUS audio (partial)
+
+The capability negotiation framework for OPUS shipped in TinkerBox #174 + TinkerTab #263/#265. Tab5's register frame advertises `audio_codec: ["pcm"]` for uplink (OPUS encoder gated off pending TinkerTab #264 — SILK NSQ crash on ESP32-P4) and `audio_downlink_codec: ["pcm","opus"]` for downlink. Dragon's response in `session_start.config` confirms the negotiated codec.
+
+When OPUS uplink lands (issue #264 unblocked), the AUD0 wire format gets a sub-tag indicating codec. For now everyone uses PCM.
+
+## TinkerClaw mode (3) does NOT use this path
+
+`VOICE_MODE_CALL` is independent of `voice_mode` 0/1/2/3 (the STT/LLM/TTS tier picker). A call is just frames-on-the-wire; there's no LLM involvement. The router, ConversationEngine, and the entire intelligence stack are bypassed.
+
+If a call ends and the user goes back to voice/text turns, the previous `voice_mode` (whatever it was before VOICE_MODE_CALL took over) restores.
+
+## Related docs
+
+- [`voice-turn.md`](voice-turn.md) — the simpler text+voice path (no calls)
+- [`vision-turn.md`](vision-turn.md) — single-shot photo with ConvEngine routing
+- [`../protocol.md`](../protocol.md) §18 (Video + Call Audio) — wire format reference
+- [`../../GLOSSARY.md`](../../GLOSSARY.md) — `VID0`, `AUD0`, `VOICE_MODE_CALL`, `relay`

--- a/docs/flows/vision-turn.md
+++ b/docs/flows/vision-turn.md
@@ -1,0 +1,225 @@
+# Vision Turn — End-to-End Trace
+
+> Concrete walkthrough of what happens when a user takes a photo on
+> the Tab5 camera screen with the chat overlay armed for share.  The
+> photo travels Tab5 → REST upload → Dragon media store → WS
+> announcement → ConversationEngine → router (vision-capable model)
+> → reply, with the photo persisted in conversation history so
+> follow-up text turns still see it.  This flow is what PR #186 made
+> work end-to-end.
+
+## Setup
+
+- Tab5 boot: WS connected to Dragon, voice_mode = 0 (Local) with router fleet active.
+- Fleet's local-tier vision model: `minicpm_v4` (priority 10).
+- User has just opened chat and tapped the "Send photo" button (it sets `s_chat_share_armed = true` in [`ui_camera.c`](https://github.com/lorcan35/TinkerTab/blob/main/main/ui_camera.c)).
+- Camera screen now showing live viewfinder.
+
+## The trace
+
+```mermaid
+sequenceDiagram
+    participant U as 👤 User
+    participant T as Tab5
+    participant D as Dragon
+    participant R as Router
+    participant V as MiniCPM-V<br/>(Ollama backend)
+
+    U->>T: Tap white shutter circle
+    T->>T: capture_btn_cb()<br/>tab5_camera_capture()<br/>save IMG_NNNN.jpg to SD
+    T->>D: HTTP POST /api/media/upload<br/>(JPEG bytes, X-Session-Id)
+    D->>D: MediaStore.put_blob()<br/>→ media_id
+    D->>T: 200 {"media_id":"abc123…"}
+    T->>D: WS {"type":"user_image",<br/>"media_id":"abc123…"}
+    Note over D: server.py _handle_user_media
+    D->>D: ConversationEngine.process_text_stream<br/>(media_id=abc123…)
+    Note over D: MessageStore.add_message<br/>encodes content with __mm__: marker
+    D->>D: _build_context (hydrates marker→<br/>OpenAI multimodal array)
+    D->>R: generate_stream_with_messages(messages)
+    Note over R: infer_required_caps → {TEXT, VISION}<br/>tier_filter: voice_mode=0 → {local}<br/>candidates: [minicpm_v4]<br/>winner: minicpm_v4 (priority 10)
+    R->>V: lazy instantiate Ollama backend<br/>POST /api/chat<br/>(content + images: [base64])
+    V->>R: token stream
+    R->>D: pass-through tokens
+    D->>T: WS {"type":"llm","text":"<token>"} (×N)
+    D->>T: WS {"type":"llm_done"}
+    Note over T: chat overlay shows reply text
+
+    Note over T,V: ─── Cross-modal continuity ───
+    U->>T: Type follow-up: "what color was the chair?"
+    T->>D: WS {"type":"text","content":"what color..."}
+    D->>D: _handle_text → process_text_stream
+    Note over D: MessageStore.get_context loads<br/>last 10 msgs INCLUDING the photo<br/>(hydrated to image_url + text)
+    D->>R: generate_stream_with_messages
+    Note over R: messages still have VISION content<br/>→ router picks minicpm_v4 again
+    R->>V: POST /api/chat (with full context)
+    V->>R: tokens
+    R->>D: tokens
+    D->>T: WS llm tokens
+    Note over T: Follow-up answer references the photo
+```
+
+### Step-by-step
+
+#### 1. User taps the shutter button
+[`main/ui_camera.c: capture_btn_cb`](https://github.com/lorcan35/TinkerTab/blob/main/main/ui_camera.c) at line ~903.  Calls `tab5_camera_capture()` to grab a frame, applies cam_rot rotation if `cam_rot != 0`, saves to `/sdcard/IMG_NNNN.jpg` (counter resumed from existing files at screen-create time).
+
+`s_chat_share_armed` was set when the user opened the camera from the chat "Send photo" button. If true (as in this scenario), the next save also fires `voice_upload_chat_image(path)` via the shared task_worker.
+
+#### 2. Tab5 uploads the JPEG over HTTP
+[`main/voice.c: voice_upload_chat_image`](https://github.com/lorcan35/TinkerTab/blob/main/main/voice.c) loads the file from SD into a PSRAM buffer (max 6 MB per audit S2) and POSTs to `http://<dragon_host>:<dragon_port>/api/media/upload`.
+
+```
+POST /api/media/upload HTTP/1.1
+Host: 192.168.1.91:3502
+X-Session-Id: c3bd83829cee...
+Content-Type: application/octet-stream
+Authorization: Bearer <DRAGON_API_TOKEN>
+Content-Length: 5290341
+
+<JPEG bytes>
+```
+
+The upload is queued on `task_worker` (8 KB stack on shared FreeRTOS task) so the WS RX loop doesn't stall during a multi-MB transfer.
+
+#### 3. Dragon stores the blob
+[`dragon_voice/api/media_routes.py: handle_media_upload`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/api/media_routes.py) → [`media/store.py: MediaStore.put_blob`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/media/store.py).
+
+Pillow opens the bytes (validates it's actually a JPEG/BMP/PNG), resizes to ≤ 660 px wide (dashboard + Tab5 chat constraint), re-encodes as JPEG quality 80, writes to `/home/radxa/media/<32-char-hex>.jpg`.
+
+The 32-hex `media_id` is the SHA-256 of the resized bytes (so duplicate uploads are deduplicated naturally). MediaStore tracks creation time + an LRU access timestamp; a 24-hour TTL purger runs hourly via [`lifecycle/purge.py: media_cleanup_loop`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/lifecycle/purge.py).
+
+The 200 response: `{"media_id":"5dc97c03a51c43beb80151f3e3e56a34.jpg"}`.
+
+#### 4. Tab5 announces the image on the WS
+[`voice.c: voice_send_user_image`](https://github.com/lorcan35/TinkerTab/blob/main/main/voice.c) sends:
+```json
+{"type":"user_image","media_id":"5dc97c03a51c43beb80151f3e3e56a34.jpg"}
+```
+
+The legacy `user_image` message and the newer `user_media` (which adds an explicit `text` field) both end up in the same handler. PR #186 unified the two paths.
+
+#### 5. Dragon receives + capability check
+[`dragon_voice/server.py: _handle_user_media`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/server.py#L2499) — the WS dispatcher routes `user_media` here.
+
+First, lookup: `image_path = await self._media_store.get_path(media_id)`. If the file vanished (TTL expired, manual cleanup), respond with `error_event(code="media_not_found")` and bail.
+
+Next, capability check (post-#300): get the active LLM via `conn_state.get("conversation")._llm`. Refuse with `error_event(code="vision_unsupported")` if `Modality.VISION not in llm.capabilities`. The check works uniformly for single-backend setups (whose `capabilities` is computed from the model id) and for the router (whose `capabilities` is the union of fleet caps in the active tier).
+
+#### 6. Re-thread through ConversationEngine
+The bug-prone old code (pre-#186) bypassed ConversationEngine entirely — the photo never made it into `messages` table, so follow-up text turns couldn't reference it. The new code:
+
+```python
+async with self._ws_keepalive_during_inference(ws, label="vision"):
+    async for token in conv.process_text_stream(
+        session_id=session_id,
+        text=text,
+        input_mode="vision",
+        media_id=media_id,
+    ):
+        ...
+```
+
+`process_text_stream` is the canonical entry — same as text turns. The new `media_id` parameter tells it to persist the user message as a multimodal one.
+
+#### 7. Persist the multimodal message
+[`messages.py: add_message`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/messages.py) — when `media_id` is non-None, content is encoded as:
+```
+__mm__:{"media_id":"5dc97c03...","text":"What's in this image?"}
+```
+
+This lands in `messages.content` (TEXT column). The marker prefix lets `get_context` later detect a multimodal row and hydrate it back to OpenAI format. Persisting the *reference* (not the base64) keeps the DB small and ensures the Tab5 → Dragon → Tab5 chat history replay works.
+
+> **Schema constraint:** `messages.input_mode` CHECK is `('voice','text','system')` — vision turns use `"text"` (the multimodal nature lives in the content marker, not the input_mode). LEARNINGS describes the schema migration that would relax this.
+
+#### 8. Build context with media hydration
+[`conversation.py: _build_context`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/conversation.py) calls `MessageStore.get_context(session_id, max_messages=10, media_store=self._media_store)`.
+
+For each historical message with the `__mm__:` marker, [`messages.py: _hydrate_multimodal_content`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/messages.py) reads the file from disk, base64-encodes it inline, and returns:
+```python
+[
+    {"type":"image_url","image_url":{"url":"data:image/jpeg;base64,..."}},
+    {"type":"text","text":"What's in this image?"}
+]
+```
+
+If the media file expired (TTL hit), it substitutes `f"{text} [image expired]"` so the LLM doesn't hallucinate against missing data.
+
+The system prompt still gets memory facts + tool descriptions injected as in any text turn.
+
+#### 9. Router routing
+[`router.py: generate_stream_with_messages`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/llm/router.py) runs `infer_required_caps(messages)`:
+- The user content has `image_url` part → `+ Modality.VISION`.
+- No `video_url`, no `input_audio` → no other caps added.
+- Required: `{TEXT, VISION}`.
+
+`choose(required_caps, voice_mode=0)`:
+- tier_filter: `{"local"}` from `TIER_FOR_MODE[0]`.
+- candidates: filter fleet for `tier == "local"` AND `{TEXT, VISION} ⊆ capabilities`.
+- With the canonical fleet, `minicpm_v4` (caps: text+vision+video, tier: local, priority: 10) is the only match.
+- Winner: `minicpm_v4`.
+
+Logged: `router: chose minicpm_v4 for [TEXT, VISION] tier=local`.
+
+#### 10. Lazy sub-backend instantiation
+First time the router needs `minicpm_v4`, it constructs an `OllamaBackend` with `ollama_model="hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M"` and `keep_alive="120s"`. Subsequent calls reuse the same instance.
+
+If multiple WS connections hit the router for the same spec concurrently, the `_instance_lock` serializes the construction so we never double-create.
+
+#### 11. Ollama call with multimodal translation
+[`ollama_llm.py: _translate_to_ollama_format`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/llm/ollama_llm.py) converts each message in the list:
+- OpenAI `{"role":"user","content":[{"type":"image_url",...},{"type":"text","text":"..."}]}` →
+- Ollama `{"role":"user","content":"<text part>","images":["<base64 without data: prefix>"]}`
+
+(See LEARNINGS #90 for the ugly 400 error the system used to produce before this translator existed.)
+
+The POST body is sent to `localhost:11434/api/chat`. Ollama hands it to the loaded MiniCPM-V model. On Dragon Q6A CPU this takes 5-7 minutes per frame (genuinely slow — see TROUBLESHOOTING). If you run the same model via LM Studio on a workstation in the LAN tier, latency drops to ~5-10 s.
+
+#### 12. Token stream + LLM done
+Same path as a text turn — tokens stream through the rolling buffer in [`conversation.py:376+`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/conversation.py), Tab5 sees `{"type":"llm","text":"<token>"}` events, the chat overlay accumulates the reply.
+
+`{"type":"llm_done","llm_ms":<elapsed>}` ends the turn. Response persisted to `messages` table as a normal `assistant` row. No multimodal marker on the assistant side — Tab5 just sees text.
+
+#### 13. (Optional) Follow-up text turn references the photo
+Now the powerful part. User types "what color was the chair?" via the chat input. Tab5 sends `{"type":"text","content":"what color was the chair?"}`.
+
+`_handle_text` → `process_text_stream` (no `media_id` this time) → `_build_context` loads the last 10 messages. The earlier user-image message is still there — `MessageStore.get_context` hydrates it back to the OpenAI multimodal array.
+
+Router runs `infer_required_caps` again — sees the historical `image_url` content → required = `{TEXT, VISION}`. Picks `minicpm_v4` again. Pushes the full conversation to Ollama. The model sees both messages: photo + new question. Reply: "It was the green office chair near the window."
+
+> **The "router stays sticky" pattern:** As long as the photo is in context, every turn picks the same vision model. If you let the photo age out of the 10-message window (or call `clear`), the next text turn falls back to `ministral`.
+
+## Cost & latency
+
+| Scenario | Frame upload | LLM time | Total |
+|----------|-------------|----------|-------|
+| Local mode, MiniCPM-V on Q6A CPU | ~150 ms | **~7 min** | ~7 min |
+| Local mode + LAN tier (LM Studio on DGX) | ~200 ms | ~5-15 s | ~5-15 s |
+| Cloud mode, qwen3.6-flash | ~300 ms | ~3-6 s | ~3-6 s |
+| Cloud mode, gemini-3-flash-preview (native video) | ~300 ms | ~2-4 s | ~2-4 s |
+| Cloud mode, opus-4.7 (premium) | ~300 ms | ~10-20 s | ~10-20 s |
+
+Per-frame cost in Cloud mode: $0.0003 - $0.05 depending on model. The `vision_capability` event tells Tab5 the per-frame cost so the camera-screen chip can show "VISION · qwen3.6-flash · ~$0.0003/frame" before the user pulls the trigger.
+
+## Where things go wrong
+
+| Symptom | Cause | Fix / mitigation |
+|---------|-------|------------------|
+| `{"error":"media_not_found"}` immediately on upload | TTL expired, file deleted, or media_id typo | Re-upload; check 24h purger isn't running too aggressively |
+| `{"error":"vision_unsupported"}` | Active LLM lacks Modality.VISION | Switch to a vision-capable model — Cloud mode, or add a vision spec to local fleet |
+| Ollama 400 "json: cannot unmarshal array" | OllamaBackend hitting old code path | Update — this was the symptom of LEARNINGS #90 |
+| Vision turn works, follow-up text doesn't see photo | `_build_context` not hydrating | Check `media_store=` is wired in `ConversationEngine.__init__` (#186 startup change) |
+| haiku-3.5 returns "does not support image input" | OR brokered to Bedrock route which is text-only | Capability registry in `_OPENROUTER_CAPS` correctly declares haiku-3.5 text-only — see LEARNINGS #93 |
+| MiniCPM-V hits 300s timeout | Q6A is slow; default `wait_for` is 300s | Bump `OllamaBackend.wait_for` for vision models OR move to LAN tier OR Cloud mode |
+
+## Variations on this flow
+
+- **Voice + image** (user speaks while showing a photo): Tab5 captures both, sends `user_media` with `text` populated by the STT result. Same router logic.
+- **Image from URL** (Dragon-rendered media in chat): same MediaStore but the source is a Dragon-side render (Pygments code block, Pillow table, etc.) instead of a Tab5 upload.
+- **Video frames** (future, see `video-call.md` and the `user_video` proposal): N frames sampled from a `.MJP` recording on Tab5 SD. `infer_required_caps` upgrades to `{TEXT, VIDEO}`. Router picks a VIDEO-capable model (gemini-3-flash-preview natively, or any VISION model with multi-image stitching).
+
+## Related docs
+
+- [`voice-turn.md`](voice-turn.md) — the simpler text-only path
+- [`video-call.md`](video-call.md) — bidirectional video over WS
+- [`../router-cookbook.md`](../router-cookbook.md) — fleet recipes including LAN tier
+- [`../../GLOSSARY.md`](../../GLOSSARY.md) — `Modality`, `tier`, `fleet`, `multimodal marker` definitions

--- a/docs/flows/voice-turn.md
+++ b/docs/flows/voice-turn.md
@@ -1,0 +1,195 @@
+# Voice Turn — End-to-End Trace
+
+> Concrete walkthrough of what happens when a user taps the home-screen
+> orb on Tab5 and asks "what time is it?".  Each step has a file:line
+> reference so you can chase the actual code.  When an answer arrives
+> through the speaker ~3-90 seconds later, all 18 of these steps have
+> happened.
+
+## Setup
+
+- Tab5 boot: WS connected to Dragon, `voice.state == READY`.
+- Voice mode: 0 (Local) — STT=Moonshine, LLM=ollama ministral-3:3b, TTS=Piper.
+- User on home screen, looking at the Tinker orb.
+
+## The trace
+
+```mermaid
+sequenceDiagram
+    participant U as 👤 User
+    participant T as Tab5
+    participant D as Dragon
+    participant O as Ollama (LLM)
+
+    U->>T: Tap orb
+    T->>T: ui_voice_show() + voice_start_listening()
+    T->>D: WS {"type":"start"}
+    Note over T: VOICE_STATE_LISTENING<br/>orb breathes, mic capturing
+    U->>T: "what time is it?"
+    T->>D: binary PCM frames (16 kHz int16)
+    U->>T: Tap orb again (or auto-stop on silence)
+    T->>D: WS {"type":"stop"}
+
+    Note over D: VAD declared end-of-utterance
+    D->>D: Moonshine STT → "what time is it?"
+    D->>T: WS {"type":"stt","text":"..."}
+    D->>D: ConversationEngine.process_text_stream
+    D->>D: build_context (memory + tool descriptions)
+    D->>O: POST /api/chat (ministral-3:3b)
+    O->>D: token stream
+    D->>T: WS {"type":"llm","text":"<token>"} (×N)
+
+    Note over D: First tool marker detected:<br/>&lt;tool&gt;datetime&lt;/tool&gt;
+    D->>D: ToolRegistry.execute("datetime")
+    D->>T: WS {"type":"tool_call","tool":"datetime",...}
+    D->>O: POST /api/chat (with tool result injected)
+    O->>D: final tokens
+    D->>T: WS {"type":"llm_done","llm_ms":1234}
+    D->>T: WS {"type":"tts_start","sample_rate":16000}
+    D->>T: binary PCM TTS audio (×N chunks)
+    D->>T: WS {"type":"tts_end"}
+    T->>U: Speaker plays "It's 3:42 PM"
+    Note over T: VOICE_STATE_READY (orb idle)
+```
+
+### Step-by-step
+
+#### 1. User taps orb on home screen
+[`main/ui_home.c:1261`](https://github.com/lorcan35/TinkerTab/blob/main/main/ui_home.c#L1261) — `cb_orb_speak_press` fires, calls `ui_voice_show()` then `voice_start_listening()`.
+
+The orb is in `lv_layer_top()` so it works on any home page.  Halo
+ring animation continues while voice flow runs.  ([`ui_voice.c:611`](https://github.com/lorcan35/TinkerTab/blob/main/main/ui_voice.c#L611))
+
+#### 2. Tab5 transitions LISTENING and starts mic capture
+[`main/voice.c:355`](https://github.com/lorcan35/TinkerTab/blob/main/main/voice.c#L355) — `voice_set_state(LISTENING)`. The state callback updates the home orb tint, fires `tab5_debug_obs_event("voice.state", "LISTENING")` for the e2e harness, and the persistent mic task ([`voice.c:2400+`](https://github.com/lorcan35/TinkerTab/blob/main/main/voice.c#L2400)) wakes via its event semaphore.
+
+The mic task pulls 4-channel TDM samples from the ES7210 ADC at 48 kHz, downsamples 3:1 to 16 kHz, extracts the slot-0 (primary mic) channel, and chunks them at 30 ms boundaries.
+
+#### 3. Tab5 sends `{"type":"start"}` on WS
+[`main/voice.c:voice_start_listening`](https://github.com/lorcan35/TinkerTab/blob/main/main/voice.c) sends a JSON text frame: `{"type":"start"}`. (For dictation mode it adds `"mode":"dictate"` — see `dictation` doc.)
+
+Dragon's WS handler ([`dragon_voice/server.py:752`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/server.py#L752)) receives it via the dispatcher and arms the pipeline for an utterance.
+
+#### 4. Tab5 streams binary mic frames
+Untagged binary WS frames carry raw 16 kHz mono int16 PCM. Each frame is one ~30 ms chunk (~960 bytes). On Dragon, [`server.py: _on_audio`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/server.py) feeds them into the pipeline's circular buffer. The pipeline's VAD ([`pipeline.py: VoicePipeline._on_chunk`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/pipeline.py)) tracks energy + silence duration to decide end-of-utterance.
+
+> **Why untagged?** Legacy mic path predates the VID0/AUD0 magic prefix; `AUD0`-tagged binary is reserved for `VOICE_MODE_CALL` where the audio bypasses STT.
+
+#### 5. User stops talking → silence triggers `stop`
+Either VAD detects 600 ms of silence and Tab5 auto-stops, or the user taps the orb again. Either way: `{"type":"stop"}` is sent. ([`voice.c:voice_stop`](https://github.com/lorcan35/TinkerTab/blob/main/main/voice.c))
+
+Voice state on Tab5 transitions to `PROCESSING`; orb dims to indicate "thinking".
+
+#### 6. Dragon runs Moonshine STT
+[`dragon_voice/stt/moonshine_stt.py: transcribe`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/stt/moonshine_stt.py) — the buffered audio is fed to `moonshine_voice` (medium model, streaming variant). On Dragon Q6A this takes ~400-800 ms for a 2-second utterance.
+
+A `{"type":"stt","text":"what time is it?"}` event goes back to Tab5 so the chat overlay can show what was heard.
+
+#### 7. ConversationEngine takes over
+[`dragon_voice/conversation.py: process_text_stream`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/conversation.py) — the canonical text-turn entry point. Even voice turns end up here once STT is done; vision turns also enter here post-#186.
+
+The engine first persists the user message via [`messages.py: MessageStore.add_message`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/messages.py) (append-only — `id, session_id, role:"user", content, input_mode:"voice", created_at`).
+
+#### 8. Build context: memory + tools + history
+[`conversation.py: _build_context`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/conversation.py) does three things:
+1. Loads recent message history (10 for local backends, 30 for cloud) via `MessageStore.get_context(media_store=...)`. Multimodal markers (`__mm__:` content prefix) hydrate to OpenAI `image_url` content arrays here.
+2. Asks `MemoryService.get_relevant_context(user_text)` for relevant facts (cosine-similarity search over nomic-embed-text 768-dim vectors). Top hits are appended to the system prompt.
+3. Renders the tool registry into the system prompt — compact format for local models, full for cloud (`registry.format_for_llm(compact=is_local)`).
+
+A token-budget trim runs over the assembled context (25.6K for local, 100K for cloud) — see [`messages.py: trim_context_to_budget`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/messages.py).
+
+#### 9. Hand context to the LLM (or router)
+With `backend: "router"`, `self._llm` is a `CapabilityAwareRouter`. [`router.py: generate_stream_with_messages`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/llm/router.py) runs `infer_required_caps(messages)` (text-only here — no images), picks the lowest-priority spec in the active tier (`ministral` priority 0 in local), lazily instantiates the sub-backend if needed, and delegates.
+
+For the legacy single-backend case, `self._llm` is just `OllamaBackend` directly.
+
+#### 10. Ollama call
+[`ollama_llm.py: generate_stream_with_messages`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/llm/ollama_llm.py) translates content arrays to Ollama format (a no-op for text-only turns), POSTs `/api/chat` to `localhost:11434`, and async-iterates the stream of NDJSON chunks.
+
+Each chunk's `message.content` field is a token; the keepalive parameter (10 minutes for ministral, much shorter for vision models per fleet config) keeps the model resident between calls.
+
+#### 11. Token streaming with marker-aware buffering
+[`conversation.py: 376-388`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/conversation.py#L376) — tokens flow back to Tab5 as `{"type":"llm","text":"<token>"}` via the WS unless they look like the start of a tool marker (`<tool>` or `<tool_call>`). The rolling buffer holds tokens at marker boundaries; benign prose flushes immediately so the user sees text accumulate in real time.
+
+WebSocket keepalive pings at 5 s intervals via [`server.py: _ws_keepalive_during_inference`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/server.py) prevent Tab5's PONG-watch from tripping during a 60-90 s local inference. Without this, Tab5 would reconnect mid-stream and Dragon's P13 "device already has connection" guard would evict the in-flight LLM.
+
+#### 12. Tool detected: datetime
+The model emits `<tool>datetime</tool><args>{}</args>`. Buffer hits the marker boundary. [`tools/registry.py: parse_tool_call`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/tools/registry.py) handles three accepted dialects (legacy `<tool>`, standard `<tool_call>`, bracketed `[NAME]`) and tolerates the small-model XML quirks documented in PR #74/#79.
+
+A `{"type":"tool_call","tool":"datetime","args":{}}` event goes to Tab5 — chat overlay shows "Looking up time…" thinking bubble.
+
+#### 13. Tool execution
+[`tools/datetime_tool.py`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/tools/datetime_tool.py) returns the current local time. The result is appended to the conversation as a `tool` role message (so it's in the next prompt's context).
+
+A `{"type":"tool_result","tool":"datetime","result":...,"execution_ms":2}` event reaches Tab5; the thinking bubble closes.
+
+#### 14. Second LLM call with the tool result
+ConversationEngine loops back to step 9 with the tool result injected. `MAX_TOOL_CALLS=3` per turn caps runaway agents; if hit, an info event `tool_call_limit` surfaces to Tab5 as a toast.
+
+The model's second response: "It's 3:42 PM."
+
+#### 15. Empty-reply guard (#75/#79)
+Some FC-trained models emit a tool call and stop, leaving no user-visible text. [`tools/response_wrap.py: synthesize_wrap`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/tools/response_wrap.py) catches this and synthesizes a one-line natural-language ack from the tool result. Triggered when `looks_like_useful_text(response)` returns False AND at least one tool fired.
+
+#### 16. `llm_done` + persist assistant response
+`{"type":"llm_done","llm_ms":1234}` goes to Tab5. [`messages.py: add_message(role="assistant", ...)`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/messages.py) persists the final response.
+
+The Tab5-side `chat.llm_done` debug-obs event fires here too — the e2e harness uses this to know an LLM cycle finished.
+
+#### 17. TTS pipeline
+[`tts/piper_tts.py: synthesize_stream`](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/tts/piper_tts.py) — Piper en_US-lessac-medium runs on Dragon CPU at ~real-time (~1× factor). Output is 22050 Hz mono int16 PCM, resampled to 16 kHz before sending to Tab5.
+
+`{"type":"tts_start","sample_rate":16000}` → binary PCM chunks (4-32 KB) → `{"type":"tts_end"}`.
+
+In Cloud mode the TTS comes from OpenRouter's `gpt-audio-mini` at 24 kHz instead; the resample step targets 16 kHz uniformly.
+
+#### 18. Tab5 plays back
+[`main/voice.c: voice_play`](https://github.com/lorcan35/TinkerTab/blob/main/main/voice.c) feeds binary frames into the playback ring buffer. A drain task dequeues into `esp_codec_dev_write()` to the ES8388 DAC, upsampling 1:3 from 16 kHz to 48 kHz to match the I2S hardware rate.
+
+Voice state transitions: `PROCESSING` → `SPEAKING` (on `tts_start`) → `READY` (on `tts_end`). Orb idles. The full conversation is now in `messages` table for resume.
+
+## Latency budget
+
+Typical Q6A ARM64 timings for "what time is it?":
+
+| Step | Local mode | Cloud mode |
+|------|-----------|-----------|
+| Mic capture (utterance length) | ~2 s | ~2 s |
+| Network: Tab5 → Dragon | ~5 ms | ~5 ms |
+| Moonshine STT | ~600 ms | (cloud STT: ~500 ms) |
+| ConversationEngine + memory + tool prompt | ~50 ms | ~50 ms |
+| LLM first call (incl. tool call) | **~30 s** ministral | ~600 ms haiku-3 |
+| Tool execution (datetime) | ~2 ms | ~2 ms |
+| LLM second call | ~25 s | ~400 ms |
+| Piper TTS | ~600 ms (real-time) | (cloud TTS: ~400 ms) |
+| Network + Tab5 playback prebuffer | ~150 ms | ~150 ms |
+| **Total** | **~58 s** | **~2-3 s** |
+
+Local mode is brutal on Q6A — ministral-3:3b takes ~25-90 s/turn under load (the e2e harness allows 180 s before timing out). The NPU Genie path runs Llama 3.2 1B at ~8 tok/s but is currently text-only and much smaller, so it's a different quality tradeoff.
+
+## Where things go wrong
+
+| Symptom | Cause | Fix / mitigation |
+|---------|-------|------------------|
+| Tab5 reconnects mid-stream, sees no reply | Local LLM > 30 s, no keepalive pings | `_ws_keepalive_during_inference` (#76) |
+| LLM emits tool call but no visible reply | Some FC-trained models drop user text after tool | `synthesize_wrap` (#77/#79) |
+| Stale tool list — model never sees `weather`, `note`, etc. | Compact format hardcoded for local models | Per-PR fix; see [`historical/AUDIT-WAVE-14.md`](../historical/AUDIT-WAVE-14.md) |
+| Tab5 shows "Disconnected" mid-LLM | WiFi blip; WS reconnect tries ngrok first when `conn_m=0` | Auto-reconnect with exponential backoff |
+| Memory context wrong — recalls another user's facts | Per-connection deep-copy of config (#) | See [`historical/AUDIT-WAVE-14.md`](../historical/AUDIT-WAVE-14.md) |
+| `chat.llm_done` event missed by harness | Cursor-stealing in events polling | `Tab5Driver.events(peek=True)` (#295) |
+
+## Variations on this flow
+
+- **Text turn:** skip steps 1-6. Tab5 sends `{"type":"text","content":"..."}` directly. ConversationEngine entry is the same.
+- **Dictation:** step 3 sends `{"mode":"dictate"}`. STT emits `stt_partial` events as you speak. End-of-utterance is 5 s of silence (`DICTATION_AUTO_STOP_FRAMES=250`). Post-process generates a title + summary.
+- **Vision turn:** see [`vision-turn.md`](vision-turn.md) — the photo enters the conversation, the router picks a vision-capable model.
+- **Call:** see [`video-call.md`](video-call.md) — bidirectional audio bypasses STT entirely.
+- **TinkerClaw mode (3):** ConversationEngine is bypassed. The transcript goes straight to the gateway via `tinkerclaw_llm.py`; the gateway's agent runtime owns tool execution.
+
+## Related docs
+
+- [`../ARCHITECTURE.md`](../ARCHITECTURE.md) — the system at altitude
+- [`../protocol.md`](../protocol.md) — full WS field-by-field reference
+- [`../router-cookbook.md`](../router-cookbook.md) — fleet-config recipes
+- [`../../GLOSSARY.md`](../../GLOSSARY.md) — terms used here
+- [`vision-turn.md`](vision-turn.md), [`video-call.md`](video-call.md) — sibling flows


### PR DESCRIPTION
## Summary
Closes the "readable to someone fresh" gap. CLAUDE.md was a runbook (*operate* it); this PR adds the *map* (understand it).

## New documents

**`docs/ARCHITECTURE.md`** — canonical "what is TinkerClaw?" doc with mermaid diagrams (component layout, network topology, router decision tree), per-piece hardware/software table, the four voice modes, code-tree map, hardware reference for Dragon Q6A.

**`docs/flows/voice-turn.md`** — 18-step end-to-end PTT trace with `file:line` refs throughout. Mermaid sequence diagram. Latency budget. "Where things go wrong" table. Variations covered (text/dictation/vision/call/TinkerClaw).

**`docs/flows/vision-turn.md`** — Camera → /api/media/upload → user_image WS → router → reply. Cross-modal continuity walkthrough. Cost + latency by fleet pick.

**`docs/flows/video-call.md`** — Tab5 ↔ Dragon ↔ browser broadcast relay. VID0/AUD0 wire format. Bidirectional mermaid sequence. Endpoint table.

**`GLOSSARY.md`** — ~80 terms across both repos, alphabetical. Each term links to canonical definition.

## Wiring
- `README.md` gets a one-line nav strip + "first time here?" callout to ARCHITECTURE.md
- `CLAUDE.md` gets a banner distinguishing runbook vs map

## Stats
~2500 lines of new docs covering every aspect a fresh reader would need. No code changes.

## Test plan
- [x] All mermaid diagrams render in GitHub preview
- [x] All file:line refs point at real code (verified during writing)
- [x] No PRs cited that don't exist
- [x] Cross-references resolve (GLOSSARY ↔ flows ↔ ARCHITECTURE all link both ways)
