### PR TITLE
fix(ws): text-path TTS kills Piper on timeout (Phase 2 L3, refs #89)

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -1984,8 +1984,24 @@ class VoiceServer:
                             })
                         except Exception:
                             pass
-                except Exception:
-                    logger.exception("TTS for text input failed")
+                except (asyncio.TimeoutError, Exception) as tts_err:
+                    # #89 Phase 2 L3: kill any in-flight Piper subprocess
+                    # before bailing.  Without this the text path leaks
+                    # the zombie until Python exits — same class of bug
+                    # as A1 (cancel) but on the timeout edge.  Mirrors
+                    # the voice-path pattern at pipeline.py:1411-1421.
+                    if pipeline._tts and hasattr(pipeline._tts, "kill_active_procs"):
+                        try:
+                            pipeline._tts.kill_active_procs()
+                        except Exception:
+                            logger.debug("kill_active_procs raised", exc_info=True)
+                    if isinstance(tts_err, asyncio.TimeoutError):
+                        logger.warning(
+                            "Text-path TTS timed out after %ds — killed Piper procs",
+                            tts_timeout,
+                        )
+                    else:
+                        logger.exception("TTS for text input failed")
                     # Always send tts_end so Tab5 doesn't hang in SPEAKING
                     if not ws.closed:
                         await ws.send_json({"type": "tts_end", "tts_ms": 0})

--- a/tests/test_text_path_tts_kill_on_timeout.py
+++ b/tests/test_text_path_tts_kill_on_timeout.py
@@ -1,0 +1,45 @@
+"""Phase 2 L3 (#89, refs #94): text-path TTS kill-on-timeout.
+
+The voice path's L3 fix shipped earlier in this phase
+(`pipeline._synthesize_and_send` calls `kill_active_procs` on
+TimeoutError — see test_tts_flush_and_kill.py).  The text path was
+left behind: `_handle_text_body` wrapped `pipeline._tts.synthesize`
+with a `wait_for(timeout=tts_timeout)` but the surrounding
+`except Exception` only logged + sent `tts_end`, leaving any
+in-flight Piper subprocess to run to completion and hold the audio
+device + an FD.
+
+Same class of bug as A1 (cancel didn't kill text-path Piper) — but
+on the timeout edge.  This test pins down via source inspection so
+a future refactor of `_handle_text_body` doesn't accidentally drop
+the kill.
+"""
+from __future__ import annotations
+
+import inspect
+
+
+def test_handle_text_body_kills_piper_on_tts_timeout() -> None:
+    """``_handle_text_body``'s TTS except branch must call
+    ``kill_active_procs()`` to clean up an in-flight Piper subprocess
+    on timeout / failure.  Mirrors the voice path at
+    ``pipeline.py:1411-1421`` (audit L3 / Phase 2 of #89)."""
+    from dragon_voice.server import VoiceServer
+    src = inspect.getsource(VoiceServer._handle_text_body)
+    # The except must catch TimeoutError explicitly so the timeout
+    # branch is distinguishable from a generic synthesize failure.
+    assert "asyncio.TimeoutError" in src, (
+        "text-path TTS except must catch TimeoutError so we can log "
+        "the right thing on a real timeout vs a generic failure"
+    )
+    # The kill itself must be present and guarded by the
+    # hasattr check so non-Piper TTS backends don't blow up.
+    assert "kill_active_procs" in src, (
+        "text-path TTS except must invoke kill_active_procs to clean "
+        "up the in-flight Piper subprocess on timeout (Phase 2 L3)"
+    )
+    # Must still send tts_end so Tab5 doesn't hang in SPEAKING.
+    assert '"tts_end"' in src and '"tts_ms": 0' in src, (
+        "text-path TTS except must still emit tts_end with tts_ms=0 "
+        "so Tab5 leaves SPEAKING state"
+    )


### PR DESCRIPTION
## Summary
Phase 2 L3 of the UX-gap remediation (#89). The voice path's L3 fix landed in the wider Phase 2 work; the text path was left behind: `_handle_text_body` wrapped `synthesize()` in `wait_for(timeout=tts_timeout)` but the surrounding `except Exception` only logged and sent `tts_end`, letting any in-flight Piper subprocess run to completion holding the audio device + an FD.

This mirrors the voice-path pattern at [pipeline.py:1411-1421](https://github.com/lorcan35/TinkerBox/blob/main/dragon_voice/pipeline.py#L1411-L1421) — same shape, same class of bug as A1 (cancel) but on the timeout edge.

## Test plan
- [x] `pytest tests/test_text_path_tts_kill_on_timeout.py tests/test_tts_flush_and_kill.py tests/test_d_tier_polish.py -q` — 18 passed
- [x] `ruff` narrow gate — clean
- [x] Source import sanity check
- [ ] Live: deploy, force a Piper stall on a long text reply, confirm `lsof | grep piper` empty post-timeout (next Dragon push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)