### PR TITLE
fix(llm): override generate_stream_with_messages on LMStudioBackend (LSP-1)

### DIFF
--- a/dragon_voice/llm/lmstudio_llm.py
+++ b/dragon_voice/llm/lmstudio_llm.py
@@ -135,6 +135,88 @@ class LMStudioBackend(LLMBackend):
                 {"role": "assistant", "content": "".join(full_response)}
             )
 
+    async def generate_stream_with_messages(
+        self, messages: list[dict]
+    ) -> AsyncIterator[str]:
+        """Stream tokens using a full OpenAI-format message list.
+
+        LSP-1 fix (audit 2026-05-03): without this override, LMStudioBackend
+        inherited `LLMBackend.generate_stream_with_messages` which formats
+        messages via `f"{role}: {content}"` and re-routes through
+        `generate_stream(prompt, system_prompt)`.  When the content of a
+        user message is a multimodal array (e.g. `[{"type": "image_url",
+        "image_url": {...}}, {"type": "text", "text": "what is this?"}]`),
+        the f-string materialises the literal Python repr —
+        `"User: [{'type': 'image_url', ...}]"` — and the model sees a
+        string description of the array instead of the actual image.  Net
+        effect: every router-driven vision turn that picked LM Studio
+        silently became text-only with garbled JSON-as-text, and the
+        request still came back with a confident wrong answer.
+
+        LM Studio's `/chat/completions` is OpenAI-compatible natively; it
+        already understands the multimodal content array shape.  This
+        override just hands `messages` straight through.
+
+        Used by ConversationEngine which manages its own DB-backed context.
+        Does NOT touch self._conversation — session isolation is handled
+        by the caller (matches the OpenRouter override at
+        openrouter_llm.py:321).
+        """
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=120, sock_read=60),
+                headers={"Content-Type": "application/json"},
+            )
+
+        payload = {
+            "model": self._model,
+            "messages": messages,
+            "stream": True,
+            "max_tokens": self._config.max_tokens,
+            "temperature": self._config.temperature,
+        }
+
+        async with self._lock:
+            try:
+                async with self._session.post(
+                    f"{self._base_url}/chat/completions",
+                    json=payload,
+                ) as resp:
+                    if resp.status != 200:
+                        error_text = await resp.text()
+                        logger.error(
+                            "LM Studio error %d: %s", resp.status, error_text[:300]
+                        )
+                        yield f"[LM Studio error: {resp.status}]"
+                        return
+
+                    async for line in resp.content:
+                        line = line.decode("utf-8", errors="replace").strip()
+                        if not line or not line.startswith("data: "):
+                            continue
+
+                        data_str = line[6:]
+                        if data_str == "[DONE]":
+                            break
+
+                        try:
+                            chunk = json.loads(data_str)
+                        except json.JSONDecodeError:
+                            continue
+
+                        choices = chunk.get("choices", [])
+                        if not choices:
+                            continue
+
+                        delta = choices[0].get("delta", {})
+                        token = delta.get("content", "")
+                        if token:
+                            yield token
+
+            except aiohttp.ClientError as e:
+                logger.error("LM Studio request failed: %s", e)
+                yield f"[Connection error: {e}]"
+
     def clear_history(self) -> None:
         """Clear conversation history."""
         self._conversation.clear()

