### PR TITLE
docs: onboarding tracks for users + tinkerers + hackers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,203 @@
+# Contributing to TinkerBox
+
+> Thanks for showing up.  This doc covers the workflow, the rules,
+> and the gotchas — most of which are also in [`CLAUDE.md`](CLAUDE.md)
+> but consolidated here so a new contributor doesn't have to read
+> 850 lines to figure out the branch-naming convention.
+
+## TL;DR
+
+- **One concern per PR.**  Refactor, fix, and feature changes don't share commits.
+- **Issue first.**  Open a GitHub issue before opening a PR.  Title the issue clearly; the PR title can match.
+- **Branch from `main`.**  Names: `feat/<slug>` / `fix/<slug>` / `chore/<slug>` / `docs/<slug>` / `investigate/<slug>`.
+- **Conventional-commit prefix** on the subject (`feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`).
+- **Reference the issue:** `closes #N` to auto-close, `refs #N` to link without closing.
+- **Squash-merge.**  No merge commits in `main`.  Delete the branch after merge.
+- **Don't force-push shared branches.**  Force-push your own feature branch is fine.
+- **Run the local lint + tests before pushing.**  See "Local pre-push" below.
+
+## First time? Read these in order
+
+1. [`WELCOME.md`](WELCOME.md) — multi-audience landing
+2. [`docs/dev-setup.md`](docs/dev-setup.md) — get your local environment able to run + iterate
+3. [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — system overview so you know where your change lives
+4. [`LEARNINGS.md`](LEARNINGS.md) — search before you debug; we've probably already hit your bug
+
+## Workflow
+
+### 1. Open an issue first
+
+```
+gh issue create --title "feat: short description" --body "..."
+```
+
+Use the issue body to describe:
+- **What:** the change you want to make
+- **Why:** the problem or use case driving it
+- **Approach:** how you plan to do it (so we can sanity-check before you write code)
+
+For bug reports, use the format from CLAUDE.md:
+```markdown
+## Bug / Problem
+What the user sees. Symptoms, frequency, impact.
+
+## Root Cause
+Technical explanation of WHY this happens.
+
+## Culprit
+Exact file(s) and line(s) responsible.
+
+## Fix
+What was changed and why this fixes it.
+
+## Resolved
+Commit hash + PR if applicable.
+```
+
+### 2. Branch from `main`
+
+```bash
+git checkout main && git pull --ff-only origin main
+git checkout -b feat/my-thing
+```
+
+Branch-name convention:
+- `feat/<slug>` — new feature
+- `fix/<slug>` — bug fix
+- `chore/<slug>` — repo maintenance, dep bumps
+- `docs/<slug>` — docs only
+- `investigate/<slug>` — exploration that may or may not ship
+- `refactor/<slug>` — restructure without behavior change
+- `test/<slug>` — add/fix tests
+
+Cross-stack audit items already have Wave IDs (`W14-C01`, `W15-H09`, …) — reuse them in the branch and commit message instead of opening a duplicate issue.
+
+### 3. Commit conventions
+
+Conventional-commit prefix on the **subject line**, then a blank line, then the body explaining *why* (the *what* should already be in the diff).
+
+```
+feat(llm): refresh OpenRouter model registry to live 2026-04-27 catalog (refs #183)
+
+Pulled the live OpenRouter /api/v1/models endpoint and updated both
+the capability registry and the pricing table to current reality.
+
+[Body explains the why, references prior PRs, etc.]
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+Reference issues with `refs #N` to link, `closes #N` to auto-close on merge.
+
+**Atomic commits.**  One logical change per commit.  The PR can have multiple commits but a reviewer should be able to skim each one independently.
+
+### 4. PR scope discipline (the rule that saves review hours)
+
+- **One concern per PR.**  Refactors don't contain bug fixes.  Bug fixes don't contain "while we're here" cleanups.  Doc updates don't contain behavior changes.  If you find something else that needs fixing mid-PR, open a new issue and move on.
+- **Extract before decompose.**  When splitting a large file, the first PR *moves* code to its new home with identical behavior — no restructuring of internals.  Decomposing internals is follow-up PRs.
+- **Tests move with code.**  If you're extracting a function that has tests, the tests move in the same commit.  If it has no tests, add at least one before extraction lands.
+- **Small is kind.**  Prefer 5 small PRs over 1 big one.
+
+### 5. Open the PR
+
+```bash
+gh pr create --title "feat(llm): one-line summary (refs #N)" --body "..."
+```
+
+PR description should include:
+- **Summary:** 1-3 sentences of what changed
+- **Why:** the problem the change solves
+- **Test plan:** checkboxes for what you ran/tested
+- **Screenshots** if UI work
+
+Use `gh pr view` to monitor CI gates (see below).
+
+### 6. Squash-merge + delete branch
+
+```bash
+gh pr merge --squash --delete-branch
+git checkout main && git pull --ff-only origin main
+```
+
+We **always squash-merge** on `main`.  No merge commits.  This keeps the history bisectable: every commit on `main` is a green PR.
+
+## CI gates (enforced by `.github/workflows/ci.yml`)
+
+- **Ruff** with a narrow code list:
+  ```
+  F821, F722, F811, F823, B006, B904, E722, B007, RUF006
+  ```
+  This is the *real-bug* gate — not a style gate.  Adding codes is a two-line change to `ci.yml`; prove a code catches a real bug before promoting it.
+- **Named unit tests only.**  E2E tests (`test_api_e2e.py`, `test_e2e_dragon.py`) run locally, not in CI.  When you add a new test file that can run without a live server, add it to the CI test list in `ci.yml`.
+- **CI uses `DRAGON_API_TOKEN=ci-bearer-token` + `TINKERCLAW_TOKEN=ci-tc-token`.**  Tests that need tokens must read them from env, not hardcoded.
+
+## Local pre-push (takes ~10 seconds)
+
+```bash
+ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ dashboard.py tests/
+pytest -q tests/test_auth_middleware.py tests/test_media_pipeline.py tests/test_session_cas.py
+```
+
+Pick the test files relevant to your change.  If you touched middleware: `test_auth_middleware` + `test_security_headers` + `test_rate_limit`.  Media: `test_media_*`.  LLM/router: `test_capability_declaration`, `test_router_routing`, `test_multimodal_persistence`.
+
+The full local suite (excluding the audit/async one) is ~556 tests in 11 seconds:
+```bash
+python3 -m pytest tests/ --ignore=tests/audit -q
+```
+
+Don't run the e2e (`tests/test_api_e2e.py`) suite unless you've booted a local server.
+
+## Anti-slop rules
+
+These apply to humans and AI contributors equally:
+
+- **No defensive code for impossible scenarios.**  Trust internal callers.  Validate at system boundaries (HTTP request, WS frame, NVS read) — not between two functions in the same module.
+- **Delete, don't comment out.**  Git remembers.  `# TODO: remove this` is a lie; either fix it in this PR or open an issue.
+- **No comments that restate well-named code.**  Comments exist to explain *why*, or to warn about non-obvious constraints.  `# increment counter` above `counter += 1` is noise.
+- **No speculative abstractions.**  A factory class with one caller is a one-caller class pretending to be a factory.  Build it when the second caller arrives.
+- **No "helpful" refactors next to the feature.**  If it's worth doing, it's worth a separate PR.  If it isn't, drop it.
+- **Name things for the reader, not the writer.**  Method names describe what the caller gets; variable names describe what the thing *is*.  `_handle_ws_voice` beats `_process_incoming_voice_socket_request_with_fallback`.
+- **`LEARNINGS.md` is not optional.**  Every bug fix with a non-obvious root cause adds an entry with Date / Symptom / Root Cause / Fix / Prevention.  Skip only if the fix is genuinely one-line and self-explaining.
+
+## File-split smell test (for refactoring PRs)
+
+A file is too big when it has more than one *reason to change*.  Before extracting, answer: "what stakeholder cares about the code I'm moving?"  If it's the same stakeholder as the rest of the file, don't extract yet.
+
+Good candidates:
+- middleware (ops/security)
+- debug endpoints (dev/diagnostics)
+- lifecycle (ops/reliability)
+- business endpoints (product)
+
+Reference: the [`server.py` decomposition (#65)](https://github.com/lorcan35/TinkerBox/pull/65) split the 2,747-LOC monolith into `middleware/`, `handlers/`, `lifecycle/`, and a slimmed `server.py`.
+
+## Specific contribution recipes
+
+| I want to… | Read this |
+|------------|-----------|
+| Add a new agentic tool | [`docs/adding-a-tool.md`](docs/adding-a-tool.md) |
+| Add a new LLM model to the fleet | [`docs/router-cookbook.md`](docs/router-cookbook.md) "Adding a new OpenRouter model" |
+| Author a skill that emits widgets | [`docs/SKILL_AUTHORING.md`](docs/SKILL_AUTHORING.md) + TinkerTab's [`docs/WIDGETS.md`](https://github.com/lorcan35/TinkerTab/blob/main/docs/WIDGETS.md) |
+| Add a channel adapter (Telegram, Slack, etc.) | Existing example: [`docs/telegram-bot.md`](docs/telegram-bot.md) — minimal aiohttp polling bot |
+| Add a STT or TTS backend | Subclass `dragon_voice/stt/base.py` or `dragon_voice/tts/base.py`; register in `__init__.py`; add tests |
+| Find a bug in the WS dispatcher | Read [`docs/UX-GAPS.md`](docs/UX-GAPS.md) Phase 1 first — many WS dispatcher gotchas are catalogued |
+| Run the e2e harness | [TinkerTab `tests/e2e/README.md`](https://github.com/lorcan35/TinkerTab/blob/main/tests/e2e/README.md) — Python harness drives Tab5 over the debug API |
+
+## Cross-stack changes (touching both repos)
+
+Many features touch both Dragon (this repo) and Tab5 firmware (TinkerTab).  Coordinate as follows:
+
+1. Open an issue in **whichever repo's the harder side** of the change.  Cross-link the other repo's issue in the body.
+2. PR in TinkerBox first if Dragon needs to support a new field.  Tab5 firmware can ignore unknown fields per the protocol's forward-compat design.
+3. PR in TinkerTab next, depending on the merged TinkerBox change.
+4. Update [`docs/protocol.md`](docs/protocol.md) **in the same PR as the protocol-changing side**, not as a follow-up.
+
+## Where to ask questions
+
+- **Architecture / design:** open a `[Q]`-prefixed issue.
+- **"How do I do X?":** read [`WELCOME.md`](WELCOME.md) → relevant track first; if that doesn't answer, open a `[Q]` issue.
+- **Stuck on a build error:** check [`LEARNINGS.md`](LEARNINGS.md) — there are 90+ entries of post-mortems.
+
+## License
+
+By contributing, you agree your contributions are licensed under the same license as the project (see `LICENSE`).

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 **The Brain of TinkerClaw** -- Dragon Q6A server stack for the TinkerClaw voice assistant platform.
 
-📚 **Docs:** [Architecture](docs/ARCHITECTURE.md) · [Protocol](docs/protocol.md) · [Router cookbook](docs/router-cookbook.md) · [Flows](docs/flows/) · [Glossary](GLOSSARY.md) · [Lessons](LEARNINGS.md) · [CLAUDE.md](CLAUDE.md) (runbook)
+📚 **Docs:** [WELCOME](WELCOME.md) · [Get started](docs/getting-started-user.md) · [Architecture](docs/ARCHITECTURE.md) · [Protocol](docs/protocol.md) · [Router cookbook](docs/router-cookbook.md) · [Flows](docs/flows/) · [Glossary](GLOSSARY.md) · [Security](SECURITY.md) · [Contributing](CONTRIBUTING.md) · [Lessons](LEARNINGS.md) · [CLAUDE.md](CLAUDE.md) (runbook)
 
-> **First time here?** Start with [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — system overview, diagrams, where every piece fits.  Then pick a [flow trace](docs/flows/) for a concrete walk-through.
+> **First time here?** [`WELCOME.md`](WELCOME.md) is the multi-audience landing page — pick your track (use it / build it / hack it).  If you're an end user, jump straight to [`docs/getting-started-user.md`](docs/getting-started-user.md).
 
 TinkerBox runs on a Radxa Dragon Q6A (Qualcomm QCS6490, ARM64) and provides the
 complete AI pipeline for TinkerClaw devices: speech-to-text, language model

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,252 @@
+# Security
+
+> Threat model, trust boundaries, auth-token lifecycle, data inventory,
+> and disclosure path for TinkerClaw.
+
+This is the Dragon-side security doc.  Tab5 firmware has its own
+[SECURITY.md in TinkerTab](https://github.com/lorcan35/TinkerTab/blob/main/SECURITY.md)
+covering the firmware-specific surface (debug HTTP server, USB/serial
+access, OTA verification).
+
+---
+
+## TL;DR honest assessment
+
+TinkerClaw is **a personal-use enthusiast project**, not a hardened
+appliance.  The default deployment trusts the LAN, leans on
+cloud-provider security for ngrok-exposed surfaces, runs ESP32-P4
+firmware **without secure boot or flash encryption**, and persists
+plaintext conversation history on Dragon.  This is fine for "home AI
+assistant in my house" and not fine for "deploy this for users I
+don't know."
+
+If your threat model includes adversaries on your LAN, hostile
+firmware modifications, or untrusted physical access to either device,
+you'll need to layer additional protections.  This doc tells you
+exactly where the boundaries are so you can decide.
+
+---
+
+## 1. Trust boundaries
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│ INTERNET (untrusted)                                          │
+│   ┌─────────────────────────────┐                             │
+│   │ ngrok tunnel:               │                             │
+│   │  *.ngrok.dev → Dragon       │                             │
+│   │  (TLS terminated by ngrok)  │                             │
+│   └──────────────┬──────────────┘                             │
+└──────────────────┼────────────────────────────────────────────┘
+                   ↓ HTTPS, then plain HTTP localhost on Dragon
+┌──────────────────┼────────────────────────────────────────────┐
+│ LAN (assumed-trusted by default config)                       │
+│                  ↓                                            │
+│   ┌────────────────────────────┐    ┌──────────────────────┐  │
+│   │ Dragon Q6A 192.168.1.91    │←──→│ Tab5 192.168.1.90    │  │
+│   │  3500/3502 aiohttp         │ WS │  port 8080 debug srv │  │
+│   │  18789 gateway (lo only)   │    │  (LAN-only)          │  │
+│   │  11434 ollama   (lo only)  │    └──────────────────────┘  │
+│   │  8888 searxng   (lo only)  │                              │
+│   └─────┬──────────────────────┘                              │
+│         ↓                                                     │
+│   ┌────────────────────────────┐                              │
+│   │ OpenRouter (cloud)         │  (Cloud / Hybrid mode only)  │
+│   │  https://openrouter.ai/api │                              │
+│   └────────────────────────────┘                              │
+└───────────────────────────────────────────────────────────────┘
+```
+
+**Trust assumptions:**
+
+| Boundary | What we trust | What we don't |
+|----------|--------------|---------------|
+| Internet → ngrok tunnel | TLS up to ngrok edge; ngrok's auth flow on the tunnel itself | ngrok's logging policy (treat as semi-public); free-tier replay via the ngrok dashboard |
+| ngrok → Dragon | aiohttp bearer-token check on `/api/*` (per [`middleware/auth.py`](dragon_voice/middleware/auth.py)) | Anything in `PUBLIC_PREFIXES` (no auth) |
+| LAN device → Dragon | Bearer token on `/api/*`, WS upgrade requires bearer too, deep-copied per-connection config | Default config trusts LAN — anyone on your WiFi can hit `/health`, `/call`, `/static/`, `/dashboard` |
+| Dragon → ollama/searxng/gateway | localhost-only binding; no auth | Anyone with shell access on Dragon |
+| Dragon → OpenRouter | `OPENROUTER_API_KEY` from `/home/radxa/.env`; HTTPS | OpenRouter sees full payload (audio, transcripts, photos) |
+| Dragon → Tab5 (WS) | Bearer-auth on WS upgrade | TLS on LAN: NONE (plain `ws://` on LAN; `wss://` only via ngrok) |
+
+---
+
+## 2. Auth tokens
+
+Three distinct tokens, all bearer-style, none currently rotated automatically.
+
+### `DRAGON_API_TOKEN`
+
+- **Purpose:** Gates Dragon's `/api/*` REST surface and the WS upgrade at `/ws/voice`.
+- **Storage:** `/home/radxa/.env` on Dragon (loaded by systemd `EnvironmentFile=`). Survives `scp -r dragon_voice/` deploys because the env file isn't overwritten.
+- **Generation:** Manually set by deployer on first install (`openssl rand -hex 32` typical). No auto-rotation.
+- **Public endpoints (NO auth):** `/health` (no privacy concern), `/ws/voice` (the bearer is checked *during* the WS upgrade, not as a public-prefix bypass — see [`auth.py`](dragon_voice/middleware/auth.py)), `/dashboard`, `/api/media/{id}` (HMAC-signed URLs from `MediaUrlSigner` instead of bearer — W14-H04), `/call` + `/static/` (browser call client; sensitive routes stay under `/api/v1/*`).
+- **If leaked:** Anyone with the token can: read all session history via `/api/v1/sessions/*`, store memory facts, ingest documents, send WS commands as the device. Rotate by editing `.env` + restarting `tinkerclaw-voice` + updating Tab5 NVS via `/settings`.
+
+### `auth_tok` (Tab5 NVS)
+
+- **Purpose:** Gates Tab5 firmware's debug HTTP server on port 8080 (LAN-only).
+- **Storage:** Tab5 NVS partition, namespace `"settings"`, key `auth_tok`. 32 hex chars.
+- **Generation:** Auto-generated on first boot via `esp_random()` if missing. Persists across reboots; only NVS erase rotates it.
+- **Public endpoints (NO auth):** `/info` (uptime, heap, voice state — no secrets), `/selftest` (8-check health probe).
+- **Logging:** Token print on serial log is *masked* (`05ee****b9f2`) to prevent accidental leak via screenshot/log paste. The unmasked value is recoverable via `esptool read_flash 0x9000 0x6000` if you have physical USB access — see TinkerTab's [`reference_tab5_debug_access.md`](https://github.com/lorcan35/TinkerTab/blob/main/docs/historical/) (ironically also lives in personal memory rather than a versioned doc — TODO).
+- **If leaked:** Anyone on your LAN can drive the device remotely: tap, type, navigate, swap modes, take photos, reboot. NOT a path to Dragon.
+
+### `OPENROUTER_API_KEY`
+
+- **Purpose:** Cloud LLM + audio backend access.
+- **Storage:** `/home/radxa/.env`.
+- **If leaked:** Whoever has it can rack up your OpenRouter bill. Rotate via OpenRouter dashboard immediately. The `cap_mils` daily-budget enforcement on Tab5 only protects *you* from your own spending; it doesn't protect against an attacker.
+
+### Other tokens
+
+- **`TINKERCLAW_TOKEN`** (gateway) — localhost-only; mostly informational. Rotate by editing both `~/.tinkerclaw/tinkerclaw.json` and `dragon_voice/config.yaml`.
+- **ngrok auth** — managed via `~/.ngrok/ngrok.yml`. ngrok's web dashboard shows tunnel traffic logs; treat them as semi-public.
+
+---
+
+## 3. Network exposure
+
+By systemd unit, what's listening:
+
+| Service | Port | Bind | Auth | ngrok-exposed? |
+|---------|------|------|------|----------------|
+| tinkerclaw-voice | 3502 | 0.0.0.0 (LAN) | `/api/*` + `/ws/voice` bearer; public prefixes have no auth | **Yes** (`tinkerclaw-voice.ngrok.dev`) |
+| tinkerclaw-dashboard | 3500 | 0.0.0.0 (LAN) | proxies to 3502; bearer required on proxied calls | **Yes** (`tinkerclaw-dashboard.ngrok.dev`) |
+| tinkerclaw-gateway | 18789 | 127.0.0.1 only | gateway-internal token | **Yes** (`tinkerclaw-gateway.ngrok.dev`) — be careful, this *is* tunnelled |
+| ollama | 11434 | 127.0.0.1 only | none (localhost-trusted) | No |
+| searxng | 8888 | 127.0.0.1 only | none | No |
+| Chromium CDP | 9222 | 127.0.0.1 only | none | No |
+
+**Implications for hostile-LAN scenarios:**
+- Anyone on your WiFi can browse `http://192.168.1.91:3500` (dashboard) — proxied calls are bearer-auth-gated, but the dashboard *exists* publicly.
+- Anyone on your WiFi can hit `http://192.168.1.91:3502/health` and `/call`.
+- Anyone on your WiFi can attempt WS upgrades at `/ws/voice`; bearer rejection is constant-time so timing oracle is mitigated.
+- The ngrok URLs are guessable if someone knows your account name. Bearer-token check still gates `/api/*`, so this is mostly a DoS / metadata-exposure concern, not unauthorized data access.
+
+To harden: bind public services to specific interfaces, add a reverse proxy with mTLS, or move to `ngrok` paid tier with IP restrictions.
+
+---
+
+## 4. Data inventory
+
+What gets persisted, where, and for how long.
+
+### On Dragon
+
+| Data | Storage | Retention | Cloud-exposed? |
+|------|---------|-----------|----------------|
+| Conversation messages (text, role, timestamps, model used, latency) | `~/tinkerclaw/tinkerclaw.db` SQLite, `messages` table | `database.message_retention_days` (default 30) | When voice_mode ≥ 1: prompts go to OpenRouter. The DB stays local. |
+| Multimodal user content (photos, audio attachments) | `~/media/` files + `messages.content __mm__:` markers | 24-hour TTL via `lifecycle/purge.py: media_cleanup_loop` | Photos sent to OR with the prompt when in vision mode |
+| Memory facts | `messages` table + `memory_facts` table (768-dim embeddings via nomic-embed-text) | Permanent unless deleted via API or memory-tab dashboard | Stays local unless cloud LLM is in the loop (which sees them in system prompt as RAG context) |
+| Documents (ingested files) | `memory_documents` + `memory_chunks` tables | Permanent | Same as memory facts |
+| Sessions | `sessions` table | `database.paused_session_retention_days` (default 30) | metadata only |
+| Devices (registered Tab5s) | `devices` table | Permanent | metadata only |
+| Events / audit log | `events` table | Same as messages | local |
+| Notes (audio + transcripts) | `notes` table + audio files in `~/media/` | Until manually deleted | Transcribed via STT; cloud STT path sends audio to OpenRouter |
+
+### Outbound to OpenRouter (Cloud / Hybrid modes)
+
+When `voice_mode >= 1`:
+- **STT:** Audio bytes → `openai/gpt-audio-mini` (16 kHz mono base64 WAV).
+- **LLM:** Prompt + last 30 messages of context (incl. memory RAG, tool descriptions, multimodal content if vision).
+- **TTS:** Text → audio.
+
+OpenRouter's policy applies; per their docs they don't train on API traffic by default but log for abuse / billing.
+
+### Outbound to Telegram (if `tinkerclaw-telegram` enabled)
+
+- User messages from Telegram + bot replies. Stored at `/home/radxa/tinkerclaw/telegram/<chat_id>.json` for memory.
+
+### Outbound to ngrok
+
+- All traffic that passes through your tunnels is visible to ngrok. Traffic logs are accessible via ngrok dashboard.
+
+---
+
+## 5. Firmware integrity
+
+### Tab5 (ESP32-P4)
+
+- **Secure Boot:** **Disabled.** No bootloader signature verification. Anyone with USB-JTAG can flash arbitrary firmware.
+- **Flash Encryption:** **Disabled.** NVS contents (incl. `auth_tok`, `wifi_pass`, `dragon_host`, etc.) are recoverable via `esptool read_flash`.
+- **OTA Verification:** SHA256 hash check (`SEC07`, see CLAUDE.md). After download, the firmware is hashed and compared against `version.json` on Dragon. Mismatch → `ESP_ERR_INVALID_CRC` and abort. Hash comes from the same channel as the firmware though — so this protects against MitM on the OTA path *only if* `version.json` itself isn't compromised. We don't sign the OTA bundle.
+- **OTA Rollback:** ESP-IDF auto-rollback enabled. New firmware boots in PENDING_VERIFY; if it crashes before `tab5_ota_mark_valid()`, bootloader reverts.
+
+To harden Tab5 firmware integrity:
+1. Enable Secure Boot V2 in sdkconfig (signed bootloader + app).
+2. Enable Flash Encryption (encrypts the entire flash at rest).
+3. Sign OTA bundles end-to-end with the same key.
+
+This is a roughly 4-hour engineering effort + a key-management story we don't currently have.
+
+### Dragon (Ubuntu ARM64)
+
+- Standard Linux: SSH key auth, `radxa` user, sudo for systemd. No additional integrity verification of `dragon_voice/` itself; deploys are trust-on-first-deploy (you `scp` what you have).
+- No code signing, no reproducible builds.
+
+---
+
+## 6. Known limitations / non-goals
+
+These are honest gaps. Some are deliberate for an enthusiast project; some are tracked.
+
+| Limitation | Tracked? | Workaround |
+|-----------|----------|------------|
+| Plain `ws://` on LAN (no encryption Tab5 ↔ Dragon) | Open issue | Use `conn_m=2` to force ngrok WSS; LAN traffic stays in your house |
+| No bearer-token rotation | Not tracked | Manually rotate via `.env` + restart |
+| No rate limiting on `/api/v1/*` beyond per-IP middleware (W15-H01) | Partially mitigated | Run on a private LAN only |
+| `/dashboard` reachable from LAN without auth | By design (dashboard proxies to bearer-gated APIs) | Bind to localhost + reverse proxy if you don't want LAN access |
+| ngrok tunnels expose service URLs to anyone who guesses the subdomain | By design (free tier limitation) | ngrok paid tier with IP restrictions; or close the tunnel when not needed |
+| OpenRouter sees full conversation payloads in cloud mode | Inherent | Use Local mode for sensitive conversations |
+| Tab5 firmware not signed | Tracked (Secure Boot V2 work item) | Don't put Tab5 in adversarial physical environments |
+| MediaStore TTL of 24h could be shorter | Configurable | Edit `lifecycle/purge.py` |
+| Memory facts can be RAG-injected into every cloud-mode call | By design | Use `forget` tool to remove specific facts; clear DB to wipe |
+
+---
+
+## 7. Reporting a vulnerability
+
+This is a personal project; there's no formal SLA. That said:
+
+- **For TinkerBox** (this repo): file a private issue or email the project owner. Don't open a public issue for findings that affect users in the wild (none currently exist publicly that I'm aware of).
+- **For TinkerTab** (firmware): same path; cross-reference the issue in this repo.
+
+Acknowledge time: best-effort, typically within a week. Patch time: depends on severity. We'll credit you in the changelog if you'd like.
+
+If you find something that affects ngrok-exposed surfaces (WS auth bypass, RCE via the WS dispatcher, etc.), please don't post the PoC publicly until a patch ships.
+
+---
+
+## 8. What we got right (so you know where to focus auditing)
+
+- WS bearer auth is constant-time (no timing oracle on credential rejection).
+- Per-connection deep-copy of config (one device's `config_update` can't corrupt another's pipeline).
+- HMAC-signed media URLs (W14-H04 — the `MediaUrlSigner` makes `/api/media/{id}` safe to publish in chat without exposing arbitrary blob access).
+- Dictation auto-stop, mic mute, quiet-hours all enforced server-side too (the device can't silently override Dragon-side privacy decisions).
+- Multi-model router's tier-policy + capability-decline surfaces hostile model routing as an explicit error rather than a silent failure.
+
+---
+
+## 9. Auditor's checklist (for hackers)
+
+If you're doing a security review, this is the order I'd suggest:
+
+1. **Read [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) + [`docs/protocol.md`](docs/protocol.md)** to understand what crosses what boundary.
+2. **Audit [`dragon_voice/middleware/auth.py`](dragon_voice/middleware/auth.py)** — the auth gate is small (~100 lines).
+3. **Map the public-prefix list** in `auth.py:PUBLIC_PREFIXES` and verify each is safe by design.
+4. **Review the WS dispatcher** in `dragon_voice/server.py: _handle_ws_voice` — every `cmd_type == "..."` branch is reachable post-`register`. Look for un-validated input → tool execution / file paths / DB queries.
+5. **Check `MediaStore.put_blob`** path traversal — file IDs are SHA-256 derived, but verify the validation chain.
+6. **Walk a vision turn end-to-end** via [`docs/flows/vision-turn.md`](docs/flows/vision-turn.md) and check what data leaves Dragon and what gets persisted.
+7. **Pull NVS via esptool from a Tab5** to confirm `auth_tok` extraction is as advertised; this is the LAN-attack escalation path if someone gets physical USB access.
+8. **Read [`LEARNINGS.md`](LEARNINGS.md)** — many entries are post-mortems for what we got wrong. The same patterns may exist elsewhere.
+
+If you find something, see Section 7 above.
+
+---
+
+## See also
+
+- [TinkerTab `SECURITY.md`](https://github.com/lorcan35/TinkerTab/blob/main/SECURITY.md) — firmware-side counterpart.
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — trust boundaries and component layout.
+- [`docs/protocol.md`](docs/protocol.md) — full WS contract.
+- [`LEARNINGS.md`](LEARNINGS.md) — the war stories.

--- a/WELCOME.md
+++ b/WELCOME.md
@@ -1,0 +1,174 @@
+# Welcome to TinkerClaw
+
+> Pick your track. The docs branch by *what you want to do*, not by
+> which repo a file lives in.  All three tracks are first-class —
+> the project is built for tinkerers and hackers as much as for
+> people who just want a voice assistant that doesn't snitch on them.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  I just want to USE it                                  │
+│  → "Getting Started for Users" (5 minutes)              │
+│    docs/getting-started-user.md                         │
+└─────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────┐
+│  I want to BUILD or extend it                           │
+│  → "Dev setup" (30 min) → CONTRIBUTING → "Add a tool"   │
+│    docs/dev-setup.md, CONTRIBUTING.md, docs/adding-a-tool.md
+└─────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────┐
+│  I want to LOOK UNDER THE HOOD                          │
+│  → ARCHITECTURE → PROTOCOL → flows/ → SECURITY          │
+│    docs/ARCHITECTURE.md, docs/protocol.md,              │
+│    docs/flows/, SECURITY.md                             │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## What is TinkerClaw?
+
+A privacy-conscious voice assistant that runs on hardware you own.
+
+You talk to a **5-inch portrait touchscreen** ("Tab5") sitting on your
+desk or shelf.  All the intelligence — speech-to-text, the AI model
+that thinks about your question, text-to-speech for the reply —
+runs on **a small Linux box** ("Dragon Q6A") somewhere on your home
+network.  Cloud AI providers (Claude, GPT, Gemini, etc.) are
+*optional*; the default mode runs everything locally and never
+touches the internet.
+
+The product is voice-first.  It has a chat screen, a camera screen,
+a notes app, and a settings screen — but the main thing is: tap the
+glowing orb, ask a question, get a spoken answer.
+
+Want video?  Yes — Tab5 has a camera, can send photos for analysis,
+and can do bidirectional video calls with another Tab5 or with a
+browser at `/call` on your Dragon.
+
+Want skills/automations?  Yes — the system is designed around a
+"skills" platform where authors emit typed widget state that Tab5
+renders opinionatedly.  See [`docs/SKILL_AUTHORING.md`](docs/SKILL_AUTHORING.md).
+
+Want to swap out which AI runs?  Yes — the multi-model router
+([`docs/router-cookbook.md`](docs/router-cookbook.md)) picks per-turn
+based on what the message needs.  Text → cheap fast model; vision →
+vision-capable model; video → native-video model.  Mix local +
+cloud + LAN tier (e.g., a workstation running LM Studio).
+
+---
+
+## Track 1 — "I just want to use it"
+
+You've been handed (or bought) a Tab5 + Dragon.  Now what?
+
+→ **Read [`docs/getting-started-user.md`](docs/getting-started-user.md)** — power-on to first conversation in plain English, plus what you can ask, what each voice mode does, what it costs, what privacy you get.
+
+If you're stuck:
+- Hardware questions about the Tab5 itself: [TinkerTab `docs/HARDWARE.md`](https://github.com/lorcan35/TinkerTab/blob/main/docs/HARDWARE.md)
+- Voice not working: troubleshooting in [`docs/getting-started-user.md`](docs/getting-started-user.md) bottom section
+- Worried about privacy: [`SECURITY.md`](SECURITY.md) "Data inventory" section explains what gets sent where
+
+---
+
+## Track 2 — "I want to build / extend / contribute"
+
+You want to add a tool, a skill, a new LLM backend, a channel
+adapter, or fix a bug.
+
+→ **Start with [`docs/dev-setup.md`](docs/dev-setup.md)** — get your
+local env able to run + flash + iterate.
+
+Then in order:
+1. [`CONTRIBUTING.md`](CONTRIBUTING.md) — workflow, branch naming, commit conventions, CI gates.
+2. [`docs/adding-a-tool.md`](docs/adding-a-tool.md) — worked example: build a new agentic tool from scratch.
+3. [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — system overview so you know where your change fits.
+4. [`docs/SKILL_AUTHORING.md`](docs/SKILL_AUTHORING.md) — if you're emitting widgets to Tab5.
+5. [`docs/router-cookbook.md`](docs/router-cookbook.md) — if you're plugging in a new LLM model.
+6. [`tests/e2e/README.md`](https://github.com/lorcan35/TinkerTab/blob/main/tests/e2e/README.md) (in TinkerTab) — Python harness for end-to-end testing.
+
+When you're stuck on a weird error: [`LEARNINGS.md`](LEARNINGS.md) is a long, brutal log of post-mortems. Search before you debug.
+
+---
+
+## Track 3 — "I want to look under the hood"
+
+You're a security researcher, a protocol nerd, a "how does this thing
+*actually* work" person.  Or you're auditing for a deployment.
+
+→ **Start with [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)** — the canonical map.
+
+Then in order:
+1. [`docs/protocol.md`](docs/protocol.md) — full WebSocket wire format.  Implement-from-this quality.
+2. [`docs/flows/`](docs/flows/) — three end-to-end traces (voice, vision, video call) with file:line refs.
+3. [`SECURITY.md`](SECURITY.md) — threat model, trust boundaries, auth-token lifecycle, data inventory, known limitations honestly stated.
+4. [`GLOSSARY.md`](GLOSSARY.md) — when an unfamiliar term shows up.
+5. [`LEARNINGS.md`](LEARNINGS.md) — gotchas, root-cause analyses, post-mortems.  Often more useful than reading the code.
+
+For Tab5-side firmware:
+- [TinkerTab `docs/HARDWARE.md`](https://github.com/lorcan35/TinkerTab/blob/main/docs/HARDWARE.md) — pinout + IC list
+- [TinkerTab `SECURITY.md`](https://github.com/lorcan35/TinkerTab/blob/main/SECURITY.md) — firmware-specific surface
+
+---
+
+## How the docs are organised
+
+Both repos follow the same convention:
+
+```
+README.md           — public-facing landing
+WELCOME.md          — this file (multi-audience track index)
+SECURITY.md         — threat model + disclosure
+CONTRIBUTING.md     — how to contribute
+GLOSSARY.md         — terminology
+CLAUDE.md           — operational runbook (deploy, debug, restart, monitor)
+LEARNINGS.md        — post-mortems and institutional knowledge
+
+docs/
+  ARCHITECTURE.md   — system overview (TinkerBox only — covers both halves)
+  protocol.md       — WS wire format (TinkerBox only — single source of truth)
+  HARDWARE.md       — Tab5 pinout (TinkerTab only)
+  VOICE_PIPELINE.md — Tab5 voice chain (TinkerTab only)
+  flows/            — end-to-end request traces (TinkerBox only)
+  router-cookbook.md — fleet recipes (TinkerBox only)
+  SKILL_AUTHORING.md — skill SDK reference (TinkerBox)
+  WIDGETS.md        — widget design lock (TinkerTab)
+  npu-setup.md      — Qualcomm NPU bring-up (TinkerBox)
+  dev-setup.md      — developer environment setup (both)
+  adding-a-tool.md  — tinkerer walkthrough (TinkerBox)
+  getting-started-user.md — normie quickstart (TinkerBox)
+  release-notes.md  — what's new (TinkerBox)
+  historical/       — archived / superseded docs
+  UI-COMPLETENESS.md — UI debt tracker (TinkerTab)
+```
+
+---
+
+## What this project is NOT
+
+Honest list, so you know what you're getting into:
+
+- **Not a hardened appliance.**  Default deployment trusts the LAN, runs Tab5 firmware without secure boot, persists plaintext conversation history.  Fine for "home AI in my house"; not fine for "deploy this for users I don't know."  See [`SECURITY.md`](SECURITY.md).
+- **Not a polished consumer product.**  The Tab5 hardware and the Dragon SBC are enthusiast hardware.  You'll need to be comfortable with USB flashing, SSH, systemd, and at least one programming language to operate this stack.
+- **Not a managed service.**  No cloud control plane, no automatic updates, no support hotline.  When something breaks, you'll be reading logs.
+- **Not a voice-only system.**  Despite the "voice-first" framing, there's a chat screen, a camera screen, a notes app, a video-call client.  Voice is the most important loop, not the only one.
+- **Not committed to one LLM provider.**  The router design (#183-#188) deliberately makes it trivial to swap or mix models.  We don't lock in to Anthropic, OpenAI, Google, DeepSeek, or any other vendor.
+
+---
+
+## Companion projects
+
+- [**TinkerTab**](https://github.com/lorcan35/TinkerTab) — the firmware running on the Tab5 hardware.  Pair with this repo.
+- [**OpenClaw / TinkerClaw Gateway**](https://github.com/lorcan35/openclaw) — optional agentic sidecar for `voice_mode=3` (long-running autonomous tasks).
+
+---
+
+## Help
+
+- Issues: file in the relevant repo (TinkerBox for Dragon, TinkerTab for Tab5).
+- Security: see [`SECURITY.md`](SECURITY.md).
+- Questions about the architecture: read [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) first; if it doesn't answer, file an issue with `[Q]` prefix.
+
+Welcome aboard. 🐉

--- a/docs/adding-a-tool.md
+++ b/docs/adding-a-tool.md
@@ -1,0 +1,472 @@
+# Adding a Tool — Worked Example
+
+> Build a real agentic tool from scratch.  By the end of this doc
+> you'll have a working `dice_roll` tool that the LLM can call when
+> a user says "roll a d20" or "give me three random numbers between
+> 1 and 100" — registered, tested, and merged.
+>
+> Estimated time: 30-45 minutes (most of it reading + understanding,
+> not typing).
+
+## What is a tool?
+
+A **tool** is a Python class that the LLM can invoke during a
+conversation by emitting a marker like `<tool>NAME</tool><args>{...}</args>`.
+Dragon parses the marker, calls your tool with the JSON args, and
+injects the result back into the LLM's context so it can keep going.
+
+This is how the assistant goes from "knowing only what the LLM was
+trained on" to "able to actually do things" — fetch weather, search
+the web, save memory facts, look up the time, do math, etc.
+
+15 tools ship with Dragon today.  Look in
+[`dragon_voice/tools/`](../dragon_voice/tools/) for examples.
+
+## The Tool contract
+
+Every tool subclasses `dragon_voice.tools.base.Tool`:
+
+```python
+from dragon_voice.tools.base import Tool
+
+
+class MyTool(Tool):
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def description(self) -> str: ...
+
+    @property
+    def parameters_schema(self) -> dict: ...
+
+    async def execute(self, args: dict) -> dict: ...
+```
+
+Four pieces:
+
+| Method | Purpose |
+|--------|---------|
+| `name` | Unique identifier the LLM emits.  Snake_case, matches the `<tool>name</tool>` marker. |
+| `description` | One-line human-readable description.  Injected into the LLM system prompt; this is what the model uses to decide when to call your tool. |
+| `parameters_schema` | JSON Schema describing the args.  Same format as OpenAI function-calling. |
+| `execute` | Async method.  Receives the parsed args dict, returns a result dict.  Whatever you return gets serialised to JSON and shown to the LLM as the tool result. |
+
+That's the whole API.  No middleware, no tool-runner, no scheduling.
+The registry handles all of that.
+
+---
+
+## Walkthrough — build `dice_roll`
+
+### 1. Open an issue
+
+```bash
+gh issue create --title "feat(tools): dice_roll tool for random number generation" --body "$(cat <<'EOF'
+## Why
+Users frequently ask "roll a d20" or "pick a random number between
+X and Y" in casual conversation.  The local LLM has to fake this
+without entropy, which gives bad results (it'll often pick "7"
+because that's a common answer in training data).
+
+## What
+New tool `dice_roll` with two args:
+- `count`: int (default 1) — number of dice
+- `sides`: int (default 6) — sides per die
+
+Returns:
+- `rolls`: list of ints
+- `total`: sum of rolls
+- `count` + `sides`: echo of inputs
+
+## Acceptance
+- LLM correctly fires the tool on natural-language prompts
+- Edge cases handled: count > 100 capped, sides between 2-1000
+- Unit tests cover happy path + arg validation
+EOF
+)"
+```
+
+Suppose this becomes issue **#999**.
+
+### 2. Branch
+
+```bash
+git checkout main && git pull --ff-only origin main
+git checkout -b feat/dice-roll-tool
+```
+
+### 3. Write the tool
+
+Create `dragon_voice/tools/dice_roll_tool.py`:
+
+```python
+"""Dice-roll tool: roll N dice with M sides for the LLM."""
+
+import random
+
+from dragon_voice.tools.base import Tool
+
+
+class DiceRollTool(Tool):
+    """Rolls dice with configurable count + sides."""
+
+    # Caps protect against runaway agents; LLMs occasionally
+    # decide to "roll a billion dice" if you let them.
+    MAX_COUNT = 100
+    MAX_SIDES = 1000
+
+    @property
+    def name(self) -> str:
+        return "dice_roll"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Roll one or more fair dice. Use when the user asks for a "
+            "random number, dice roll, or to pick randomly from a range. "
+            "Returns the individual rolls and their sum."
+        )
+
+    @property
+    def parameters_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer",
+                    "description": "Number of dice to roll (1-100). Default 1.",
+                    "default": 1,
+                    "minimum": 1,
+                    "maximum": self.MAX_COUNT,
+                },
+                "sides": {
+                    "type": "integer",
+                    "description": "Sides per die (2-1000). Default 6.",
+                    "default": 6,
+                    "minimum": 2,
+                    "maximum": self.MAX_SIDES,
+                },
+            },
+        }
+
+    async def execute(self, args: dict) -> dict:
+        # Defensive arg parsing — the LLM might pass strings instead
+        # of ints, omit fields, or pass bonkers values. Validate here
+        # rather than crash; surface a clean error.
+        try:
+            count = int(args.get("count", 1))
+            sides = int(args.get("sides", 6))
+        except (TypeError, ValueError):
+            return {"error": "count and sides must be integers"}
+
+        if count < 1 or count > self.MAX_COUNT:
+            return {"error": f"count must be between 1 and {self.MAX_COUNT}"}
+        if sides < 2 or sides > self.MAX_SIDES:
+            return {"error": f"sides must be between 2 and {self.MAX_SIDES}"}
+
+        rolls = [random.randint(1, sides) for _ in range(count)]
+        return {
+            "rolls": rolls,
+            "total": sum(rolls),
+            "count": count,
+            "sides": sides,
+        }
+```
+
+### 4. Register the tool
+
+Tools are registered at startup in
+[`dragon_voice/lifecycle/startup.py`](../dragon_voice/lifecycle/startup.py).
+Find the section that constructs the `ToolRegistry` (search for `tool_registry.register`) and add:
+
+```python
+from dragon_voice.tools.dice_roll_tool import DiceRollTool
+
+# ... existing registrations ...
+
+server._tool_registry.register(DiceRollTool())
+logger.info("DiceRollTool registered")
+```
+
+> **Note:** the *order* of registration matters for one specific case
+> — the small-LLM compact-tool format hard-codes a top-5 priority
+> list in [`tools/registry.py: _PRIORITY_TOOLS`](../dragon_voice/tools/registry.py).
+> If you want your tool included in the compact format that local
+> models see, add the name there too.  For an opt-in tool like
+> `dice_roll` that's not high-traffic, leaving it out is fine —
+> cloud-mode LLMs see the full tool list and will use it.
+
+### 5. Write tests
+
+Create `tests/test_dice_roll_tool.py`:
+
+```python
+"""Unit tests for the dice_roll tool (closes #999)."""
+
+import pytest
+
+from dragon_voice.tools.dice_roll_tool import DiceRollTool
+
+
+@pytest.fixture
+def tool():
+    return DiceRollTool()
+
+
+@pytest.mark.asyncio
+async def test_default_args(tool):
+    """Default: 1 die, 6 sides."""
+    result = await tool.execute({})
+    assert "rolls" in result
+    assert len(result["rolls"]) == 1
+    assert 1 <= result["rolls"][0] <= 6
+    assert result["count"] == 1
+    assert result["sides"] == 6
+    assert result["total"] == result["rolls"][0]
+
+
+@pytest.mark.asyncio
+async def test_multiple_dice(tool):
+    """3d20 — three twenty-sided dice."""
+    result = await tool.execute({"count": 3, "sides": 20})
+    assert len(result["rolls"]) == 3
+    for r in result["rolls"]:
+        assert 1 <= r <= 20
+    assert result["total"] == sum(result["rolls"])
+
+
+@pytest.mark.asyncio
+async def test_string_args_coerced(tool):
+    """LLM might pass '5' instead of 5 — coerce."""
+    result = await tool.execute({"count": "5", "sides": "10"})
+    assert len(result["rolls"]) == 5
+
+
+@pytest.mark.asyncio
+async def test_count_too_high_rejected(tool):
+    result = await tool.execute({"count": 1000})
+    assert "error" in result
+    assert "count must be between 1 and 100" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_sides_too_low_rejected(tool):
+    result = await tool.execute({"sides": 1})
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_invalid_arg_type(tool):
+    result = await tool.execute({"count": "blue"})
+    assert "error" in result
+
+
+def test_metadata(tool):
+    """Tool metadata is well-formed."""
+    assert tool.name == "dice_roll"
+    assert "random" in tool.description.lower()
+
+    schema = tool.parameters_schema
+    assert schema["type"] == "object"
+    assert "count" in schema["properties"]
+    assert schema["properties"]["count"]["maximum"] == 100
+    assert "sides" in schema["properties"]
+    assert schema["properties"]["sides"]["minimum"] == 2
+
+
+def test_to_dict(tool):
+    """Serialised form for API responses."""
+    d = tool.to_dict()
+    assert d["name"] == "dice_roll"
+    assert "description" in d
+    assert "parameters" in d
+```
+
+Add the new test file to the CI named-set in `.github/workflows/ci.yml`:
+
+```yaml
+# in ci.yml's pytest invocation
+- tests/test_dice_roll_tool.py
+```
+
+### 6. Run tests locally
+
+```bash
+pytest -q tests/test_dice_roll_tool.py
+# Should pass 8/8.
+
+# Full suite check
+pytest tests/ --ignore=tests/audit -q
+# Should pass 564/564 (was 556 before your tests).
+```
+
+### 7. Lint
+
+```bash
+ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/
+# Should pass.
+```
+
+### 8. Test live (optional but recommended)
+
+If you have Dragon running locally:
+
+```bash
+python3 -m dragon_voice
+```
+
+In another terminal:
+
+```bash
+# Hit the tools listing endpoint
+curl -s -H "Authorization: Bearer $DRAGON_API_TOKEN" \
+    http://localhost:3502/api/v1/tools | jq '.tools[] | select(.name == "dice_roll")'
+
+# Should show your tool's metadata.
+
+# Execute the tool directly
+curl -s -X POST -H "Authorization: Bearer $DRAGON_API_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"count": 3, "sides": 20}' \
+    http://localhost:3502/api/v1/tools/dice_roll/execute
+
+# Should return {"rolls": [...], "total": ..., "count": 3, "sides": 20}
+```
+
+For full LLM integration, deploy to Dragon and ask "roll three d20" via Tab5.  The LLM should fire `<tool>dice_roll</tool><args>{"count":3,"sides":20}</args>`, get back the result, and announce the rolls.
+
+### 9. Commit + PR
+
+```bash
+git add dragon_voice/tools/dice_roll_tool.py \
+        tests/test_dice_roll_tool.py \
+        dragon_voice/lifecycle/startup.py \
+        .github/workflows/ci.yml
+
+git commit -m "$(cat <<'EOF'
+feat(tools): dice_roll tool for random number generation (closes #999)
+
+LLMs without an RNG fake "random" by picking common-in-training
+numbers (often "7" for d20).  This adds a real entropy-backed
+tool the LLM can call when a user asks for a random number or
+dice roll.
+
+Tool surface
+------------
+- name: dice_roll
+- args: count (1-100, default 1), sides (2-1000, default 6)
+- returns: rolls (list[int]), total (int), count, sides
+
+Caps protect against runaway agents asking for a billion dice.
+Defensive arg parsing returns {"error": "..."} on bad input
+rather than raising.
+
+Tests
+-----
+8 assertions: default args, multiple dice, string-coerced args,
+upper/lower-bound rejection, invalid type, metadata correctness,
+to_dict serialisation.  Full suite: 564 passed (+8), 0 regressions.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+
+git push -u origin feat/dice-roll-tool
+
+gh pr create --title "feat(tools): dice_roll tool for random number generation (closes #999)" --body "..."
+```
+
+### 10. Squash-merge
+
+After CI green and review:
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+---
+
+## Patterns to follow
+
+### Defensive arg parsing
+
+LLMs sometimes return weird args.  Coerce + validate:
+
+```python
+async def execute(self, args: dict) -> dict:
+    try:
+        count = int(args.get("count", 1))
+    except (TypeError, ValueError):
+        return {"error": "count must be an integer"}
+    # ...
+```
+
+### Returning errors
+
+Return `{"error": "message"}` instead of raising.  The registry
+catches exceptions but a clean error dict gets surfaced to the user
+better than "Tool execution failed."
+
+### Long-running tools
+
+If your tool talks to the network, don't hold up the LLM:
+
+```python
+async def execute(self, args: dict) -> dict:
+    timeout = args.get("timeout_s", 5)
+    try:
+        async with asyncio.timeout(timeout):
+            result = await self._fetch(args["url"])
+    except asyncio.TimeoutError:
+        return {"error": f"timeout after {timeout}s"}
+    # ...
+```
+
+`MAX_TOOL_CALLS=3` per turn already caps total tool time, but per-tool timeouts prevent one runaway from eating the whole budget.
+
+### Side-effect tools (state changes)
+
+For tools that change state (memory, files, external APIs), think about idempotency.  An LLM might call your tool twice on the same args.  If that's bad (sends two emails, charges twice), debounce inside the tool or accept an idempotency key.
+
+The `remember` tool ([`memory_tools.py`](../dragon_voice/tools/memory_tools.py)) handles this by deduplicating embeddings — same fact text → no second insert.
+
+### Confirmation-gated tools
+
+For tools with irreversible consequences (delete, send, charge), use the confirmation pattern from
+[`tools/memory_tools.py: ForgetFactTool`](../dragon_voice/tools/memory_tools.py).  The first call returns `{"requires_confirmation": true, "preview": "..."}`; the LLM's follow-up call with `{"confirmed": true}` actually executes.
+
+### WebSocket events from inside a tool
+
+Tools sometimes need to surface progress to Tab5.  The registry passes `on_tool_call` / `on_tool_result` callbacks; tools that need richer events should use the unified `progress` event bus (β-arch, issue #123) rather than inventing per-tool event types.
+
+---
+
+## Patterns to avoid
+
+- **Don't query Dragon's own DB from a tool.**  Use the existing services (MemoryService, MessageStore).  Direct DB access from a tool bypasses the deep-copy-per-connection isolation.
+- **Don't call the LLM from inside a tool.**  Tools are leaf operations.  Recursive LLM calls happen at the ConversationEngine level (capped at MAX_TOOL_CALLS=3).
+- **Don't make the description more than ~100 characters.**  The system prompt is precious context; long descriptions push out memory facts and history.
+- **Don't use `print` or `logging.info` for tool I/O.**  Return the result.  Logging is for diagnostics, not for surfacing data to the LLM.
+
+---
+
+## Reference
+
+- Tool ABC: [`dragon_voice/tools/base.py`](../dragon_voice/tools/base.py)
+- Registry: [`dragon_voice/tools/registry.py`](../dragon_voice/tools/registry.py)
+- Existing tools (15+): [`dragon_voice/tools/`](../dragon_voice/tools/)
+- Tool-calling dialect spec: registry.py module docstring
+- Empty-reply guard for FC-only models: [`tools/response_wrap.py`](../dragon_voice/tools/response_wrap.py)
+- Test patterns: any `tests/test_*_tool.py` file
+- Conventions: [`../CONTRIBUTING.md`](../CONTRIBUTING.md)
+
+---
+
+## Where to next
+
+You've shipped a tool.  Next ideas:
+- **Skill that uses your tool** — [`SKILL_AUTHORING.md`](SKILL_AUTHORING.md)
+- **MCP-bridged tool** — point at an external Model Context Protocol server in [`dragon_voice/mcp/`](../dragon_voice/mcp/)
+- **Tool that emits widgets to Tab5** — see `timesense_tool.py` for the reference (Pomodoro emits `widget_live` state)
+- **Channel-specific tool** — e.g., a Slack-message tool that only fires when invoked from a Slack adapter

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,0 +1,412 @@
+# Developer Environment Setup
+
+> Get from "I cloned the repo" to "I can run + iterate + flash"
+> for both Dragon (Python) and Tab5 (ESP-IDF firmware).
+> Estimated time: 30-45 minutes the first time.
+
+This is the cross-repo setup doc.  Tab5 firmware setup lives in
+the TinkerTab side; Dragon Python setup lives here.  You probably
+need both unless you only care about one half.
+
+---
+
+## Prerequisites
+
+| Requirement | Why |
+|-------------|-----|
+| **Linux or macOS workstation** | ESP-IDF is best on Linux; Dragon deploys via SSH from a Unix env |
+| **Git + GitHub CLI (`gh`)** | Branching, PRs |
+| **Python 3.12+** | Dragon Python service |
+| **Dragon Q6A SBC** (optional but recommended for full flow) | The actual server |
+| **M5Stack Tab5 hardware** (optional) | Otherwise the firmware doesn't have anywhere to flash |
+| **OpenRouter API key** (optional, free to start) | Cloud-mode LLM access |
+
+If you don't have Tab5/Dragon hardware, you can still iterate on Dragon Python code and run the unit-test suite (556 tests, 11s on a laptop).
+
+---
+
+## Part 1 — Dragon (this repo, TinkerBox)
+
+### 1.1 Clone + venv
+
+```bash
+git clone https://github.com/lorcan35/TinkerBox.git
+cd TinkerBox
+
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+> **Note:** On Dragon itself, `pip install --break-system-packages` is required (PEP 668).  On a workstation venv, the above is fine.
+
+### 1.2 Set up `.env`
+
+Create `~/.env` (or copy to Dragon as `/home/radxa/.env`):
+
+```bash
+# Required for Cloud / Hybrid voice modes
+OPENROUTER_API_KEY=sk-or-v1-...
+
+# Required for Dragon REST API auth (any random 32-char hex)
+DRAGON_API_TOKEN=$(openssl rand -hex 32)
+
+# Optional: TinkerClaw gateway (only if you set up the sidecar)
+TINKERCLAW_TOKEN=$(openssl rand -hex 24)
+```
+
+Get an OpenRouter key at <https://openrouter.ai/keys> — they have a free tier good for development.
+
+### 1.3 Test locally
+
+```bash
+# Run the unit test suite (no Dragon hardware needed)
+python3 -m pytest tests/ --ignore=tests/audit -q
+
+# Should finish in ~11 seconds with 556 tests passing.
+```
+
+If tests pass, your Python environment is good.
+
+### 1.4 Run the voice server locally
+
+```bash
+# Start the Dragon-side voice service on port 3502
+python3 -m dragon_voice
+```
+
+You should see logs about Moonshine STT loading, Piper TTS loading, the LLM backend (defaults to ollama / ministral-3:3b).  If you don't have ollama running locally, it'll log warnings but still start.
+
+Visit `http://localhost:3502/health` — should return `{"status":"ok",...}`.
+
+To run with a specific config:
+
+```bash
+DRAGON_API_TOKEN=ci-bearer-token python3 -m dragon_voice --log-level DEBUG
+```
+
+### 1.5 SSH access to Dragon (optional)
+
+If you have a Dragon Q6A and want to deploy to it:
+
+```bash
+# Add your SSH key to Dragon's authorized_keys
+ssh-copy-id radxa@192.168.1.91
+
+# Test passwordless login
+ssh radxa@192.168.1.91 'uname -a'
+
+# Deploy your local working tree
+scp -r dragon_voice/ radxa@192.168.1.91:/home/radxa/
+
+# Restart the service to pick up changes
+ssh radxa@192.168.1.91 'sudo systemctl restart tinkerclaw-voice'
+
+# Watch logs
+ssh radxa@192.168.1.91 'sudo journalctl -u tinkerclaw-voice -f'
+```
+
+**Important:** After every `scp`, clear `__pycache__` on Dragon to avoid stale `.pyc` import errors:
+
+```bash
+ssh radxa@192.168.1.91 'find /home/radxa/dragon_voice -name __pycache__ -exec rm -rf {} +'
+```
+
+### 1.6 ngrok setup (optional but recommended)
+
+If you want Tab5 to reach Dragon when you're not on the same WiFi:
+
+```bash
+# On Dragon
+ngrok config add-authtoken <your-ngrok-token>
+
+# Start the systemd unit (already configured in the repo)
+sudo systemctl enable --now tinkerclaw-ngrok
+```
+
+Three tunnels go up:
+- `tinkerclaw-voice.ngrok.dev` → 3502 (voice WS)
+- `tinkerclaw-dashboard.ngrok.dev` → 3500 (dashboard)
+- `tinkerclaw-gateway.ngrok.dev` → 18789 (TinkerClaw — optional)
+
+Tab5 firmware tries the LAN first then falls back to ngrok automatically (`conn_m=0` default).
+
+### 1.7 Ollama setup (for Local mode)
+
+```bash
+# On Dragon (or local for testing)
+curl -fsSL https://ollama.com/install.sh | sh
+
+# Pull the default model
+ollama pull ministral-3:3b
+ollama pull nomic-embed-text  # for embeddings (memory + RAG)
+
+# Verify
+ollama list
+```
+
+For the multi-model router, see [`router-cookbook.md`](router-cookbook.md) for which models to pull.
+
+---
+
+## Part 2 — Tab5 firmware (TinkerTab repo)
+
+### 2.1 Clone TinkerTab
+
+```bash
+git clone https://github.com/lorcan35/TinkerTab.git ~/projects/TinkerTab
+cd ~/projects/TinkerTab
+```
+
+### 2.2 Install ESP-IDF v5.5.2
+
+The firmware is **pinned to ESP-IDF v5.5.2** (per `dependencies.lock`).  Don't use a different version — the manifest will fail to resolve components.
+
+```bash
+# Install via the official installer
+mkdir -p ~/esp
+cd ~/esp
+git clone -b v5.5.2 --recursive https://github.com/espressif/esp-idf.git
+
+cd ~/esp/esp-idf
+./install.sh esp32p4
+
+# Source the env script (do this in every shell that builds firmware)
+source ~/esp/esp-idf/export.sh
+```
+
+Confirm with:
+
+```bash
+idf.py --version
+# Should print: ESP-IDF v5.5.2
+```
+
+### 2.3 Set the target
+
+```bash
+cd ~/projects/TinkerTab
+idf.py set-target esp32p4
+```
+
+This generates `sdkconfig` from `sdkconfig.defaults`.
+
+### 2.4 Configure WiFi + Dragon connection
+
+```bash
+idf.py menuconfig
+```
+
+Navigate to:
+- **TinkerClaw → WiFi credentials** — set SSID + password
+- **TinkerClaw → Dragon host/port** — defaults to 192.168.1.91:3502
+- **TinkerClaw → Dragon API token** — paste the value of `DRAGON_API_TOKEN` from Dragon's `.env`
+
+Save and exit.
+
+For non-interactive setup, edit `sdkconfig.local`:
+
+```text
+CONFIG_TAB5_WIFI_SSID="MyHomeWifi"
+CONFIG_TAB5_WIFI_PASS="hunter2"
+CONFIG_TAB5_DRAGON_HOST="192.168.1.91"
+CONFIG_TAB5_DRAGON_PORT=3502
+CONFIG_TAB5_DRAGON_TOKEN="your-token-here"
+```
+
+### 2.5 Build
+
+```bash
+idf.py build
+```
+
+First build takes ~5-10 minutes.  Subsequent incrementals are 30-90 seconds.
+
+If you change `sdkconfig.defaults` or pull new components:
+
+```bash
+idf.py fullclean build
+```
+
+### 2.6 Flash + monitor
+
+Plug Tab5 into a USB-C port on your workstation.  It enumerates as `/dev/ttyACM0` on Linux.
+
+```bash
+idf.py -p /dev/ttyACM0 flash
+
+# If the board enters ROM-download mode after flashing (common on
+# ESP32-P4), trigger a watchdog reset:
+python -m esptool --chip esp32p4 -p /dev/ttyACM0 \
+    --before no_reset --after watchdog_reset read_mac
+```
+
+Monitor serial output:
+
+```bash
+python3 -c "
+import serial, time
+s = serial.Serial('/dev/ttyACM0', 115200, timeout=5)
+time.sleep(0.3)
+s.write(b'\r')
+while True:
+    if s.in_waiting:
+        print(s.read(s.in_waiting).decode('utf-8', errors='replace'), end='', flush=True)
+"
+```
+
+Or use `idf.py monitor` (Ctrl+] to exit).
+
+### 2.7 USB permissions on Linux
+
+If you get `Permission denied: '/dev/ttyACM0'`:
+
+```bash
+sudo usermod -a -G dialout $USER
+# Log out and back in for the group change to take effect.
+```
+
+### 2.8 First-boot Tab5 verification
+
+After flash, on a phone or laptop on the same WiFi:
+
+```bash
+curl -s http://<tab5-ip>:8080/info | python3 -m json.tool
+```
+
+Should show `voice_connected: true` if Dragon is reachable.
+
+The auth token for the debug server is on the serial log (look for `auth token:`) — masked but the first/last 4 chars confirm which token is active.  Full token recoverable via `esptool read_flash 0x9000 0x6000` if needed.
+
+---
+
+## Part 3 — Iteration loops
+
+### Dragon-only change
+
+```bash
+# 1. Edit dragon_voice/...
+# 2. Run unit tests
+pytest -q tests/test_<your_area>.py
+
+# 3. Lint
+ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/
+
+# 4. Deploy to Dragon
+scp -r dragon_voice/ radxa@192.168.1.91:/home/radxa/
+ssh radxa@192.168.1.91 'find /home/radxa/dragon_voice -name __pycache__ -exec rm -rf {} +; sudo systemctl restart tinkerclaw-voice'
+
+# 5. Watch logs
+ssh radxa@192.168.1.91 'sudo journalctl -u tinkerclaw-voice -f --since "30 seconds ago"'
+```
+
+### Tab5-only change
+
+```bash
+. ~/esp/esp-idf/export.sh
+cd ~/projects/TinkerTab
+idf.py build && idf.py -p /dev/ttyACM0 flash
+python -m esptool --chip esp32p4 -p /dev/ttyACM0 --before no_reset --after watchdog_reset read_mac
+```
+
+### Cross-stack change (touches both)
+
+1. Make Dragon change first (the protocol-extending side).
+2. Test Dragon change with the existing Tab5 firmware (Tab5 ignores unknown fields).
+3. Make Tab5 change.
+4. Update `docs/protocol.md` *in the same PR* as the protocol-changing side.
+
+### E2E harness for full-system testing
+
+The Python harness in [`tests/e2e/`](https://github.com/lorcan35/TinkerTab/blob/main/tests/e2e/) (TinkerTab repo) drives Tab5 through long user-story scenarios via the debug HTTP API.
+
+```bash
+cd ~/projects/TinkerTab
+export TAB5_URL=http://<tab5-ip>:8080
+export TAB5_TOKEN=<auth_tok-from-NVS>
+
+# Three scenarios
+python3 tests/e2e/runner.py story_smoke    # ~2 min
+python3 tests/e2e/runner.py story_full     # ~2 min
+python3 tests/e2e/runner.py story_stress   # ~10 min
+
+# All three with a clean reboot first
+python3 tests/e2e/runner.py all --reboot
+```
+
+Reports + screenshots land in `tests/e2e/runs/<scenario>-<timestamp>/`.
+
+---
+
+## Part 4 — Common pitfalls
+
+### "Cannot find ESP-IDF environment"
+
+You forgot to `source ~/esp/esp-idf/export.sh`.  Add it to your shell rc to skip the manual step:
+
+```bash
+# in ~/.bashrc or ~/.zshrc
+alias idfenv='. ~/esp/esp-idf/export.sh'
+```
+
+### "Connection refused" on `localhost:3502`
+
+You haven't started `dragon_voice`.  See section 1.4.
+
+### Tests pass locally but CI fails
+
+Likely the test you added uses a hardcoded path or token instead of env vars.  CI uses `DRAGON_API_TOKEN=ci-bearer-token`.
+
+### `__pycache__` issues after deploy
+
+```bash
+ssh radxa@192.168.1.91 'find /home/radxa/dragon_voice -name __pycache__ -exec rm -rf {} +'
+```
+
+This is annoying enough that we recommend baking it into your deploy script.
+
+### `idf.py build` complains about target
+
+```bash
+idf.py set-target esp32p4
+```
+
+After every `git checkout` of a different branch.
+
+### Tab5 doesn't connect to Dragon
+
+1. Check `dragon_host` in NVS via `GET /settings`:
+   ```bash
+   curl -s -H "Authorization: Bearer $TAB5_TOKEN" http://<tab5-ip>:8080/settings | python3 -m json.tool | grep dragon
+   ```
+2. If wrong, fix it:
+   ```bash
+   curl -X POST -H "Authorization: Bearer $TAB5_TOKEN" http://<tab5-ip>:8080/settings -d '{"dragon_host":"192.168.1.91"}'
+   ```
+3. Reboot Tab5:
+   ```bash
+   curl -X POST -H "Authorization: Bearer $TAB5_TOKEN" http://<tab5-ip>:8080/reboot
+   ```
+
+### Stale firmware on Tab5
+
+```bash
+# Force-reflash after a partition change
+idf.py -p /dev/ttyACM0 erase-flash flash
+```
+
+---
+
+## Part 5 — Where to go next
+
+You're set up.  Pick a thread:
+
+- **Add a new agentic tool:** [`adding-a-tool.md`](adding-a-tool.md)
+- **Add a new LLM model to the fleet:** [`router-cookbook.md`](router-cookbook.md)
+- **Author a skill that emits widgets:** [`SKILL_AUTHORING.md`](SKILL_AUTHORING.md)
+- **Add a channel adapter:** [`telegram-bot.md`](telegram-bot.md) is the reference example
+- **Trace one request through the whole system:** [`flows/voice-turn.md`](flows/voice-turn.md)
+- **Read the war stories:** [`../LEARNINGS.md`](../LEARNINGS.md)
+
+Welcome aboard. 🐉

--- a/docs/getting-started-user.md
+++ b/docs/getting-started-user.md
@@ -1,0 +1,280 @@
+# Getting Started — for Users
+
+> Your Tab5 just turned on. Now what?
+>
+> This is the user-facing quickstart. **No code, no terminal, no
+> SSH.** It assumes someone has already set up Dragon for you (or
+> that it came pre-configured). If you're setting up Dragon from
+> scratch yourself, see [`dev-setup.md`](dev-setup.md) instead —
+> that path is more involved.
+
+---
+
+## What you're looking at
+
+You have two pieces:
+
+1. **Tab5** — the 5-inch portrait touchscreen. The thing you'll
+   actually talk to.  Powered by a USB-C cable.
+2. **Dragon** — a small Linux box (probably hidden in a closet or on
+   a shelf).  This is the "brain" — it does the speech-to-text, the
+   AI thinking, and the text-to-speech.  Connected to your home WiFi
+   over Ethernet, always on.
+
+The two talk to each other over your home WiFi.  The Tab5 finds
+Dragon automatically once they're both on the same network.
+
+---
+
+## First conversation, in 5 minutes
+
+### Step 1 — Plug in Tab5
+
+Use the USB-C cable + power brick that came with the Tab5.  The
+screen will boot up after about 25 seconds.  You'll see:
+
+1. A boot animation
+2. A WiFi setup screen (only on first boot)
+3. The home screen — a clock, a glowing orb, a greeting
+
+### Step 2 — Connect to your WiFi (first boot only)
+
+If the Tab5 has never seen your network before, it shows a Wi-Fi
+setup screen with a list of nearby networks.
+
+1. Tap your home network in the list
+2. Tap the password field, then tap each character on the keyboard
+3. Tap "Connect"
+
+You'll see "Connected" and a tick.  Tap "Continue."
+
+The Tab5 will then look for Dragon on the network.  If Dragon is on
+and reachable, you'll see "Dragon connected" in the status bar.  If
+not, you'll see "Dragon offline" — see "When something goes wrong"
+below.
+
+### Step 3 — Tap the orb, talk to it
+
+On the home screen there's a glowing circular orb in the middle.
+That's the microphone button.
+
+1. **Tap and hold the orb.**
+2. **Speak your question** — try "What time is it?"
+3. **Release.** The orb dims while it thinks.
+4. After a moment, the answer comes out the speaker and shows up in
+   the chat overlay at the top.
+
+That's it.  You're using a private AI assistant.
+
+---
+
+## What you can ask it
+
+The default mode (Local) runs everything on your Dragon — slower
+(60-90 seconds per answer) but completely private.  Try:
+
+- "What time is it?"
+- "What day is today?"
+- "Calculate 456 times 789." (it'll fire a calculator tool)
+- "What's the weather in Paris?" (it'll search the web)
+- "Remember that my favourite colour is blue." (it'll save the fact)
+- "What's my favourite colour?" (it should recall it)
+
+If you switch to **Cloud mode** (we'll get to that), answers come
+back in 3-5 seconds and quality is much higher — but it costs money
+(typically pennies per conversation) and your audio + transcript
+gets sent to the cloud LLM provider.
+
+---
+
+## The four modes (and when to use each)
+
+The Tab5 has a small **mode chip** at the top of the home screen
+that says "Local," "Hybrid," "Cloud," or "TinkerClaw."  Tap or
+long-press it to bring up the mode picker.
+
+| Mode | Speed | Privacy | Cost | Quality | Use when |
+|------|-------|---------|------|---------|----------|
+| **Local** (default) | Slow (~60-90s) | All local | Free | Decent for short replies | Everyday questions you don't want logged anywhere |
+| **Hybrid** | Fast STT/TTS, slow LLM | Audio → cloud, thinking local | ~$0.01/turn | Local-quality replies, fast voice | Voice-driven note-taking; quick exchanges |
+| **Cloud** | Fast (~3-5s) | Audio + thinking → cloud | ~$0.05-0.20/turn depending on model | Best | Real conversation, complex questions, image analysis |
+| **TinkerClaw** | Slow but powerful | Mixed | varies | Excellent for long tasks | Multi-step jobs ("research this, summarise it, save the result") |
+
+The Tab5 keeps a daily spend cap.  By default it auto-switches you
+back to Local once you spend $1 in a day on Cloud.  Bump the cap in
+Settings if you'd like.
+
+---
+
+## What you can do besides voice
+
+### Send a photo
+
+Tap the **camera tile** in the bottom nav sheet (swipe up from
+bottom).  Take a photo with the white shutter circle, then tap "Send
+photo" to share it with the AI.  Ask "What is this?" and the photo
+comes back analysed.
+
+### Type instead of speaking
+
+Tap the **chat tile** in the nav sheet.  There's a text input at the
+bottom; tap it, type, hit Done.  The AI sees it the same way as
+voice (skipping the speech-to-text step).
+
+### Take notes
+
+Long-press the orb on the home screen instead of tapping.  This
+starts **dictation mode** — record a long note (5+ minutes if you
+want), it auto-stops on silence, then the AI generates a title +
+summary for you.
+
+### Make a video call
+
+In the nav sheet there's a **Call** tile.  This starts a video call
+that any browser on your network (or anywhere via the ngrok URL,
+if your installer set that up) can join by visiting `/call` on
+your Dragon's address.
+
+---
+
+## Privacy in plain English
+
+Each mode is different.  Honest summary:
+
+- **Local mode:** Your audio, transcript, and replies all stay on
+  your Dragon.  Nothing leaves your network.  Conversation history
+  is saved on Dragon's disk for 30 days then deleted.
+- **Hybrid mode:** Audio is sent to OpenRouter (the cloud audio
+  service) for speech-to-text and text-to-speech.  Your text prompt
+  + recent conversation context stays on Dragon and gets answered
+  by the local LLM.  OpenRouter sees the audio + the spoken text
+  but not your prior conversation history.
+- **Cloud mode:** Everything goes to OpenRouter — audio, the
+  question, your recent conversation context, any photos.
+  OpenRouter doesn't train on this data by default but does log it
+  for billing and abuse prevention.
+- **TinkerClaw mode:** Same as Cloud for the AI, but with
+  additional capability to take actions on your behalf (browse
+  websites, send messages, etc.) via the gateway.
+
+Memory facts you save (via "remember this…") are stored locally on
+Dragon.  Photos uploaded for analysis are deleted from Dragon after
+24 hours.  WebSocket traffic between Tab5 and Dragon on your home
+network is currently **not encrypted** — it's all on your LAN, but
+if someone else is on your WiFi and is determined, they could see
+the audio and replies.  See [`../SECURITY.md`](../SECURITY.md) for
+the full story.
+
+If you want zero cloud exposure: stay in Local mode, set
+`cap_mils=0` to lock out cloud completely.
+
+---
+
+## Common questions
+
+### "Why is Local mode so slow?"
+
+The local LLM (default: ministral-3:3b) runs on Dragon's CPU,
+which is a Snapdragon ARM chip — fine for a small AI but not a
+desktop GPU.  Each response is 30-90 seconds of thinking.  Cloud
+mode answers in 3-5 seconds because OpenRouter has datacenter
+hardware.
+
+If you want fast + private: get a workstation with a GPU running LM
+Studio on your LAN, then add it as a "LAN tier" entry in Dragon's
+fleet config — see [`router-cookbook.md`](router-cookbook.md).
+
+### "Can I add my own AI model?"
+
+Yes.  See [`router-cookbook.md`](router-cookbook.md) — it's
+designed for non-experts to drop in OpenRouter model IDs or
+locally-running Ollama models.
+
+### "How do I update the firmware?"
+
+Tab5 checks for updates from Dragon hourly.  When one's available,
+the Settings screen shows an "Apply Update" button.  Tap it.  The
+device reboots into the new firmware.  If something breaks during
+the first boot, ESP-IDF auto-rolls back to the previous version.
+
+### "How do I reset everything to factory?"
+
+In Settings, scroll to "About" → "Erase NVS".  This wipes WiFi
+credentials, the Dragon address, the daily spend counter, etc.
+You'll need to re-do the WiFi setup on next boot.  Conversation
+history lives on Dragon, not Tab5, so this won't erase that.
+
+### "What if I want to delete my conversation history?"
+
+On Dragon, the dashboard at `http://<your-dragon-ip>:3500` has a
+**Conversations** tab where you can browse and delete sessions.
+Or use the Tab5 chat screen's "New Chat" button to clear context
+without deleting history.
+
+### "What happens if Dragon goes down?"
+
+Tab5 falls back to a "Dragon offline" indicator and stops accepting
+voice input.  Notes recorded via dictation get queued locally and
+upload when Dragon's back.  No data is lost.
+
+---
+
+## When something goes wrong
+
+### Tab5 says "Dragon offline"
+
+1. Check Dragon is plugged in and the Ethernet cable is in.
+2. On a phone or laptop, try `http://<dragon-ip>:3502/health` — should return `{"status": "ok"}`.
+3. If Dragon's reachable but Tab5 can't see it, check Tab5's saved Dragon address in Settings → "Network" → "Dragon host".
+4. If you've moved Dragon to a new network, you'll need to update the address.
+
+### Tab5 says "Connecting…" forever
+
+1. Power-cycle Tab5 by unplugging USB-C for 5 seconds.
+2. If still stuck, hold the orb during boot to enter recovery — it'll re-show the WiFi setup screen.
+
+### "Daily budget cap reached" message
+
+You've spent your daily Cloud-mode allowance.  Either wait until
+midnight or bump the cap in Settings → "Voice & Spending" →
+"Daily cap".  Local + Hybrid modes are free and unaffected.
+
+### Voice quality is bad / robotic / glitchy
+
+Try a different voice mode.  Cloud mode TTS is much higher quality
+than local Piper.  If even Cloud TTS sounds bad, it's probably the
+Tab5 speaker — check Settings → "Audio" → "Volume" and "Mute" — and
+ensure nothing is covering the speaker grille.
+
+### Camera screen shows green tint or weird colours
+
+That's the SC202CS sensor's auto-exposure.  In low light it
+oversaturates green.  Try better lighting or tap the sun icon to
+manually adjust.
+
+### Something else
+
+The Tab5 has a built-in debug page.  On a phone or laptop on the
+same WiFi, browse to `http://<tab5-ip>:8080/info` — this returns a
+JSON status with heap, uptime, voice state, WiFi info.  If you want
+deeper diagnostics, the full debug-server reference is in TinkerTab's
+[CLAUDE.md "Debug Server" section](https://github.com/lorcan35/TinkerTab/blob/main/CLAUDE.md#debug-server-adb-style-remote-control).
+
+If none of this works, **file an issue** with:
+- What you were trying to do
+- What happened instead
+- The output of `http://<tab5-ip>:8080/info` if you can get it
+- A screenshot if visual
+
+---
+
+## Where to go next
+
+You're up and running.  Want more?
+
+- **Configure the AI's behaviour:** Settings has dials for "intelligence", "voice", "autonomy" that change how the AI replies.  Long-press the home-screen mode chip for the picker.
+- **Add a skill:** [`SKILL_AUTHORING.md`](SKILL_AUTHORING.md) is the developer guide; if you're not a developer, ask one.
+- **Look under the hood:** [`ARCHITECTURE.md`](ARCHITECTURE.md) explains how the system works.
+- **See what just shipped:** [`release-notes.md`](release-notes.md).
+
+Enjoy. 🐉

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,181 @@
+# Release Notes
+
+> User-facing summary of recent changes.  For exhaustive change
+> history, see `git log --oneline` or
+> [GitHub Releases](https://github.com/lorcan35/TinkerBox/releases).
+>
+> Format: most recent first.  Each entry calls out what changed, why
+> it matters, and which PRs delivered it.
+
+---
+
+## 2026-04-28 — Onboarding sweep
+
+Big push to make the documentation work for *all three* audiences
+the project actually has — non-technical users, tinkerers/builders,
+and security/protocol researchers.
+
+**For users (normies):**
+- New [`docs/getting-started-user.md`](getting-started-user.md) —
+  "I just got a Tab5, now what?"  Power-on to first conversation in
+  five minutes.  Plain-English explanation of the four voice modes,
+  privacy summary, cost note, troubleshooting.
+- [`WELCOME.md`](../WELCOME.md) at the repo root — multi-audience
+  landing page that branches by intent.
+
+**For tinkerers:**
+- New [`CONTRIBUTING.md`](../CONTRIBUTING.md) — workflow, branch
+  naming, commit conventions, CI gates.  Extracted from `CLAUDE.md`
+  so contributors don't have to read 850 lines of operational
+  runbook.
+- New [`docs/dev-setup.md`](dev-setup.md) — get from clone to
+  iterate-locally for both Dragon (Python) and Tab5 (ESP-IDF)
+  sides.  ESP-IDF v5.5.2 install, USB perms, ngrok, Ollama setup.
+- New [`docs/adding-a-tool.md`](adding-a-tool.md) — worked example
+  building a `dice_roll` tool from scratch.  Test patterns,
+  registration, defensive arg parsing, anti-patterns.
+
+**For hackers:**
+- New [`SECURITY.md`](../SECURITY.md) (and counterpart in TinkerTab)
+  — honest threat model.  Trust boundaries, auth-token lifecycle
+  (`DRAGON_API_TOKEN`, `auth_tok`, `OPENROUTER_API_KEY`), data
+  inventory (what gets persisted where, what crosses to OpenRouter),
+  network exposure map, firmware integrity status (no secure boot
+  or flash encryption currently), known limitations, responsible-
+  disclosure path, auditor's checklist.
+
+PRs: TinkerBox onboarding sweep (this release).
+
+---
+
+## 2026-04-28 — Architecture + flow traces
+
+Project went from "great runbook for current contributors" to
+"readable to someone walking in cold."
+
+- **[`docs/ARCHITECTURE.md`](ARCHITECTURE.md)** — canonical "what is
+  TinkerClaw?" doc with mermaid diagrams (component layout, network
+  topology, router decision tree).  Every reader's first stop.
+- **`docs/flows/`** — three end-to-end traces with file:line refs
+  throughout: [voice turn](flows/voice-turn.md), [vision turn](flows/vision-turn.md),
+  [video call](flows/video-call.md).  Mermaid sequence diagrams.
+  Latency budgets.  Failure-mode tables.
+- **[`GLOSSARY.md`](../GLOSSARY.md)** — ~80 terms across both repos.
+- TinkerTab gets its own [HARDWARE.md](https://github.com/lorcan35/TinkerTab/blob/main/docs/HARDWARE.md)
+  + [GLOSSARY.md](https://github.com/lorcan35/TinkerTab/blob/main/GLOSSARY.md).
+
+PRs: [#190](https://github.com/lorcan35/TinkerBox/pull/190) (TinkerBox), [#302](https://github.com/lorcan35/TinkerTab/pull/302) (TinkerTab).
+
+---
+
+## 2026-04-28 — Doc cleanup
+
+Archived 7 superseded documents to `docs/historical/`, deleted 3
+that had no value (a misplaced Python tree, a stale pytest harness,
+a git-stash index), and fixed CLAUDE.md drift on endpoint count
+(47 → 53), schema tables (6/9 → 11), and test count (153 → 556).
+
+PRs: [#189](https://github.com/lorcan35/TinkerBox/pull/189) (TinkerBox), [#301](https://github.com/lorcan35/TinkerTab/pull/301) (TinkerTab).
+
+---
+
+## 2026-04-27 — Multi-model router
+
+The single most consequential feature shipped this month.  Dragon
+now supports a fleet of LLM backends — pick per-turn based on
+modalities + tier policy.
+
+**What you can do now:**
+- Route text turns to the cheap `deepseek-v4-flash` ($0.14/M in,
+  $0.28/M out) but vision turns to `qwen3.6-flash` ($0.25/$1.50,
+  multimodal, 1M context) automatically.
+- Mix local + cloud + LAN tiers in one fleet.  e.g., ministral-3:3b
+  on Dragon for text + LM Studio on a workstation for vision.
+- Cross-modal continuity: send a photo, then ask "what colour was
+  the chair?" — the follow-up text turn still sees the photo because
+  the multimodal user message is persisted in conversation history.
+
+**Reference:**
+- [`docs/router-cookbook.md`](router-cookbook.md) — copy-paste fleet
+  recipes (default fleet, sub-$0.50/M cheapskate, top-tier-only,
+  DGX LAN tier).
+- [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) "Multi-Model Router"
+  section.
+- [`docs/flows/vision-turn.md`](flows/vision-turn.md) for the
+  end-to-end trace.
+
+**Provider catalog (verified live 2026-04-27):**
+- Anthropic: Sonnet 4.6, Opus 4.7, Haiku 4.5
+- OpenAI: GPT-5.5, GPT-5.5 Pro
+- Google: Gemini 3.1 Pro Preview (native video!), Gemini 3 Flash Preview, Gemma 4
+- DeepSeek: V4 Pro, V4 Flash, R1
+- Qwen: 3.6 family (multimodal, 1M context)
+- Moonshot Kimi K2.6, x-AI Grok 4.20, Z-ai GLM 5.x, Xiaomi MiMo
+
+PRs: #184 (capability declarations), #185 (router), #186 (server
+integration + cross-modal continuity), #187 (OR registry refresh),
+#188 (router docs).
+
+---
+
+## 2026-04-27 — Tab5 e2e harness + debug additions
+
+The firmware now has a Python-driven scenario runner that drives
+real user flows via the debug API.  Three canonical stories:
+`story_smoke` (~2 min, 14 steps), `story_full` (~24 steps),
+`story_stress` (10 min, 77 steps).  Reports + screenshots in
+`tests/e2e/runs/<scenario>-<ts>/`.
+
+Bonus debug-server additions: `GET /screen`, `POST /input/text`,
+seven new `tab5_debug_obs_event` call sites in `voice.c` /
+`debug_server.c` / `ui_camera.c`.
+
+PRs: TinkerTab #294 (debug events + /screen), #295 (harness), #297 (/input/text), #299/#300 (input/text scoping fix), #298 (docs).
+
+---
+
+## 2026-04-27 — Tab5 video recording (#291)
+
+REC button on the camera screen.  Records motion-JPEG to
+`/sdcard/VID_NNNN.MJP` at 5 fps, then auto-uploads to Dragon's
+`/api/media/upload`.
+
+Why `.MJP` and not `.mjpeg`: FATFS LFN is disabled on Tab5 (saves
+RAM), so we're stuck with 8.3 short names.  Players sniff magic
+bytes; the extension is cosmetic.
+
+PR: TinkerTab #291.
+
+---
+
+## 2026-04-21 — Wave 14 closed
+
+63-item systematic audit (cross-stack: 6 CRITICAL, 23 HIGH, 22
+MEDIUM, 12 LOW).  Major fixes shipped over the prior week:
+
+- LVGL `lv_async_call` was NOT thread-safe (does `lv_malloc`
+  + `lv_timer_create` against unprotected TLSF).  PR #257 hand-
+  wrapped the empirical site; #259 added `tab5_lv_async_call`
+  helper and replaced all 49 sites.  100% uptime in 5-min mixed
+  nav+screenshot stress (was 50% pre-fix).
+- WS keepalive during inference (PR #76) — local-mode 4B-class
+  models routinely take 60-90s per turn; without keepalive pings
+  Tab5's PONG-watch evicted in-flight LLM streams.
+- Empty-reply guard (PR #77/#79) — FC-trained models that emit a
+  tool call and stop now get a one-line natural-language ack
+  synthesised from the tool result.
+- Default Local LLM swapped to ministral-3:3b after an 11-model
+  gauntlet.
+
+Full audit: [`docs/historical/AUDIT-WAVE-14.md`](historical/AUDIT-WAVE-14.md).
+Wave 15 active: [`docs/AUDIT-WAVE-15.md`](AUDIT-WAVE-15.md).
+
+---
+
+## Earlier history
+
+For releases before 2026-04, see `git log --oneline` or the closed
+issues marked `release/*`.  CHANGELOG.md was archived to
+`docs/historical/` as it stopped updating around 2026-04-01 — the
+manually-maintained format didn't keep up with the post-router
+work.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,30 @@
+# Examples
+
+Minimal templates for common contributor tasks. Each subfolder is a
+self-contained example with a `README.md` explaining what it does
+and how to integrate it.
+
+| Folder | What it shows |
+|--------|--------------|
+| [`tool-hello-world/`](tool-hello-world/) | Smallest possible agentic tool — single file, fully tested, registers in 2 lines |
+
+More examples land here as the skill platform matures. If you've
+built something useful for a custom deployment, PR it as an example.
+
+## Conventions
+
+- Each example is dependency-free beyond what's in the main
+  `requirements.txt`.
+- Each example is opt-in — copying the file into `dragon_voice/` and
+  registering it is the one-and-only step.
+- Examples are not regression-tested in CI by default. If you want
+  CI coverage, add the test path to `.github/workflows/ci.yml`.
+- Examples are MIT-licensed via the project license.
+
+## See also
+
+- [`../docs/adding-a-tool.md`](../docs/adding-a-tool.md) — the full
+  walkthrough using a `dice_roll` example
+- [`../docs/SKILL_AUTHORING.md`](../docs/SKILL_AUTHORING.md) — for
+  skills that emit widgets
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — workflow rules

--- a/examples/tool-hello-world/hello_world_tool.py
+++ b/examples/tool-hello-world/hello_world_tool.py
@@ -1,0 +1,79 @@
+"""Hello-world tool — smallest possible agentic tool.
+
+What it does
+------------
+The LLM can call this tool to greet someone by name.  Returns a
+JSON object with the greeting and a timestamp.  Useful as a
+template; not useful in production.
+
+How to use it
+-------------
+1. Copy this file into ``dragon_voice/tools/hello_world_tool.py``.
+2. Register it in ``dragon_voice/lifecycle/startup.py`` next to the
+   other ``server._tool_registry.register(...)`` calls::
+
+       from dragon_voice.tools.hello_world_tool import HelloWorldTool
+       server._tool_registry.register(HelloWorldTool())
+
+3. Restart ``tinkerclaw-voice`` (or your local ``python3 -m
+   dragon_voice``).  The LLM will see the new tool in its system
+   prompt and can invoke it on prompts like "say hi to Alice".
+
+Test it
+-------
+    curl -s -X POST -H "Authorization: Bearer $DRAGON_API_TOKEN" \\
+         -H "Content-Type: application/json" \\
+         -d '{"name": "World"}' \\
+         http://localhost:3502/api/v1/tools/hello_world/execute
+
+Should return::
+
+    {"greeting": "Hello, World!", "at": "..."}
+
+For a fuller worked example with tests + caps + arg validation,
+see ``docs/adding-a-tool.md``.
+"""
+
+from datetime import datetime, timezone
+
+from dragon_voice.tools.base import Tool
+
+
+class HelloWorldTool(Tool):
+    """Greet someone by name."""
+
+    @property
+    def name(self) -> str:
+        return "hello_world"
+
+    @property
+    def description(self) -> str:
+        # Keep this under ~100 chars — it's injected into every
+        # LLM system prompt and pushes out memory facts + history.
+        return (
+            "Say hello to someone by name. Use when the user asks "
+            "to greet a person."
+        )
+
+    @property
+    def parameters_schema(self) -> dict:
+        # JSON Schema — same shape as OpenAI function-calling.
+        return {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Person to greet.",
+                    "default": "World",
+                },
+            },
+        }
+
+    async def execute(self, args: dict) -> dict:
+        # Defensive arg parsing — the LLM occasionally returns weird
+        # values.  Coerce-to-string + sane default beats raising.
+        name = str(args.get("name") or "World")
+        return {
+            "greeting": f"Hello, {name}!",
+            "at": datetime.now(timezone.utc).isoformat(),
+        }


### PR DESCRIPTION
## Summary
Closes the audience-coverage audit gap.  We had great docs for *current contributors who already know the project*; now there's real onboarding for the three actual cohorts.

## New documents

### For end users (normies) — score was 2/10
- **`WELCOME.md`** at repo root — multi-audience landing page branching by intent (use it / build it / hack it)
- **`docs/getting-started-user.md`** — power-on to first conversation in 5 min. Plain-English voice modes, privacy summary, cost note, troubleshooting

### For tinkerers — score was 7/10
- **`CONTRIBUTING.md`** — workflow, branches, conventions, CI gates, anti-slop rules
- **`docs/dev-setup.md`** — clone-to-iterate for both Dragon (Python) and Tab5 (ESP-IDF) with common pitfalls
- **`docs/adding-a-tool.md`** — worked example: build a `dice_roll` tool from scratch including tests + registration + patterns
- **`examples/tool-hello-world/`** — minimal copy-paste tool template

### For hackers — score was 6/10
- **`SECURITY.md`** — honest threat model. Trust boundaries, auth-token lifecycle, data inventory (what's persisted, what crosses to OpenRouter), firmware integrity status, known limitations, responsible disclosure, auditor's checklist

### Plus
- **`docs/release-notes.md`** — user-facing change summary
- **README nav strip** expanded with the new docs

## Stats
~3500 lines of new docs. No code changes. Pairs with TinkerTab's matching PR.

## Test plan
- [x] All cross-references resolve
- [x] All file:line refs in adding-a-tool.md point at real code
- [x] Token claims in SECURITY.md verified against `dragon_voice/middleware/auth.py`
- [x] Endpoint count + schema table count + test count match prior CLAUDE.md fixes (53/11/556)