### PR TITLE
refactor(server): extract codec negotiation (~16 LOC) to codec_negotiation module

### DIFF
--- a/dragon_voice/codec_negotiation.py
+++ b/dragon_voice/codec_negotiation.py
@@ -1,0 +1,108 @@
+"""Audio codec negotiation — handles `config_update` frames that
+include an `audio_uplink_codec` field for mid-session codec swap.
+
+Wave 23 SOLID-audit follow-up — fifth sub-handler extract from
+`_handle_config_update` (after vision_capability #214,
+cap_downgrade #215, config_swap #216, config_swap_guards #217).
+
+## What this does
+
+Tab5 may send a `config_update` with `audio_uplink_codec` to swap
+the uplink codec mid-session (e.g. from a Settings toggle).  This
+module:
+
+  1. Parses the codec from the WS frame (with backward-compat
+     alias `audio_codec`).
+  2. Calls `pipeline.set_uplink_codec(...)` to apply it on the
+     active pipeline.
+  3. Sends a confirmation `config_update` echoing the codec that
+     was *actually* applied.
+
+The "actually applied" piece matters for fallback observability:
+if Tab5 requests `opus` but Dragon doesn't have libopus available,
+`set_uplink_codec` falls back to `pcm` and the client needs to
+know.
+
+## Failure isolation
+
+If no pipeline is wired yet (boot race) the function is a no-op.
+The `safe_send_json` callable is passed in (DIP) — same shape as
+the other extracted modules.
+
+## Why a separate module
+
+Codec negotiation is a different axis of change than backend
+selection (PR 216), validation guards (PR 217), and per-mode UX
+notifications (vision/cap_downgrade).  It can grow independently
+to handle Opus capability ACKs, downlink codec negotiation, etc.
+without touching the WS dispatcher.
+
+Refs: PR #173, TinkerTab #262 (initial codec-swap protocol).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+# Type alias for the WS-send callable signature.  Matches
+# VoiceServer._safe_send_json (a staticmethod with no self
+# dependency).
+SafeSendJson = Callable[[web.WebSocketResponse, dict], Awaitable[bool]]
+
+
+def _extract_codec_from_cmd(cmd: dict) -> Optional[str]:
+    """Read the codec from a config_update WS frame.  Tries the
+    canonical `audio_uplink_codec` field first, then the legacy
+    `audio_codec` alias for backward compat with older Tab5
+    firmware.  Returns None when neither is present."""
+    return cmd.get("audio_uplink_codec") or cmd.get("audio_codec")
+
+
+async def maybe_swap_uplink_codec(
+    ws: web.WebSocketResponse,
+    *,
+    cmd: dict,
+    conn_state: Any,                  # ConnState (or compat dict)
+    safe_send_json: SafeSendJson,
+) -> None:
+    """If `cmd` requests an audio_uplink_codec swap, apply it on the
+    active pipeline and ACK with the codec that was actually applied.
+
+    No-op when:
+      * `cmd` carries no codec field
+      * no pipeline is wired yet (boot race)
+      * the WS is already closed (ACK is best-effort)
+
+    Args:
+        ws: Open WebSocket to Tab5.
+        cmd: The parsed `config_update` WS frame.
+        conn_state: ConnState (or compat dict) — read for `pipeline`.
+        safe_send_json: VoiceServer._safe_send_json (passed in to
+            preserve the WS-send retry/swallow policy without
+            importing VoiceServer here).
+
+    Returns:
+        None.  All side effects flow through the pipeline + ws.
+    """
+    requested = _extract_codec_from_cmd(cmd)
+    if requested is None:
+        return
+
+    pipeline = conn_state.get("pipeline")
+    if pipeline is None:
+        # Connection still booting — codec selection happens at
+        # pipeline init from the conn_config; client will see the
+        # final codec via session_start, no-op here.
+        return
+
+    applied = pipeline.set_uplink_codec(str(requested))
+    if not ws.closed:
+        await safe_send_json(ws, {
+            "type": "config_update",
+            "audio_uplink_codec": applied,
+            "reason": "codec_negotiation",
+        })

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -21,6 +21,7 @@ import aiohttp
 from aiohttp import web, WSMsgType
 
 from dragon_voice.cap_downgrade import maybe_speak_cap_downgrade_alert
+from dragon_voice.codec_negotiation import maybe_swap_uplink_codec
 from dragon_voice.config_swap import select_backends_for_mode
 from dragon_voice.config_swap_guards import validate_config_swap_prereqs
 from dragon_voice.conn_state import ConnState
@@ -2143,18 +2144,16 @@ class VoiceServer:
         # send config_update with audio_uplink_codec to swap mid-session
         # (e.g. from a Settings toggle).  Apply via pipeline; reply with
         # the codec actually applied so a fallback (opus -> pcm because
-        # libopus missing) is observable on the client.
-        client_uplink_codec = cmd.get("audio_uplink_codec") or cmd.get("audio_codec")
-        if client_uplink_codec is not None:
-            pipeline = conn_state.get("pipeline")
-            if pipeline is not None:
-                applied = pipeline.set_uplink_codec(str(client_uplink_codec))
-                if not ws.closed:
-                    await self._safe_send_json(ws, {
-                        "type": "config_update",
-                        "audio_uplink_codec": applied,
-                        "reason": "codec_negotiation",
-                    })
+        # libopus missing) is observable on the client.  Extracted to
+        # codec_negotiation.maybe_swap_uplink_codec in the SOLID-audit
+        # follow-up (sister of vision_capability / cap_downgrade /
+        # config_swap_guards).
+        await maybe_swap_uplink_codec(
+            ws,
+            cmd=cmd,
+            conn_state=conn_state,
+            safe_send_json=self._safe_send_json,
+        )
 
         if voice_mode is not None:
             # OCP-1 (audit 2026-05-03): convert raw int → VoiceMode enum

--- a/tests/test_codec_negotiation.py
+++ b/tests/test_codec_negotiation.py
@@ -1,0 +1,180 @@
+"""Tests for ``dragon_voice.codec_negotiation.maybe_swap_uplink_codec``.
+
+Pin the four branches:
+
+  1. Happy path: cmd carries audio_uplink_codec + pipeline is wired
+     → set_uplink_codec called; ACK sent with the actually-applied
+     codec.
+  2. Backward-compat: legacy `audio_codec` alias is recognised.
+  3. No codec field → no-op.
+  4. No pipeline (boot race) → no-op.
+
+Plus the fallback-observability invariant: when set_uplink_codec
+returns a different codec than requested (e.g. opus → pcm because
+libopus missing), the ACK echoes the *applied* one, not the requested.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.codec_negotiation import maybe_swap_uplink_codec
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    return ws
+
+
+def _make_pipeline_returning(applied_codec: str) -> MagicMock:
+    p = MagicMock()
+    p.set_uplink_codec = MagicMock(return_value=applied_codec)
+    return p
+
+
+def _make_safe_send_json() -> AsyncMock:
+    return AsyncMock(return_value=True)
+
+
+# ── Happy path ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_canonical_field_swap_applies_and_acks():
+    ws = _make_ws()
+    pipeline = _make_pipeline_returning("opus")
+    conn = {"pipeline": pipeline}
+    send = _make_safe_send_json()
+
+    await maybe_swap_uplink_codec(
+        ws,
+        cmd={"audio_uplink_codec": "opus"},
+        conn_state=conn,
+        safe_send_json=send,
+    )
+
+    pipeline.set_uplink_codec.assert_called_once_with("opus")
+    send.assert_awaited_once()
+    payload = send.await_args.args[1]
+    assert payload == {
+        "type": "config_update",
+        "audio_uplink_codec": "opus",
+        "reason": "codec_negotiation",
+    }
+
+
+@pytest.mark.asyncio
+async def test_legacy_audio_codec_alias_recognised():
+    """Older Tab5 firmware may send the field as `audio_codec`."""
+    ws = _make_ws()
+    pipeline = _make_pipeline_returning("pcm")
+    send = _make_safe_send_json()
+
+    await maybe_swap_uplink_codec(
+        ws,
+        cmd={"audio_codec": "pcm"},
+        conn_state={"pipeline": pipeline},
+        safe_send_json=send,
+    )
+
+    pipeline.set_uplink_codec.assert_called_once_with("pcm")
+    assert send.await_args.args[1]["audio_uplink_codec"] == "pcm"
+
+
+@pytest.mark.asyncio
+async def test_canonical_field_takes_precedence_over_legacy_alias():
+    """If both fields are present (transitional firmware), the
+    canonical name wins."""
+    ws = _make_ws()
+    pipeline = _make_pipeline_returning("opus")
+    send = _make_safe_send_json()
+
+    await maybe_swap_uplink_codec(
+        ws,
+        cmd={"audio_uplink_codec": "opus", "audio_codec": "pcm"},
+        conn_state={"pipeline": pipeline},
+        safe_send_json=send,
+    )
+    pipeline.set_uplink_codec.assert_called_once_with("opus")
+
+
+# ── Fallback observability ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ack_echoes_applied_codec_not_requested():
+    """When the pipeline falls back (e.g. opus requested, libopus
+    missing → applied='pcm'), the ACK must echo the APPLIED codec
+    so the client sees the fallback.  This is the whole point of
+    the codec-negotiation reply pattern from #173."""
+    ws = _make_ws()
+    pipeline = _make_pipeline_returning("pcm")  # fallback
+    send = _make_safe_send_json()
+
+    await maybe_swap_uplink_codec(
+        ws,
+        cmd={"audio_uplink_codec": "opus"},  # requested opus
+        conn_state={"pipeline": pipeline},
+        safe_send_json=send,
+    )
+
+    payload = send.await_args.args[1]
+    assert payload["audio_uplink_codec"] == "pcm"  # NOT "opus"
+
+
+# ── No-op branches ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_codec_field_is_noop():
+    ws = _make_ws()
+    pipeline = _make_pipeline_returning("opus")
+    send = _make_safe_send_json()
+
+    await maybe_swap_uplink_codec(
+        ws,
+        cmd={"voice_mode": 0},  # no codec field
+        conn_state={"pipeline": pipeline},
+        safe_send_json=send,
+    )
+
+    pipeline.set_uplink_codec.assert_not_called()
+    send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_pipeline_is_noop():
+    """Connection still booting — pipeline not wired yet.  Codec
+    selection happens at pipeline init from conn_config; client
+    will see the final codec via session_start."""
+    ws = _make_ws()
+    send = _make_safe_send_json()
+
+    await maybe_swap_uplink_codec(
+        ws,
+        cmd={"audio_uplink_codec": "opus"},
+        conn_state={"pipeline": None},
+        safe_send_json=send,
+    )
+    send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ws_closed_skips_ack():
+    """Pipeline still gets the swap, but the ACK is best-effort —
+    silent skip when the WS is closed."""
+    ws = _make_ws(closed=True)
+    pipeline = _make_pipeline_returning("opus")
+    send = _make_safe_send_json()
+
+    await maybe_swap_uplink_codec(
+        ws,
+        cmd={"audio_uplink_codec": "opus"},
+        conn_state={"pipeline": pipeline},
+        safe_send_json=send,
+    )
+
+    pipeline.set_uplink_codec.assert_called_once_with("opus")
+    send.assert_not_awaited()


