### PR TITLE
refactor(server): extract cap_downgrade alert out of _handle_config_update

### DIFF
--- a/dragon_voice/cap_downgrade.py
+++ b/dragon_voice/cap_downgrade.py
@@ -1,0 +1,84 @@
+"""Budget-cap-downgrade speak-system alert.
+
+Wave 23 SOLID-audit follow-up (sibling of vision_capability extract):
+splits the third sub-responsibility out of `_handle_config_update`.
+After this PR, the bottom of `_handle_config_update` is a thin
+coordinator that calls three focused functions:
+
+  * config swap (still inline — biggest extract candidate next)
+  * `vision_capability.emit_vision_capability` (PR #214)
+  * `cap_downgrade.maybe_speak_cap_downgrade_alert` (this module)
+
+## What this does
+
+When Tab5 sends a `config_update` whose `reason` field is
+`"cap_downgrade"` (i.e. the daily budget cap was hit and Tab5
+auto-flipped voice mode back to LOCAL), Dragon speaks a short
+TTS alert via the active pipeline so the user hears the change
+even with the screen off.
+
+The `pipeline.speak_system(...)` call returns an awaitable; we
+spawn it as a tracked background task so it doesn't block the
+config_update flow.  Tracking lives in `conn_state["bg_tasks"]`
+(or `conn_state.bg_tasks`) so `_handle_disconnect` can cancel
+the alert if the user closes the WS mid-utterance (Wave 14
+W14-C06).
+
+## Failure isolation
+
+The whole call is best-effort.  If anything raises (pipeline
+gone, speak_system not implemented on the active pipeline class,
+TTS backend down, asyncio task creation fails), the failure is
+logged and swallowed.  A failed alert must never tear down the
+config_update flow itself.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# The ack message Dragon speaks when Tab5 reports a cap_downgrade.
+# Centralised here so the wording is in one place + can be A/B-tested
+# or i18n'd in a follow-up without grepping the WS dispatcher.
+_CAP_DOWNGRADE_ALERT_TEXT = "Daily budget cap reached. Switched back to local mode."
+
+
+def maybe_speak_cap_downgrade_alert(cmd: dict, conn_state: Any) -> None:
+    """If the config_update reports a cap_downgrade, spawn a tracked
+    background TTS task that speaks the cap-hit alert.
+
+    No-op when:
+      * `cmd["reason"]` is not `"cap_downgrade"`
+      * the connection has no pipeline yet (boot race)
+      * the active pipeline class doesn't expose `speak_system`
+        (e.g. tests with a stub pipeline)
+
+    Args:
+        cmd: The parsed `config_update` WS frame.
+        conn_state: ConnState (or compat dict) for the connection.
+            Must expose `.get("pipeline")` and `["bg_tasks"]` —
+            both are satisfied by ConnState's dict-protocol shim
+            and by plain dicts used in tests.
+
+    Returns:
+        None.  All work is fire-and-forget; the spawned task is
+        discoverable via `conn_state["bg_tasks"]` for later
+        cancellation by `_handle_disconnect`.
+    """
+    try:
+        if cmd.get("reason") != "cap_downgrade":
+            return
+        pipeline = conn_state.get("pipeline")
+        if not pipeline or not hasattr(pipeline, "speak_system"):
+            return
+        # Wave 14 W14-C06: track the task so _handle_disconnect can
+        # cancel it if the user closes mid-utterance.
+        bg = conn_state["bg_tasks"]
+        t = asyncio.create_task(pipeline.speak_system(_CAP_DOWNGRADE_ALERT_TEXT))
+        bg.add(t)
+        t.add_done_callback(bg.discard)
+    except Exception:
+        logger.exception("cap_downgrade alert failed")

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -20,6 +20,7 @@ from typing import AsyncIterator, Optional
 import aiohttp
 from aiohttp import web, WSMsgType
 
+from dragon_voice.cap_downgrade import maybe_speak_cap_downgrade_alert
 from dragon_voice.conn_state import ConnState
 from dragon_voice.media.store import MediaStore
 from dragon_voice.media.pipeline import MediaPipeline
@@ -2468,21 +2469,12 @@ class VoiceServer:
 
             # v4·D Gauntlet G7-F: speak a short alert when the Tab5
             # auto-downgrades because the daily cap was hit.
-            try:
-                if cmd.get("reason") == "cap_downgrade":
-                    pipeline = conn_state.get("pipeline")
-                    if pipeline and hasattr(pipeline, "speak_system"):
-                        # Wave 14 W14-C06: track the task so
-                        # _handle_disconnect can cancel it if the user
-                        # closes mid-utterance.
-                        bg = conn_state["bg_tasks"]
-                        t = asyncio.create_task(pipeline.speak_system(
-                            "Daily budget cap reached. Switched back to local mode."
-                        ))
-                        bg.add(t)
-                        t.add_done_callback(bg.discard)
-            except Exception:
-                logger.exception("cap_downgrade alert failed")
+            # Extracted to cap_downgrade.maybe_speak_cap_downgrade_alert
+            # in the SOLID-audit follow-up — this and the vision-
+            # capability emit above were the two cleanest "different
+            # axis of change" sub-responsibilities to split out of
+            # _handle_config_update.
+            maybe_speak_cap_downgrade_alert(cmd, conn_state)
 
     async def _handle_user_media(self, ws, conn_state, cmd):
         """Handle image/audio uploaded by Tab5 for multimodal LLM analysis.

