### PR TITLE
refactor(server): extract config-update prereq guards (~80 LOC) to config_swap_guards

### DIFF
--- a/dragon_voice/config_swap_guards.py
+++ b/dragon_voice/config_swap_guards.py
@@ -1,0 +1,194 @@
+"""Config-update prerequisite validation guards.
+
+Wave 23 SOLID-audit follow-up — fourth sub-handler extract from
+`_handle_config_update` (after vision_capability #214, cap_downgrade
+#215, config_swap #216).
+
+This module owns the three pre-swap validation guards that must pass
+before a `config_update` actually rotates backends:
+
+  * **TinkerClaw gateway health** — if vmode==TINKERCLAW, hit the
+    gateway's `/health` endpoint and confirm it returns 200 within 5 s.
+  * **OpenRouter API key presence** — if vmode needs cloud STT/TTS or
+    LLM, confirm `conn_config.llm.openrouter_api_key` is non-empty.
+  * **TinkerClaw token presence** — if vmode==TINKERCLAW, confirm
+    `conn_config.llm.tinkerclaw_token` is non-empty (otherwise the
+    backend's `__init__` would raise ValueError mid-swap and the
+    user would see a stack trace instead of a clean revert).
+
+All three guards share the same failure shape: log the error, send a
+γ-arch `error_event` WS frame, send a `voice_mode=0` revert
+config_update so Tab5 visually flips back to LOCAL, then signal
+"caller should short-circuit out of `_handle_config_update`."
+
+## API
+
+A single async entry point `await validate_config_swap_prereqs(...)`
+returns ``True`` if all guards passed, ``False`` if any guard failed
+(in which case the WS error + revert frames have already been sent).
+The caller's contract is just:
+
+    if not await validate_config_swap_prereqs(ws, vmode, conn_config,
+                                              safe_send_json):
+        return
+
+This replaces ~60 LOC of inline guard chain.
+
+## Why a single entry point
+
+The three guards are short-circuit linked: TC-gateway → OR-key →
+TC-token.  Pre-extract the caller had three identical-shaped
+``if ...: return`` blocks; collapsing into one entry point removes
+the repeated short-circuit pattern and makes the caller body
+expressive about intent ("validate prerequisites or bail").
+
+## DIP
+
+The `safe_send_json` callable is passed in rather than imported.
+This keeps `config_swap_guards` from depending on `VoiceServer` —
+the WS-send retry/swallow policy lives on the server, the validation
+policy lives here.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable
+
+import aiohttp
+from aiohttp import web
+
+from dragon_voice.errors import Scope, Severity, error_event
+from dragon_voice.voice_modes import VoiceMode
+
+logger = logging.getLogger(__name__)
+
+# Type alias for the WS-send callable signature.  Matches
+# VoiceServer._safe_send_json — a staticmethod with no self dependency.
+SafeSendJson = Callable[[web.WebSocketResponse, dict], Awaitable[bool]]
+
+
+# Per-failure payloads.  Centralised here so Tab5 sees a stable code
+# string per failure class even if the human-readable message gets
+# tweaked.
+_REVERT_PAYLOAD: dict = {"type": "config_update", "voice_mode": 0}
+
+
+async def _check_tinkerclaw_gateway(
+    ws: web.WebSocketResponse,
+    conn_config: Any,
+    safe_send_json: SafeSendJson,
+) -> bool:
+    """Hit the TinkerClaw gateway's /health endpoint with a 5 s timeout.
+    Returns True on 200, False on any other status / exception (and
+    sends the WS error + revert frames).
+    """
+    try:
+        tc_url = (conn_config.llm.tinkerclaw_url or "http://localhost:18789").rstrip("/")
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=5),
+        ) as tc_session:
+            async with tc_session.get(f"{tc_url}/health") as tc_resp:
+                if tc_resp.status != 200:
+                    logger.error("TinkerClaw health check returned %d", tc_resp.status)
+                    raise RuntimeError(f"health check returned {tc_resp.status}")
+        logger.info("TinkerClaw gateway health OK at %s", tc_url)
+        return True
+    except Exception as tc_err:
+        logger.error("TinkerClaw gateway not reachable: %s", tc_err)
+        # Audit G5 (2026-04-20): revert to Local so Tab5 doesn't sit
+        # wedged on mode 3 showing an error.
+        # Audit D5 (#137): γ-arch error_event + plain config_update revert.
+        if not ws.closed:
+            await safe_send_json(ws, error_event(
+                code="tc_gateway_unreachable",
+                message="TinkerClaw gateway is not reachable — reverted to local.",
+                severity=Severity.FATAL,
+                scope=Scope.GATEWAY,
+            ))
+            await safe_send_json(ws, _REVERT_PAYLOAD)
+        return False
+
+
+async def _check_openrouter_key(
+    ws: web.WebSocketResponse,
+    conn_config: Any,
+    safe_send_json: SafeSendJson,
+) -> bool:
+    """If the configured llm has no openrouter_api_key, send the
+    γ-arch revert frames and return False."""
+    if conn_config.llm.openrouter_api_key:
+        return True
+    logger.error("Cloud mode requested but no API key configured")
+    if not ws.closed:
+        await safe_send_json(ws, error_event(
+            code="openrouter_key_missing",
+            message="OpenRouter key not configured — reverted to local.",
+            severity=Severity.FATAL,
+            scope=Scope.LLM,
+        ))
+        await safe_send_json(ws, _REVERT_PAYLOAD)
+    return False
+
+
+async def _check_tinkerclaw_token(
+    ws: web.WebSocketResponse,
+    conn_config: Any,
+    safe_send_json: SafeSendJson,
+) -> bool:
+    """B7 (audit, #137): TC mode needs a token; without one the
+    backend's __init__ raises ValueError, which would leak via the
+    A4 raw-exception path in the swap loop.  Validate up-front like
+    the OpenRouter key check above so the user sees a clean γ-arch
+    error and a clean revert instead of a stack trace."""
+    if (conn_config.llm.tinkerclaw_token or "").strip():
+        return True
+    logger.error("TC mode requested but tinkerclaw_token is blank")
+    if not ws.closed:
+        await safe_send_json(ws, error_event(
+            code="tc_token_missing",
+            message="TinkerClaw token not configured — reverted to local",
+            severity=Severity.FATAL,
+            scope=Scope.GATEWAY,
+        ))
+        await safe_send_json(ws, _REVERT_PAYLOAD)
+    return False
+
+
+async def validate_config_swap_prereqs(
+    ws: web.WebSocketResponse,
+    *,
+    vmode: VoiceMode,
+    conn_config: Any,                  # VoiceConfig
+    safe_send_json: SafeSendJson,
+) -> bool:
+    """Validate all prerequisites for switching to ``vmode``.
+
+    Returns ``True`` iff every applicable guard passed.  Returns
+    ``False`` if any guard failed — the failing guard has already
+    sent the WS error_event + revert config_update frames; the
+    caller's only obligation is to short-circuit out of
+    ``_handle_config_update``.
+
+    Guard execution order:
+      1. TC gateway health (only when vmode==TINKERCLAW).
+      2. OpenRouter API key presence (only when vmode needs OR key).
+      3. TC token presence (only when vmode==TINKERCLAW).
+
+    The TC-gateway check is first because a dead gateway is the
+    most common failure in dev (forgot to start tinkerclaw-gateway
+    service); the user gets the most-likely-relevant error message
+    fastest.
+    """
+    if vmode.is_tinkerclaw():
+        if not await _check_tinkerclaw_gateway(ws, conn_config, safe_send_json):
+            return False
+
+    if vmode.needs_openrouter_key():
+        if not await _check_openrouter_key(ws, conn_config, safe_send_json):
+            return False
+
+    if vmode.is_tinkerclaw():
+        if not await _check_tinkerclaw_token(ws, conn_config, safe_send_json):
+            return False
+
+    return True

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -22,6 +22,7 @@ from aiohttp import web, WSMsgType
 
 from dragon_voice.cap_downgrade import maybe_speak_cap_downgrade_alert
 from dragon_voice.config_swap import select_backends_for_mode
+from dragon_voice.config_swap_guards import validate_config_swap_prereqs
 from dragon_voice.conn_state import ConnState
 from dragon_voice.media.store import MediaStore
 from dragon_voice.media.pipeline import MediaPipeline
@@ -2184,79 +2185,17 @@ class VoiceServer:
                         conn_config.llm.openrouter_model if vmode.is_cloud() else "(local)",
                         conn_config.llm.max_tokens)
 
-            # Validate TinkerClaw gateway is reachable before switching to TC mode
-            if vmode.is_tinkerclaw():
-                try:
-                    tc_url = (conn_config.llm.tinkerclaw_url or "http://localhost:18789").rstrip("/")
-                    async with aiohttp.ClientSession(
-                        timeout=aiohttp.ClientTimeout(total=5)
-                    ) as tc_session:
-                        async with tc_session.get(f"{tc_url}/health") as tc_resp:
-                            if tc_resp.status != 200:
-                                logger.error("TinkerClaw health check returned %d", tc_resp.status)
-                                raise RuntimeError(f"health check returned {tc_resp.status}")
-                    logger.info("TinkerClaw gateway health OK at %s", tc_url)
-                except Exception as tc_err:
-                    logger.error("TinkerClaw gateway not reachable: %s", tc_err)
-                    # Audit G5 (2026-04-20): revert to Local so Tab5 doesn't
-                    # sit wedged on mode 3 showing an error. Matches the
-                    # OpenRouter-key-missing path below.
-                    # Audit D5 (#137): same γ-arch shape as B7 / OR-key
-                    # for consistency — error_event + plain config_update
-                    # revert.
-                    if not ws.closed:
-                        await self._safe_send_json(ws, error_event(
-                            code="tc_gateway_unreachable",
-                            message="TinkerClaw gateway is not reachable — reverted to local.",
-                            severity=Severity.FATAL,
-                            scope=Scope.GATEWAY,
-                        ))
-                        await self._safe_send_json(ws, {
-                            "type": "config_update",
-                            "voice_mode": 0,
-                        })
-                    return
-
-            # Validate API key for cloud modes (1=Hybrid, 2=Cloud need OpenRouter)
-            # Mode 3 (TinkerClaw) doesn't need Dragon's OpenRouter key — uses own gateway.
-            #
-            # Audit D5 (#137): pre-fix the toast was a bare
-            # `config_update.error` raw-string that didn't tell the user
-            # what happened next.  Migrated to the same γ-arch error_event
-            # + revert pattern as B7 (TC token check) for consistency.
-            if vmode.needs_openrouter_key() and not conn_config.llm.openrouter_api_key:
-                logger.error("Cloud mode requested but no API key configured")
-                if not ws.closed:
-                    await self._safe_send_json(ws, error_event(
-                        code="openrouter_key_missing",
-                        message="OpenRouter key not configured — reverted to local.",
-                        severity=Severity.FATAL,
-                        scope=Scope.LLM,
-                    ))
-                    await self._safe_send_json(ws, {
-                        "type": "config_update",
-                        "voice_mode": 0,
-                    })
-                return
-
-            # B7 (audit, #137): TC mode needs a token; without one the
-            # backend's __init__ raises ValueError, which would leak via
-            # the A4 raw-exception path below.  Validate up-front like
-            # the OpenRouter key check above so the user sees a clean
-            # γ-arch error and a clean revert instead of a stack trace.
-            if vmode.is_tinkerclaw() and not (conn_config.llm.tinkerclaw_token or "").strip():
-                logger.error("TC mode requested but tinkerclaw_token is blank")
-                if not ws.closed:
-                    await self._safe_send_json(ws, error_event(
-                        code="tc_token_missing",
-                        message="TinkerClaw token not configured — reverted to local",
-                        severity=Severity.FATAL,
-                        scope=Scope.GATEWAY,
-                    ))
-                    await self._safe_send_json(ws, {
-                        "type": "config_update",
-                        "voice_mode": 0,
-                    })
+            # SOLID-audit follow-up: TC gateway / OR key / TC token
+            # validation guards extracted to config_swap_guards.
+            # Returns False iff any guard failed (in which case it
+            # already sent the γ-arch error_event + revert frames);
+            # caller's only obligation is to short-circuit out.
+            if not await validate_config_swap_prereqs(
+                ws,
+                vmode=vmode,
+                conn_config=conn_config,
+                safe_send_json=self._safe_send_json,
+            ):
                 return
 
             # Update session system prompt in DB for conversation engine

--- a/tests/test_config_swap_guards.py
+++ b/tests/test_config_swap_guards.py
@@ -1,0 +1,315 @@
+"""Tests for ``dragon_voice.config_swap_guards.validate_config_swap_prereqs``.
+
+Pin every guard branch and the short-circuit chain.  Pre-extract these
+were 80 LOC of inline early-return guards in
+``server.py:_handle_config_update``; now each failure path has a
+named test so a regression to the γ-arch error_event payloads or to
+the revert-to-LOCAL behaviour gets caught at unit-test time.
+
+Six branches:
+  1. LOCAL mode: no checks needed → True, no WS sends.
+  2. CLOUD mode + OR key present → True.
+  3. CLOUD mode + OR key missing → False, error_event + revert sent.
+  4. TINKERCLAW mode + gateway unreachable → False, error_event + revert.
+  5. TINKERCLAW mode + gateway up + token missing → False, error_event + revert.
+  6. TINKERCLAW mode + gateway up + token present → True.
+
+The TC-gateway HTTP call is mocked with aioresponses-style monkey-patching
+on aiohttp.ClientSession.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dragon_voice.config_swap_guards import validate_config_swap_prereqs
+from dragon_voice.voice_modes import VoiceMode
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    return ws
+
+
+def _make_conn_config(
+    *,
+    openrouter_api_key: str = "",
+    tinkerclaw_token: str = "",
+    tinkerclaw_url: str = "http://localhost:18789",
+) -> MagicMock:
+    cfg = MagicMock()
+    cfg.llm.openrouter_api_key = openrouter_api_key
+    cfg.llm.tinkerclaw_token = tinkerclaw_token
+    cfg.llm.tinkerclaw_url = tinkerclaw_url
+    return cfg
+
+
+def _make_safe_send_json() -> AsyncMock:
+    """Returns a callable mirroring VoiceServer._safe_send_json's
+    signature.  Always returns True so the caller doesn't think the
+    WS dropped mid-revert."""
+    return AsyncMock(return_value=True)
+
+
+class _FakeAsyncCM:
+    """Minimal `async with` context-manager wrapper around an inner
+    object.  ``async with X as inner`` returns the wrapped value;
+    raises if `raise_on_enter` is set."""
+
+    def __init__(self, inner: Any = None, raise_on_enter: BaseException | None = None):
+        self._inner = inner
+        self._raise = raise_on_enter
+
+    async def __aenter__(self):
+        if self._raise is not None:
+            raise self._raise
+        return self._inner
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False  # don't swallow
+
+
+def _patch_aiohttp_session(*, status: int = 200, raise_on_get: BaseException | None = None):
+    """Build a ClientSession patch that returns either a fake response
+    (with the given .status) or raises from .get(...).
+    Returns the patch context manager."""
+    fake_resp = MagicMock()
+    fake_resp.status = status
+
+    fake_session = MagicMock()
+    if raise_on_get is not None:
+        # Calling tc_session.get(url) raises immediately — never reaches
+        # the `async with` part.
+        fake_session.get = MagicMock(side_effect=raise_on_get)
+    else:
+        # tc_session.get(url) returns an async-context-manager that
+        # yields fake_resp on __aenter__.
+        fake_session.get = MagicMock(return_value=_FakeAsyncCM(inner=fake_resp))
+
+    # `async with aiohttp.ClientSession(...) as tc_session` returns
+    # fake_session.  Wrap the whole ClientSession ctor so it returns an
+    # async-CM that yields fake_session.
+    return patch(
+        "dragon_voice.config_swap_guards.aiohttp.ClientSession",
+        return_value=_FakeAsyncCM(inner=fake_session),
+    )
+
+
+# ─── LOCAL — no checks at all ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_local_mode_passes_with_no_checks():
+    """LOCAL mode triggers neither TC nor OR-key checks → True with
+    zero WS sends."""
+    ws = _make_ws()
+    cfg = _make_conn_config()
+    send = _make_safe_send_json()
+
+    out = await validate_config_swap_prereqs(
+        ws,
+        vmode=VoiceMode.LOCAL,
+        conn_config=cfg,
+        safe_send_json=send,
+    )
+    assert out is True
+    send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_hybrid_mode_with_or_key_passes():
+    ws = _make_ws()
+    cfg = _make_conn_config(openrouter_api_key="sk-test-key")
+    send = _make_safe_send_json()
+
+    out = await validate_config_swap_prereqs(
+        ws,
+        vmode=VoiceMode.HYBRID,
+        conn_config=cfg,
+        safe_send_json=send,
+    )
+    assert out is True
+    send.assert_not_awaited()
+
+
+# ─── CLOUD/HYBRID without OR key — fails ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cloud_without_or_key_sends_error_event_and_revert():
+    ws = _make_ws()
+    cfg = _make_conn_config(openrouter_api_key="")  # explicitly missing
+    send = _make_safe_send_json()
+
+    out = await validate_config_swap_prereqs(
+        ws,
+        vmode=VoiceMode.CLOUD,
+        conn_config=cfg,
+        safe_send_json=send,
+    )
+    assert out is False
+    # First send is the γ-arch error_event; second is the revert.
+    assert send.await_count == 2
+    err_payload = send.await_args_list[0].args[1]
+    revert_payload = send.await_args_list[1].args[1]
+    assert err_payload.get("type") == "error"
+    assert err_payload.get("code") == "openrouter_key_missing"
+    assert revert_payload == {"type": "config_update", "voice_mode": 0}
+
+
+@pytest.mark.asyncio
+async def test_or_key_check_skipped_when_ws_closed():
+    """If the WS is already closed, we still return False but don't
+    waste cycles trying to send frames the client can't receive."""
+    ws = _make_ws(closed=True)
+    cfg = _make_conn_config(openrouter_api_key="")
+    send = _make_safe_send_json()
+
+    out = await validate_config_swap_prereqs(
+        ws,
+        vmode=VoiceMode.HYBRID,
+        conn_config=cfg,
+        safe_send_json=send,
+    )
+    assert out is False
+    send.assert_not_awaited()
+
+
+# ─── TINKERCLAW gateway-unreachable ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tinkerclaw_gateway_unreachable_sends_error_event_and_revert():
+    """When the TC gateway HTTP call raises, the guard sends the
+    γ-arch error + revert and returns False."""
+    ws = _make_ws()
+    cfg = _make_conn_config(tinkerclaw_token="tk-test-token")
+    send = _make_safe_send_json()
+
+    with _patch_aiohttp_session(raise_on_get=ConnectionRefusedError("gateway not running")):
+        out = await validate_config_swap_prereqs(
+            ws,
+            vmode=VoiceMode.TINKERCLAW,
+            conn_config=cfg,
+            safe_send_json=send,
+        )
+
+    assert out is False
+    assert send.await_count == 2
+    err_payload = send.await_args_list[0].args[1]
+    assert err_payload.get("code") == "tc_gateway_unreachable"
+
+
+@pytest.mark.asyncio
+async def test_tinkerclaw_gateway_returns_500_sends_error_event():
+    """A non-200 status from the gateway is a failure too — pinned so
+    a future "accept any status" regression gets caught."""
+    ws = _make_ws()
+    cfg = _make_conn_config(tinkerclaw_token="tk-test-token")
+    send = _make_safe_send_json()
+
+    with _patch_aiohttp_session(status=503):
+        out = await validate_config_swap_prereqs(
+            ws,
+            vmode=VoiceMode.TINKERCLAW,
+            conn_config=cfg,
+            safe_send_json=send,
+        )
+
+    assert out is False
+    assert send.await_count == 2
+    assert send.await_args_list[0].args[1].get("code") == "tc_gateway_unreachable"
+
+
+# ─── TINKERCLAW token missing ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tinkerclaw_with_blank_token_after_gateway_ok_sends_error():
+    """If the gateway is up but the token is missing, the second
+    guard fires and sends tc_token_missing."""
+    ws = _make_ws()
+    cfg = _make_conn_config(tinkerclaw_token="")  # explicitly blank
+    send = _make_safe_send_json()
+
+    with _patch_aiohttp_session(status=200):
+        out = await validate_config_swap_prereqs(
+            ws,
+            vmode=VoiceMode.TINKERCLAW,
+            conn_config=cfg,
+            safe_send_json=send,
+        )
+
+    assert out is False
+    # Two sends: error_event + revert (no OR-key guard for TC mode).
+    assert send.await_count == 2
+    assert send.await_args_list[0].args[1].get("code") == "tc_token_missing"
+
+
+@pytest.mark.asyncio
+async def test_tinkerclaw_with_whitespace_only_token_treated_as_blank():
+    """`"   "` should be treated as blank — pin the .strip() invariant."""
+    ws = _make_ws()
+    cfg = _make_conn_config(tinkerclaw_token="   ")
+    send = _make_safe_send_json()
+
+    with _patch_aiohttp_session(status=200):
+        out = await validate_config_swap_prereqs(
+            ws,
+            vmode=VoiceMode.TINKERCLAW,
+            conn_config=cfg,
+            safe_send_json=send,
+        )
+
+    assert out is False
+    assert send.await_args_list[0].args[1].get("code") == "tc_token_missing"
+
+
+# ─── TINKERCLAW happy path ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tinkerclaw_with_gateway_ok_and_token_present_passes():
+    ws = _make_ws()
+    cfg = _make_conn_config(tinkerclaw_token="tk-test-token")
+    send = _make_safe_send_json()
+
+    with _patch_aiohttp_session(status=200):
+        out = await validate_config_swap_prereqs(
+            ws,
+            vmode=VoiceMode.TINKERCLAW,
+            conn_config=cfg,
+            safe_send_json=send,
+        )
+
+    assert out is True
+    send.assert_not_awaited()
+
+
+# ─── Short-circuit invariant ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tc_gateway_failure_short_circuits_token_check():
+    """If the gateway check fails, the token check must NOT run —
+    one error per attempt, not two."""
+    ws = _make_ws()
+    # Both would-fail: blank token AND unreachable gateway.
+    cfg = _make_conn_config(tinkerclaw_token="")
+    send = _make_safe_send_json()
+
+    with _patch_aiohttp_session(raise_on_get=ConnectionRefusedError("gateway down")):
+        out = await validate_config_swap_prereqs(
+            ws,
+            vmode=VoiceMode.TINKERCLAW,
+            conn_config=cfg,
+            safe_send_json=send,
+        )
+
+    assert out is False
+    # Only the gateway-unreachable error fired; token check skipped.
+    assert send.await_count == 2  # 1 error + 1 revert
+    assert send.await_args_list[0].args[1].get("code") == "tc_gateway_unreachable"


### PR DESCRIPTION
## What

Fourth Wave 22a-style sub-handler extract from \`_handle_config_update\` (after vision_capability #214, cap_downgrade #215, config_swap #216).

Pulls the three pre-swap validation guards out of the inline early-return chain into [\`dragon_voice/config_swap_guards.py\`](dragon_voice/config_swap_guards.py):

| Guard | Trigger | On failure |
|---|---|---|
| TC gateway /health (5 s timeout) | vmode == TINKERCLAW | \`tc_gateway_unreachable\` error_event + revert |
| OpenRouter API key presence | vmode in {HYBRID, CLOUD} | \`openrouter_key_missing\` error_event + revert |
| TC token presence | vmode == TINKERCLAW | \`tc_token_missing\` error_event + revert |

All three combined behind a single async entry point \`await validate_config_swap_prereqs(...)\` that returns \`False\` on any failure (after sending the WS frames) — caller's only obligation is to short-circuit out.

## Call site shrinks 70 LOC → 8 LOC

Pre-extract the three guards were three identical-shaped \`if ...: ... return\` blocks inline (~80 LOC of duplicated WS-send + revert + return scaffolding).  Post-extract:

\`\`\`python
if not await validate_config_swap_prereqs(
    ws,
    vmode=vmode,
    conn_config=conn_config,
    safe_send_json=self._safe_send_json,
):
    return
\`\`\`

The \`_safe_send_json\` callable is **passed in** rather than imported — keeps the new module from depending on \`VoiceServer\`. Clean DIP: WS-send retry/swallow policy lives on the server, validation policy lives in this module.

## Tests

[\`tests/test_config_swap_guards.py\`](tests/test_config_swap_guards.py) — 10 tests pin every branch:

| # | Branch | Pinned |
|---|---|---|
| 1 | LOCAL — no checks needed | True, no WS sends |
| 2 | HYBRID + OR key present | True |
| 3 | CLOUD without OR key | False, \`openrouter_key_missing\` + revert |
| 4 | WS-closed during failure | False, no sends attempted |
| 5 | TC + gateway raises ConnectionRefusedError | False, \`tc_gateway_unreachable\` + revert |
| 6 | TC + gateway returns 503 | False, same code |
| 7 | TC + gateway OK + blank token | False, \`tc_token_missing\` + revert |
| 8 | TC + whitespace-only token | False, same code (pins \`.strip()\` invariant) |
| 9 | TC + gateway OK + token present | True, no sends |
| 10 | Short-circuit invariant | Gateway failure stops the chain; token check doesn't run |

Helper \`_FakeAsyncCM\` + \`_patch_aiohttp_session(...)\` factor out the async-context-manager mocking so each test stays one screen of intent.

## server.py shrink

| Metric | Value |
|---|---|
| This PR | 2637 → 2576 LOC (−61, −2.3 %) |
| Cumulative round-2 | 2714 → 2576 LOC (−138, **−5.1 %**) |

\`_handle_config_update\` is now ~310 LOC (down from 446 at start of round 2), with **four** sub-responsibilities now living in their own modules with their own tests.

## Verification

\`\`\`
\$ python3 -m pytest tests/test_config_swap_guards.py -v
10 passed in 0.09s

\$ python3 -m pytest tests/ --ignore=tests/audit -q
747 passed, 108 subtests passed, 1 skipped, 0 failed in 11.27s

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \\
    dragon_voice/ tests/
All checks passed!
\`\`\`

## Remaining inline chunks in _handle_config_update

* Codec negotiation (~25 LOC, easy next)
* Session DB update + API key propagation (~40 LOC)
* Pipeline + ConvEngine swap loop (~80 LOC, tied to A06 lock semantics)
* config_update ACK message build (~50 LOC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)