### PR TITLE
refactor(server): extract backend selection to config_swap.select_backends_for_mode (~42 LOC)

### DIFF
--- a/dragon_voice/config_swap.py
+++ b/dragon_voice/config_swap.py
@@ -1,0 +1,154 @@
+"""Voice-mode → backend selection (the heart of `_handle_config_update`).
+
+2026-05-03 SOLID audit follow-up — third sub-handler extraction from
+`_handle_config_update`.  Sister of:
+
+  * `vision_capability.emit_vision_capability` (PR #214)
+  * `cap_downgrade.maybe_speak_cap_downgrade_alert` (PR #215)
+
+This module owns the mapping from `(VoiceMode, llm_model_request) →
+(stt_backend, tts_backend, llm_backend)` and the matching mutation of
+`conn_config.llm` (model id + mode-aware system prompt + max_tokens).
+The validation paths (TC health check, OpenRouter key check, TC token
+check) stay in `server.py` for now — they need to send WS error frames
+and early-return out of the handler, which is harder to factor out
+without growing a "skip the rest of config_update" return code.
+
+## API surface
+
+A single function `select_backends_for_mode(vmode, conn_config,
+llm_model=None) -> BackendSelection` returns the chosen triple.  It
+mutates `conn_config.llm` in place to apply mode-aware overrides
+(system prompt, max tokens, model id).  Both behaviours match the
+pre-extract code byte-for-byte.
+
+## Why a dataclass return value
+
+The pre-extract code wrote into three local variables (`stt_be`,
+`tts_be`, `llm_be`) and used them ~5 times further down in
+`_handle_config_update`.  Returning a dataclass keeps that surface
+typed without forcing the caller to thread three positional args.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from dragon_voice.config import (
+    SYSTEM_PROMPT_CLOUD,
+    SYSTEM_PROMPT_HYBRID,
+    SYSTEM_PROMPT_LOCAL,
+    MAX_TOKENS_CLOUD,
+    MAX_TOKENS_HYBRID,
+    MAX_TOKENS_LOCAL,
+)
+from dragon_voice.voice_modes import VoiceMode
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BackendSelection:
+    """Result of `select_backends_for_mode`.  Holds the three backend
+    names that were chosen.  Side effects on `conn_config.llm` (model
+    id + system_prompt + max_tokens overrides) happened during the
+    selection — see the function docstring."""
+
+    stt_backend: str
+    tts_backend: str
+    llm_backend: str
+
+
+def select_backends_for_mode(
+    vmode: VoiceMode,
+    conn_config: Any,                  # VoiceConfig — Any to dodge cycle
+    llm_model: Optional[str] = None,
+) -> BackendSelection:
+    """Resolve STT/TTS/LLM backend names for `vmode` and apply
+    mode-aware overrides to `conn_config.llm` in place.
+
+    ## Backend triple per VoiceMode
+
+    | Mode | STT | TTS | LLM |
+    |------|-----|-----|-----|
+    | LOCAL | moonshine | piper | local_backend (default ollama) |
+    | HYBRID | openrouter | openrouter | local_backend (default ollama) |
+    | CLOUD | openrouter | openrouter | openrouter |
+    | TINKERCLAW | moonshine* | piper* | tinkerclaw |
+    | ONBOARD | (Tab5-side only — never reaches Dragon) | — | — |
+
+    *TinkerClaw with `"cloud"` in the requested `llm_model` overrides
+    its STT/TTS to OpenRouter (matches Tab5's voice_mode=3 + cloud
+    suffix UX).
+
+    ## conn_config.llm mutations
+
+    * `tinkerclaw_model` — set when vmode==TINKERCLAW and `llm_model`
+      is non-empty.
+    * `openrouter_model` — set when vmode==CLOUD and `llm_model` is
+      non-empty.
+    * `ollama_model` — set when local-tier + `llm_model` is a plain
+      identifier (no `/` — vendor-prefix means cloud override).
+    * `system_prompt` + `max_tokens` — flipped per VoiceMode tier
+      (LOCAL/HYBRID/CLOUD); TINKERCLAW skips because the gateway
+      manages its own personality.
+
+    ## Wire-protocol invariant
+
+    Pre-extract behaviour is preserved bit-for-bit.  This is a pure
+    refactor to give the mode→backend mapping its own home + tests.
+
+    Args:
+        vmode: The active VoiceMode for the connection.
+        conn_config: Per-connection VoiceConfig (mutated in place).
+        llm_model: Optional model id from the WS frame.  Empty / None
+            means "keep the configured default for this tier".
+
+    Returns:
+        BackendSelection with the three chosen backend names.
+    """
+    # ── STT + TTS ───────────────────────────────────────────────
+    if vmode.is_local():
+        stt_be, tts_be = "moonshine", "piper"
+    elif vmode.is_tinkerclaw():
+        # TinkerClaw mode: default local STT/TTS.
+        # "cloud" suffix in llm_model → use OpenRouter STT/TTS.
+        if llm_model and "cloud" in llm_model.lower():
+            stt_be, tts_be = "openrouter", "openrouter"
+        else:
+            stt_be, tts_be = "moonshine", "piper"
+    else:
+        stt_be, tts_be = "openrouter", "openrouter"
+
+    # ── LLM ─────────────────────────────────────────────────────
+    if vmode.is_tinkerclaw():
+        # TinkerClaw mode — gateway handles everything.
+        llm_be = "tinkerclaw"
+        if llm_model:
+            conn_config.llm.tinkerclaw_model = llm_model
+    elif vmode.is_cloud():
+        llm_be = "openrouter"
+        if llm_model:
+            conn_config.llm.openrouter_model = llm_model
+    else:
+        llm_be = conn_config.llm.local_backend or "ollama"
+        if llm_model and llm_be == "ollama" and "/" not in llm_model:
+            conn_config.llm.ollama_model = llm_model
+            logger.info("Local model switched to: %s", llm_model)
+
+    # ── Mode-aware system prompt + max_tokens ───────────────────
+    # TINKERCLAW: skip — TinkerClaw owns personality + token budget.
+    if vmode.is_tinkerclaw():
+        pass
+    elif vmode.is_local():
+        conn_config.llm.system_prompt = SYSTEM_PROMPT_LOCAL
+        conn_config.llm.max_tokens = MAX_TOKENS_LOCAL
+    elif vmode.is_hybrid():
+        conn_config.llm.system_prompt = SYSTEM_PROMPT_HYBRID
+        conn_config.llm.max_tokens = MAX_TOKENS_HYBRID
+    else:
+        conn_config.llm.system_prompt = SYSTEM_PROMPT_CLOUD
+        conn_config.llm.max_tokens = MAX_TOKENS_CLOUD
+
+    return BackendSelection(stt_backend=stt_be, tts_backend=tts_be, llm_backend=llm_be)

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -21,6 +21,7 @@ import aiohttp
 from aiohttp import web, WSMsgType
 
 from dragon_voice.cap_downgrade import maybe_speak_cap_downgrade_alert
+from dragon_voice.config_swap import select_backends_for_mode
 from dragon_voice.conn_state import ConnState
 from dragon_voice.media.store import MediaStore
 from dragon_voice.media.pipeline import MediaPipeline
@@ -2168,48 +2169,15 @@ class VoiceServer:
                 )
                 vmode = VoiceMode.LOCAL
 
-            # STT+TTS: local for LOCAL, cloud for HYBRID/CLOUD/TINKERCLAW
-            if vmode.is_local():
-                stt_be, tts_be = "moonshine", "piper"
-            elif vmode.is_tinkerclaw():
-                # TinkerClaw mode: default local STT/TTS
-                # "cloud" suffix in llm_model → use OpenRouter STT/TTS
-                if llm_model and "cloud" in llm_model.lower():
-                    stt_be, tts_be = "openrouter", "openrouter"
-                else:
-                    stt_be, tts_be = "moonshine", "piper"
-            else:
-                stt_be, tts_be = "openrouter", "openrouter"
-
-            # LLM backend selection
-            if vmode.is_tinkerclaw():
-                # TinkerClaw mode — gateway handles everything
-                llm_be = "tinkerclaw"
-                if llm_model:
-                    conn_config.llm.tinkerclaw_model = llm_model
-            elif vmode.is_cloud():
-                llm_be = "openrouter"
-                if llm_model:
-                    conn_config.llm.openrouter_model = llm_model
-            else:
-                llm_be = conn_config.llm.local_backend or "ollama"
-                if llm_model and llm_be == "ollama" and "/" not in llm_model:
-                    conn_config.llm.ollama_model = llm_model
-                    logger.info("Local model switched to: %s", llm_model)
-
-            # Apply mode-aware system prompt and max_tokens.
-            # TINKERCLAW: skip — TinkerClaw owns personality + token budget.
-            if vmode.is_tinkerclaw():
-                pass  # TinkerClaw manages its own prompts and limits
-            elif vmode.is_local():
-                conn_config.llm.system_prompt = SYSTEM_PROMPT_LOCAL
-                conn_config.llm.max_tokens = MAX_TOKENS_LOCAL
-            elif vmode.is_hybrid():
-                conn_config.llm.system_prompt = SYSTEM_PROMPT_HYBRID
-                conn_config.llm.max_tokens = MAX_TOKENS_HYBRID
-            else:
-                conn_config.llm.system_prompt = SYSTEM_PROMPT_CLOUD
-                conn_config.llm.max_tokens = MAX_TOKENS_CLOUD
+            # SOLID-audit follow-up: backend selection extracted to
+            # config_swap.select_backends_for_mode().  The function
+            # owns the (vmode, llm_model) → (stt, tts, llm) mapping AND
+            # the matching mutation of conn_config.llm (model id +
+            # mode-aware system_prompt + max_tokens).  Behaviour is
+            # bit-for-bit identical to the prior inline chain;
+            # tests/test_config_swap.py pins all 12 branches.
+            sel = select_backends_for_mode(vmode, conn_config, llm_model=llm_model)
+            stt_be, tts_be, llm_be = sel.stt_backend, sel.tts_backend, sel.llm_backend
 
             logger.info("Connection %s: voice_mode=%d (%s) → stt=%s tts=%s llm=%s model=%s tokens=%d",
                         ws_id, int(vmode), vmode.name, stt_be, tts_be, llm_be,

--- a/tests/test_config_swap.py
+++ b/tests/test_config_swap.py
@@ -1,0 +1,184 @@
+"""Tests for ``dragon_voice.config_swap.select_backends_for_mode``.
+
+Pin the full mode-tier → backend-triple mapping that previously lived
+inline in ``server.py:_handle_config_update`` (lines 2152-2212).
+
+Per VoiceMode, four assertions:
+  1. The right STT/TTS/LLM triple is returned.
+  2. The mode-specific system_prompt is applied to ``conn_config.llm``.
+  3. The mode-specific max_tokens is applied.
+  4. The right model-id field on conn_config is updated when an
+     ``llm_model`` arg is passed (and skipped when not relevant).
+
+Plus dedicated tests for the TinkerClaw-with-"cloud"-suffix override,
+the local-mode "vendor/model" rejection, and the TinkerClaw skip-
+prompt path.
+"""
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass, field
+
+from dragon_voice.config import (
+    SYSTEM_PROMPT_CLOUD,
+    SYSTEM_PROMPT_HYBRID,
+    SYSTEM_PROMPT_LOCAL,
+    MAX_TOKENS_CLOUD,
+    MAX_TOKENS_HYBRID,
+    MAX_TOKENS_LOCAL,
+)
+from dragon_voice.config_swap import select_backends_for_mode
+from dragon_voice.voice_modes import VoiceMode
+
+
+@dataclass
+class _StubLlmCfg:
+    """Minimal subset of LLMConfig used by select_backends_for_mode."""
+    backend: str = "ollama"
+    local_backend: str = ""
+    openrouter_model: str = ""
+    ollama_model: str = "ministral-3:3b"
+    tinkerclaw_model: str = ""
+    system_prompt: str = "(initial)"
+    max_tokens: int = 0
+
+
+@dataclass
+class _StubVoiceCfg:
+    llm: _StubLlmCfg = field(default_factory=_StubLlmCfg)
+
+
+class SelectBackendsTests(unittest.TestCase):
+    # ── LOCAL ────────────────────────────────────────────────────
+
+    def test_local_picks_moonshine_piper_ollama(self):
+        cfg = _StubVoiceCfg()
+        sel = select_backends_for_mode(VoiceMode.LOCAL, cfg)
+
+        self.assertEqual(sel.stt_backend, "moonshine")
+        self.assertEqual(sel.tts_backend, "piper")
+        self.assertEqual(sel.llm_backend, "ollama")
+        self.assertEqual(cfg.llm.system_prompt, SYSTEM_PROMPT_LOCAL)
+        self.assertEqual(cfg.llm.max_tokens, MAX_TOKENS_LOCAL)
+
+    def test_local_with_plain_model_id_updates_ollama_model(self):
+        cfg = _StubVoiceCfg()
+        select_backends_for_mode(VoiceMode.LOCAL, cfg, llm_model="gemma3:4b")
+        self.assertEqual(cfg.llm.ollama_model, "gemma3:4b")
+
+    def test_local_with_vendor_prefix_rejects_model_update(self):
+        """`anthropic/claude-3.5-haiku` is a CLOUD identifier; if it
+        somehow lands in a LOCAL config_update, skip the ollama_model
+        write rather than corrupt the local config."""
+        cfg = _StubVoiceCfg()
+        cfg.llm.ollama_model = "ministral-3:3b"
+        select_backends_for_mode(
+            VoiceMode.LOCAL, cfg,
+            llm_model="anthropic/claude-3.5-haiku",
+        )
+        # The "/" guard at config_swap.py:135 keeps the ollama_model
+        # untouched.
+        self.assertEqual(cfg.llm.ollama_model, "ministral-3:3b")
+
+    def test_local_with_local_backend_override(self):
+        """When `local_backend` is set, use it instead of defaulting
+        to ollama (e.g. user configured npu_genie)."""
+        cfg = _StubVoiceCfg()
+        cfg.llm.local_backend = "npu_genie"
+        sel = select_backends_for_mode(VoiceMode.LOCAL, cfg)
+        self.assertEqual(sel.llm_backend, "npu_genie")
+
+    # ── HYBRID ───────────────────────────────────────────────────
+
+    def test_hybrid_picks_openrouter_stt_tts_local_llm(self):
+        cfg = _StubVoiceCfg()
+        sel = select_backends_for_mode(VoiceMode.HYBRID, cfg)
+
+        self.assertEqual(sel.stt_backend, "openrouter")
+        self.assertEqual(sel.tts_backend, "openrouter")
+        self.assertEqual(sel.llm_backend, "ollama")  # local-tier LLM
+        self.assertEqual(cfg.llm.system_prompt, SYSTEM_PROMPT_HYBRID)
+        self.assertEqual(cfg.llm.max_tokens, MAX_TOKENS_HYBRID)
+
+    # ── CLOUD ────────────────────────────────────────────────────
+
+    def test_cloud_picks_openrouter_for_all_three(self):
+        cfg = _StubVoiceCfg()
+        sel = select_backends_for_mode(VoiceMode.CLOUD, cfg)
+
+        self.assertEqual(sel.stt_backend, "openrouter")
+        self.assertEqual(sel.tts_backend, "openrouter")
+        self.assertEqual(sel.llm_backend, "openrouter")
+        self.assertEqual(cfg.llm.system_prompt, SYSTEM_PROMPT_CLOUD)
+        self.assertEqual(cfg.llm.max_tokens, MAX_TOKENS_CLOUD)
+
+    def test_cloud_with_llm_model_updates_openrouter_model(self):
+        cfg = _StubVoiceCfg()
+        select_backends_for_mode(
+            VoiceMode.CLOUD, cfg,
+            llm_model="anthropic/claude-opus-4.7",
+        )
+        self.assertEqual(cfg.llm.openrouter_model, "anthropic/claude-opus-4.7")
+
+    # ── TINKERCLAW ───────────────────────────────────────────────
+
+    def test_tinkerclaw_default_uses_local_stt_tts(self):
+        cfg = _StubVoiceCfg()
+        sel = select_backends_for_mode(VoiceMode.TINKERCLAW, cfg)
+
+        self.assertEqual(sel.stt_backend, "moonshine")
+        self.assertEqual(sel.tts_backend, "piper")
+        self.assertEqual(sel.llm_backend, "tinkerclaw")
+
+    def test_tinkerclaw_with_cloud_suffix_overrides_to_openrouter_stt_tts(self):
+        """A llm_model containing 'cloud' (e.g.
+        'cloud:claude-sonnet-4.6') flips STT/TTS to OpenRouter while
+        keeping TinkerClaw as the LLM gateway.  Matches Tab5's
+        voice_mode=3 + cloud-suffix UX."""
+        cfg = _StubVoiceCfg()
+        sel = select_backends_for_mode(
+            VoiceMode.TINKERCLAW, cfg,
+            llm_model="cloud:claude-sonnet-4.6",
+        )
+        self.assertEqual(sel.stt_backend, "openrouter")
+        self.assertEqual(sel.tts_backend, "openrouter")
+        self.assertEqual(sel.llm_backend, "tinkerclaw")
+        self.assertEqual(cfg.llm.tinkerclaw_model, "cloud:claude-sonnet-4.6")
+
+    def test_tinkerclaw_skips_system_prompt_and_max_tokens_override(self):
+        """TinkerClaw owns its own personality + token budget — Dragon
+        must not stomp the LLMConfig prompts/tokens for TC mode."""
+        cfg = _StubVoiceCfg()
+        cfg.llm.system_prompt = "(should not be touched)"
+        cfg.llm.max_tokens = 999
+        select_backends_for_mode(VoiceMode.TINKERCLAW, cfg)
+        self.assertEqual(cfg.llm.system_prompt, "(should not be touched)")
+        self.assertEqual(cfg.llm.max_tokens, 999)
+
+    def test_tinkerclaw_without_llm_model_does_not_touch_tinkerclaw_model(self):
+        cfg = _StubVoiceCfg()
+        cfg.llm.tinkerclaw_model = "minimax/MiniMax-M2.5"
+        select_backends_for_mode(VoiceMode.TINKERCLAW, cfg, llm_model=None)
+        # Field unchanged when no model arg provided.
+        self.assertEqual(cfg.llm.tinkerclaw_model, "minimax/MiniMax-M2.5")
+
+    # ── ONBOARD ──────────────────────────────────────────────────
+
+    def test_onboard_falls_through_to_cloud_branch(self):
+        """Mode 4 (Onboard) is Tab5-side only — Dragon never sees it
+        in normal operation.  But if it does arrive, it falls into the
+        else branches: STT/TTS=openrouter, LLM=ollama (local default).
+        This pins the existing fall-through behaviour."""
+        cfg = _StubVoiceCfg()
+        sel = select_backends_for_mode(VoiceMode.ONBOARD, cfg)
+        # ONBOARD isn't local/hybrid/cloud/TC — falls into the else
+        # of each branch chain.
+        self.assertEqual(sel.stt_backend, "openrouter")
+        self.assertEqual(sel.tts_backend, "openrouter")
+        self.assertEqual(sel.llm_backend, "ollama")
+        self.assertEqual(cfg.llm.system_prompt, SYSTEM_PROMPT_CLOUD)
+        self.assertEqual(cfg.llm.max_tokens, MAX_TOKENS_CLOUD)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Third Wave 22a-style sub-handler extract from \`_handle_config_update\` (after [#214](https://github.com/lorcan35/TinkerBox/pull/214) vision_capability and [#215](https://github.com/lorcan35/TinkerBox/pull/215) cap_downgrade). Pulls the **mode-tier → backend-triple mapping** and the matching mutation of \`conn_config.llm\` (model id + system_prompt + max_tokens) into a new [\`dragon_voice/config_swap.py\`](dragon_voice/config_swap.py) module.

## Call site shrinks to two lines

\`\`\`python
sel = select_backends_for_mode(vmode, conn_config, llm_model=llm_model)
stt_be, tts_be, llm_be = sel.stt_backend, sel.tts_backend, sel.llm_backend
\`\`\`

The function preserves the historic in-place mutation of \`conn_config.llm\` (model id field per tier + mode-aware system prompt + max_tokens override). **Behaviour is bit-for-bit identical to the prior inline chain.**

## Tests

[\`tests/test_config_swap.py\`](tests/test_config_swap.py) — 12 tests pinning every branch:

| # | Branch | Pinned behaviour |
|---|---|---|
| 1 | LOCAL default | moonshine + piper + ollama, system prompt + max_tokens applied |
| 2 | LOCAL with plain model id | ollama_model updated |
| 3 | LOCAL with vendor-prefix | ollama_model NOT updated (the \`/\` guard) |
| 4 | LOCAL with local_backend override | uses npu_genie etc. |
| 5 | HYBRID | openrouter+openrouter+ollama (LLM stays local) |
| 6 | CLOUD default | all three openrouter |
| 7 | CLOUD with llm_model | openrouter_model updated |
| 8 | TINKERCLAW default | moonshine+piper+tinkerclaw |
| 9 | TINKERCLAW with \"cloud\" suffix | openrouter STT/TTS, TC LLM |
| 10 | TINKERCLAW skip prompt+tokens | gateway owns personality + budget |
| 11 | TINKERCLAW without llm_model | tinkerclaw_model unchanged |
| 12 | ONBOARD (mode 4) | falls through to else branches; pinned even though Tab5-side-only in practice |

The previously-implicit invariants (TC skip-prompt, \`/\`-guard on local model id) are now first-class assertions instead of \"obvious on read\" inline conditions.

## server.py shrink

| Metric | Value |
|---|---|
| This PR | 2669 → 2637 LOC (−32 net; 42 LOC inline removed, 10 LOC of comment + call added) |
| Cumulative across this round (#211–#214/215/this) | 2714 → 2637 LOC (−77, −2.8 %) |

## Verification

\`\`\`
\$ python3 -m pytest tests/test_config_swap.py -v
12 passed in 0.02s

\$ python3 -m pytest tests/ --ignore=tests/audit -q
737 passed, 108 subtests passed, 1 skipped, 0 failed in 11.25s

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \\
    dragon_voice/ tests/
All checks passed!
\`\`\`

## Where _handle_config_update stands now

| Then | Now |
|---|---|
| 446 LOC owning ~6 sub-responsibilities mixed inline | ~370 LOC, with three sub-responsibilities in their own modules with their own tests |

Sub-responsibilities now extracted:
* \`vision_capability.emit_vision_capability\` (#214)
* \`cap_downgrade.maybe_speak_cap_downgrade_alert\` (#215)
* \`config_swap.select_backends_for_mode\` (this PR)

**Remaining inline chunks** in \`_handle_config_update\`:
* TC health check + OpenRouter key check + TC token check (validation paths that early-return)
* Session DB update + API key propagation
* Pipeline + ConvEngine swap loop
* config_update ACK message build

Each is a smaller, more focused next-extract candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)