### PR TITLE
refactor(server): extract config_update ACK build (~36 LOC) to config_update_ack

### DIFF
--- a/dragon_voice/config_update_ack.py
+++ b/dragon_voice/config_update_ack.py
@@ -1,0 +1,160 @@
+"""Config-update ACK message builder.
+
+Wave 23 SOLID-audit follow-up — seventh sub-handler extract from
+`_handle_config_update` (after vision_capability #214,
+cap_downgrade #215, config_swap #216, config_swap_guards #217,
+codec_negotiation #218, backend_swap #219).
+
+Sends Tab5 the post-swap `config_update` confirmation message
+containing the active backend triple + the active model name +
+(when the capability-aware router is active) the per-modality
+fleet summary so Tab5's camera screen can light up its
+capability chips dynamically.
+
+## API surface
+
+```python
+active_model = await emit_config_update_ack(
+    ws,
+    vmode=vmode,
+    conn_config=conn_config,
+    backends=sel,
+    conversation=self._conversation,
+    safe_send_json=self._safe_send_json,
+)
+```
+
+Returns the resolved `active_model` string so downstream steps
+(`vision_capability.emit_vision_capability`) can reuse it without
+recomputing — that helper needs it for the substring-fallback
+display name when no router pick is available.
+
+## Active-model resolution rules
+
+| LLM backend | Source field |
+|-------------|--------------|
+| openrouter (`vmode.is_cloud()`) | `conn_config.llm.openrouter_model` |
+| tinkerclaw | `conn_config.llm.tinkerclaw_model` |
+| ollama | `conn_config.llm.ollama_model` |
+| anything else | `""` |
+
+The `vmode.is_cloud()` check is paranoia: pre-extract the code
+gated this branch on `voice_mode == 2` (now `vmode.is_cloud()` —
+PR #211); the LLM backend name "openrouter" is the same predicate
+in normal flow but using the typed mode keeps the intent
+self-describing.
+
+## Wire format
+
+```json
+{
+  "type": "config_update",
+  "config": {
+    "stt": "moonshine",
+    "tts": "piper",
+    "llm": "ollama",
+    "llm_model": "ministral-3:3b",
+    "voice_mode": 0,
+    "cloud_mode": false,
+    "fleet_summary": {...}        // only present when router active
+  }
+}
+```
+
+## Failure isolation
+
+`safe_send_json` is the WS-send callable passed in for DIP — same
+shape as the other extracted modules.  When the WS is closed,
+the active_model is still computed + returned (so downstream
+callers don't get an empty string) but the actual send is
+skipped.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from aiohttp import web
+
+from dragon_voice.config_swap import BackendSelection
+from dragon_voice.voice_modes import VoiceMode
+
+logger = logging.getLogger(__name__)
+
+
+SafeSendJson = Callable[[web.WebSocketResponse, dict], Awaitable[bool]]
+
+
+def _resolve_active_model(
+    vmode: VoiceMode,
+    conn_config: Any,
+    llm_backend: str,
+) -> str:
+    """Pick the user-visible active-model string for the ACK payload.
+
+    Pure function — no I/O, no mutation.  Exposed for direct use by
+    callers that need the resolved name without sending the ACK
+    (e.g. tests).
+    """
+    if vmode.is_cloud():
+        return conn_config.llm.openrouter_model or ""
+    if llm_backend == "tinkerclaw":
+        return conn_config.llm.tinkerclaw_model or ""
+    if llm_backend == "ollama":
+        return conn_config.llm.ollama_model or ""
+    return ""
+
+
+async def emit_config_update_ack(
+    ws: web.WebSocketResponse,
+    *,
+    vmode: VoiceMode,
+    conn_config: Any,
+    backends: BackendSelection,
+    conversation: Optional[Any],   # ConversationEngine — Any to dodge cycle
+    safe_send_json: SafeSendJson,
+) -> str:
+    """Send the post-swap config_update confirmation to Tab5.
+
+    Returns the resolved active_model string so callers can reuse
+    it without recomputing (the vision_capability emit downstream
+    needs it for the substring-fallback display name).
+
+    When `ws.closed`, returns the active_model but skips the send —
+    the downstream caller still gets a usable string.
+    """
+    active_model = _resolve_active_model(vmode, conn_config, backends.llm_backend)
+
+    if ws.closed:
+        return active_model
+
+    config_payload: dict = {
+        "stt": backends.stt_backend,
+        "tts": backends.tts_backend,
+        "llm": backends.llm_backend,
+        "llm_model": active_model,
+        "voice_mode": int(vmode),
+        # cloud_mode is the legacy binary toggle; True for any mode
+        # that touches cloud (Hybrid/Cloud/TC).  Onboard is Tab5-side-
+        # only and never reaches Dragon.
+        "cloud_mode": int(vmode) >= 1,
+    }
+
+    # #183 PR 3 + Wave 22b (#202): when the capability-aware router is
+    # active, advertise the per-modality fleet summary so Tab5
+    # firmware can light up vision/video/audio capability chips
+    # dynamically.  Single-backend configurations get a None back
+    # from `fleet_summary()` and the field is omitted (Tab5 firmware
+    # falls back to the legacy `vision_capability` event for
+    # backward-compat).
+    if conversation is not None:
+        summary = conversation.fleet_summary(int(vmode))
+        if summary is not None:
+            config_payload["fleet_summary"] = summary
+
+    await safe_send_json(ws, {
+        "type": "config_update",
+        "config": config_payload,
+    })
+
+    return active_model

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -25,6 +25,7 @@ from dragon_voice.cap_downgrade import maybe_speak_cap_downgrade_alert
 from dragon_voice.codec_negotiation import maybe_swap_uplink_codec
 from dragon_voice.config_swap import select_backends_for_mode
 from dragon_voice.config_swap_guards import validate_config_swap_prereqs
+from dragon_voice.config_update_ack import emit_config_update_ack
 from dragon_voice.conn_state import ConnState
 from dragon_voice.media.store import MediaStore
 from dragon_voice.media.pipeline import MediaPipeline
@@ -2267,58 +2268,34 @@ class VoiceServer:
             self._tts_name = tts_be
             self._llm_name = llm_be
 
-            # Confirm to Tab5
-            if not ws.closed:
-                # Report actual model for any mode
-                if vmode.is_cloud():
-                    active_model = conn_config.llm.openrouter_model
-                elif llm_be == "tinkerclaw":
-                    active_model = conn_config.llm.tinkerclaw_model
-                elif llm_be == "ollama":
-                    active_model = conn_config.llm.ollama_model
-                else:
-                    active_model = ""
-                # #183 PR 3: when the router is active, advertise the
-                # full per-modality fleet summary so Tab5 firmware can
-                # light up vision/video/audio capability chips
-                # dynamically.  Existing single-backend advertisements
-                # below are unchanged for backward-compat with current
-                # firmware that only reads `vision_capability`.
-                config_payload = {
-                    "stt": stt_be, "tts": tts_be,
-                    "llm": llm_be,
-                    "llm_model": active_model,
-                    "voice_mode": int(vmode),
-                    # cloud_mode is the legacy binary toggle; True for any
-                    # mode that touches cloud (Hybrid/Cloud/TC).  Onboard
-                    # is Tab5-side-only and never reaches Dragon.
-                    "cloud_mode": int(vmode) >= 1,
-                }
-                # Wave 22b (#202): use ConversationEngine.fleet_summary().
-                if self._conversation:
-                    summary = self._conversation.fleet_summary(int(vmode))
-                    if summary is not None:
-                        config_payload["fleet_summary"] = summary
-                await ws.send_json({
-                    "type": "config_update",
-                    "config": config_payload,
-                })
+            # SOLID-audit follow-up: ACK build + active_model
+            # resolution + fleet_summary inclusion all extracted to
+            # config_update_ack.emit_config_update_ack.  Returns the
+            # resolved active_model string so the vision_capability
+            # emit downstream can reuse it for the substring-fallback
+            # display name.
+            active_model = await emit_config_update_ack(
+                ws,
+                vmode=vmode,
+                conn_config=conn_config,
+                backends=sel,
+                conversation=self._conversation,
+                safe_send_json=self._safe_send_json,
+            )
 
-                # v4·D Phase 4b vision capability advertisement.  Tab5's
-                # camera screen renders a "VISION · <model> READY" chip based
-                # on this.  Extracted to vision_capability.emit_vision_capability
-                # in the SOLID-audit follow-up — the inline 80-LOC block was
-                # tangled with the config_update ACK + cap_downgrade speak;
-                # three sub-responsibilities that change for different
-                # reasons (router fleet shape vs Tab5 chip rendering vs cap
-                # policy) and shouldn't share a method body.
-                await emit_vision_capability(
-                    ws,
-                    conversation=self._conversation,
-                    vmode=vmode,
-                    conn_config=conn_config,
-                    active_model=active_model,
-                )
+            # v4·D Phase 4b vision capability advertisement.  Tab5's
+            # camera screen renders a "VISION · <model> READY" chip based
+            # on this.  Both this and the ACK builder above check
+            # ws.closed internally, so they're safe to call
+            # unconditionally — the ws.closed guard that used to wrap
+            # both is gone post-extract.
+            await emit_vision_capability(
+                ws,
+                conversation=self._conversation,
+                vmode=vmode,
+                conn_config=conn_config,
+                active_model=active_model,
+            )
 
             # v4·D Gauntlet G7-F: speak a short alert when the Tab5
             # auto-downgrades because the daily cap was hit.

--- a/tests/test_config_update_ack.py
+++ b/tests/test_config_update_ack.py
@@ -1,0 +1,246 @@
+"""Tests for ``dragon_voice.config_update_ack``.
+
+Pin two surfaces:
+
+  * ``_resolve_active_model`` — pure function that picks the
+    user-visible model name per vmode + LLM backend.  Five
+    branches (CLOUD / TINKERCLAW / OLLAMA / fallback / empty
+    config field).
+  * ``emit_config_update_ack`` — async ACK builder.  Pin payload
+    shape, fleet_summary inclusion contract, ws-closed skip,
+    return-value contract.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.config_swap import BackendSelection
+from dragon_voice.config_update_ack import (
+    _resolve_active_model,
+    emit_config_update_ack,
+)
+from dragon_voice.voice_modes import VoiceMode
+
+
+def _make_conn_config(
+    *,
+    openrouter_model: str = "",
+    tinkerclaw_model: str = "",
+    ollama_model: str = "",
+) -> MagicMock:
+    cfg = MagicMock()
+    cfg.llm.openrouter_model = openrouter_model
+    cfg.llm.tinkerclaw_model = tinkerclaw_model
+    cfg.llm.ollama_model = ollama_model
+    return cfg
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    return ws
+
+
+def _make_safe_send_json() -> AsyncMock:
+    return AsyncMock(return_value=True)
+
+
+def _make_conversation_with_summary(summary):
+    """Build a ConversationEngine stub whose fleet_summary returns
+    the given dict (or None for non-router backends)."""
+    conv = MagicMock()
+    conv.fleet_summary = MagicMock(return_value=summary)
+    return conv
+
+
+def _backends(*, llm: str = "ollama") -> BackendSelection:
+    return BackendSelection(
+        stt_backend="moonshine",
+        tts_backend="piper",
+        llm_backend=llm,
+    )
+
+
+# ─── _resolve_active_model — pure function ────────────────────────
+
+
+class TestResolveActiveModel:
+    def test_cloud_returns_openrouter_model(self):
+        cfg = _make_conn_config(openrouter_model="anthropic/claude-sonnet-4.6")
+        out = _resolve_active_model(VoiceMode.CLOUD, cfg, "openrouter")
+        assert out == "anthropic/claude-sonnet-4.6"
+
+    def test_tinkerclaw_returns_tinkerclaw_model(self):
+        cfg = _make_conn_config(tinkerclaw_model="minimax/MiniMax-M2.5")
+        out = _resolve_active_model(VoiceMode.TINKERCLAW, cfg, "tinkerclaw")
+        assert out == "minimax/MiniMax-M2.5"
+
+    def test_local_with_ollama_returns_ollama_model(self):
+        cfg = _make_conn_config(ollama_model="ministral-3:3b")
+        out = _resolve_active_model(VoiceMode.LOCAL, cfg, "ollama")
+        assert out == "ministral-3:3b"
+
+    def test_other_backend_returns_empty(self):
+        """Non-ollama local backends (npu_genie, dual, lmstudio) drop
+        through to "" because the ACK has no field for them yet."""
+        cfg = _make_conn_config()
+        out = _resolve_active_model(VoiceMode.LOCAL, cfg, "npu_genie")
+        assert out == ""
+
+    def test_missing_model_field_returns_empty_string_not_none(self):
+        """Empty config field → "" (not None) so the ACK payload
+        always serializes the field as a string."""
+        cfg = _make_conn_config(openrouter_model="")
+        out = _resolve_active_model(VoiceMode.CLOUD, cfg, "openrouter")
+        assert out == ""
+
+
+# ─── emit_config_update_ack — async ACK builder ──────────────────
+
+
+class TestEmitConfigUpdateAck:
+    @pytest.mark.asyncio
+    async def test_local_payload_shape(self):
+        ws = _make_ws()
+        cfg = _make_conn_config(ollama_model="ministral-3:3b")
+        send = _make_safe_send_json()
+
+        out = await emit_config_update_ack(
+            ws,
+            vmode=VoiceMode.LOCAL,
+            conn_config=cfg,
+            backends=_backends(llm="ollama"),
+            conversation=None,
+            safe_send_json=send,
+        )
+
+        assert out == "ministral-3:3b"
+        send.assert_awaited_once()
+        envelope = send.await_args.args[1]
+        assert envelope["type"] == "config_update"
+        cfg_payload = envelope["config"]
+        assert cfg_payload == {
+            "stt": "moonshine",
+            "tts": "piper",
+            "llm": "ollama",
+            "llm_model": "ministral-3:3b",
+            "voice_mode": 0,
+            "cloud_mode": False,
+        }
+        # No fleet_summary key when conversation is None.
+        assert "fleet_summary" not in cfg_payload
+
+    @pytest.mark.asyncio
+    async def test_cloud_payload_has_cloud_mode_true(self):
+        ws = _make_ws()
+        cfg = _make_conn_config(openrouter_model="anthropic/claude-opus-4.7")
+        send = _make_safe_send_json()
+
+        await emit_config_update_ack(
+            ws,
+            vmode=VoiceMode.CLOUD,
+            conn_config=cfg,
+            backends=BackendSelection("openrouter", "openrouter", "openrouter"),
+            conversation=None,
+            safe_send_json=send,
+        )
+        cfg_payload = send.await_args.args[1]["config"]
+        assert cfg_payload["voice_mode"] == 2
+        assert cfg_payload["cloud_mode"] is True
+        assert cfg_payload["llm_model"] == "anthropic/claude-opus-4.7"
+
+    @pytest.mark.asyncio
+    async def test_local_payload_has_cloud_mode_false(self):
+        ws = _make_ws()
+        cfg = _make_conn_config(ollama_model="ministral-3:3b")
+        send = _make_safe_send_json()
+
+        await emit_config_update_ack(
+            ws,
+            vmode=VoiceMode.LOCAL,
+            conn_config=cfg,
+            backends=_backends(llm="ollama"),
+            conversation=None,
+            safe_send_json=send,
+        )
+        cfg_payload = send.await_args.args[1]["config"]
+        assert cfg_payload["cloud_mode"] is False
+
+    @pytest.mark.asyncio
+    async def test_router_active_includes_fleet_summary(self):
+        """When ConversationEngine.fleet_summary returns a dict (i.e.
+        the active LLM is a CapabilityAwareRouter), it MUST land in
+        the payload so Tab5 can render its capability chips."""
+        ws = _make_ws()
+        cfg = _make_conn_config(openrouter_model="qwen/qwen3.6-flash")
+        send = _make_safe_send_json()
+        fleet = {
+            "text":     "ministral-3:3b",
+            "vision":   "qwen/qwen3.6-flash",
+            "video":    None,
+            "audio_in": None,
+            "audio_out": None,
+            "tool_calling": "ministral-3:3b",
+        }
+        conv = _make_conversation_with_summary(fleet)
+
+        await emit_config_update_ack(
+            ws,
+            vmode=VoiceMode.CLOUD,
+            conn_config=cfg,
+            backends=BackendSelection("openrouter", "openrouter", "openrouter"),
+            conversation=conv,
+            safe_send_json=send,
+        )
+
+        cfg_payload = send.await_args.args[1]["config"]
+        assert cfg_payload["fleet_summary"] == fleet
+        # fleet_summary asked with the right voice_mode int
+        conv.fleet_summary.assert_called_once_with(2)
+
+    @pytest.mark.asyncio
+    async def test_non_router_omits_fleet_summary_field(self):
+        """Single-backend configurations return None from
+        fleet_summary; the field MUST be omitted from the payload
+        (not present-with-null) so Tab5's old firmware that relies
+        on missing-field semantics keeps working."""
+        ws = _make_ws()
+        cfg = _make_conn_config(ollama_model="ministral-3:3b")
+        send = _make_safe_send_json()
+        conv = _make_conversation_with_summary(None)  # non-router
+
+        await emit_config_update_ack(
+            ws,
+            vmode=VoiceMode.LOCAL,
+            conn_config=cfg,
+            backends=_backends(llm="ollama"),
+            conversation=conv,
+            safe_send_json=send,
+        )
+
+        cfg_payload = send.await_args.args[1]["config"]
+        assert "fleet_summary" not in cfg_payload
+
+    @pytest.mark.asyncio
+    async def test_ws_closed_skips_send_but_returns_active_model(self):
+        """If the WS is already closed (client reconnecting),
+        skip the send but still return the active_model so
+        downstream callers (vision_capability emit) get a real
+        string and don't fall through to ""."""
+        ws = _make_ws(closed=True)
+        cfg = _make_conn_config(openrouter_model="anthropic/claude-haiku-4.5")
+        send = _make_safe_send_json()
+
+        out = await emit_config_update_ack(
+            ws,
+            vmode=VoiceMode.CLOUD,
+            conn_config=cfg,
+            backends=BackendSelection("openrouter", "openrouter", "openrouter"),
+            conversation=None,
+            safe_send_json=send,
+        )
+
+        assert out == "anthropic/claude-haiku-4.5"
+        send.assert_not_awaited()


