### PR TITLE
fix(config): wire HTTP /api/config swap through ConversationEngine.swap_llm (DIP-2)

### DIFF
--- a/dragon_voice/handlers/config_api.py
+++ b/dragon_voice/handlers/config_api.py
@@ -5,13 +5,21 @@
   :func:`dragon_voice.config.config_to_dict`).
 * :func:`handle_set_config` — ``POST /config`` — hot-reloads the
   config file, applies a partial override from the request body,
-  validates, then swaps backends on every active voice pipeline.
+  validates, then swaps backends on every active voice pipeline AND
+  the shared :class:`ConversationEngine` (Wave 22b / DIP-2).
 
 Backend swaps acquire each connection's ``conn_lock`` first (A06) to
 prevent races with a concurrent WS ``config_update`` from the same
 device.  Two concurrent ``swap_backends`` calls would interleave
 shutdown/init of the same backend instance, producing use-after-free
 errors on the shared Ollama / OpenRouter session objects.
+
+After the per-pipeline swap, the conversation engine's ``_llm`` is
+also rotated through :meth:`ConversationEngine.swap_llm` so the
+HTTP path mirrors the WS ``config_update`` path landed in Wave 22b
+(PR #207).  Pre-fix the HTTP path swapped only the pipeline backend,
+leaving ``self._conversation._llm`` pointing at the *old* backend —
+all subsequent text turns rendered through the stale instance.
 """
 from __future__ import annotations
 
@@ -97,6 +105,27 @@ async def handle_set_config(request: web.Request, *, server: Any) -> web.Respons
                 except Exception as e:
                     logger.warning("Backend swap failed for %s: %s", ws_id, e)
                     swap_errors.append(str(e))
+
+        # DIP-2 (audit 2026-05-03): also swap the shared ConversationEngine's
+        # LLM backend.  Pre-fix the HTTP path only rotated per-pipeline
+        # backends; ConversationEngine kept its old `_llm` reference and
+        # every subsequent text turn rendered through the stale instance.
+        # Wave 22b (PR #207) extracted ConversationEngine.swap_llm as the
+        # canonical swap path used by both WS and HTTP handlers; this is
+        # the missing wiring on the HTTP side.  voice_mode=None because
+        # HTTP /api/config is a config-level swap (not per-connection
+        # tier change); the router branch uses None as "leave tier alone".
+        conv = getattr(server, "_conversation", None)
+        if conv is not None:
+            try:
+                await conv.swap_llm(
+                    new_config.llm,
+                    pool=server._backend_pool,
+                    voice_mode=None,
+                )
+            except Exception as e:  # noqa: BLE001 — best-effort, fall through
+                logger.warning("ConversationEngine LLM swap failed: %s", e)
+                swap_errors.append(f"conversation: {e}")
 
         pipelines_with_swap = sum(
             1 for c in server._active_connections.values() if c.get("pipeline")

--- a/tests/test_config_api_handlers.py
+++ b/tests/test_config_api_handlers.py
@@ -118,6 +118,96 @@ class SetConfigHandlerTests(unittest.TestCase):
         # swap_backends called exactly once on the pipeline-holding conn.
         pipeline.swap_backends.assert_awaited_once_with(cfg)
 
+    def test_happy_path_also_swaps_conversation_llm(self):
+        """DIP-2 (audit 2026-05-03): the HTTP swap path must rotate the
+        shared ConversationEngine's LLM, not just per-pipeline backends.
+
+        Pre-fix the WS config_update path called swap_llm but the HTTP
+        path didn't — leaving ConvEngine on the stale backend after
+        every POST /api/config.  This test pins the canonical wiring.
+        """
+        cfg = _make_stub_backends(stt="x_stt", tts="x_tts", llm="x_llm")
+        cfg.llm = MagicMock()  # the slice swap_llm receives
+        pipeline = MagicMock()
+        pipeline.swap_backends = AsyncMock()
+        conversation = MagicMock()
+        conversation.swap_llm = AsyncMock(return_value=(MagicMock(), True))
+        backend_pool: dict = {}
+
+        server = MagicMock()
+        server._config = MagicMock()
+        server._conversation = conversation
+        server._backend_pool = backend_pool
+        server._active_connections = {
+            "ws_a": {"pipeline": pipeline, "conn_lock": None},
+        }
+
+        req = _ReqWithJson(body={"llm": {"backend": "x_llm"}})
+
+        async def go():
+            with patch.object(cfg_mod, "load_config", return_value=cfg):
+                return await cfg_mod.handle_set_config(req, server=server)
+
+        resp = asyncio.run(go())
+        self.assertEqual(resp.status, 200)
+        # Both swap surfaces hit, in order: pipeline first, then ConvEngine.
+        pipeline.swap_backends.assert_awaited_once_with(cfg)
+        conversation.swap_llm.assert_awaited_once_with(
+            cfg.llm, pool=backend_pool, voice_mode=None,
+        )
+
+    def test_conversation_swap_failure_does_not_500(self):
+        """If swap_llm raises (e.g. backend init throws), the HTTP
+        handler keeps the per-pipeline swap result and returns 200 so
+        the caller still sees the partial-success state."""
+        cfg = _make_stub_backends(stt="x_stt", tts="x_tts", llm="x_llm")
+        cfg.llm = MagicMock()
+        pipeline = MagicMock()
+        pipeline.swap_backends = AsyncMock()
+        conversation = MagicMock()
+        conversation.swap_llm = AsyncMock(side_effect=RuntimeError("init blew up"))
+
+        server = MagicMock()
+        server._config = MagicMock()
+        server._conversation = conversation
+        server._backend_pool = {}
+        server._active_connections = {
+            "ws_a": {"pipeline": pipeline, "conn_lock": None},
+        }
+
+        req = _ReqWithJson(body={"llm": {"backend": "x_llm"}})
+
+        async def go():
+            with patch.object(cfg_mod, "load_config", return_value=cfg):
+                return await cfg_mod.handle_set_config(req, server=server)
+
+        resp = asyncio.run(go())
+        # Per-pipeline swap succeeded; conversation swap failure is a
+        # warning, not a 500 — caller can re-issue if it cares.
+        self.assertEqual(resp.status, 200)
+        pipeline.swap_backends.assert_awaited_once()
+        conversation.swap_llm.assert_awaited_once()
+
+    def test_no_conversation_attribute_does_not_500(self):
+        """During boot, server._conversation may not exist yet — the
+        handler should still succeed (skips the ConvEngine swap)."""
+        cfg = _make_stub_backends()
+        cfg.llm = MagicMock()
+        server = MagicMock(spec=["_active_connections", "_config", "_stt_name",
+                                 "_tts_name", "_llm_name", "_backend_pool"])
+        server._active_connections = {}
+        server._backend_pool = {}
+        # Note: no _conversation attribute set.
+
+        req = _ReqWithJson(body={"llm": {"backend": "new_llm"}})
+
+        async def go():
+            with patch.object(cfg_mod, "load_config", return_value=cfg):
+                return await cfg_mod.handle_set_config(req, server=server)
+
+        resp = asyncio.run(go())
+        self.assertEqual(resp.status, 200)
+
 
 class GetConfigHandlerTests(unittest.TestCase):
     def test_returns_redacted_config(self):


### PR DESCRIPTION
## Bug

The 2026-05-03 SOLID audit ([`docs/AUDIT-solid-2026-05-03.md`](docs/AUDIT-solid-2026-05-03.md), DIP-2 / P1) found that `POST /api/config` mutates per-pipeline backends but never rotates the shared `ConversationEngine`'s `_llm` reference.

**Net effect:** every text turn served after an HTTP config swap renders through the OLD LLM until either Dragon restarts or a WS `config_update` arrives. Silent stale state.

## Root cause

Wave 22b ([#207](https://github.com/lorcan35/TinkerBox/pull/207)) extracted `ConversationEngine.swap_llm` as the canonical swap surface specifically to close this WS-vs-HTTP divergence — but only the WS callsite was wired up. The HTTP handler in [dragon_voice/handlers/config_api.py:80](dragon_voice/handlers/config_api.py#L80) was left calling `pipeline.swap_backends(...)` directly, which doesn't touch the ConvEngine at all.

## Fix

After the per-pipeline swap loop, also invoke `swap_llm` on `server._conversation` — same shape as the WS handler at [server.py:2385](dragon_voice/server.py#L2385).

\`\`\`python
conv = getattr(server, \"_conversation\", None)
if conv is not None:
    try:
        await conv.swap_llm(
            new_config.llm,
            pool=server._backend_pool,
            voice_mode=None,
        )
    except Exception as e:
        logger.warning(\"ConversationEngine LLM swap failed: %s\", e)
        swap_errors.append(f\"conversation: {e}\")
\`\`\`

Design choices:
* `voice_mode=None` because `/api/config` is a config-level swap (no per-connection tier change implied) — the router branch of `swap_llm` reads `None` as \"leave tier alone\".
* Partial-success semantics preserved: if `swap_llm` raises (e.g. backend init throws), it's logged + appended to `swap_errors` and the handler still returns 200, matching the existing per-pipeline failure path.
* `getattr(..., None)` guard for boot-time swaps before ConvEngine wiring.

## Tests

`tests/test_config_api_handlers.py` gains three new assertions:

* `test_happy_path_also_swaps_conversation_llm` — pins the canonical `swap_llm(cfg.llm, pool=backend_pool, voice_mode=None)` call shape.
* `test_conversation_swap_failure_does_not_500` — partial-success semantics preserved when `swap_llm` raises.
* `test_no_conversation_attribute_does_not_500` — boot-time guard.

\`\`\`
\$ python3 -m pytest tests/test_config_api_handlers.py -v
7 passed in 0.08s

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/handlers/ tests/
All checks passed!
\`\`\`

## Closes

SOLID-AUDIT 2026-05-03 finding **DIP-2** (P1) — also retroactively closes the prior audit's `F6` which was reopened against the *new* canonical path post-Wave-22b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)