--- a/tests/test_lmstudio_multimodal.py
+++ b/tests/test_lmstudio_multimodal.py
@@ -1,0 +1,193 @@
+"""Tests for ``LMStudioBackend.generate_stream_with_messages`` (LSP-1, audit 2026-05-03).
+
+Pre-fix LMStudioBackend inherited the broken default impl from
+:class:`LLMBackend` which f-string-formats messages and re-routes
+through ``generate_stream(prompt, system_prompt)``.  When a user
+message's ``content`` is a multimodal array (OpenAI vision shape),
+the f-string produced ``"User: [{'type': 'image_url', ...}]"`` and
+the model never saw the image — silent text-only degradation.
+
+These tests pin:
+  1. The override exists on LMStudioBackend (not the base default).
+  2. A multimodal content array is forwarded verbatim to the
+     ``/chat/completions`` payload.
+  3. SSE streaming surfaces tokens correctly from the override path.
+
+Run:
+    python3 -m pytest -v tests/test_lmstudio_multimodal.py
+"""
+from __future__ import annotations
+
+import inspect
+import unittest
+
+import pytest
+
+from dragon_voice.config import LLMConfig
+from dragon_voice.llm.base import LLMBackend
+from dragon_voice.llm.lmstudio_llm import LMStudioBackend
+
+
+def _make_backend() -> LMStudioBackend:
+    cfg = LLMConfig(
+        backend="lmstudio",
+        lmstudio_url="http://localhost:1234/v1",
+        lmstudio_model="test-model",
+        max_tokens=64,
+        temperature=0.5,
+    )
+    return LMStudioBackend(cfg)
+
+
+class _FakeSseResponse:
+    """Mimic an aiohttp streaming response for the SSE path."""
+
+    def __init__(self, lines: list[bytes], status: int = 200):
+        self.status = status
+        self.content = self._iter_lines(lines)
+        self._text = b"".join(lines).decode()
+
+    @staticmethod
+    async def _iter_lines(lines):
+        for line in lines:
+            yield line
+
+    async def text(self):
+        return self._text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeSession:
+    """Minimal aiohttp.ClientSession stub.  Captures the post payload."""
+
+    def __init__(self, sse_lines: list[bytes], status: int = 200):
+        self.closed = False
+        self._sse_lines = sse_lines
+        self._status = status
+        self.last_payload: dict | None = None
+        self.last_url: str | None = None
+
+    def post(self, url, *, json):  # noqa: A002 — aiohttp's keyword is `json`
+        self.last_url = url
+        self.last_payload = json
+        return _FakeSseResponse(self._sse_lines, status=self._status)
+
+    async def close(self):
+        self.closed = True
+
+
+class LmStudioMultimodalTests(unittest.TestCase):
+    def test_override_exists_on_subclass(self):
+        """LSP-1 anchor: the override must be defined on
+        LMStudioBackend itself, not inherited from LLMBackend."""
+        # Inspect the method resolution: it should resolve to the
+        # subclass, not the base.
+        own = LMStudioBackend.generate_stream_with_messages
+        base = LLMBackend.generate_stream_with_messages
+        self.assertIsNot(
+            own,
+            base,
+            "LMStudioBackend.generate_stream_with_messages must override"
+            " the base default — see LSP-1 in docs/AUDIT-solid-2026-05-03.md.",
+        )
+        # It should still be an async generator function (yields tokens).
+        self.assertTrue(inspect.isasyncgenfunction(own))
+
+
+class TestLmStudioMultimodalAsync:
+    """pytest-style async tests for the streaming path.
+
+    Class name starts with `Test` so pytest collects these (unittest's
+    ``unittest.TestCase`` doesn't play well with ``@pytest.mark.asyncio``).
+    """
+
+    @pytest.mark.asyncio
+    async def test_multimodal_content_array_forwarded_verbatim(self):
+        """The vision content array must reach the /chat/completions
+        payload as a list, not a string repr."""
+        sse = [
+            b'data: {"choices":[{"delta":{"content":"a red"}}]}\n',
+            b'data: {"choices":[{"delta":{"content":" chair"}}]}\n',
+            b"data: [DONE]\n",
+        ]
+        backend = _make_backend()
+        backend._session = _FakeSession(sse)
+
+        multimodal = [
+            {"role": "system", "content": "You are a vision assistant."},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/jpeg;base64,/9j/..."},
+                    },
+                    {"type": "text", "text": "what color is the chair?"},
+                ],
+            },
+        ]
+
+        tokens = []
+        async for tok in backend.generate_stream_with_messages(multimodal):
+            tokens.append(tok)
+
+        # Tokens streamed from SSE.
+        assert tokens == ["a red", " chair"]
+
+        # Critical: the payload sent to LM Studio must contain the
+        # ORIGINAL list — not a string-formatted repr.  This is the
+        # exact failure mode LSP-1 documented.
+        payload = backend._session.last_payload
+        assert payload is not None
+        assert payload["model"] == "test-model"
+        user_content = payload["messages"][1]["content"]
+        assert isinstance(user_content, list), (
+            f"multimodal content array must reach /chat/completions as a list, "
+            f"got {type(user_content).__name__}: {user_content!r}"
+        )
+        # Round-trip the parts to confirm nothing got stringified.
+        assert user_content[0]["type"] == "image_url"
+        assert user_content[0]["image_url"]["url"].startswith("data:image/jpeg")
+        assert user_content[1] == {"type": "text", "text": "what color is the chair?"}
+
+    @pytest.mark.asyncio
+    async def test_does_not_mutate_self_conversation(self):
+        """Override must NOT touch self._conversation — that history
+        belongs to the legacy generate_stream() path used by the
+        non-ConvEngine code paths.  ConvEngine manages its own
+        context (mirrors openrouter_llm.py:321 design)."""
+        sse = [b'data: {"choices":[{"delta":{"content":"ok"}}]}\n', b"data: [DONE]\n"]
+        backend = _make_backend()
+        backend._session = _FakeSession(sse)
+        backend._conversation = [{"role": "user", "content": "previous"}]
+
+        async for _ in backend.generate_stream_with_messages(
+            [{"role": "user", "content": "new"}]
+        ):
+            pass
+
+        assert backend._conversation == [{"role": "user", "content": "previous"}], (
+            "generate_stream_with_messages must not mutate self._conversation"
+        )
+
+    @pytest.mark.asyncio
+    async def test_status_error_yields_error_marker(self):
+        backend = _make_backend()
+        backend._session = _FakeSession([], status=503)
+
+        tokens = []
+        async for tok in backend.generate_stream_with_messages(
+            [{"role": "user", "content": "x"}]
+        ):
+            tokens.append(tok)
+        # Single error marker; matches the legacy generate_stream shape.
+        assert tokens == ["[LM Studio error: 503]"]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

