### PR TITLE
fix(monitor): raise mem warn/crit thresholds for post-pool steady state (closes #29)

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -80,9 +80,16 @@ class VoiceServer:
         self._purge_task: Optional[asyncio.Task] = None
         self._memory_monitor_task: Optional[asyncio.Task] = None
 
-        # Memory thresholds (MB) — Dragon has 8GB total, Ollama ~1.5GB, TinkerClaw ~300MB
-        self._mem_warn_mb = 2048   # Force GC above this
-        self._mem_crit_mb = 3072   # Restart pipeline above this (after GC)
+        # Memory thresholds (MB) — Dragon has 11 GB total.  Ollama runs in
+        # a separate process and doesn't count toward voice-server RSS.
+        # Post-W15-C01 (STT/TTS/LLM pooled across reconnects), Moonshine's
+        # ~2.5 GB plus Piper + Python steady-state lands the voice server
+        # at ~2.7 GB resident — the prior 2048/3072 thresholds fired warn
+        # constantly and triggered crit-restart on legitimate steady-state
+        # peaks (#29).  Bumped so warn fires above the floor and crit
+        # gives real headroom before the pipeline-restart hammer.
+        self._mem_warn_mb = 3072   # Force GC above this
+        self._mem_crit_mb = 4096   # Restart pipeline above this (after GC)
 
         # Backend names for status page
         self._stt_name = config.stt.backend

--- a/tests/test_lifecycle_monitors.py
+++ b/tests/test_lifecycle_monitors.py
@@ -50,7 +50,7 @@ class MemoryMonitorLoopTests(unittest.TestCase):
     patched ``get_rss_mb`` / ``get_cpu_temp`` + a tiny stub ``server``.
     """
 
-    def _make_server(self, warn=2048, crit=3072):
+    def _make_server(self, warn=3072, crit=4096):
         s = MagicMock()
         s._mem_warn_mb = warn
         s._mem_crit_mb = crit


### PR DESCRIPTION
## Summary
- The RSS leak in #29 was already fixed by W15-C01 (PR #52) when STT/TTS/LLM became pooled across reconnects — Moonshine model now loads once per process.
- What was left was threshold calibration: pooled steady state is ~2.7 GB resident, but the monitor still used warn=2048/crit=3072 — warn fired constantly and crit triggered false-positive pipeline restarts on legitimate transient peaks.
- Bumps warn 2048 → 3072 and crit 3072 → 4096. Test default tracks production.

## Verification
- [x] `pytest tests/test_lifecycle_monitors.py tests/test_backend_pool.py -q` — 10 passed
- [x] `ruff` narrow gate — clean
- [ ] Live: deploy + 1 h soak, confirm no warn-GC log entries during idle and no crit-restart events under stress (deferred — happy to bake on next Dragon push)

## Why this closes #29
The issue's three proposed fixes were:
1. Raise threshold 3072 → 4096 ← this PR
2. Explicit `del` + `gc.collect()` on STT/TTS shutdown ← obviated by pooling (shutdown is a no-op for pooled backends; their lifetime is process-scoped)
3. Module-level singleton STT/TTS ← W15-C01 delivered this via the shared backend pool

The architectural fix shipped weeks ago; this is the calibration tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)