### PR TITLE
refactor(server): introduce VoiceMode enum, kill 17 magic-number comparisons (OCP-1)

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -52,6 +52,7 @@ from dragon_voice.middleware import (
 )
 from dragon_voice.pipeline import VoicePipeline
 from dragon_voice.sessions import SessionManager
+from dragon_voice.voice_modes import VoiceMode
 from dragon_voice.audio import resample_pcm16_async
 from dragon_voice.tools.response_wrap import looks_like_useful_text, synthesize_wrap
 
@@ -2149,10 +2150,23 @@ class VoiceServer:
                     })
 
         if voice_mode is not None:
-            # STT+TTS: local for mode 0, cloud for mode 1+2+3
-            if voice_mode == 0:
+            # OCP-1 (audit 2026-05-03): convert raw int → VoiceMode enum
+            # at the boundary so all branches below use semantic
+            # predicates instead of magic-number comparisons.  Invalid
+            # values fall through to LOCAL semantically so a malformed
+            # WS frame can never wedge the server in an unknown state.
+            vmode = VoiceMode.from_int(voice_mode)
+            if vmode is None:
+                logger.warning(
+                    "config_update: unknown voice_mode=%s — treating as LOCAL",
+                    voice_mode,
+                )
+                vmode = VoiceMode.LOCAL
+
+            # STT+TTS: local for LOCAL, cloud for HYBRID/CLOUD/TINKERCLAW
+            if vmode.is_local():
                 stt_be, tts_be = "moonshine", "piper"
-            elif voice_mode == 3:
+            elif vmode.is_tinkerclaw():
                 # TinkerClaw mode: default local STT/TTS
                 # "cloud" suffix in llm_model → use OpenRouter STT/TTS
                 if llm_model and "cloud" in llm_model.lower():
@@ -2163,12 +2177,12 @@ class VoiceServer:
                 stt_be, tts_be = "openrouter", "openrouter"
 
             # LLM backend selection
-            if voice_mode == 3:
+            if vmode.is_tinkerclaw():
                 # TinkerClaw mode — gateway handles everything
                 llm_be = "tinkerclaw"
                 if llm_model:
                     conn_config.llm.tinkerclaw_model = llm_model
-            elif voice_mode == 2:
+            elif vmode.is_cloud():
                 llm_be = "openrouter"
                 if llm_model:
                     conn_config.llm.openrouter_model = llm_model
@@ -2178,27 +2192,27 @@ class VoiceServer:
                     conn_config.llm.ollama_model = llm_model
                     logger.info("Local model switched to: %s", llm_model)
 
-            # Apply mode-aware system prompt and max_tokens
-            # Mode 3 (TinkerClaw): skip — TinkerClaw owns personality
-            if voice_mode == 3:
+            # Apply mode-aware system prompt and max_tokens.
+            # TINKERCLAW: skip — TinkerClaw owns personality + token budget.
+            if vmode.is_tinkerclaw():
                 pass  # TinkerClaw manages its own prompts and limits
-            elif voice_mode == 0:
+            elif vmode.is_local():
                 conn_config.llm.system_prompt = SYSTEM_PROMPT_LOCAL
                 conn_config.llm.max_tokens = MAX_TOKENS_LOCAL
-            elif voice_mode == 1:
+            elif vmode.is_hybrid():
                 conn_config.llm.system_prompt = SYSTEM_PROMPT_HYBRID
                 conn_config.llm.max_tokens = MAX_TOKENS_HYBRID
             else:
                 conn_config.llm.system_prompt = SYSTEM_PROMPT_CLOUD
                 conn_config.llm.max_tokens = MAX_TOKENS_CLOUD
 
