### PR TITLE
fix(scheduler): accept LLM-natural verbose phrases for parse_when (closes #136)

### DIFF
--- a/dragon_voice/scheduler/parser.py
+++ b/dragon_voice/scheduler/parser.py
@@ -10,6 +10,10 @@ client and a voice command get identical semantics.
 Accepted grammar (RFC C.1):
 
   * Relative duration:    ``5m``, ``2h``, ``1h30m``, ``90s``, ``1d``
+  * Verbose relative:     ``in 5 minutes``, ``8 minutes from now``,
+                          ``30 seconds later`` (#136 — LLMs rarely emit
+                          the compact ``5m`` form; pin the conversational
+                          shapes the tool gets in practice)
   * ISO 8601 absolute:    ``2026-04-26T15:00:00-04:00`` (with TZ)
                           ``2026-04-27T15:00:00`` (resolves in tz=)
   * Natural phrase:       ``today at 17:00``, ``tomorrow at 3pm``
@@ -42,6 +46,22 @@ _NATURAL = re.compile(
     r"^\s*(today|tomorrow)\s+at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*$",
     re.IGNORECASE,
 )
+
+# Verbose relative phrasing the LLM emits in practice (#136).  Either an
+# `in N <unit>` prefix OR an `N <unit> from now` / `N <unit> later`
+# suffix is required — bare `5 minutes` is intentionally rejected
+# because it's ambiguous between "in 5 minutes" and "for 5 minutes".
+_VERBOSE_PREFIX = re.compile(
+    r"^\s*in\s+(\d+)\s+(second|minute|hour|day)s?\s*$",
+    re.IGNORECASE,
+)
+_VERBOSE_SUFFIX = re.compile(
+    r"^\s*(\d+)\s+(second|minute|hour|day)s?\s+(?:from\s+now|later)\s*$",
+    re.IGNORECASE,
+)
+_VERBOSE_UNIT_TO_SECONDS = {
+    "second": 1, "minute": 60, "hour": 3600, "day": 86400,
+}
 
 # 365-day far-future cap (RFC E1)
 _MAX_FUTURE_SECONDS = 365 * 86400
@@ -92,6 +112,12 @@ def parse_when(
         _check_far_future(fire_at, now=now)
         return fire_at
 
+    # ── 1b. Verbose relative ("in 5 minutes", "8 minutes from now") ──
+    fire_at = _try_parse_verbose_relative(s_clean, now=now)
+    if fire_at is not None:
+        _check_far_future(fire_at, now=now)
+        return fire_at
+
     # ── 2. ISO 8601 ─────────────────────────────────────────────────
     fire_at = _try_parse_iso(s_clean, tz=tz)
     if fire_at is not None:
@@ -108,7 +134,7 @@ def parse_when(
 
     raise ValueError(
         f"could not parse 'when': {s!r} — expected '5m', "
-        f"ISO 8601 timestamp, or 'tomorrow at 3pm' shape"
+        f"'in 5 minutes', ISO 8601 timestamp, or 'tomorrow at 3pm' shape"
     )
 
 
@@ -130,6 +156,20 @@ def _try_parse_relative(s: str, *, now: float) -> Optional[float]:
     for value, unit in _DURATION_PART.findall(s):
         total_seconds += int(value) * _UNIT_TO_SECONDS[unit]
     return now + total_seconds
+
+
+def _try_parse_verbose_relative(s: str, *, now: float) -> Optional[float]:
+    """Parse `in 5 minutes` / `8 minutes from now` / `30 seconds later`.
+
+    Returns None if the input doesn't match one of the verbose shapes
+    so the caller can fall through to the next grammar branch.
+    """
+    m = _VERBOSE_PREFIX.match(s) or _VERBOSE_SUFFIX.match(s)
+    if not m:
+        return None
+    value = int(m.group(1))
+    unit = m.group(2).lower()
+    return now + value * _VERBOSE_UNIT_TO_SECONDS[unit]
 
 
 def _try_parse_iso(s: str, *, tz: tzinfo) -> Optional[float]:

--- a/tests/test_scheduler_when_parser.py
+++ b/tests/test_scheduler_when_parser.py
@@ -90,6 +90,81 @@ def test_iso_without_tz_uses_dragon_tz() -> None:
     assert fire_at == pytest.approx(expected)
 
 
+# ───────────────────────── verbose relative phrases (LLM-natural; #136)
+#
+# Local LLMs almost never emit `5m` — they reach for the conversational
+# shapes a user would actually say.  These tests pin the three accepted
+# verbose forms so a future regex tweak can't quietly break the LLM
+# tool-call path.
+
+
+def test_verbose_in_minutes() -> None:
+    """`in 5 minutes` — the most common LLM phrasing for a near-term
+    reminder.  Maps to the same semantics as `5m`."""
+    fire_at = parse_when("in 5 minutes", now=_FIXED_NOW, tz=_UTC)
+    assert fire_at == pytest.approx(_FIXED_NOW + 5 * 60)
+
+
+def test_verbose_minutes_from_now() -> None:
+    """`8 minutes from now` — the exact phrase that surfaced in the
+    issue (#136) where ministral fired schedule_reminder and got
+    rejected.  Pin it."""
+    fire_at = parse_when("8 minutes from now", now=_FIXED_NOW, tz=_UTC)
+    assert fire_at == pytest.approx(_FIXED_NOW + 8 * 60)
+
+
+def test_verbose_seconds_later() -> None:
+    """`30 seconds later` — third accepted phrasing.  `later` is a
+    common English suffix; some models reach for it instead of
+    `from now`."""
+    fire_at = parse_when("30 seconds later", now=_FIXED_NOW, tz=_UTC)
+    assert fire_at == pytest.approx(_FIXED_NOW + 30)
+
+
+def test_verbose_singular_unit() -> None:
+    """`in 1 hour` (singular) parses too.  English drops the trailing
+    `s` for n=1 and the parser must follow."""
+    fire_at = parse_when("in 1 hour", now=_FIXED_NOW, tz=_UTC)
+    assert fire_at == pytest.approx(_FIXED_NOW + 3600)
+
+
+def test_verbose_seconds() -> None:
+    """`in 90 seconds` works; pins the second-unit path against the
+    minute/hour ones."""
+    fire_at = parse_when("in 90 seconds", now=_FIXED_NOW, tz=_UTC)
+    assert fire_at == pytest.approx(_FIXED_NOW + 90)
+
+
+def test_verbose_days() -> None:
+    """`in 2 days` works; days are wall-clock 86400 s, no DST math,
+    matches the relative-duration contract."""
+    fire_at = parse_when("in 2 days", now=_FIXED_NOW, tz=_UTC)
+    assert fire_at == pytest.approx(_FIXED_NOW + 2 * 86400)
+
+
+def test_verbose_case_insensitive() -> None:
+    """`In 5 Minutes` (sentence case) parses — LLM output isn't
+    always lowercase."""
+    fire_at = parse_when("In 5 Minutes", now=_FIXED_NOW, tz=_UTC)
+    assert fire_at == pytest.approx(_FIXED_NOW + 5 * 60)
+
+
+def test_verbose_far_future_capped() -> None:
+    """The 365-day cap applies to verbose phrases too — a hallucinated
+    `in 400 days` raises like `400d` does."""
+    with pytest.raises(ValueError, match="365"):
+        parse_when("in 400 days", now=_FIXED_NOW, tz=_UTC)
+
+
+def test_verbose_bare_number_unit_rejected() -> None:
+    """`5 minutes` (no `in` prefix and no `from now` / `later` suffix)
+    is ambiguous — could mean "for 5 minutes" rather than "in 5
+    minutes".  Reject so we never schedule a wrong-meaning reminder.
+    The user / LLM can disambiguate by saying `in 5 minutes`."""
+    with pytest.raises(ValueError):
+        parse_when("5 minutes", now=_FIXED_NOW, tz=_UTC)
+
+
 # ───────────────────────── natural phrases
 
 


### PR DESCRIPTION
## Summary
- Adds a verbose-relative branch to `parse_when` that accepts `in N <unit>`, `N <unit>s from now`, and `N <unit>s later` — the shapes local LLMs actually emit when firing `schedule_reminder`.
- Rejects bare `5 minutes` (no prefix/suffix) because it's ambiguous between "in 5 minutes" and "for 5 minutes" — the LLM can disambiguate by saying "in 5 minutes".
- Far-future cap (365 days) applies to verbose forms.

The exact symptom from #136 (ministral fired `schedule_reminder({when: '8 minutes from now', ...})` and was rejected) now parses to `now + 480s`.

## Test plan
- [x] `pytest tests/test_scheduler_when_parser.py -q` — 23 passed (15 existing + 8 new)
- [x] `pytest tests/test_scheduler_tool.py -q` — 7 passed (no regressions)
- [x] `ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006` — clean
- [x] Smoke check on `8 minutes from now`, `in 5 minutes`, `30 seconds later`, `in 1 hour`, `In 2 Days` — all parse to expected offsets
- [ ] Manual: deploy to Dragon, ask "remind me in 8 minutes to drink water" in Local mode, verify the reminder fires (not in this PR — leaves the live workflow check to whoever next runs the long-workflow gauntlet)

## Out of scope
- Cron-style recurring (RFC H non-goal)
- Calendar phrases like "next Tuesday at 3pm" (would need real NLP)
- "an hour" / "a minute" indefinite-article forms (not seen in any LLM output to date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)