### PR TITLE
refactor(server): extract vision-capability emit out of _handle_config_update

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -23,6 +23,7 @@ from aiohttp import web, WSMsgType
 from dragon_voice.conn_state import ConnState
 from dragon_voice.media.store import MediaStore
 from dragon_voice.media.pipeline import MediaPipeline
+from dragon_voice.vision_capability import emit_vision_capability
 from dragon_voice.config import (
     VoiceConfig,
     SYSTEM_PROMPT_LOCAL, SYSTEM_PROMPT_HYBRID, SYSTEM_PROMPT_CLOUD,
@@ -2451,79 +2452,19 @@ class VoiceServer:
 
                 # v4·D Phase 4b vision capability advertisement.  Tab5's
                 # camera screen renders a "VISION · <model> READY" chip based
-                # on this.  #183 PR 3: prefer the router's per-modality
-                # pick when available; fall back to the legacy
-                # substring-on-model-name heuristic for single-backend
-                # configurations.
-                try:
-                    vision_model = ""
-                    per_frame_mils = 0
-                    # OCP-2 (audit 2026-05-03): single source of truth for
-                    # per-frame mils.  Kills the parallel switch on
-                    # gpt-4o/sonnet/haiku/gemini that silently defaulted
-                    # Opus 4.x, Grok 4.x, Kimi K2.6, Qwen 3.6, GLM, MiMo
-                    # to 0 mils — every cloud-vision turn on those models
-                    # was invisible to the daily-cap budget enforcement.
-                    from dragon_voice.llm.openrouter_llm import vision_per_frame_mils
-                    # ENC-1 (audit 2026-05-03): replaced the prior
-                    # `isinstance(self._conversation._llm, CapabilityAwareRouter)`
-                    # private-attribute reach-through with the public
-                    # `ConversationEngine.choose_vision_model(voice_mode)`
-                    # accessor.  Returns ModelSpec | None — None falls
-                    # through to the substring-based capability gate
-                    # below for single-backend configurations.
-                    # Combined with OCP-1 (#211): pass int(vmode) so the
-                    # router still receives the integer tier key it
-                    # expects.
-                    spec = (
-                        self._conversation.choose_vision_model(int(vmode))
-                        if self._conversation else None
-                    )
-                    if spec is not None:
-                        vision_model = spec.model_id
-                        # Local-tier sub-backends are free regardless of
-                        # the canonical pricing table (which is OR-only);
-                        # short-circuit to avoid a `_default`-table
-                        # surprise on a local vision model id.
-                        per_frame_mils = (
-                            0 if spec.tier == "local"
-                            else vision_per_frame_mils(spec.model_id)
-                        )
-                    else:
-                        # Note: `or_model_lc` (was `vm`) renamed to avoid
-                        # shadowing the outer `vmode` VoiceMode added in
-                        # the OCP-1 audit fix.
-                        or_model_lc = conn_config.llm.openrouter_model.lower() \
-                            if vmode.is_cloud() else ""
-                        om = conn_config.llm.ollama_model.lower() \
-                            if vmode.is_local() else ""
-                        if vmode.is_cloud():
-                            # Vision-capability gate stays substring-based
-                            # for now (the router branch above is the
-                            # capability-aware path).  Pricing now goes
-                            # through the centralized helper so adding a
-                            # vendor to the substring list automatically
-                            # gets correct mils via _PRICING_MILS_PER_M.
-                            if any(hint in or_model_lc for hint in (
-                                    "gpt-4o", "sonnet", "haiku", "gemini",
-                                    "opus", "grok", "kimi", "qwen3.6", "glm",
-                                    "mimo")):
-                                vision_model = active_model
-                                per_frame_mils = vision_per_frame_mils(
-                                    conn_config.llm.openrouter_model
-                                )
-                        elif vmode.is_local():
-                            if "vision" in om or "llava" in om:
-                                vision_model = active_model
-                                per_frame_mils = 0
-                    await ws.send_json({
-                        "type":           "vision_capability",
-                        "can_see":        bool(vision_model),
-                        "model":          vision_model,
-                        "per_frame_mils": per_frame_mils,
-                    })
-                except Exception:
-                    logger.exception("vision_capability emit failed")
+                # on this.  Extracted to vision_capability.emit_vision_capability
+                # in the SOLID-audit follow-up — the inline 80-LOC block was
+                # tangled with the config_update ACK + cap_downgrade speak;
+                # three sub-responsibilities that change for different
+                # reasons (router fleet shape vs Tab5 chip rendering vs cap
+                # policy) and shouldn't share a method body.
+                await emit_vision_capability(
+                    ws,
+                    conversation=self._conversation,
+                    vmode=vmode,
+                    conn_config=conn_config,
+                    active_model=active_model,
+                )
 
             # v4·D Gauntlet G7-F: speak a short alert when the Tab5
             # auto-downgrades because the daily cap was hit.

--- a/dragon_voice/vision_capability.py
+++ b/dragon_voice/vision_capability.py
@@ -1,0 +1,141 @@
+"""Vision-capability advertisement — emits the `vision_capability`
+WS frame after each `config_update` so Tab5's camera screen knows
+which model (if any) will handle a vision turn at the current voice
+mode, and what each frame will cost in mils.
+
+2026-05-03 SOLID audit follow-up: extracted from
+`server.py:_handle_config_update` (~80 LOC).  Pre-extract this lived
+inline at the bottom of the 446-LOC handler, tangled with the
+config_update ACK + cap_downgrade speak-system trigger.  The three
+sub-responsibilities — config swap, vision advertise, cap-downgrade
+speak — change for different reasons (router fleet shape vs Tab5
+chip rendering vs cap policy) and shouldn't share a method.
+
+This module is the first step of the Wave 22a `WsDispatcher`-style
+decomposition: pull self-contained sub-responsibilities into
+purpose-specific modules so the giant handlers can shrink to thin
+coordinators.
+
+## Routing strategy
+
+Two paths handle vision-capability detection:
+
+1. **Router path** — when the active backend is a
+   `CapabilityAwareRouter`, ask `ConversationEngine.choose_vision_model`
+   for the spec it would pick.  Already covers ~12 cloud vendors via
+   `_PRICING_MILS_PER_M` (see OCP-2, PR #210) plus any local-tier
+   vision model in the fleet.
+
+2. **Single-backend fallback** — when the router isn't active,
+   substring-match the configured model id against the known vision
+   vendor list.  This list IS still hardcoded; promoting it to the
+   centralized capability registry is a separate audit follow-up
+   (OCP-1 sibling on the read path).
+
+Both paths route per-frame pricing through `vision_per_frame_mils()`
+so adding a vendor to the registry automatically gets correct mils.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from aiohttp import web
+
+from dragon_voice.llm.openrouter_llm import vision_per_frame_mils
+from dragon_voice.voice_modes import VoiceMode
+
+logger = logging.getLogger(__name__)
+
+
+# Substring hints for the single-backend (non-router) fallback.
+# Matches a vendor's marker substring against the configured model id;
+# any match means "this model handles vision".
+#
+# Kept here, not in voice_modes, because it's specifically about the
+# *current* OpenRouter cloud model registry — a different axis of
+# change than VoiceMode tier semantics.  Add new vision-capable
+# OpenRouter vendors here when they ship.
+_VISION_HINT_SUBSTRINGS_CLOUD: tuple[str, ...] = (
+    "gpt-4o", "sonnet", "haiku", "gemini",
+    "opus", "grok", "kimi", "qwen3.6", "glm", "mimo",
+)
+
+# Local-mode (Ollama) vision hints — same shape as the cloud list.
+_VISION_HINT_SUBSTRINGS_LOCAL: tuple[str, ...] = ("vision", "llava")
+
+
+async def emit_vision_capability(
+    ws: web.WebSocketResponse,
+    *,
+    conversation: Optional[Any],   # ConversationEngine — Any to dodge cycle
+    vmode: VoiceMode,
+    conn_config: Any,              # VoiceConfig — Any to dodge cycle
+    active_model: str,
+) -> None:
+    """Send a `vision_capability` WS frame to Tab5.
+
+    Always emits exactly one message (or zero if `ws.send_json` raises);
+    never raises out to the caller.  All exceptions are logged + eaten
+    so a config_update flow doesn't get torn down by a render failure
+    on a chip that's purely informational.
+
+    Args:
+        ws: Open WebSocket to Tab5.  Caller must check `ws.closed`
+            before invoking.
+        conversation: The active ConversationEngine, or None during
+            boot.  When the engine's LLM is a `CapabilityAwareRouter`,
+            its `choose_vision_model(voice_mode)` returns the spec
+            the router would pick — used here to populate the chip.
+        vmode: The active VoiceMode (post-config_update).
+        conn_config: Per-connection VoiceConfig — read for the
+            single-backend fallback's openrouter_model / ollama_model
+            substring match.
+        active_model: The post-swap LLM model id Tab5 sees on the
+            config_update ACK.  Used as the substring-fallback
+            display name when no router pick is available.
+    """
+    vision_model = ""
+    per_frame_mils = 0
+
+    # Router path — preferred when an active fleet exists.
+    spec = (
+        conversation.choose_vision_model(int(vmode))
+        if conversation is not None else None
+    )
+    if spec is not None:
+        vision_model = spec.model_id
+        # Local-tier sub-backends are free regardless of the canonical
+        # pricing table (which is OR-only); short-circuit to avoid a
+        # `_default`-table surprise on a local vision model id.
+        per_frame_mils = (
+            0 if spec.tier == "local"
+            else vision_per_frame_mils(spec.model_id)
+        )
+    else:
+        # Single-backend fallback — substring match on the configured
+        # model id.  Pricing routes through the centralized helper so
+        # adding a vendor to the substring list automatically gets
+        # correct mils via _PRICING_MILS_PER_M.
+        if vmode.is_cloud():
+            or_model_lc = conn_config.llm.openrouter_model.lower()
+            if any(h in or_model_lc for h in _VISION_HINT_SUBSTRINGS_CLOUD):
+                vision_model = active_model
+                per_frame_mils = vision_per_frame_mils(
+                    conn_config.llm.openrouter_model,
+                )
+        elif vmode.is_local():
+            om = conn_config.llm.ollama_model.lower()
+            if any(h in om for h in _VISION_HINT_SUBSTRINGS_LOCAL):
+                vision_model = active_model
+                per_frame_mils = 0  # local Ollama vision = no $ cost
+
+    try:
+        await ws.send_json({
+            "type":           "vision_capability",
+            "can_see":        bool(vision_model),
+            "model":          vision_model,
+            "per_frame_mils": per_frame_mils,
+        })
+    except Exception:
+        logger.exception("vision_capability emit failed")

--- a/tests/test_vision_capability_emit.py
+++ b/tests/test_vision_capability_emit.py
@@ -1,0 +1,210 @@
+"""Tests for ``dragon_voice.vision_capability.emit_vision_capability``.
+
+Pre-extract the vision-capability advertisement was 80 LOC inline in
+``server.py:_handle_config_update``.  Now that it's a free function
+with explicit inputs we can pin behaviour with unit tests instead of
+relying on the e2e harness.
+
+Six branches we care about:
+
+  1. **Router-active + cloud router pick** → router wins, mils > 0.
+  2. **Router-active + local router pick** → router wins, mils = 0.
+  3. **Router-active + no router pick** → falls through to substring
+     gate; cloud substring matches → mils > 0.
+  4. **No router + cloud substring miss** → can_see = False, mils = 0.
+  5. **No router + local Ollama vision substring** → can_see = True,
+     mils = 0.
+  6. **send_json raises** → silently logged, no exception out.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.vision_capability import emit_vision_capability
+from dragon_voice.voice_modes import VoiceMode
+
+
+def _make_conn_config(*, openrouter_model: str = "", ollama_model: str = "") -> MagicMock:
+    """Minimal VoiceConfig stub — only the fields the emitter reads."""
+    cfg = MagicMock()
+    cfg.llm.openrouter_model = openrouter_model
+    cfg.llm.ollama_model = ollama_model
+    return cfg
+
+
+def _make_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.send_json = AsyncMock()
+    return ws
+
+
+def _make_router_conversation(spec):
+    """Build a ConversationEngine stub whose `choose_vision_model`
+    returns ``spec`` (or None)."""
+    conv = MagicMock()
+    conv.choose_vision_model = MagicMock(return_value=spec)
+    return conv
+
+
+def _spec(model_id: str, tier: str):
+    """Minimal ModelSpec stub."""
+    s = MagicMock()
+    s.model_id = model_id
+    s.tier = tier
+    return s
+
+
+# ─── Router branches ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_router_picks_cloud_vision_model_emits_priced_chip():
+    ws = _make_ws()
+    conv = _make_router_conversation(_spec("anthropic/claude-sonnet-4.6", "cloud"))
+
+    await emit_vision_capability(
+        ws,
+        conversation=conv,
+        vmode=VoiceMode.CLOUD,
+        conn_config=_make_conn_config(openrouter_model="anthropic/claude-sonnet-4.6"),
+        active_model="anthropic/claude-sonnet-4.6",
+    )
+
+    ws.send_json.assert_awaited_once()
+    payload = ws.send_json.await_args.args[0]
+    assert payload["type"] == "vision_capability"
+    assert payload["can_see"] is True
+    assert payload["model"] == "anthropic/claude-sonnet-4.6"
+    assert payload["per_frame_mils"] > 0  # sonnet cloud → real mils
+    # Router's choose was asked for VoiceMode.CLOUD as int(2)
+    conv.choose_vision_model.assert_called_once_with(2)
+
+
+@pytest.mark.asyncio
+async def test_router_picks_local_vision_model_emits_zero_mils():
+    """Local-tier sub-backends short-circuit to per_frame=0 regardless
+    of what the canonical pricing table would say (which is OR-only)."""
+    ws = _make_ws()
+    conv = _make_router_conversation(
+        _spec("hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M", "local"),
+    )
+
+    await emit_vision_capability(
+        ws,
+        conversation=conv,
+        vmode=VoiceMode.LOCAL,
+        conn_config=_make_conn_config(),
+        active_model="ministral-3:3b",
+    )
+
+    payload = ws.send_json.await_args.args[0]
+    assert payload["can_see"] is True
+    assert payload["model"] == "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M"
+    assert payload["per_frame_mils"] == 0
+
+
+# ─── Single-backend (non-router) substring fallback ───────────────
+
+
+@pytest.mark.asyncio
+async def test_no_router_cloud_substring_match_emits_priced_chip():
+    """When ConversationEngine is non-router AND configured cloud model
+    matches a known vision-vendor substring, advertise it."""
+    ws = _make_ws()
+    conv = _make_router_conversation(spec=None)  # router has no pick
+
+    await emit_vision_capability(
+        ws,
+        conversation=conv,
+        vmode=VoiceMode.CLOUD,
+        conn_config=_make_conn_config(openrouter_model="anthropic/claude-opus-4.7"),
+        active_model="anthropic/claude-opus-4.7",
+    )
+
+    payload = ws.send_json.await_args.args[0]
+    assert payload["can_see"] is True
+    assert payload["model"] == "anthropic/claude-opus-4.7"
+    assert payload["per_frame_mils"] > 0  # OCP-2 fix: opus is now priced
+
+
+@pytest.mark.asyncio
+async def test_no_router_cloud_substring_miss_emits_no_capability():
+    """An OpenRouter model that's not in the vision-vendor substring
+    list (e.g. plain DeepSeek text-only) advertises ``can_see=False``."""
+    ws = _make_ws()
+    conv = _make_router_conversation(spec=None)
+
+    await emit_vision_capability(
+        ws,
+        conversation=conv,
+        vmode=VoiceMode.CLOUD,
+        conn_config=_make_conn_config(openrouter_model="deepseek/deepseek-v4-flash"),
+        active_model="deepseek/deepseek-v4-flash",
+    )
+
+    payload = ws.send_json.await_args.args[0]
+    assert payload["can_see"] is False
+    assert payload["model"] == ""
+    assert payload["per_frame_mils"] == 0
+
+
+@pytest.mark.asyncio
+async def test_no_router_local_ollama_vision_substring_match():
+    """Ollama models with 'vision' or 'llava' in the name advertise
+    a free-tier vision capability."""
+    ws = _make_ws()
+    conv = _make_router_conversation(spec=None)
+
+    await emit_vision_capability(
+        ws,
+        conversation=conv,
+        vmode=VoiceMode.LOCAL,
+        conn_config=_make_conn_config(ollama_model="llava:7b"),
+        active_model="llava:7b",
+    )
+
+    payload = ws.send_json.await_args.args[0]
+    assert payload["can_see"] is True
+    assert payload["model"] == "llava:7b"
+    assert payload["per_frame_mils"] == 0
+
+
+@pytest.mark.asyncio
+async def test_conversation_none_no_router_call():
+    """During boot the engine may not be wired yet — must not crash."""
+    ws = _make_ws()
+    await emit_vision_capability(
+        ws,
+        conversation=None,
+        vmode=VoiceMode.CLOUD,
+        conn_config=_make_conn_config(openrouter_model="anthropic/claude-haiku-4.5"),
+        active_model="anthropic/claude-haiku-4.5",
+    )
+    payload = ws.send_json.await_args.args[0]
+    # Falls through to substring gate; haiku is in the cloud vision list.
+    assert payload["can_see"] is True
+
+
+# ─── Failure-isolation contract ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_failure_swallowed():
+    """If `ws.send_json` raises, the emitter logs + returns cleanly so
+    a render failure on the chip doesn't tear down the config_update
+    flow."""
+    ws = _make_ws()
+    ws.send_json = AsyncMock(side_effect=ConnectionResetError("client gone"))
+    conv = _make_router_conversation(spec=None)
+
+    # Must NOT raise.
+    await emit_vision_capability(
+        ws,
+        conversation=conv,
+        vmode=VoiceMode.LOCAL,
+        conn_config=_make_conn_config(),
+        active_model="ministral-3:3b",
+    )
+    ws.send_json.assert_awaited_once()


### PR DESCRIPTION
## What

First **Wave 22a-style sub-handler extraction** from \`_handle_config_update\` (446 LOC, audit's #1 SRP offender).

Pulls the vision-capability advertisement (~80 LOC inline) out into a free function \`emit_vision_capability\` in a new [\`dragon_voice/vision_capability.py\`](dragon_voice/vision_capability.py) module.

## Why this is the right first cut

\`_handle_config_update\` owns three different responsibilities that change for different reasons:

| Responsibility | Why it changes |
|---|---|
| Config swap (STT/TTS/LLM backend selection + validation + pipeline + ConvEngine swap) | Router fleet shape, mode tier policy |
| **Vision-capability advertisement** | Tab5 camera-screen chip render data |
| Cap-downgrade speak-system trigger | Budget-cap policy |

The vision block is the most self-contained — pure function inputs (\`vmode\`, \`conn_config\`, \`active_model\`, \`conversation\`, \`ws\`), single output (a \`vision_capability\` WS frame), no return value to the caller. **Perfect first slice.**

## What moved

The full vision-capability block from server.py:2452-2526 (including the OCP-2 / OCP-1 / ENC-1 audit fixes from #210/#211/#212) → \`vision_capability.emit_vision_capability(...)\`.

The new module also pulls the substring registries (\`_VISION_HINT_SUBSTRINGS_CLOUD\`, \`_VISION_HINT_SUBSTRINGS_LOCAL\`) out of inline tuples into module-level constants so adding a new vendor doesn't require finding the right line inside a 446-LOC handler.

## Server.py shrink

| Metric | Value |
|---|---|
| This PR | 2736 → 2677 LOC (−59, −2.2 %) |
| \`_handle_config_update\` vision block | ~80 LOC inline → 9 LOC call |

## Tests

[\`tests/test_vision_capability_emit.py\`](tests/test_vision_capability_emit.py) — 7 tests pinning all six branches:

| # | Branch | Expected |
|---|---|---|
| 1 | Router-active + cloud router pick | Priced chip (mils > 0) |
| 2 | Router-active + local router pick | Free chip (mils = 0) |
| 3 | No-router-pick + cloud substring match | Priced chip via \`vision_per_frame_mils()\` |
| 4 | No-router-pick + cloud substring miss | \`can_see=False\` |
| 5 | No-router-pick + local Ollama \"vision\"/\"llava\" | Free chip |
| 6 | ConversationEngine None during boot | Falls through to substring gate; doesn't crash |
| 7 | \`ws.send_json\` raises | Swallowed via \`logger.exception\`, no crash |

These tests would have caught the prior OCP-2 silent-zero bug fixed in [#210](https://github.com/lorcan35/TinkerBox/pull/210); the previously-zeroed cloud vendors (Opus, Grok, Kimi, Qwen 3.6, GLM, MiMo) are now exercised by branch #3.

## Verification

\`\`\`
\$ python3 -m pytest tests/test_vision_capability_emit.py -v
7 passed in 0.09s

\$ python3 -m pytest tests/ --ignore=tests/audit -q
719 passed, 108 subtests passed, 1 skipped, 0 failed in 11.31s

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \\
    dragon_voice/ tests/
All checks passed!
\`\`\`

## Sets the pattern

This is the **model for future Wave 22a-style extractions**: pure function with explicit dependencies, dedicated module, dedicated test file pinning each branch. No \`self\` reach-throughs, no \`ConversationEngine\` private access (uses the public \`choose_vision_model\` accessor from #212). Each per-handler sub-responsibility can extract this same way without forcing a big-bang dispatcher rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)