### PR TITLE
fix(pricing): centralize vision per-frame mils via _PRICING_MILS_PER_M (OCP-2)

### DIFF
--- a/dragon_voice/llm/openrouter_llm.py
+++ b/dragon_voice/llm/openrouter_llm.py
@@ -461,6 +461,44 @@ def price_for_model(model: str, prompt_tokens: int, completion_tokens: int) -> i
     return cost_in + cost_out
 
 
+# Per-frame token-count approximation for vision-capable models.  Different
+# vendors charge differently (gpt-4o tile-based ~480 tokens for a typical
+# detail tile, Sonnet ~1500, Gemini ~258 fixed) but 1500 is a reasonable
+# midpoint that matches what the prior inline switch in server.py was
+# implicitly assuming for sonnet/haiku/gemini; gpt-4o ends up ~3× over-
+# charged which is fine — over-counting is the safe direction since the
+# daily cap exists to STOP spending, not to track to-the-mil precision.
+_VISION_TOKENS_PER_FRAME_APPROX = 1500
+
+
+def vision_per_frame_mils(model: str) -> int:
+    """Estimate the per-frame mils cost of a vision turn for ``model``.
+
+    OCP-2 fix (audit 2026-05-03): the prior inline switch in
+    ``server.py:_handle_config_update`` hardcoded prices for
+    ``gpt-4o``/``sonnet``/``haiku``/``gemini`` and silently defaulted
+    Opus 4.x, Grok 4.x, Kimi, Qwen 3.6, GLM, MiMo etc. to **0 mils per
+    frame** — so every cloud-vision turn on those models was invisible
+    to the daily-cap budget enforcement.
+
+    This helper routes through :func:`price_for_model` with a fixed
+    1500-token-per-frame approximation so any model added to the
+    canonical ``_PRICING_MILS_PER_M`` registry automatically gets
+    real per-frame pricing without a parallel switch.
+
+    Local models (no ``/`` in the id) cost zero — they run on-device.
+    Unknown cloud models fall through to the ``_default`` pricing entry
+    in the registry, which is conservatively high — never zero.
+
+    Returns mils as an int so it serialises cleanly through WS JSON.
+    """
+    return price_for_model(
+        model,
+        prompt_tokens=_VISION_TOKENS_PER_FRAME_APPROX,
+        completion_tokens=0,
+    )
+
+
 # ── Capability registry (#183) ─────────────────────────────────────────
 # Per-model declared modalities for the multi-model router.  Each entry
 # is the set of caps OpenRouter exposes for that model.  Keep in sync

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -2444,6 +2444,13 @@ class VoiceServer:
                     # contained until a future ConvEngine.choose_vision_model
                     # follow-up subsumes it.
                     from dragon_voice.llm.router import CapabilityAwareRouter
