### PR TITLE
refactor(server): extract pipeline + ConvEngine backend swap (~80 LOC) to backend_swap

### DIFF
--- a/dragon_voice/backend_swap.py
+++ b/dragon_voice/backend_swap.py
@@ -1,0 +1,183 @@
+"""Pipeline + ConversationEngine LLM backend swap.
+
+Wave 23 SOLID-audit follow-up — sixth sub-handler extract from
+`_handle_config_update` (after vision_capability #214,
+cap_downgrade #215, config_swap #216, config_swap_guards #217,
+codec_negotiation #218).
+
+This module owns the actual hot-swap moment: take the post-validated
+config, rotate the per-connection pipeline + the shared
+ConversationEngine's LLM, handle the swap-failure error path with
+γ-arch error_events + revert frames.  It's the biggest remaining
+inline chunk in `_handle_config_update` (~80 LOC).
+
+## Two backends, one moment
+
+Pre-Wave-22b (#207), the pipeline and ConvEngine swap paths drifted
+— the WS dispatcher swapped both inline; the HTTP `/api/config`
+handler only swapped pipelines.  Wave 22b extracted
+`ConversationEngine.swap_llm` as the canonical ConvEngine-side
+swap; this PR extracts the WS-side caller into a single function so
+both swap surfaces happen in one place with one error-handling
+policy.
+
+## API
+
+`await swap_pipeline_and_conversation_backends(ws, ...) -> bool`
+
+Returns ``True`` iff the **pipeline** swap succeeded (or no pipeline
+existed yet).  Returns ``False`` if `pipeline.swap_backends` raised
+— in which case the γ-arch error_event + revert frames have already
+been sent and the caller should short-circuit out of
+`_handle_config_update`.
+
+The ConvEngine swap failure is logged but does NOT cause `False` —
+matches the pre-extract behaviour where ConvEngine swap exceptions
+were caught + swallowed (since the pipeline swap is the user-visible
+path; ConvEngine drift is a "next text turn might be wrong" concern,
+not a "config_update flow is broken" one).
+
+## TinkerClaw session-key injection
+
+Pre-extract the swap loop also injected a session key onto the
+post-swap pipeline LLM via `SupportsSessionKey`.  That happens here
+too — the session_id comes from `conn_state["session_id"]`.
+
+## DIP
+
+`safe_send_json` is passed in.  `conversation` and `backend_pool`
+are passed in (rather than reaching back into VoiceServer's
+attributes).  The whole module compiles without importing
+`VoiceServer`.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from aiohttp import web
+
+from dragon_voice.errors import DragonError, Scope, Severity, error_event
+
+logger = logging.getLogger(__name__)
+
+
+SafeSendJson = Callable[[web.WebSocketResponse, dict], Awaitable[bool]]
+
+# Revert payload sent on any swap failure — flips Tab5 back to LOCAL
+# voice mode visually so the user understands the swap didn't take.
+_REVERT_TO_LOCAL: dict = {"type": "config_update", "voice_mode": 0}
+
+
+async def swap_pipeline_and_conversation_backends(
+    ws: web.WebSocketResponse,
+    *,
+    conn_state: Any,                  # ConnState or dict
+    conn_config: Any,                 # VoiceConfig
+    llm_be: str,                      # post-selection LLM backend name
+    voice_mode: int,                  # raw int — for ConvEngine.swap_llm router-mode
+    conversation: Optional[Any],      # ConversationEngine (server._conversation)
+    backend_pool: dict,               # server._backend_pool
+    safe_send_json: SafeSendJson,
+) -> bool:
+    """Hot-swap the pipeline backends + ConversationEngine LLM.
+
+    Args:
+        ws: Open WebSocket to Tab5.
+        conn_state: Per-connection state — read for `pipeline`,
+            `session_id`, `ws_id`.
+        conn_config: Post-validation, post-selection VoiceConfig.
+        llm_be: The selected LLM backend name (from
+            `select_backends_for_mode`).  Drives the TC session-key
+            injection branch.
+        voice_mode: Raw int form of the active mode (router uses
+            `set_voice_mode(int)` to flip its tier filter).
+        conversation: The shared ConversationEngine, or None during
+            boot.  When non-None, its LLM is also swapped (canonical
+            Wave 22b path via `swap_llm`).
+        backend_pool: The shared backend instance pool that
+            `swap_llm` reuses to avoid re-loading Ollama / re-opening
+            aiohttp sessions on every config_update.
+        safe_send_json: WS-send callable (passed in for DIP — keeps
+            this module from importing VoiceServer).
+
+    Returns:
+        True if the pipeline swap succeeded (or no pipeline existed).
+        False if the pipeline swap raised — caller MUST short-circuit
+        out of `_handle_config_update`.  The γ-arch error_event +
+        revert frames have already been sent.
+    """
+    # ── Pipeline swap (the user-visible failure path) ───────────
+    pipeline = conn_state.get("pipeline")
+    if pipeline:
+        try:
+            # swap_backends() handles cancel internally and sets
+            # _swapping flag to drop audio during swap.
+            await pipeline.swap_backends(conn_config)
+            # Inject session key for TinkerClaw conversation continuity.
+            # Wave 21b (#204): isinstance(SupportsSessionKey) over hasattr.
+            # `pipeline._llm` is a private attribute on Pipeline; the
+            # getattr-with-None still guards the rare case where swap
+            # leaves it unset.
+            from dragon_voice.llm.base import SupportsSessionKey
+            pipe_llm = getattr(pipeline, "_llm", None)
+            if llm_be == "tinkerclaw" and isinstance(pipe_llm, SupportsSessionKey):
+                pipe_llm.set_session_key(conn_state.get("session_id", ""))
+        except DragonError as de:
+            # Already a γ-arch structured error — emit verbatim.
+            logger.warning("Backend swap failed (DragonError): %s", de.message)
+            await safe_send_json(ws, de.to_event())
+            await safe_send_json(ws, _REVERT_TO_LOCAL)
+            return False
+        except Exception:
+            # A4 (audit, #137): the prior code did
+            # `f"Backend swap failed: {e}"` which leaked raw Python
+            # exception text (e.g. the multi-line OpenRouter / TC
+            # ValueError) into Tab5's voice caption.  Send a γ-arch
+            # error event with a user-friendly message instead; the
+            # full trace is still in the logs via logger.exception
+            # below.
+            logger.exception(
+                "Backend swap failed for %s",
+                conn_state.get("ws_id", "?"),
+            )
+            await safe_send_json(ws, error_event(
+                code="backend_swap_failed",
+                message="Couldn't switch backends — reverted to local",
+                severity=Severity.FATAL,
+                scope=Scope.LLM,
+            ))
+            await safe_send_json(ws, _REVERT_TO_LOCAL)
+            return False
+
+    # ── ConversationEngine swap (the silent-failure path) ───────
+    # W15-C01: prefer the pooled instance so we don't re-load Ollama /
+    # re-open the aiohttp session on every config_update.  Only the
+    # pipeline owns the shutdown of a pooled backend.
+    #
+    # #183 PR 3: when the active backend is the capability-aware
+    # router, voice_mode changes don't require a backend swap —
+    # the router holds the entire fleet and just flips its tier
+    # policy via set_voice_mode().  Saves the cost of recreating
+    # sub-backends + losing their warm-loaded models.
+    #
+    # Wave 22b (#202): canonical swap via ConversationEngine.swap_llm —
+    # closes the WS / HTTP swap-path divergence (HTTP path uses
+    # pipeline.swap_backends; ConvEngine now has its own public swap
+    # that both can call going forward).
+    if conversation is not None:
+        try:
+            await conversation.swap_llm(
+                conn_config.llm,
+                pool=backend_pool,
+                voice_mode=voice_mode,
+            )
+        except Exception as e:
+            # ConvEngine swap failure is logged but does NOT cause
+            # return False — pipeline swap succeeded, the user-visible
+            # path works for the next voice turn; the next text turn
+            # may use the stale ConvEngine LLM until the next
+            # config_update fires.  Matches pre-extract behaviour.
+            logger.exception("ConversationEngine LLM swap failed: %s", e)
+
+    return True

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -20,6 +20,7 @@ from typing import AsyncIterator, Optional
 import aiohttp
 from aiohttp import web, WSMsgType
 
+from dragon_voice.backend_swap import swap_pipeline_and_conversation_backends
 from dragon_voice.cap_downgrade import maybe_speak_cap_downgrade_alert
 from dragon_voice.codec_negotiation import maybe_swap_uplink_codec
 from dragon_voice.config_swap import select_backends_for_mode
@@ -2238,82 +2239,28 @@ class VoiceServer:
                 conn_config.tts.openrouter_api_key = conn_config.llm.openrouter_api_key
                 conn_config.tts.openrouter_url = conn_config.llm.openrouter_url
 
-            # Hot-swap backends on pipeline AND conversation engine.
+            # SOLID-audit follow-up: pipeline swap + ConvEngine swap
+            # extracted to backend_swap.swap_pipeline_and_conversation_backends.
             # Phase 1 (issue #91): conn_lock acquisition was previously here in
             # the inline body; now handled by `_spawn_handler_task` on the
             # outer task wrapper.  Same US-P01 serialization with stop/text
             # handlers is preserved.
-            pipeline = conn_state.get("pipeline")
-            if pipeline:
-                try:
-                    # swap_backends() now handles cancel internally
-                    # and sets _swapping flag to drop audio during swap
-                    await pipeline.swap_backends(conn_config)
-                    # Inject session key for TinkerClaw conversation continuity.
-                    # Wave 21b (#204): isinstance(SupportsSessionKey) over hasattr.
-                    # `pipeline._llm` is a private attribute on Pipeline; the
-                    # getattr-with-None still guards the rare case where swap
-                    # leaves it unset.
-                    from dragon_voice.llm.base import SupportsSessionKey
-                    pipe_llm = getattr(pipeline, "_llm", None)
-                    if llm_be == "tinkerclaw" and isinstance(pipe_llm, SupportsSessionKey):
-                        pipe_llm.set_session_key(conn_state.get("session_id", ""))
-                except DragonError as de:
-                    # Already a γ-arch structured error — emit verbatim.
-                    logger.warning("Backend swap failed (DragonError): %s", de.message)
-                    await self._safe_send_json(ws, de.to_event())
-                    await self._safe_send_json(ws, {
-                        "type": "config_update",
-                        "voice_mode": 0,
-                    })
-                    return
-                except Exception:
-                    # A4 (audit, #137): the prior code did
-                    # `f"Backend swap failed: {e}"` which leaked raw
-                    # Python exception text (e.g. the multi-line
-                    # OpenRouter / TC ValueError) into Tab5's voice
-                    # caption.  Send a γ-arch error event with a
-                    # user-friendly message instead; the full trace is
-                    # still in the logs via logger.exception below.
-                    logger.exception(
-                        "Backend swap failed for %s",
-                        conn_state.get("ws_id", "?"),
-                    )
-                    await self._safe_send_json(ws, error_event(
-                        code="backend_swap_failed",
-                        message="Couldn't switch backends — reverted to local",
-                        severity=Severity.FATAL,
-                        scope=Scope.LLM,
-                    ))
-                    await self._safe_send_json(ws, {
-                        "type": "config_update",
-                        "voice_mode": 0,
-                    })
-                    return
-
-            # Also swap ConversationEngine LLM (used by _handle_text).
-            # W15-C01: prefer the pooled instance so we don't re-load Ollama /
-            # re-open the aiohttp session on every config_update.  Only the
-            # pipeline owns the shutdown of a pooled backend.
             #
-            # #183 PR 3: when the active backend is the capability-aware
-            # router, voice_mode changes don't require a backend swap —
-            # the router holds the entire fleet and just flips its tier
-            # policy via set_voice_mode().  Saves the cost of recreating
-            # sub-backends + losing their warm-loaded models.
-            # Wave 22b (#202): canonical swap via ConversationEngine.swap_llm —
-            # closes the WS / HTTP swap-path divergence (HTTP path uses
-            # pipeline.swap_backends; ConvEngine now has its own public swap
-            # that both can call going forward).
-            if self._conversation:
-                try:
-                    await self._conversation.swap_llm(
-                        conn_config.llm,
-                        pool=self._backend_pool,
-                        voice_mode=voice_mode,
-                    )
-                except Exception as e:
-                    logger.exception("ConversationEngine LLM swap failed: %s", e)
+            # Returns False on pipeline.swap_backends failure (γ-arch
+            # error_event + revert frames already sent); short-circuit out.
+            # Returns True even if the ConvEngine swap fails (logged but
+            # silent — pipeline swap is the user-visible path).
+            if not await swap_pipeline_and_conversation_backends(
+                ws,
+                conn_state=conn_state,
+                conn_config=conn_config,
+                llm_be=llm_be,
+                voice_mode=int(vmode),
+                conversation=self._conversation,
+                backend_pool=self._backend_pool,
+                safe_send_json=self._safe_send_json,
+            ):
+                return
 
             # Update displayed names
             self._stt_name = stt_be

--- a/tests/test_backend_swap.py
+++ b/tests/test_backend_swap.py
@@ -1,0 +1,328 @@
+"""Tests for ``dragon_voice.backend_swap.swap_pipeline_and_conversation_backends``.
+
+Pin the eight branches:
+
+  1. No pipeline (boot race) → True; ConvEngine swap still runs.
+  2. Happy path (pipeline + ConvEngine present) → True; both swap.
+  3. TinkerClaw with SupportsSessionKey → set_session_key called
+     with the conn's session_id.
+  4. TinkerClaw with non-SupportsSessionKey LLM → no set_session_key
+     attempt (no AttributeError leak).
+  5. Pipeline raises DragonError → False; structured error_event +
+     revert sent.
+  6. Pipeline raises generic Exception → False; γ-arch generic
+     error_event ("backend_swap_failed") + revert.
+  7. ConvEngine swap raises → True (silent — failure logged + swallowed).
+  8. ConversationEngine None (boot) → True; only pipeline swap runs.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.backend_swap import swap_pipeline_and_conversation_backends
+from dragon_voice.errors import DragonError, Scope, Severity
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    return ws
+
+
+def _make_safe_send_json() -> AsyncMock:
+    return AsyncMock(return_value=True)
+
+
+def _make_pipeline_with_llm(llm) -> MagicMock:
+    """Build a Pipeline stub whose `_llm` is the given object."""
+    p = MagicMock()
+    p.swap_backends = AsyncMock()
+    p._llm = llm
+    return p
+
+
+def _make_conn_state(*, pipeline=None, session_id="sess-X") -> dict:
+    return {
+        "pipeline": pipeline,
+        "session_id": session_id,
+        "ws_id": "ws-test",
+    }
+
+
+def _make_conn_config() -> MagicMock:
+    cfg = MagicMock()
+    return cfg
+
+
+def _make_conversation_with_swap_llm(*, raises=None) -> MagicMock:
+    conv = MagicMock()
+    if raises is not None:
+        conv.swap_llm = AsyncMock(side_effect=raises)
+    else:
+        conv.swap_llm = AsyncMock(return_value=(MagicMock(), True))
+    return conv
+
+
+# ── 1. No pipeline (boot race) ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_pipeline_skips_pipeline_swap_runs_conv_swap():
+    ws = _make_ws()
+    conn = _make_conn_state(pipeline=None)
+    cfg = _make_conn_config()
+    conv = _make_conversation_with_swap_llm()
+    send = _make_safe_send_json()
+
+    out = await swap_pipeline_and_conversation_backends(
+        ws,
+        conn_state=conn,
+        conn_config=cfg,
+        llm_be="ollama",
+        voice_mode=0,
+        conversation=conv,
+        backend_pool={},
+        safe_send_json=send,
+    )
+
+    assert out is True
+    conv.swap_llm.assert_awaited_once()
+    send.assert_not_awaited()  # no error, no revert
+
+
+# ── 2. Happy path ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_happy_path_swaps_both_returns_true():
+    ws = _make_ws()
+    pipeline = _make_pipeline_with_llm(MagicMock())
+    conn = _make_conn_state(pipeline=pipeline)
+    cfg = _make_conn_config()
+    conv = _make_conversation_with_swap_llm()
+    send = _make_safe_send_json()
+
+    out = await swap_pipeline_and_conversation_backends(
+        ws,
+        conn_state=conn,
+        conn_config=cfg,
+        llm_be="ollama",
+        voice_mode=0,
+        conversation=conv,
+        backend_pool={},
+        safe_send_json=send,
+    )
+
+    assert out is True
+    pipeline.swap_backends.assert_awaited_once_with(cfg)
+    conv.swap_llm.assert_awaited_once()
+    send.assert_not_awaited()
+
+
+# ── 3-4. TinkerClaw session-key injection ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tinkerclaw_with_supports_session_key_calls_set_session_key():
+    """When the post-swap pipeline LLM implements SupportsSessionKey
+    AND we're in TC mode, the session_id from conn_state is injected."""
+    from dragon_voice.llm.base import SupportsSessionKey
+
+    # Build a fake LLM that implements SupportsSessionKey
+    class _SessionKeyLLM:
+        def __init__(self):
+            self.session_keys: list[str] = []
+
+        def set_session_key(self, k: str) -> None:
+            self.session_keys.append(k)
+
+    fake_llm = _SessionKeyLLM()
+    # Sanity: it really IS a SupportsSessionKey
+    assert isinstance(fake_llm, SupportsSessionKey)
+
+    ws = _make_ws()
+    pipeline = _make_pipeline_with_llm(fake_llm)
+    conn = _make_conn_state(pipeline=pipeline, session_id="sess-XYZ")
+    cfg = _make_conn_config()
+    conv = _make_conversation_with_swap_llm()
+
+    out = await swap_pipeline_and_conversation_backends(
+        ws,
+        conn_state=conn,
+        conn_config=cfg,
+        llm_be="tinkerclaw",
+        voice_mode=3,
+        conversation=conv,
+        backend_pool={},
+        safe_send_json=_make_safe_send_json(),
+    )
+
+    assert out is True
+    assert fake_llm.session_keys == ["sess-XYZ"]
+
+
+@pytest.mark.asyncio
+async def test_tinkerclaw_with_non_supporting_llm_skips_session_key():
+    """If the post-swap LLM doesn't implement SupportsSessionKey,
+    the isinstance() guard must skip the .set_session_key(...) call.
+
+    Note: assertion is "function returns True without crashing" —
+    on a Mock with `spec=[]`, accessing `.set_session_key` raises
+    AttributeError, which would surface as a test failure here
+    if the production guard didn't actually skip.
+    """
+    fake_llm = MagicMock(spec=[])  # empty spec — no methods at all
+    ws = _make_ws()
+    pipeline = _make_pipeline_with_llm(fake_llm)
+    conn = _make_conn_state(pipeline=pipeline)
+    cfg = _make_conn_config()
+
+    out = await swap_pipeline_and_conversation_backends(
+        ws,
+        conn_state=conn,
+        conn_config=cfg,
+        llm_be="tinkerclaw",
+        voice_mode=3,
+        conversation=_make_conversation_with_swap_llm(),
+        backend_pool={},
+        safe_send_json=_make_safe_send_json(),
+    )
+
+    assert out is True  # absence-of-AttributeError IS the assertion
+
+
+# ── 5. Pipeline raises DragonError → False, structured error ────
+
+
+@pytest.mark.asyncio
+async def test_pipeline_dragon_error_emits_structured_event_and_returns_false():
+    ws = _make_ws()
+    pipeline = _make_pipeline_with_llm(MagicMock())
+    de = DragonError(
+        code="custom_swap_failure",
+        message="Specific structured message",
+        severity=Severity.FATAL,
+        scope=Scope.LLM,
+    )
+    pipeline.swap_backends = AsyncMock(side_effect=de)
+    conn = _make_conn_state(pipeline=pipeline)
+    cfg = _make_conn_config()
+    send = _make_safe_send_json()
+
+    out = await swap_pipeline_and_conversation_backends(
+        ws,
+        conn_state=conn,
+        conn_config=cfg,
+        llm_be="openrouter",
+        voice_mode=2,
+        conversation=_make_conversation_with_swap_llm(),
+        backend_pool={},
+        safe_send_json=send,
+    )
+
+    assert out is False
+    # Two sends: structured DragonError event + revert
+    assert send.await_count == 2
+    err_payload = send.await_args_list[0].args[1]
+    revert_payload = send.await_args_list[1].args[1]
+    # DragonError emits its own structured payload via .to_event()
+    assert err_payload.get("code") == "custom_swap_failure"
+    assert revert_payload == {"type": "config_update", "voice_mode": 0}
+
+
+# ── 6. Pipeline raises generic Exception → False, generic γ-arch ─
+
+
+@pytest.mark.asyncio
+async def test_pipeline_generic_exception_emits_friendly_event_and_returns_false():
+    """A4 (audit #137): raw exception text must NOT leak into the
+    user-visible payload — the γ-arch wrapper sends a friendly
+    'backend_swap_failed' message instead."""
+    ws = _make_ws()
+    pipeline = _make_pipeline_with_llm(MagicMock())
+    pipeline.swap_backends = AsyncMock(
+        side_effect=ValueError("internal libopus version mismatch — DO NOT LEAK"),
+    )
+    conn = _make_conn_state(pipeline=pipeline)
+    cfg = _make_conn_config()
+    send = _make_safe_send_json()
+
+    out = await swap_pipeline_and_conversation_backends(
+        ws,
+        conn_state=conn,
+        conn_config=cfg,
+        llm_be="openrouter",
+        voice_mode=2,
+        conversation=_make_conversation_with_swap_llm(),
+        backend_pool={},
+        safe_send_json=send,
+    )
+
+    assert out is False
+    err_payload = send.await_args_list[0].args[1]
+    assert err_payload.get("code") == "backend_swap_failed"
+    # The raw exception text must NOT appear in the user-visible payload.
+    payload_str = str(err_payload)
+    assert "libopus version mismatch" not in payload_str
+    assert "DO NOT LEAK" not in payload_str
+
+
+# ── 7. ConvEngine swap failure is silent ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_conv_swap_failure_is_logged_but_returns_true():
+    """The ConvEngine swap is "best effort" — its failure should NOT
+    block config_update and should NOT send any client-visible
+    error.  The user-visible pipeline swap already succeeded; the
+    ConvEngine drift is a "next text turn might be wrong" concern,
+    not a "config_update is broken" one."""
+    ws = _make_ws()
+    pipeline = _make_pipeline_with_llm(MagicMock())
+    conn = _make_conn_state(pipeline=pipeline)
+    cfg = _make_conn_config()
+    conv = _make_conversation_with_swap_llm(raises=RuntimeError("ConvEngine failed"))
+    send = _make_safe_send_json()
+
+    out = await swap_pipeline_and_conversation_backends(
+        ws,
+        conn_state=conn,
+        conn_config=cfg,
+        llm_be="ollama",
+        voice_mode=0,
+        conversation=conv,
+        backend_pool={},
+        safe_send_json=send,
+    )
+
+    assert out is True  # pipeline swap succeeded → True regardless
+    send.assert_not_awaited()  # NO client-visible error
+    conv.swap_llm.assert_awaited_once()
+
+
+# ── 8. ConversationEngine None (boot) ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_conversation_none_skips_conv_swap():
+    """During boot ConvEngine may not be wired; must not crash."""
+    ws = _make_ws()
+    pipeline = _make_pipeline_with_llm(MagicMock())
+    conn = _make_conn_state(pipeline=pipeline)
+    cfg = _make_conn_config()
+
+    out = await swap_pipeline_and_conversation_backends(
+        ws,
+        conn_state=conn,
+        conn_config=cfg,
+        llm_be="ollama",
+        voice_mode=0,
+        conversation=None,
+        backend_pool={},
+        safe_send_json=_make_safe_send_json(),
+    )
+
+    assert out is True
+    pipeline.swap_backends.assert_awaited_once()


