### PR TITLE
feat(typing): mypy --strict curated clean list (refs #51, W14-M15)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,10 @@ jobs:
           # aiosqlite is used by dragon_voice.db but wasn't in requirements.txt.
           pip install aiosqlite
           pip install -r requirements.txt
-          # Test + lint tooling.
-          pip install ruff pytest pytest-asyncio
+          # Test + lint + type-check tooling.  W14-M15 / #51: mypy
+          # gates a curated strict-clean list (see "Type-check" step
+          # below); not all of dragon_voice/ is strict-clean yet.
+          pip install ruff pytest pytest-asyncio mypy
 
       - name: Lint (ruff — real-bug gate)
         run: |
@@ -43,6 +45,20 @@ jobs:
           #   BLE001 blind except (~100 hits)       → W14-H13
           ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \
             dragon_voice/ dashboard.py tests/
+
+      - name: Type-check (mypy --strict, curated clean list)
+        run: |
+          # W14-M15 / #51: mypy --strict on a deliberately-narrow set of
+          # files.  Adding a file to this list means it must pass strict
+          # checks today AND every PR that touches it.  Use
+          # --follow-imports=silent so transitive untyped modules don't
+          # fail the gate; the strict invariant only applies to the
+          # NAMED files.  Expand the list as more modules get annotated
+          # — see docs/MYPY-CLEAN-LIST.md for the policy.
+          python -m mypy --strict --follow-imports=silent \
+            dragon_voice/api/__init__.py \
+            dragon_voice/api/utils.py \
+            dragon_voice/api/system.py
 
       - name: Run unit + middleware tests
         env:

--- a/docs/MYPY-CLEAN-LIST.md
+++ b/docs/MYPY-CLEAN-LIST.md
@@ -1,0 +1,41 @@
+# mypy --strict clean list
+
+Closes part of #51 (W14-M15 carry-over). Started 2026-04-28.
+
+## Policy
+
+CI runs `mypy --strict --follow-imports=silent` against a deliberately-narrow set of files. Adding a file to this list is a one-way ratchet:
+
+- **The file must pass `mypy --strict --follow-imports=silent` today.**
+- **Every PR that touches the file must keep it passing.**
+- The CI step lives at `.github/workflows/ci.yml` → `Type-check` job.
+
+`--follow-imports=silent` means transitive untyped modules don't fail the gate; strict invariants apply **only to the named files**. The rest of `dragon_voice/` is gradually-typed and stays gradually-typed until each module is explicitly promoted.
+
+## Why this shape
+
+The full `mypy --strict dragon_voice/` returns ~250 errors across 37 files. A whole-codebase strict pass would need a multi-day annotation sprint plus stubs for `pygments`, `Pillow`, etc. That's not a wave-sized PR. A curated clean list lets us:
+
+1. Lock in correctness on the entry points DI flows through (`api/__init__.py:setup_all_routes`).
+2. Add to the list one PR at a time — each addition is a small, reviewable diff.
+3. Catch type drift on the protected files immediately, not "next quarter when we get around to mypy."
+
+## Current clean list
+
+| File | Added | Why |
+|---|---|---|
+| `dragon_voice/api/__init__.py` | wave 10 | `setup_all_routes` is the single DI entry point — every API module hangs off this signature. |
+| `dragon_voice/api/utils.py` | wave 10 | Shared helpers used across api/. Pagination + JSON-error contract is worth pinning. |
+| `dragon_voice/api/system.py` | wave 10 | `/api/v1/system` shape is consumed by the dashboard — type drift here breaks the UI. |
+
+## Adding a file
+
+1. Run locally: `python3 -m mypy --strict --follow-imports=silent path/to/file.py`
+2. Fix every error. Annotation work, no behavior changes.
+3. Add the file to the `mypy` invocation in `.github/workflows/ci.yml`.
+4. Add the file to the table above.
+5. PR.
+
+## Removing a file
+
+Don't. If it's failing strict, fix the file or open a separate PR that explicitly drops it from the list with a one-line justification (e.g., "library upgrade broke generic types pending stubs"). Silently dropping a file from the gate is a regression.

--- a/dragon_voice/api/__init__.py
+++ b/dragon_voice/api/__init__.py
@@ -4,6 +4,7 @@ All routes are registered via setup_all_routes() called from server.py.
 """
 
 import logging
+from typing import Any, Callable
 
 from aiohttp import web
 
@@ -21,21 +22,25 @@ from dragon_voice.api.video_inject import VideoInjectRoutes
 logger = logging.getLogger(__name__)
 
 
+# DI entry-point types — kept loose (Any) here because the concrete
+# Database / SessionManager / MessageStore / ConversationEngine classes
+# come from outside this strict-checked island and would force every
+# transitive import to be strict-clean too.  W14-M15 carry-over.
 def setup_all_routes(
     app: web.Application,
-    db,
-    session_mgr,
-    message_store,
-    conversation=None,
-    voice_config=None,
+    db: Any,
+    session_mgr: Any,
+    message_store: Any,
+    conversation: Any = None,
+    voice_config: Any = None,
     start_time: float = 0,
-    get_active_connections=None,
-    tool_registry=None,
-    memory_service=None,
-    media_store=None,
-    media_url_signer=None,
-    scheduler_mgr=None,
-    get_active_conn_dict=None,   # #177: route handlers that need the dict (not just len)
+    get_active_connections: Callable[[], int] | None = None,
+    tool_registry: Any = None,
+    memory_service: Any = None,
+    media_store: Any = None,
+    media_url_signer: Any = None,
+    scheduler_mgr: Any = None,
+    get_active_conn_dict: Callable[[], dict[str, Any]] | None = None,  # #177
 ) -> None:
     """Register all API route modules on the aiohttp app.
 

--- a/dragon_voice/api/system.py
+++ b/dragon_voice/api/system.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import time
+from typing import Any, Callable
 
 from aiohttp import web
 
@@ -15,8 +16,13 @@ logger = logging.getLogger(__name__)
 
 
 class SystemRoutes:
-    def __init__(self, voice_config: VoiceConfig, start_time: float,
-                 get_active_connections: callable, get_db=None) -> None:
+    def __init__(
+        self,
+        voice_config: VoiceConfig,
+        start_time: float,
+        get_active_connections: Callable[[], int],
+        get_db: Any = None,
+    ) -> None:
         self._config = voice_config
         self._start_time = start_time
         self._get_active_connections = get_active_connections
@@ -37,14 +43,14 @@ class SystemRoutes:
         # so system polls from the dashboard don't jitter the event loop.
         import asyncio as _asyncio
 
-        def _read_meminfo():
+        def _read_meminfo() -> str:
             try:
                 with open("/proc/meminfo") as f:
                     return f.read()
             except Exception:
                 return ""
 
-        def _read_loadavg():
+        def _read_loadavg() -> str:
             try:
                 with open("/proc/loadavg") as f:
                     return f.read()
@@ -54,10 +60,12 @@ class SystemRoutes:
         meminfo_raw = await _asyncio.to_thread(_read_meminfo)
         loadavg_raw = await _asyncio.to_thread(_read_loadavg)
 
-        mem = {"total_mb": 0, "used_mb": 0, "available_mb": 0, "percent": 0}
+        mem: dict[str, float] = {
+            "total_mb": 0, "used_mb": 0, "available_mb": 0, "percent": 0,
+        }
         if meminfo_raw:
             try:
-                info = {}
+                info: dict[str, int] = {}
                 for line in meminfo_raw.splitlines():
                     parts = line.split()
                     if len(parts) >= 2:
@@ -71,7 +79,7 @@ class SystemRoutes:
             except Exception:
                 pass
 
-        cpu_percent = 0
+        cpu_percent: float = 0
         if loadavg_raw:
             try:
                 load_1m = float(loadavg_raw.split()[0])
@@ -80,7 +88,7 @@ class SystemRoutes:
             except Exception:
                 pass
 
-        result = {
+        result: dict[str, Any] = {
             "uptime_s": round(uptime_s, 1),
             "cpu_percent": cpu_percent,
             "memory": mem,

--- a/dragon_voice/api/utils.py
+++ b/dragon_voice/api/utils.py
@@ -1,5 +1,7 @@
 """Shared API utilities: error responses, pagination, JSON parsing."""
 
+from typing import Any
+
 from aiohttp import web
 
 
@@ -8,7 +10,9 @@ def json_error(message: str, status: int = 400) -> web.Response:
     return web.json_response({"error": message}, status=status)
 
 
-def paginated_response(items: list[dict], limit: int, offset: int) -> web.Response:
+def paginated_response(
+    items: list[dict[str, Any]], limit: int, offset: int
+) -> web.Response:
     """Return a paginated JSON response."""
     return web.json_response({
         "items": items,
@@ -38,10 +42,12 @@ def parse_pagination(request: web.Request, default_limit: int = 50,
     return limit, offset
 
 
-async def parse_json_body(request: web.Request) -> tuple[dict | None, web.Response | None]:
+async def parse_json_body(
+    request: web.Request,
+) -> tuple[dict[str, Any] | None, web.Response | None]:
     """Parse JSON body. Returns (body, None) on success, (None, error_response) on failure."""
     try:
-        body = await request.json()
+        body: dict[str, Any] = await request.json()
         return body, None
     except Exception:
         return None, json_error("Invalid JSON body")


### PR DESCRIPTION
## Summary
Closes part of #51 by introducing the **curated clean list** pattern for incremental mypy adoption. CI now runs \`mypy --strict --follow-imports=silent\` against an explicit set of files; adding a file is a one-way ratchet.

## Why curated, not whole-codebase
\`mypy --strict dragon_voice/\` returns ~250 errors across 37 files plus missing stubs for pygments, Pillow, etc. A whole-codebase pass would be a multi-day annotation sprint. The curated approach lets us lock in correctness one PR at a time without blocking everything else.

## Initial clean list (3 files)
| File | Why this one |
|---|---|
| \`dragon_voice/api/__init__.py\` | \`setup_all_routes\` is the single DI entry point — every API module hangs off this signature. |
| \`dragon_voice/api/utils.py\` | Shared helpers used across api/. Pagination + JSON-error contract is worth pinning. |
| \`dragon_voice/api/system.py\` | \`/api/v1/system\` shape is consumed by the dashboard — type drift here breaks the UI. |

## Changes
- 3 files annotated to be strict-clean (only annotation work, no behavior changes)
- CI step added: \`Type-check (mypy --strict, curated clean list)\`
- Policy doc at \`docs/MYPY-CLEAN-LIST.md\` — addition criteria + how to expand

## Verification
\`\`\`
$ python3 -m mypy --strict --follow-imports=silent \\
    dragon_voice/api/__init__.py \\
    dragon_voice/api/utils.py \\
    dragon_voice/api/system.py
Success: no issues found in 3 source files
\`\`\`

## Why issue stays open
#51 is the master tracker for mypy strict on the whole \`api/\` package. This PR ships infrastructure + the first 3 files; future PRs will expand the list. Each addition will be a small reviewable diff. The expanded list is tracked in \`docs/MYPY-CLEAN-LIST.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)