+                    # OCP-2 (audit 2026-05-03): single source of truth for
+                    # per-frame mils.  Kills the parallel switch on
+                    # gpt-4o/sonnet/haiku/gemini that silently defaulted
+                    # Opus 4.x, Grok 4.x, Kimi K2.6, Qwen 3.6, GLM, MiMo
+                    # to 0 mils — every cloud-vision turn on those models
+                    # was invisible to the daily-cap budget enforcement.
+                    from dragon_voice.llm.openrouter_llm import vision_per_frame_mils
                     if (self._conversation
                             and isinstance(
                                 self._conversation._llm,
@@ -2455,33 +2462,34 @@ class VoiceServer:
                         )
                         if spec:
                             vision_model = spec.model_id
-                            # Per-frame cost: cloud tier carries a known
-                            # rough rate; local tier is free.
-                            if spec.tier == "local":
-                                per_frame_mils = 0
-                            elif "gpt-4o" in spec.model_id:
-                                per_frame_mils = 1200
-                            elif "sonnet" in spec.model_id:
-                                per_frame_mils = 4500
-                            elif "haiku" in spec.model_id:
-                                per_frame_mils = 400
-                            elif "gemini" in spec.model_id:
-                                per_frame_mils = 200
+                            # Local-tier sub-backends are free regardless of
+                            # the canonical pricing table (which is OR-only);
+                            # short-circuit to avoid a `_default`-table
+                            # surprise on a local vision model id.
+                            per_frame_mils = (
+                                0 if spec.tier == "local"
+                                else vision_per_frame_mils(spec.model_id)
+                            )
                     else:
                         vm = conn_config.llm.openrouter_model.lower() \
                             if voice_mode == 2 else ""
                         om = conn_config.llm.ollama_model.lower() \
                             if voice_mode == 0 else ""
                         if voice_mode == 2:
-                            if "gpt-4o" in vm:
+                            # Vision-capability gate stays substring-based
+                            # for now (the router branch above is the
+                            # capability-aware path).  Pricing now goes
+                            # through the centralized helper so adding a
+                            # vendor to the substring list automatically
+                            # gets correct mils via _PRICING_MILS_PER_M.
+                            if any(hint in vm for hint in (
+                                    "gpt-4o", "sonnet", "haiku", "gemini",
+                                    "opus", "grok", "kimi", "qwen3.6", "glm",
+                                    "mimo")):
                                 vision_model = active_model
-                                per_frame_mils = 1200
-                            elif "sonnet" in vm:
-                                vision_model = active_model
-                                per_frame_mils = 4500
-                            elif "haiku" in vm:
-                                vision_model = active_model
-                                per_frame_mils = 400
+                                per_frame_mils = vision_per_frame_mils(
+                                    conn_config.llm.openrouter_model
+                                )
                         elif voice_mode == 0:
                             if "vision" in om or "llava" in om:
                                 vision_model = active_model

--- a/tests/test_vision_pricing.py
+++ b/tests/test_vision_pricing.py
@@ -1,0 +1,147 @@
+"""Tests for ``vision_per_frame_mils`` (OCP-2, audit 2026-05-03).
+
+The prior inline switch in ``server.py:_handle_config_update`` hardcoded
+per-frame mils for ``gpt-4o``/``sonnet``/``haiku``/``gemini`` and
+silently defaulted everything else (Opus 4.x, Grok 4.x, Kimi K2.6,
+Qwen 3.6, GLM, MiMo) to 0 — meaning every cloud-vision turn on those
+models was invisible to the daily-cap budget enforcement.
+
+These tests pin the new centralized helper:
+  - Local models (no slash) cost zero, never the ``_default`` fallback.
+  - Models in ``_PRICING_MILS_PER_M`` get real per-frame mils.
+  - Models NOT in the registry fall through to ``_default`` (~3000 mils
+    for the ~$2/M-token conservative default), never zero.
+  - All the previously-silently-zero models now round-trip through the
+    canonical pricing table.
+
+Run:
+    python3 -m pytest -v tests/test_vision_pricing.py
+"""
+from __future__ import annotations
+
+import unittest
+
+from dragon_voice.llm.openrouter_llm import (
+    _PRICING_MILS_PER_M,
+    _VISION_TOKENS_PER_FRAME_APPROX,
+    price_for_model,
+    vision_per_frame_mils,
+)
+
+
+class VisionPerFrameMilsTests(unittest.TestCase):
+    def test_local_model_no_slash_returns_zero(self):
+        """Local on-device models cost zero marginal USD."""
+        for local_id in (
+            "ministral-3:3b",
+            "gemma3:4b",
+            "qwen3:1.7b",
+            "llama3.2:3b",
+            "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M",  # local Ollama, has slashes
+        ):
+            with self.subTest(model=local_id):
+                # Note: the "hf.co/..." case has slashes but is hosted
+                # locally — price_for_model decides only by presence of
+                # ANY slash.  This matches existing semantics; if we
+                # ever care, the fix is to look at the model's caps.tier
+                # rather than its id.  For now, document the behavior.
+                if "/" not in local_id:
+                    self.assertEqual(vision_per_frame_mils(local_id), 0)
+
+    def test_empty_model_returns_zero(self):
+        self.assertEqual(vision_per_frame_mils(""), 0)
+
+    def test_known_cloud_models_get_real_mils(self):
+        """Each canonical pricing entry must produce a non-zero mils
+        cost for vision frames."""
+        for model in (
+            "openai/gpt-4o",
+            "openai/gpt-4o-mini",
+            "anthropic/claude-sonnet-4.6",
+            "anthropic/claude-3.5-haiku",
+            "anthropic/claude-haiku-4.5",
+            "google/gemini-3-flash-preview",
+            "google/gemini-3.1-pro-preview",
+        ):
+            with self.subTest(model=model):
+                cost = vision_per_frame_mils(model)
+                self.assertGreater(
+                    cost, 0,
+                    f"{model} must cost > 0 mils per vision frame",
+                )
+
+    def test_previously_silently_zero_models_now_priced(self):
+        """OCP-2 anchor: these are exactly the models the prior inline
+        switch silently defaulted to 0 mils.  All must now produce
+        real per-frame mils via the canonical pricing table."""
+        previously_silent = [
+            "anthropic/claude-opus-4.7",
+            "anthropic/claude-opus-4.6",
+            "anthropic/claude-opus-4.5",
+            "x-ai/grok-4.20",
+            "x-ai/grok-4.20-multi-agent",
+            "moonshotai/kimi-k2.6",
+            "moonshotai/kimi-k2.5",
+            "qwen/qwen3.6-flash",
+            "qwen/qwen3.6-27b",
+            "z-ai/glm-5.1",
+            "z-ai/glm-5v-turbo",
+            "xiaomi/mimo-v2.5",
+        ]
+        for model in previously_silent:
+            with self.subTest(model=model):
+                cost = vision_per_frame_mils(model)
+                self.assertGreater(
+                    cost, 0,
+                    f"OCP-2 regression: {model} must NOT silently zero — "
+                    f"prior switch defaulted everything except gpt-4o/sonnet/"
+                    f"haiku/gemini to 0 mils per frame, hiding spend from "
+                    f"the daily cap.",
+                )
+
+    def test_unknown_cloud_model_falls_through_to_default(self):
+        """An OpenRouter-shape id (vendor/model) that isn't in the
+        registry must use the conservative ``_default`` rate, never
+        zero — pricing surprises are always errors-on-the-side-of-too-
+        much, never errors-on-the-side-of-free."""
+        cost = vision_per_frame_mils("future-vendor/unreleased-model-2027")
+        # Default is $2/M tokens input → 2_000_000 mils/M × 1500 tokens
+        # ÷ 1_000_000 (ceil) = 3000 mils.
+        self.assertEqual(cost, 3000)
+
+    def test_helper_matches_price_for_model_call_shape(self):
+        """The helper is just sugar over ``price_for_model`` with a
+        fixed token approximation — assert the math agrees so a future
+        change to either side stays consistent."""
+        for model in (
+            "anthropic/claude-sonnet-4.6",
+            "anthropic/claude-opus-4.7",
+            "google/gemini-3-flash-preview",
+        ):
+            with self.subTest(model=model):
+                via_helper = vision_per_frame_mils(model)
+                direct = price_for_model(
+                    model,
+                    prompt_tokens=_VISION_TOKENS_PER_FRAME_APPROX,
+                    completion_tokens=0,
+                )
+                self.assertEqual(via_helper, direct)
+
+    def test_pricing_table_has_no_silent_zeroes(self):
+        """Belt-and-suspenders: every entry in _PRICING_MILS_PER_M must
+        produce a non-zero per-frame cost.  If anyone adds a registry
+        entry with zero input mils, this test catches it before it
+        ships."""
+        for model, entry in _PRICING_MILS_PER_M.items():
+            if model == "_default":
+                continue
+            with self.subTest(model=model):
+                self.assertGreater(
+                    entry.get("in", 0), 0,
+                    f"{model}: 'in' mils per M tokens must be > 0",
+                )
+                self.assertGreater(vision_per_frame_mils(model), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

The 2026-05-03 SOLID audit ([`docs/AUDIT-solid-2026-05-03.md`](docs/AUDIT-solid-2026-05-03.md), OCP-2 / P1) found that `_handle_config_update` carried a hardcoded vision-pricing switch:

\`\`\`python
elif \"gpt-4o\" in spec.model_id:  per_frame_mils = 1200
elif \"sonnet\" in spec.model_id:  per_frame_mils = 4500
elif \"haiku\" in spec.model_id:   per_frame_mils = 400
elif \"gemini\" in spec.model_id:  per_frame_mils = 200
\`\`\`

Disconnected from the canonical `_PRICING_MILS_PER_M` registry. **Net effect:** every cloud-vision turn on Opus 4.x, Grok 4.x, Kimi K2.6, Qwen 3.6, GLM, MiMo, etc. silently defaulted to **0 mils per frame** — invisible to the daily-cap budget enforcement.

The router happily picks Opus 4.7 for a vision turn, the user sends 50 photos, the spend counter never moves, the cap never trips. **Real budget bug.**

This is OCP because adding a new vision model required editing *three* places: this switch, `_PRICING_MILS_PER_M`, and possibly `_OPENROUTER_CAPS`.

## Fix

Add `vision_per_frame_mils(model)` helper in [`dragon_voice/llm/openrouter_llm.py`](dragon_voice/llm/openrouter_llm.py#L437) that routes through the canonical `price_for_model(model, prompt_tokens=1500, completion_tokens=0)` — using a 1500-token-per-frame approximation that matches what the prior switch was implicitly assuming for sonnet/haiku/gemini (gpt-4o ends up ~3× over-charged which is fine — over-counting is the safe direction since the daily cap exists to *stop* spending, not to track to-the-mil precision).

Replace the inline switches in [`server.py:_handle_config_update`](dragon_voice/server.py#L2438):

* **Router branch:** `spec.tier == \"local\"` stays 0; otherwise the helper handles all canonical vendors uniformly via the pricing registry.
* **Non-router cloud branch:** substring-gate widened to include the previously-missing vendors (`opus`/`grok`/`kimi`/`qwen3.6`/`glm`/`mimo`) AND pricing routed through the helper so the substring list and the pricing registry can drift independently in the future without recreating the silent-zero bug.
* **Local-tier sub-backends** still short-circuit to 0 — the `_default` table entry would otherwise quote a phantom \$2/M-token rate for a local model id.

**Conservative-by-design:** unknown cloud models fall through to the `_default` registry entry (~3000 mils/frame at the current default rate) — never zero, so a pricing surprise can never silently zero out the receipt.

## Tests

[`tests/test_vision_pricing.py`](tests/test_vision_pricing.py) (new, 7 tests + 73 subtests):

* Local models (no slash) cost zero.
* Each canonical pricing entry produces non-zero mils per frame.
* **OCP-2 anchor:** every previously-silently-zero model (Opus/Grok/Kimi/Qwen 3.6/GLM/MiMo) now produces real mils.
* Unknown cloud models fall through to `_default` (3000 mils).
* Helper math agrees with `price_for_model` directly.
* Belt-and-suspenders: **no** entry in `_PRICING_MILS_PER_M` may have a zero \"in\" rate (catches accidental future regressions).

\`\`\`
\$ python3 -m pytest tests/test_vision_pricing.py -v
7 passed, 73 subtests passed in 0.08s

\$ python3 -m pytest tests/test_router_routing.py tests/test_capability_declaration.py tests/test_vision_pricing.py -q
67 passed, 73 subtests passed

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \\
    dragon_voice/llm/openrouter_llm.py dragon_voice/server.py tests/test_vision_pricing.py
All checks passed!
\`\`\`

## Closes

SOLID-AUDIT 2026-05-03 finding **OCP-2** (P1).

## Note

This fixes the *pricing* drift specifically.  The substring-based vision-capability gate in the non-router branch (lines 2475-2485) is still present and now matches the broader vendor list, but the cleaner long-term fix is to route capability detection through `_OPENROUTER_CAPS` / the centralized capability registry too — that's a separate, larger refactor (audit OCP-1) and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)