### PR DESCRIPTION
## What

Fifth Wave 22a-style sub-handler extract from \`_handle_config_update\` (after vision_capability #214, cap_downgrade #215, config_swap #216, config_swap_guards #217).

Pulls the audio_uplink_codec mid-session swap path (~16 LOC inline) into [\`dragon_voice/codec_negotiation.py\`](dragon_voice/codec_negotiation.py).

## API

\`\`\`python
async def maybe_swap_uplink_codec(
    ws: web.WebSocketResponse,
    *,
    cmd: dict,
    conn_state: Any,
    safe_send_json: SafeSendJson,
) -> None
\`\`\`

No-op when:
* The cmd carries no codec field
* No pipeline is wired (boot race)
* WS is closed (ACK is best-effort)

Otherwise applies the codec via \`pipeline.set_uplink_codec\` and ACKs with the codec that was *actually applied* — preserving the fallback-observability contract from #173 (opus → pcm fallback must be visible to the client).

The legacy \`audio_codec\` alias is recognised alongside the canonical \`audio_uplink_codec\`; canonical wins when both are present (transitional firmware).

## Tests

[\`tests/test_codec_negotiation.py\`](tests/test_codec_negotiation.py) — 7 tests:

| # | Branch | Pinned |
|---|---|---|
| 1 | Canonical field swap | set_uplink_codec called + ACK echoed |
| 2 | Legacy \`audio_codec\` alias | Recognised |
| 3 | Both fields present | Canonical wins |
| 4 | **Fallback observability** | ACK echoes APPLIED codec (e.g. \"pcm\"), not requested (\"opus\") |
| 5 | No codec field | No-op, no pipeline call, no ACK |
| 6 | No pipeline (boot race) | No-op |
| 7 | WS closed | Pipeline still gets the swap, ACK silently skipped |

## server.py shrink

| Metric | Value |
|---|---|
| This PR | 2576 → 2575 LOC (−1 net; 16 LOC inline removed, 6 LOC comment + 5-line call added) |
| Cumulative round-2 | 2714 → 2575 LOC (−139, **−5.1 %**) |

## _handle_config_update progress

Five sub-responsibilities now in their own modules with their own tests:
* \`vision_capability.emit_vision_capability\` (#214)
* \`cap_downgrade.maybe_speak_cap_downgrade_alert\` (#215)
* \`config_swap.select_backends_for_mode\` (#216)
* \`config_swap_guards.validate_config_swap_prereqs\` (#217)
* \`codec_negotiation.maybe_swap_uplink_codec\` (this PR)

The remaining body of \`_handle_config_update\` is the session-DB-update + API-key propagation block + the pipeline/ConvEngine swap loop + the config_update ACK build. The biggest of those is the swap loop (~80 LOC tied to the A06 conn_lock semantics) — that's the natural next-but-trickier extract.

## Verification

\`\`\`
\$ python3 -m pytest tests/test_codec_negotiation.py -v
7 passed in 0.08s

\$ python3 -m pytest tests/ --ignore=tests/audit -q
754 passed, 108 subtests passed, 1 skipped, 0 failed in 11.48s

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \\
    dragon_voice/ tests/
All checks passed!
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)