--- a/tests/test_cap_downgrade_alert.py
+++ b/tests/test_cap_downgrade_alert.py
@@ -1,0 +1,131 @@
+"""Tests for ``dragon_voice.cap_downgrade.maybe_speak_cap_downgrade_alert``.
+
+Pin five branches:
+
+  1. **Happy path** — cmd reports cap_downgrade + pipeline has
+     speak_system → task is spawned + tracked in bg_tasks.
+  2. **Wrong reason** — cmd has a different reason → no task.
+  3. **No pipeline** — connection still booting → no task, no crash.
+  4. **Pipeline lacks speak_system** — e.g. a stub in tests → no task.
+  5. **Failure isolation** — anything raising inside the function is
+     logged + swallowed so the config_update flow keeps going.
+
+Tests are sync (no @pytest.mark.asyncio) because the function under
+test is sync — it spawns the task via `asyncio.create_task` but doesn't
+await it.  Tests run inside an asyncio.Loop via `asyncio.run` so
+`create_task` has a loop to attach to.
+"""
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from dragon_voice.cap_downgrade import maybe_speak_cap_downgrade_alert
+
+
+def _make_conn_state(pipeline=None) -> dict:
+    """Plain-dict conn_state stub (mirrors test_config_update_*.py shape)."""
+    return {"pipeline": pipeline, "bg_tasks": set()}
+
+
+def _make_pipeline_with_speak_system() -> MagicMock:
+    p = MagicMock()
+    p.speak_system = AsyncMock()
+    return p
+
+
+class CapDowngradeAlertTests(unittest.TestCase):
+    def test_happy_path_spawns_tracked_task(self):
+        async def go():
+            pipeline = _make_pipeline_with_speak_system()
+            conn = _make_conn_state(pipeline=pipeline)
+            cmd = {"reason": "cap_downgrade", "voice_mode": 0}
+
+            maybe_speak_cap_downgrade_alert(cmd, conn)
+
+            # Task spawned + tracked.
+            self.assertEqual(len(conn["bg_tasks"]), 1)
+            # Wait for it to actually run.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            pipeline.speak_system.assert_awaited_once_with(
+                "Daily budget cap reached. Switched back to local mode."
+            )
+
+        asyncio.run(go())
+
+    def test_wrong_reason_does_nothing(self):
+        async def go():
+            pipeline = _make_pipeline_with_speak_system()
+            conn = _make_conn_state(pipeline=pipeline)
+            for reason in (None, "", "user_initiated", "swap", "tc_fallback"):
+                cmd = {"reason": reason}
+                maybe_speak_cap_downgrade_alert(cmd, conn)
+            self.assertEqual(len(conn["bg_tasks"]), 0)
+            pipeline.speak_system.assert_not_called()
+
+        asyncio.run(go())
+
+    def test_no_pipeline_does_not_crash(self):
+        """During boot the pipeline isn't wired yet — a config_update
+        with cap_downgrade reason must skip silently."""
+        async def go():
+            conn = _make_conn_state(pipeline=None)
+            cmd = {"reason": "cap_downgrade"}
+            maybe_speak_cap_downgrade_alert(cmd, conn)
+            self.assertEqual(len(conn["bg_tasks"]), 0)
+
+        asyncio.run(go())
+
+    def test_pipeline_without_speak_system_does_nothing(self):
+        """A stub pipeline (test path or pre-Wave-14 backend) doesn't
+        have speak_system; we must skip cleanly."""
+        async def go():
+            pipeline = MagicMock(spec=[])  # empty spec — no methods
+            conn = _make_conn_state(pipeline=pipeline)
+            cmd = {"reason": "cap_downgrade"}
+            maybe_speak_cap_downgrade_alert(cmd, conn)
+            self.assertEqual(len(conn["bg_tasks"]), 0)
+
+        asyncio.run(go())
+
+    def test_failure_isolation_swallows_all(self):
+        """If anything raises (e.g. bg_tasks missing from conn_state),
+        the function logs and returns cleanly — must not crash up to
+        the caller."""
+        async def go():
+            pipeline = _make_pipeline_with_speak_system()
+            # Conn state missing bg_tasks key — will raise KeyError
+            # at `conn_state["bg_tasks"]`.
+            conn = {"pipeline": pipeline}
+            # Must NOT raise.
+            maybe_speak_cap_downgrade_alert({"reason": "cap_downgrade"}, conn)
+
+        asyncio.run(go())
+
+    def test_done_callback_discards_from_bg_tasks(self):
+        """When the spawned task completes, it removes itself from
+        bg_tasks so the set doesn't grow unbounded across many
+        cap_downgrade events in a long-lived session."""
+        async def go():
+            pipeline = _make_pipeline_with_speak_system()
+            conn = _make_conn_state(pipeline=pipeline)
+
+            maybe_speak_cap_downgrade_alert({"reason": "cap_downgrade"}, conn)
+            self.assertEqual(len(conn["bg_tasks"]), 1)
+
+            # Drain pending callbacks.  speak_system is an AsyncMock
+            # that returns immediately, so the task completes after
+            # one event-loop iteration; the done-callback runs the
+            # iteration after.
+            for _ in range(5):
+                await asyncio.sleep(0)
+
+            self.assertEqual(len(conn["bg_tasks"]), 0)
+
+        asyncio.run(go())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Sibling of [#214](https://github.com/lorcan35/TinkerBox/pull/214) (vision_capability extract). Pulls the budget-cap-downgrade speak-system trigger out of the bottom of \`_handle_config_update\` into a new [\`dragon_voice/cap_downgrade.py\`](dragon_voice/cap_downgrade.py) module.

After this PR, the bottom of \`_handle_config_update\` is a thin coordinator — three sub-responsibilities, three focused calls:

\`\`\`python
await ws.send_json({...})              # config_update ACK (still inline)
await emit_vision_capability(...)      # vision chip render data (PR #214)
maybe_speak_cap_downgrade_alert(...)   # cap-hit TTS alert (this PR)
\`\`\`

Each call site is one line + a comment. Each module owns its own contract, its own failure isolation, its own tests. None reach back into \`self\`.

## Tests

[\`tests/test_cap_downgrade_alert.py\`](tests/test_cap_downgrade_alert.py) — 6 tests:

| # | Branch | Behaviour |
|---|---|---|
| 1 | Happy path | Tracked task spawned + speak_system awaited with canonical text |
| 2 | Wrong reason (None / \"\" / \"user_initiated\" / \"swap\" / \"tc_fallback\") | No task, no speak |
| 3 | No pipeline (boot race) | Silent skip, no crash |
| 4 | Pipeline missing speak_system (test stubs) | Silent skip |
| 5 | Failure isolation: bg_tasks key missing | Caught + logged, no crash up to caller |
| 6 | Done-callback discards task from bg_tasks | Set doesn't grow unbounded across many cap_downgrade events |

The alert text moves with it (centralised as \`_CAP_DOWNGRADE_ALERT_TEXT\` so a future i18n / A/B test doesn't require grepping the WS dispatcher).

## Verification

\`\`\`
\$ python3 -m pytest tests/test_cap_downgrade_alert.py -v
6 passed in 0.01s

\$ python3 -m pytest tests/ --ignore=tests/audit -q
725 passed, 108 subtests passed, 1 skipped, 0 failed in 11.19s

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \\
    dragon_voice/ tests/
All checks passed!
\`\`\`

## server.py shrink

| Metric | Value |
|---|---|
| This PR | 2677 → 2669 LOC (−8 net; 17 LOC removed, 9 LOC of comment + 1-line call added) |
| Cumulative across this round (#211/212/213/214/this) | 2714 → 2669 (−45 LOC, plus 5 new modules with focused responsibilities) |

## Sets the stage

The remaining \`_handle_config_update\` body (~370 LOC) is now ~75% the config-swap chain itself: voice_mode resolution + STT/TTS/LLM backend selection + validation + per-pipeline + ConvEngine swap. **That's the natural target for the next (and biggest) extraction:** a \`ConfigSwapPolicy\` module that owns the mode-tier → backend-selection mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)