-            logger.info("Connection %s: voice_mode=%d → stt=%s tts=%s llm=%s model=%s tokens=%d",
-                        ws_id, voice_mode, stt_be, tts_be, llm_be,
-                        conn_config.llm.openrouter_model if voice_mode == 2 else "(local)",
+            logger.info("Connection %s: voice_mode=%d (%s) → stt=%s tts=%s llm=%s model=%s tokens=%d",
+                        ws_id, int(vmode), vmode.name, stt_be, tts_be, llm_be,
+                        conn_config.llm.openrouter_model if vmode.is_cloud() else "(local)",
                         conn_config.llm.max_tokens)
 
-            # Validate TinkerClaw gateway is reachable before switching to mode 3
-            if voice_mode == 3:
+            # Validate TinkerClaw gateway is reachable before switching to TC mode
+            if vmode.is_tinkerclaw():
                 try:
                     tc_url = (conn_config.llm.tinkerclaw_url or "http://localhost:18789").rstrip("/")
                     async with aiohttp.ClientSession(
@@ -2237,7 +2251,7 @@ class VoiceServer:
             # `config_update.error` raw-string that didn't tell the user
             # what happened next.  Migrated to the same γ-arch error_event
             # + revert pattern as B7 (TC token check) for consistency.
-            if voice_mode in (1, 2) and not conn_config.llm.openrouter_api_key:
+            if vmode.needs_openrouter_key() and not conn_config.llm.openrouter_api_key:
                 logger.error("Cloud mode requested but no API key configured")
                 if not ws.closed:
                     await self._safe_send_json(ws, error_event(
@@ -2257,7 +2271,7 @@ class VoiceServer:
             # the A4 raw-exception path below.  Validate up-front like
             # the OpenRouter key check above so the user sees a clean
             # γ-arch error and a clean revert instead of a stack trace.
-            if voice_mode == 3 and not (conn_config.llm.tinkerclaw_token or "").strip():
+            if vmode.is_tinkerclaw() and not (conn_config.llm.tinkerclaw_token or "").strip():
                 logger.error("TC mode requested but tinkerclaw_token is blank")
                 if not ws.closed:
                     await self._safe_send_json(ws, error_event(
@@ -2281,7 +2295,7 @@ class VoiceServer:
             if sid and self._db:
                 # Resolve the best "active model" string to persist,
                 # matching the client-visible payload below.
-                if voice_mode == 2:
+                if vmode.is_cloud():
                     active_model_db = conn_config.llm.openrouter_model or ""
                 elif llm_be == "tinkerclaw":
                     active_model_db = conn_config.llm.tinkerclaw_model or ""
@@ -2293,7 +2307,7 @@ class VoiceServer:
                     await self._db.update_session(
                         sid,
                         system_prompt=conn_config.llm.system_prompt,
-                        voice_mode=int(voice_mode),
+                        voice_mode=int(vmode),
                         llm_model=active_model_db[:128],
                     )
                 except Exception:
@@ -2307,7 +2321,7 @@ class VoiceServer:
             conn_config.llm.backend = llm_be
 
             # Propagate API keys for cloud STT/TTS backends (modes 1-2, or mode 3 with cloud STT)
-            if voice_mode in (1, 2) or (voice_mode == 3 and stt_be == "openrouter"):
+            if vmode.needs_cloud_stt_tts() or (vmode.is_tinkerclaw() and stt_be == "openrouter"):
                 conn_config.stt.openrouter_api_key = conn_config.llm.openrouter_api_key
                 conn_config.stt.openrouter_url = conn_config.llm.openrouter_url
                 conn_config.tts.openrouter_api_key = conn_config.llm.openrouter_api_key
@@ -2398,7 +2412,7 @@ class VoiceServer:
             # Confirm to Tab5
             if not ws.closed:
                 # Report actual model for any mode
-                if voice_mode == 2:
+                if vmode.is_cloud():
                     active_model = conn_config.llm.openrouter_model
                 elif llm_be == "tinkerclaw":
                     active_model = conn_config.llm.tinkerclaw_model
@@ -2416,12 +2430,15 @@ class VoiceServer:
                     "stt": stt_be, "tts": tts_be,
                     "llm": llm_be,
                     "llm_model": active_model,
-                    "voice_mode": voice_mode,
-                    "cloud_mode": voice_mode >= 1,
+                    "voice_mode": int(vmode),
+                    # cloud_mode is the legacy binary toggle; True for any
+                    # mode that touches cloud (Hybrid/Cloud/TC).  Onboard
+                    # is Tab5-side-only and never reaches Dragon.
+                    "cloud_mode": int(vmode) >= 1,
                 }
                 # Wave 22b (#202): use ConversationEngine.fleet_summary().
                 if self._conversation:
-                    summary = self._conversation.fleet_summary(voice_mode)
+                    summary = self._conversation.fleet_summary(int(vmode))
                     if summary is not None:
                         config_payload["fleet_summary"] = summary
                 await ws.send_json({
@@ -2458,7 +2475,7 @@ class VoiceServer:
                             )):
                         from dragon_voice.llm.base import Modality
                         spec = self._conversation._llm.choose(
-                            {Modality.TEXT, Modality.VISION}, voice_mode,
+                            {Modality.TEXT, Modality.VISION}, int(vmode),
                         )
                         if spec:
                             vision_model = spec.model_id
@@ -2471,18 +2488,21 @@ class VoiceServer:
                                 else vision_per_frame_mils(spec.model_id)
                             )
                     else:
-                        vm = conn_config.llm.openrouter_model.lower() \
-                            if voice_mode == 2 else ""
+                        # Note: `or_model_lc` (was `vm`) renamed to avoid
+                        # shadowing the outer `vmode` VoiceMode added in
+                        # the OCP-1 audit fix.
+                        or_model_lc = conn_config.llm.openrouter_model.lower() \
+                            if vmode.is_cloud() else ""
                         om = conn_config.llm.ollama_model.lower() \
-                            if voice_mode == 0 else ""
-                        if voice_mode == 2:
+                            if vmode.is_local() else ""
+                        if vmode.is_cloud():
                             # Vision-capability gate stays substring-based
                             # for now (the router branch above is the
                             # capability-aware path).  Pricing now goes
                             # through the centralized helper so adding a
                             # vendor to the substring list automatically
                             # gets correct mils via _PRICING_MILS_PER_M.
-                            if any(hint in vm for hint in (
+                            if any(hint in or_model_lc for hint in (
                                     "gpt-4o", "sonnet", "haiku", "gemini",
                                     "opus", "grok", "kimi", "qwen3.6", "glm",
                                     "mimo")):
@@ -2490,7 +2510,7 @@ class VoiceServer:
                                 per_frame_mils = vision_per_frame_mils(
                                     conn_config.llm.openrouter_model
                                 )
-                        elif voice_mode == 0:
+                        elif vmode.is_local():
                             if "vision" in om or "llava" in om:
                                 vision_model = active_model
                                 per_frame_mils = 0

--- a/dragon_voice/voice_modes.py
+++ b/dragon_voice/voice_modes.py
@@ -1,0 +1,133 @@
+"""Voice-mode registry — centralizes the five-tier mode semantics.
+
+2026-05-03 SOLID audit (OCP-1, OCP-2, OCP-6): server.py carried 17
+``voice_mode == N`` magic-number comparisons scattered across
+``_handle_config_update`` and ``_handle_text_body``.  Adding a new
+mode meant hunting all 17.  The vision-pricing OCP-2 bug fixed in
+PR #210 was an instance of the same shape: a switch-on-substring
+that silently zeroed when a new model arrived.
+
+This module replaces the magic numbers with a typed
+:class:`VoiceMode` IntEnum + the four semantic predicates the code
+actually wants to ask:
+
+  * ``is_local()`` / ``is_hybrid()`` / ``is_cloud()`` /
+    ``is_tinkerclaw()`` / ``is_onboard()`` — single-tier checks
+  * ``needs_cloud_stt_tts()`` — Hybrid + Cloud both route STT+TTS
+    through OpenRouter.  This was the ``voice_mode in (1, 2)``
+    pattern that appeared at server.py:2240 and 2310.
+  * ``needs_openrouter_key()`` — currently the same set as
+    ``needs_cloud_stt_tts()`` but kept separate so a future change
+    (e.g. local STT + cloud LLM) doesn't have to re-derive.
+  * ``is_dragon_managed_pipeline()`` — Local / Hybrid / Cloud all run
+    Dragon's STT→LLM→TTS chain.  TinkerClaw bypasses to the gateway;
+    Onboard is Tab5-side only and Dragon never sees it on the wire.
+
+The IntEnum subtype keeps wire-protocol compatibility — JSON ints
+from Tab5 still serialise straight through.  ``VoiceMode(0)`` and
+``int(VoiceMode.LOCAL)`` round-trip via the existing JSON layer
+without any adapter changes.
+
+For unparseable WS payloads (out-of-range int, missing field), use
+:meth:`VoiceMode.from_int` — it returns ``None`` instead of raising
+``ValueError`` so callers can fall back gracefully.
+"""
+from __future__ import annotations
+
+from enum import IntEnum
+from typing import Optional
+
+
+class VoiceMode(IntEnum):
+    """Five-tier voice mode controlling Dragon's STT/LLM/TTS routing.
+
+    Wire values match what Tab5 firmware sends in the
+    ``config_update`` WS frame.  Don't reorder — the integer values
+    are part of the protocol contract (see TinkerTab CLAUDE.md
+    "Voice Modes").
+    """
+
+    LOCAL = 0
+    """Moonshine STT + local NPU/Ollama LLM + Piper TTS, all on Dragon."""
+
+    HYBRID = 1
+    """OpenRouter STT/TTS + local LLM (gpt-audio-mini for STT/TTS,
+    Dragon's local backend for the LLM turn)."""
+
+    CLOUD = 2
+    """OpenRouter STT + user-selected cloud LLM + OpenRouter TTS.
+    The LLM model id comes from the WS frame's ``llm_model`` field."""
+
+    TINKERCLAW = 3
+    """TinkerClaw gateway handles the LLM turn (Dragon is just an
+    audio pipe).  STT/TTS can be either local Moonshine/Piper or
+    OpenRouter depending on the per-mode config."""
+
+    ONBOARD = 4
+    """K144 onboard LLM, Tab5-side only.  Dragon never sees this
+    mode on the wire — Tab5 silently maps it to LOCAL when sending
+    ``config_update`` so Dragon's STT/TTS still run.  Included here
+    for completeness so :meth:`from_int` recognises 4 as a valid
+    enum value rather than ``None``."""
+
+    @classmethod
+    def from_int(cls, value: Optional[int]) -> Optional["VoiceMode"]:
+        """Safe parse from a raw int (e.g. WS frame field).
+
+        Returns ``None`` for ``None``, out-of-range values, or
+        non-int types.  Use this at boundaries where the input is
+        untrusted; use the enum directly for in-tree code paths
+        that should never see an invalid value.
+        """
+        if value is None:
+            return None
+        try:
+            return cls(int(value))
+        except (ValueError, TypeError):
+            return None
+
+    # ── single-tier predicates ─────────────────────────────────
+
+    def is_local(self) -> bool:
+        return self == VoiceMode.LOCAL
+
+    def is_hybrid(self) -> bool:
+        return self == VoiceMode.HYBRID
+
+    def is_cloud(self) -> bool:
+        return self == VoiceMode.CLOUD
+
+    def is_tinkerclaw(self) -> bool:
+        return self == VoiceMode.TINKERCLAW
+
+    def is_onboard(self) -> bool:
+        return self == VoiceMode.ONBOARD
+
+    # ── semantic groupings (the real OCP wins) ────────────────
+
+    def needs_cloud_stt_tts(self) -> bool:
+        """True iff Dragon's STT and TTS should run on OpenRouter
+        rather than local Moonshine + Piper.
+
+        Pre-extract this was ``voice_mode in (1, 2)`` at
+        server.py:2240 and ``voice_mode in (1, 2) or
+        (voice_mode == 3 and stt_be == "openrouter")`` at 2310.
+        """
+        return self in (VoiceMode.HYBRID, VoiceMode.CLOUD)
+
+    def needs_openrouter_key(self) -> bool:
+        """True iff this mode requires a configured OpenRouter API
+        key.  Currently the same set as :meth:`needs_cloud_stt_tts`
+        — kept separate so a future "local STT + cloud LLM" tier
+        doesn't force a search-and-replace."""
+        return self.needs_cloud_stt_tts()
+
+    def is_dragon_managed_pipeline(self) -> bool:
+        """True iff Dragon's STT→LLM→TTS pipeline drives the turn.
+
+        Local, Hybrid, Cloud all do.  TinkerClaw bypasses to the
+        gateway (Dragon is just an audio pipe).  Onboard is
+        Tab5-side-only — Dragon never sees mode 4 since Tab5
+        silently maps it to LOCAL on the wire.
+        """
+        return self in (VoiceMode.LOCAL, VoiceMode.HYBRID, VoiceMode.CLOUD)

--- a/tests/test_voice_modes.py
+++ b/tests/test_voice_modes.py
@@ -1,0 +1,159 @@
+"""Tests for ``dragon_voice.voice_modes.VoiceMode`` (audit OCP-1/2/6).
+
+Pins three contracts that future refactors must not break:
+  1. The integer wire values are part of the protocol (Tab5 sends
+     ``"voice_mode": N`` JSON ints).  Reordering breaks Tab5 firmware
+     in the field.
+  2. ``from_int`` is a safe parser — never raises on bad input.
+  3. Each semantic predicate matches the real-world behavior the
+     code was checking with magic numbers pre-extract.
+"""
+from __future__ import annotations
+
+import unittest
+
+from dragon_voice.voice_modes import VoiceMode
+
+
+class VoiceModeWireValuesTests(unittest.TestCase):
+    """The integer values are part of the WS protocol contract."""
+
+    def test_local_is_zero(self):
+        self.assertEqual(int(VoiceMode.LOCAL), 0)
+
+    def test_hybrid_is_one(self):
+        self.assertEqual(int(VoiceMode.HYBRID), 1)
+
+    def test_cloud_is_two(self):
+        self.assertEqual(int(VoiceMode.CLOUD), 2)
+
+    def test_tinkerclaw_is_three(self):
+        self.assertEqual(int(VoiceMode.TINKERCLAW), 3)
+
+    def test_onboard_is_four(self):
+        self.assertEqual(int(VoiceMode.ONBOARD), 4)
+
+    def test_total_modes(self):
+        # If a 6th mode is added, also update Tab5 firmware's enum.
+        self.assertEqual(len(VoiceMode), 5)
+
+
+class VoiceModeFromIntTests(unittest.TestCase):
+    """``from_int`` is a safe parser — never raises."""
+
+    def test_valid_ints_round_trip(self):
+        for i in range(5):
+            with self.subTest(value=i):
+                vm = VoiceMode.from_int(i)
+                self.assertIsNotNone(vm)
+                self.assertEqual(int(vm), i)
+
+    def test_none_returns_none(self):
+        self.assertIsNone(VoiceMode.from_int(None))
+
+    def test_out_of_range_returns_none(self):
+        self.assertIsNone(VoiceMode.from_int(-1))
+        self.assertIsNone(VoiceMode.from_int(5))
+        self.assertIsNone(VoiceMode.from_int(99))
+
+    def test_string_returns_none(self):
+        # Tab5 firmware should never send a string, but if a future
+        # protocol change does, we shouldn't crash.
+        self.assertIsNone(VoiceMode.from_int("local"))
+        self.assertIsNone(VoiceMode.from_int(""))
+
+    def test_string_int_works(self):
+        # JSON sometimes deserialises numeric strings — accept those.
+        self.assertEqual(VoiceMode.from_int("2"), VoiceMode.CLOUD)
+
+
+class VoiceModeSingleTierPredicatesTests(unittest.TestCase):
+    """Each tier predicate matches exactly one mode."""
+
+    def test_is_local_only_local(self):
+        for vm in VoiceMode:
+            with self.subTest(mode=vm.name):
+                self.assertEqual(vm.is_local(), vm == VoiceMode.LOCAL)
+
+    def test_is_hybrid_only_hybrid(self):
+        for vm in VoiceMode:
+            with self.subTest(mode=vm.name):
+                self.assertEqual(vm.is_hybrid(), vm == VoiceMode.HYBRID)
+
+    def test_is_cloud_only_cloud(self):
+        for vm in VoiceMode:
+            with self.subTest(mode=vm.name):
+                self.assertEqual(vm.is_cloud(), vm == VoiceMode.CLOUD)
+
+    def test_is_tinkerclaw_only_tc(self):
+        for vm in VoiceMode:
+            with self.subTest(mode=vm.name):
+                self.assertEqual(vm.is_tinkerclaw(), vm == VoiceMode.TINKERCLAW)
+
+    def test_is_onboard_only_onboard(self):
+        for vm in VoiceMode:
+            with self.subTest(mode=vm.name):
+                self.assertEqual(vm.is_onboard(), vm == VoiceMode.ONBOARD)
+
+
+class VoiceModeSemanticGroupingTests(unittest.TestCase):
+    """The semantic groupings encode policy.  These tests pin which
+    modes belong to which group so future additions don't silently
+    break the OpenRouter-key check or the cloud-STT/TTS routing.
+    """
+
+    def test_needs_cloud_stt_tts_is_hybrid_and_cloud(self):
+        # Pre-extract: voice_mode in (1, 2) at server.py:2240.
+        expected = {VoiceMode.HYBRID, VoiceMode.CLOUD}
+        actual = {vm for vm in VoiceMode if vm.needs_cloud_stt_tts()}
+        self.assertEqual(actual, expected)
+
+    def test_needs_openrouter_key_currently_matches_cloud_stt_tts(self):
+        for vm in VoiceMode:
+            with self.subTest(mode=vm.name):
+                self.assertEqual(vm.needs_openrouter_key(), vm.needs_cloud_stt_tts())
+
+    def test_dragon_managed_pipeline_excludes_tc_and_onboard(self):
+        # TinkerClaw bypasses to the gateway; Onboard is Tab5-side-only.
+        # Dragon never sees mode 4 in practice.
+        expected = {VoiceMode.LOCAL, VoiceMode.HYBRID, VoiceMode.CLOUD}
+        actual = {vm for vm in VoiceMode if vm.is_dragon_managed_pipeline()}
+        self.assertEqual(actual, expected)
+
+    def test_tinkerclaw_is_not_dragon_managed(self):
+        # Specific anchor — TC mode bypasses Dragon's STT/LLM/TTS chain.
+        self.assertFalse(VoiceMode.TINKERCLAW.is_dragon_managed_pipeline())
+
+    def test_onboard_is_not_dragon_managed(self):
+        # Onboard is Tab5-side-only — Tab5 maps it to LOCAL on the wire.
+        self.assertFalse(VoiceMode.ONBOARD.is_dragon_managed_pipeline())
+
+
+class VoiceModeIntCompatTests(unittest.TestCase):
+    """IntEnum compatibility — must JSON-serialise as plain int and
+    round-trip through dict / NVS / DB writes that previously stored
+    ``int(voice_mode)``."""
+
+    def test_int_addition_works(self):
+        # Sanity: IntEnum values usable in arithmetic contexts.
+        self.assertEqual(VoiceMode.LOCAL + 0, 0)
+        self.assertEqual(VoiceMode.CLOUD + 0, 2)
+
+    def test_eq_int_works(self):
+        # Critical: existing code paths that still use raw int
+        # comparisons (DB writes, REST payloads) must keep working
+        # during the migration.
+        self.assertTrue(VoiceMode.LOCAL == 0)
+        self.assertTrue(VoiceMode.CLOUD == 2)
+        self.assertFalse(VoiceMode.LOCAL == 2)
+
+    def test_in_int_tuple_works(self):
+        # Pre-extract: voice_mode in (1, 2)
+        # Post-extract: vm.needs_cloud_stt_tts() — but the raw form
+        # still needs to work for places we haven't migrated yet.
+        self.assertIn(VoiceMode.CLOUD, (1, 2))
+        self.assertNotIn(VoiceMode.LOCAL, (1, 2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Closes audit **OCP-1** (P1) — the dominant residual smell from [\`docs/AUDIT-solid-2026-05-03.md\`](docs/AUDIT-solid-2026-05-03.md).

server.py carried **17 \`voice_mode == N\` magic-number comparisons** scattered across [\`_handle_config_update\`](dragon_voice/server.py#L2080) (which is itself 446 LOC). Adding a new mode meant hunting all 17, and the same shape produced the **OCP-2 vision-pricing bug** fixed in [#210](https://github.com/lorcan35/TinkerBox/pull/210) (silent-zero on every model not explicitly listed).

## New module: [\`dragon_voice/voice_modes.py\`](dragon_voice/voice_modes.py)

Typed IntEnum + four semantic predicates the code actually wants to ask:

| Predicate | What it replaces |
|---|---|
| \`is_local()\` / \`is_hybrid()\` / \`is_cloud()\` / \`is_tinkerclaw()\` / \`is_onboard()\` | \`voice_mode == 0/1/2/3/4\` |
| \`needs_cloud_stt_tts()\` | \`voice_mode in (1, 2)\` (used at server.py:2240, 2310) |
| \`needs_openrouter_key()\` | currently same as above; kept separate for forward-compat |
| \`is_dragon_managed_pipeline()\` | new — codifies that LOCAL/HYBRID/CLOUD run Dragon's pipeline; TC bypasses; Onboard is Tab5-side-only |

\`VoiceMode.from_int()\` is a **safe parser** — never raises. Out-of-range values return \`None\` so the WS-frame boundary can fall back gracefully.

## Migration

\`_handle_config_update\` now converts raw int → VoiceMode at the boundary (right after \`if voice_mode is not None:\`); every branch below uses the typed predicates. An out-of-range int falls back to LOCAL semantically + logs a warning rather than silently selecting an undefined mode.

The pre-existing \`vm\` local in the vision-capability block (line 2475) was renamed to \`or_model_lc\` to avoid shadowing the new \`vmode\` VoiceMode binding.

## Wire-protocol invariant

**Unchanged.** \`int(vmode)\` round-trips through JSON, DB writes, and \`fleet_summary(int)\` exactly as the prior raw-int version did. The IntEnum subtype keeps \`vmode == 0\` and \`int(vmode)\` working too — code that hasn't been migrated yet keeps compiling and behaving identically.

## Tests

[\`tests/test_voice_modes.py\`](tests/test_voice_modes.py) — 24 tests + 35 subtests:

* \`VoiceModeWireValuesTests\` — pin the integer protocol contract (LOCAL=0, ..., ONBOARD=4)
* \`VoiceModeFromIntTests\` — safe-parse contract: \`None\` / out-of-range / wrong-type all return \`None\`, never raise
* \`VoiceModeSingleTierPredicatesTests\` — each tier predicate matches exactly one mode (5 modes × 5 predicates = 25 subtests via parametric)
* \`VoiceModeSemanticGroupingTests\` — pin the semantic groupings (\`needs_cloud_stt_tts\` = {HYBRID, CLOUD}; \`is_dragon_managed_pipeline\` = {LOCAL, HYBRID, CLOUD})
* \`VoiceModeIntCompatTests\` — IntEnum compatibility (eq with int, in tuple, arithmetic) — these guard the migration phase where some sites still use raw int

\`\`\`
\$ python3 -m pytest tests/test_voice_modes.py -v
24 passed, 35 subtests passed in 0.03s

\$ python3 -m pytest tests/ --ignore=tests/audit -q
690 passed, 108 subtests passed, 1 skipped, 0 failed in 11.33s

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \\
    dragon_voice/ tests/
All checks passed!
\`\`\`

## What's next

This lays the groundwork for the deferred Wave 22a \`WsDispatcher\` extraction — the per-handler refactors will inherit the typed mode and never need to re-prove the same magic-number gymnastics. Two follow-up PRs queued:

* **PR-B**: \`ConversationEngine.choose_vision_model(voice_mode)\` — closes audit ENC-1 (3 \`self._conversation._llm\` reach-throughs)
* **PR-C**: \`ConnState\` dataclass — replaces the 22 untyped \`conn_state[\"...\"]\` dict accesses

🤖 Generated with [Claude Code](https://claude.com/claude-code)