The 2026-05-03 SOLID audit ([`docs/AUDIT-solid-2026-05-03.md`](docs/AUDIT-solid-2026-05-03.md), LSP-1 / P1) found that `LMStudioBackend` inherited the broken default `generate_stream_with_messages` from `LLMBackend.base`.

When the active capability-aware router picked LM Studio for a vision turn, the default impl f-string-formatted the multimodal content array — `f\"User: {content}\"` — producing `\"User: [{'type': 'image_url', ...}]\"`. The model saw a literal Python repr of the array and **never received the actual image**, but still returned a confident-sounding answer about the phantom image it described.

Silent text-only degradation. No error. No log line.

The only path that exercises this is router-driven multimodal turns where LM Studio is the lowest-priority cap-matching candidate — easy to miss in a single-backend dev setup, but the `lmstudio` capability registry already declares VISION via the same name-substring heuristic as Ollama, so the router will pick it.

## Root cause

[`LLMBackend.generate_stream_with_messages`](dragon_voice/llm/base.py#L67) provides a default that:

1. Splits messages into system + history + current
2. Formats each as `f\"{role}: {content}\"`
3. Re-routes through `generate_stream(prompt, system_prompt)`

This is fine for text-only `content: \"hello\"` strings.  It silently corrupts when `content` is a multimodal array.  Ollama overrode this correctly in [#186](https://github.com/lorcan35/TinkerBox/pull/186); OpenRouter overrode it correctly when it landed; LM Studio was missed.

## Fix

Mirror the OpenRouter override at [openrouter_llm.py:321](dragon_voice/llm/openrouter_llm.py#L321) on LMStudioBackend.  LM Studio's `/chat/completions` is OpenAI-compatible natively — it already understands the multimodal content array shape — so the override just hands `messages` straight through to the SSE POST.

The override matches OpenRouter's design (does NOT touch `self._conversation`; ConversationEngine manages its own DB-backed context).  All other behaviour is identical to the existing `generate_stream` SSE path: same auth, same timeouts, same error markers, same DONE handling.

## Tests

[`tests/test_lmstudio_multimodal.py`](tests/test_lmstudio_multimodal.py) (new, 4 tests):

* `test_override_exists_on_subclass` — pins the LSP fix at the **method-resolution layer**.  Asserts `LMStudioBackend.generate_stream_with_messages is not LLMBackend.generate_stream_with_messages`.  Catches future drift if anyone deletes the override and falls back to the base default.
* `test_multimodal_content_array_forwarded_verbatim` — feeds an OpenAI vision-shape user message (`[{type: image_url, ...}, {type: text, ...}]`) and asserts the SSE POST payload contains a `list`, not a stringified repr.
* `test_does_not_mutate_self_conversation` — pins the design choice.
* `test_status_error_yields_error_marker` — error path matches the legacy generate_stream shape.

\`\`\`
\$ python3 -m pytest tests/test_lmstudio_multimodal.py -v
4 passed in 0.07s

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \\
    dragon_voice/llm/lmstudio_llm.py tests/test_lmstudio_multimodal.py
All checks passed!
\`\`\`

## Closes

SOLID-AUDIT 2026-05-03 finding **LSP-1** (P1) — also retroactively closes the prior audit's `S10` which had been marked \"partially resolved\" after [#186](https://github.com/lorcan35/TinkerBox/pull/186).

## Note for reviewers

The base default impl in `LLMBackend.generate_stream_with_messages` is still broken for any future backend that forgets to override.  The audit also recommends raising `NotImplementedError` from the base instead, so the failure surfaces at first use rather than silently corrupting the input — but that's a separate, follow-up PR (it would force every backend to override or explicitly opt into text-only fallback).  This PR is scoped to the actual concrete bug in the only backend currently inheriting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)