### PR DESCRIPTION
## What

**Seventh** Wave 22a-style sub-handler extract from \`_handle_config_update\` (after #214/215/216/217/218/219).

Pulls the post-swap ACK message build (active model resolution + payload assembly + fleet_summary inclusion + ws.send_json) out of \`_handle_config_update\` into [\`dragon_voice/config_update_ack.py\`](dragon_voice/config_update_ack.py).

## API surface

| Function | Type | Purpose |
|---|---|---|
| \`_resolve_active_model(vmode, conn_config, llm_backend)\` | sync, pure | Pick the user-visible model name. Five branches (CLOUD / TC / OLLAMA / fallback / empty). |
| \`emit_config_update_ack(ws, ...) -> str\` | async | Build + send the ACK envelope. Returns the resolved \`active_model\` string so the vision_capability emit downstream can reuse it. |

## Indentation cleanup bonus

The pre-extract code had \`if not ws.closed: ... await ws.send_json(...)\` wrapping both the ACK build AND the vision_capability emit. **Both extracted functions now check ws.closed internally**, so the unifying guard goes away — the call sites become two straightforward awaits at the same indent level.

## Tests

[\`tests/test_config_update_ack.py\`](tests/test_config_update_ack.py) — 11 tests across two classes:

**\`TestResolveActiveModel\`** (5 tests) — pure function:
| # | Branch | Returns |
|---|---|---|
| 1 | CLOUD + openrouter_model set | \"anthropic/claude-sonnet-4.6\" |
| 2 | TINKERCLAW + tinkerclaw_model set | \"minimax/MiniMax-M2.5\" |
| 3 | LOCAL + ollama backend + ollama_model set | \"ministral-3:3b\" |
| 4 | LOCAL + npu_genie / dual / etc. backend | \"\" |
| 5 | Empty config field | \"\" (not None) — payload always serializes |

**\`TestEmitConfigUpdateAck\`** (6 tests) — async ACK builder:
| # | Branch | Pinned |
|---|---|---|
| 1 | LOCAL payload shape | Full envelope match |
| 2 | CLOUD payload | cloud_mode=True |
| 3 | LOCAL payload | cloud_mode=False |
| 4 | Router-active | fleet_summary in payload + asks ConvEngine.fleet_summary(int(vmode)) |
| 5 | Non-router | fleet_summary key OMITTED (not present-with-null — Tab5 firmware that uses missing-field semantics keeps working) |
| 6 | ws.closed | Skip send but RETURN active_model so downstream callers don't get an empty string |

## server.py shrink

| Metric | Value |
|---|---|
| This PR | 2522 → 2499 LOC (−23 net; 36 LOC inline removed, ~13 LOC comment + call added) |
| **Broke through the 2500 barrier** | server.py was 2714 LOC at start of round 2 |
| Cumulative round-2 | 2714 → 2499 LOC (−215, **−7.9 %**) |

## _handle_config_update progress

**Seven** sub-responsibilities now in their own modules with their own tests:

* \`vision_capability.emit_vision_capability\` (#214) — chip render
* \`cap_downgrade.maybe_speak_cap_downgrade_alert\` (#215) — TTS alert
* \`config_swap.select_backends_for_mode\` (#216) — backend mapping
* \`config_swap_guards.validate_config_swap_prereqs\` (#217) — pre-validation
* \`codec_negotiation.maybe_swap_uplink_codec\` (#218) — codec swap
* \`backend_swap.swap_pipeline_and_conversation_backends\` (#219) — hot swap
* \`config_update_ack.emit_config_update_ack\` (this PR) — ACK build

\`_handle_config_update\`'s remaining inline body is now ~190 LOC: top-of-function guards + voice_mode parse + rate-limit cursor + session DB update + API key propagation + the trailing call site chain. The session DB update + API key propagation (~40 LOC) is the natural next slice.

## Verification

\`\`\`
\$ python3 -m pytest tests/test_config_update_ack.py -v
11 passed in 0.08s

\$ python3 -m pytest tests/ --ignore=tests/audit -q
773 passed, 108 subtests passed, 1 skipped, 0 failed in 11.34s

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \\
    dragon_voice/ tests/
All checks passed!
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)