### PR DESCRIPTION
## What

**Sixth and biggest** Wave 22a-style sub-handler extract from \`_handle_config_update\` (after vision_capability #214, cap_downgrade #215, config_swap #216, config_swap_guards #217, codec_negotiation #218).

Pulls the actual hot-swap moment — the pipeline swap with full γ-arch error handling AND the ConvEngine LLM swap — into [\`dragon_voice/backend_swap.py\`](dragon_voice/backend_swap.py).

This is the **biggest single chunk** that's left in \`_handle_config_update\` (~80 LOC) and the **trickiest to test** because it owns the \"DragonError vs generic Exception → user-friendly γ-arch event vs raw-text leak\" distinction (the A4 audit fix from #137).

## API

\`\`\`python
async def swap_pipeline_and_conversation_backends(
    ws,
    *,
    conn_state,
    conn_config,
    llm_be: str,
    voice_mode: int,
    conversation,
    backend_pool: dict,
    safe_send_json,
) -> bool
\`\`\`

Returns \`True\` iff the **pipeline** swap succeeded (or no pipeline existed yet).  Returns \`False\` if \`pipeline.swap_backends\` raised — γ-arch error_event + revert frames have already been sent; caller MUST short-circuit out.

ConvEngine swap failure is logged but does NOT cause \`False\` — matches pre-extract behaviour where ConvEngine swap exceptions were caught + swallowed (pipeline swap is the user-visible path; ConvEngine drift is a \"next text turn might be wrong\" concern, not a \"config_update flow is broken\" one).

## Tests

[\`tests/test_backend_swap.py\`](tests/test_backend_swap.py) — 8 tests pinning every branch:

| # | Branch | Pinned |
|---|---|---|
| 1 | No pipeline (boot race) | True; ConvEngine swap still runs |
| 2 | Happy path | True; both swaps fire |
| 3 | TC + SupportsSessionKey LLM | set_session_key called with conn's session_id |
| 4 | TC + non-SupportsSessionKey LLM | No AttributeError leak (isinstance() guard) |
| 5 | Pipeline raises DragonError | False; .to_event() emitted verbatim; revert sent |
| 6 | Pipeline raises generic Exception | False; γ-arch friendly \"backend_swap_failed\" + revert; **raw exception text MUST NOT appear** (A4 audit invariant) |
| 7 | ConvEngine swap raises | True (silent); NO client-visible error |
| 8 | ConversationEngine None (boot) | True; only pipeline swap runs |

## server.py shrink

| Metric | Value |
|---|---|
| This PR | 2575 → 2522 LOC (−53, −2.1 %) |
| Cumulative round-2 | 2714 → 2522 LOC (−192, **−7.1 %**) |

## DIP

\`safe_send_json\`, \`conversation\`, and \`backend_pool\` are all passed in rather than reaching back into VoiceServer attributes. The whole module compiles without importing \`VoiceServer\` — clean dependency boundary.

## Verification

\`\`\`
\$ python3 -m pytest tests/test_backend_swap.py -v
8 passed in 0.09s

\$ python3 -m pytest tests/ --ignore=tests/audit -q
762 passed, 108 subtests passed, 1 skipped, 0 failed in 11.37s

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \\
    dragon_voice/ tests/
All checks passed!
\`\`\`

## _handle_config_update progress

Six sub-responsibilities now extracted:
* \`vision_capability.emit_vision_capability\` (#214)
* \`cap_downgrade.maybe_speak_cap_downgrade_alert\` (#215)
* \`config_swap.select_backends_for_mode\` (#216)
* \`config_swap_guards.validate_config_swap_prereqs\` (#217)
* \`codec_negotiation.maybe_swap_uplink_codec\` (#218)
* \`backend_swap.swap_pipeline_and_conversation_backends\` (this PR)

The remaining inline body is now ~210 LOC: session-DB-update + API-key propagation + the config_update ACK message build. The ACK build (~60 LOC) is the natural next-extract candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)