### PR TITLE
refactor(server): extract session DB persist + cloud API-key propagation (~40 LOC) to config_finalize

### DIFF
--- a/dragon_voice/config_finalize.py
+++ b/dragon_voice/config_finalize.py
@@ -1,0 +1,167 @@
+"""Post-validation, pre-swap config finalization helpers.
+
+Wave 23 SOLID-audit follow-up — eighth sub-handler extract from
+`_handle_config_update` (after #214/215/216/217/218/219/220).
+
+This module owns the final two pre-swap steps: persisting the
+new config to the session DB row, and propagating the OpenRouter
+API key from `conn_config.llm` into `conn_config.stt` / `.tts`
+for the modes that need cloud STT/TTS.
+
+Both run AFTER:
+  * select_backends_for_mode (#216) chose the backend names
+  * validate_config_swap_prereqs (#217) confirmed prerequisites
+
+And BEFORE:
+  * swap_pipeline_and_conversation_backends (#219) actually swaps
+
+## Two functions, one module
+
+The DB persist (`persist_session_config_to_db`) and the conn_config
+finalize (`apply_swap_config_to_conn`) are different concerns
+(persistence vs config plumbing) but both are part of the
+"finalization before swap" step.  Keeping them in one module
+makes the natural call site one logical unit:
+
+```python
+await persist_session_config_to_db(...)
+apply_swap_config_to_conn(...)
+await swap_pipeline_and_conversation_backends(...)
+```
+
+Splitting into two modules would scatter the finalization phase
+across the import graph.
+
+## Failure isolation
+
+`persist_session_config_to_db` swallows DB exceptions with a
+warning log — matches pre-extract behaviour where a failed
+session row update did NOT block the in-memory pipeline swap
+(the in-memory state IS the source of truth at runtime; the
+DB row is for cross-session resume).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from dragon_voice.voice_modes import VoiceMode
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_active_model_for_db(
+    vmode: VoiceMode,
+    conn_config: Any,
+    llm_backend: str,
+    llm_model_request: Optional[str],
+) -> str:
+    """Pick the active-model string to persist to the session row.
+
+    Same shape as `config_update_ack._resolve_active_model` BUT with
+    one extra fallback: when the chosen LLM backend isn't
+    openrouter / tinkerclaw / ollama, fall through to the user's
+    requested `llm_model` string (rather than `""`).  This matches
+    the historical pre-extract behaviour (server.py:2218 used
+    `str(llm_model or "")` here).
+
+    The two paths could be unified in a follow-up if the divergence
+    proves not to matter — but pinning behaviour first.
+    """
+    if vmode.is_cloud():
+        return conn_config.llm.openrouter_model or ""
+    if llm_backend == "tinkerclaw":
+        return conn_config.llm.tinkerclaw_model or ""
+    if llm_backend == "ollama":
+        return conn_config.llm.ollama_model or ""
+    return str(llm_model_request or "")
+
+
+async def persist_session_config_to_db(
+    db: Optional[Any],
+    *,
+    session_id: Optional[str],
+    vmode: VoiceMode,
+    conn_config: Any,                  # VoiceConfig
+    llm_backend: str,
+    llm_model_request: Optional[str],
+) -> None:
+    """Persist the post-swap config (system_prompt + voice_mode +
+    llm_model) onto the session DB row.
+
+    Chat v4·C (refs #27): the session drawer in chat-v4 surfaces the
+    active mode fingerprint, and pipeline-resume reads voice_mode +
+    llm_model from this row so a fresh device reconnection picks
+    the right backends without waiting for a config_update from
+    the client.
+
+    No-op when:
+      * `db` is None (test paths, embedded usage)
+      * `session_id` is None / empty (boot race; no session yet)
+
+    Failure isolation:
+      DB exceptions are caught + logged at WARNING level.  A failed
+      DB write must NOT block the in-memory pipeline swap — the
+      in-memory state IS the runtime source of truth; the DB row
+      is just for cross-session resume.
+    """
+    if not session_id or db is None:
+        return
+
+    active_model_db = _resolve_active_model_for_db(
+        vmode, conn_config, llm_backend, llm_model_request,
+    )
+    try:
+        await db.update_session(
+            session_id,
+            system_prompt=conn_config.llm.system_prompt,
+            voice_mode=int(vmode),
+            llm_model=active_model_db[:128],
+        )
+    except Exception:
+        logger.warning(
+            "Failed to update session system_prompt / mode",
+        )
+
+
+def apply_swap_config_to_conn(
+    conn_config: Any,                  # VoiceConfig
+    *,
+    vmode: VoiceMode,
+    stt_backend: str,
+    tts_backend: str,
+    llm_backend: str,
+) -> None:
+    """Finalize `conn_config` for the pending swap.
+
+    Two mutations in place:
+
+      1. Stamp the chosen backend names onto
+         `conn_config.{stt,tts,llm}.backend` so the pipeline-swap
+         code below picks them up.
+      2. For modes that route STT/TTS through OpenRouter (Hybrid /
+         Cloud / TC-with-cloud-suffix), propagate
+         `conn_config.llm.openrouter_api_key` and
+         `conn_config.llm.openrouter_url` over to the STT and TTS
+         sub-configs.  Without this propagation the cloud STT/TTS
+         backends crash on init with "missing API key" because
+         their config slots were initialised from the local-only
+         defaults.
+
+    No return value — pure mutation.  Pinned by tests so a future
+    refactor can't silently drop the API-key propagation step.
+    """
+    conn_config.stt.backend = stt_backend
+    conn_config.tts.backend = tts_backend
+    conn_config.llm.backend = llm_backend
+
+    # Propagate API keys for cloud STT/TTS backends:
+    #   - Hybrid + Cloud always need OpenRouter STT/TTS
+    #   - TinkerClaw mode needs OpenRouter STT/TTS only when Tab5
+    #     requested it via the "cloud" suffix in llm_model (the
+    #     resolved stt_backend will be "openrouter" in that case).
+    if vmode.needs_cloud_stt_tts() or (vmode.is_tinkerclaw() and stt_backend == "openrouter"):
+        conn_config.stt.openrouter_api_key = conn_config.llm.openrouter_api_key
+        conn_config.stt.openrouter_url = conn_config.llm.openrouter_url
+        conn_config.tts.openrouter_api_key = conn_config.llm.openrouter_api_key
+        conn_config.tts.openrouter_url = conn_config.llm.openrouter_url

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -23,6 +23,10 @@ from aiohttp import web, WSMsgType
 from dragon_voice.backend_swap import swap_pipeline_and_conversation_backends
 from dragon_voice.cap_downgrade import maybe_speak_cap_downgrade_alert
 from dragon_voice.codec_negotiation import maybe_swap_uplink_codec
+from dragon_voice.config_finalize import (
+    apply_swap_config_to_conn,
+    persist_session_config_to_db,
+)
 from dragon_voice.config_swap import select_backends_for_mode
 from dragon_voice.config_swap_guards import validate_config_swap_prereqs
 from dragon_voice.config_update_ack import emit_config_update_ack
@@ -2199,46 +2203,26 @@ class VoiceServer:
             ):
                 return
 
-            # Update session system prompt in DB for conversation engine
-            # Chat v4·C (refs #27): also persist voice_mode + llm_model
-            # onto the session row so the drawer surfaces the active
-            # mode fingerprint and pipeline-resume picks the right
-            # backends without a fresh config_update from the client.
-            sid = conn_state.get("session_id")
-            if sid and self._db:
-                # Resolve the best "active model" string to persist,
-                # matching the client-visible payload below.
-                if vmode.is_cloud():
-                    active_model_db = conn_config.llm.openrouter_model or ""
-                elif llm_be == "tinkerclaw":
-                    active_model_db = conn_config.llm.tinkerclaw_model or ""
-                elif llm_be == "ollama":
-                    active_model_db = conn_config.llm.ollama_model or ""
-                else:
-                    active_model_db = str(llm_model or "")
-                try:
-                    await self._db.update_session(
-                        sid,
-                        system_prompt=conn_config.llm.system_prompt,
-                        voice_mode=int(vmode),
-                        llm_model=active_model_db[:128],
-                    )
-                except Exception:
-                    logger.warning(
-                        "Failed to update session system_prompt / mode"
-                    )
-
-            # Apply config
-            conn_config.stt.backend = stt_be
-            conn_config.tts.backend = tts_be
-            conn_config.llm.backend = llm_be
-
-            # Propagate API keys for cloud STT/TTS backends (modes 1-2, or mode 3 with cloud STT)
-            if vmode.needs_cloud_stt_tts() or (vmode.is_tinkerclaw() and stt_be == "openrouter"):
-                conn_config.stt.openrouter_api_key = conn_config.llm.openrouter_api_key
-                conn_config.stt.openrouter_url = conn_config.llm.openrouter_url
-                conn_config.tts.openrouter_api_key = conn_config.llm.openrouter_api_key
-                conn_config.tts.openrouter_url = conn_config.llm.openrouter_url
+            # SOLID-audit follow-up: session DB persist + conn_config
+            # finalize (backend names + cloud STT/TTS API key
+            # propagation) extracted to config_finalize.{persist_session_config_to_db,
+            # apply_swap_config_to_conn}.  Both run AFTER validation +
+            # backend selection, BEFORE the actual swap.
+            await persist_session_config_to_db(
+                self._db,
+                session_id=conn_state.get("session_id"),
+                vmode=vmode,
+                conn_config=conn_config,
+                llm_backend=llm_be,
+                llm_model_request=llm_model,
+            )
+            apply_swap_config_to_conn(
+                conn_config,
+                vmode=vmode,
+                stt_backend=stt_be,
+                tts_backend=tts_be,
+                llm_backend=llm_be,
+            )
 
             # SOLID-audit follow-up: pipeline swap + ConvEngine swap
             # extracted to backend_swap.swap_pipeline_and_conversation_backends.

--- a/tests/test_config_finalize.py
+++ b/tests/test_config_finalize.py
@@ -1,0 +1,308 @@
+"""Tests for ``dragon_voice.config_finalize``.
+
+Pin two surfaces:
+
+  * ``persist_session_config_to_db`` — async DB write with failure
+    isolation.  6 branches: happy path, no-db, no-session, DB
+    raises, active_model derivation per backend, llm_model truncation
+    at 128 chars.
+
+  * ``apply_swap_config_to_conn`` — sync conn_config mutation.
+    7 branches: backend names always stamped; API key propagation
+    for HYBRID/CLOUD/TC-with-cloud-suffix; NO propagation for
+    LOCAL/TC-default.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.config_finalize import (
+    _resolve_active_model_for_db,
+    apply_swap_config_to_conn,
+    persist_session_config_to_db,
+)
+from dragon_voice.voice_modes import VoiceMode
+
+
+def _make_conn_config(
+    *,
+    openrouter_model: str = "",
+    tinkerclaw_model: str = "",
+    ollama_model: str = "",
+    openrouter_api_key: str = "sk-test",
+    openrouter_url: str = "https://openrouter.ai/api/v1",
+    system_prompt: str = "(initial)",
+) -> MagicMock:
+    cfg = MagicMock()
+    cfg.llm.openrouter_model = openrouter_model
+    cfg.llm.tinkerclaw_model = tinkerclaw_model
+    cfg.llm.ollama_model = ollama_model
+    cfg.llm.openrouter_api_key = openrouter_api_key
+    cfg.llm.openrouter_url = openrouter_url
+    cfg.llm.system_prompt = system_prompt
+    return cfg
+
+
+# ─── _resolve_active_model_for_db (pure function) ────────────────
+
+
+class TestResolveActiveModelForDb:
+    def test_cloud_returns_openrouter_model(self):
+        cfg = _make_conn_config(openrouter_model="anthropic/claude-sonnet-4.6")
+        out = _resolve_active_model_for_db(
+            VoiceMode.CLOUD, cfg, "openrouter", llm_model_request="ignored",
+        )
+        assert out == "anthropic/claude-sonnet-4.6"
+
+    def test_tinkerclaw_returns_tinkerclaw_model(self):
+        cfg = _make_conn_config(tinkerclaw_model="minimax/MiniMax-M2.5")
+        out = _resolve_active_model_for_db(
+            VoiceMode.TINKERCLAW, cfg, "tinkerclaw", llm_model_request=None,
+        )
+        assert out == "minimax/MiniMax-M2.5"
+
+    def test_local_with_ollama_returns_ollama_model(self):
+        cfg = _make_conn_config(ollama_model="ministral-3:3b")
+        out = _resolve_active_model_for_db(
+            VoiceMode.LOCAL, cfg, "ollama", llm_model_request=None,
+        )
+        assert out == "ministral-3:3b"
+
+    def test_other_backend_falls_back_to_request(self):
+        """Pinned divergence from config_update_ack._resolve_active_model:
+        the DB persist path falls back to the user's requested
+        llm_model when the chosen backend isn't openrouter / TC /
+        ollama (matching pre-extract behaviour at server.py:2218).
+        """
+        cfg = _make_conn_config()
+        out = _resolve_active_model_for_db(
+            VoiceMode.LOCAL, cfg, "npu_genie", llm_model_request="custom-id",
+        )
+        assert out == "custom-id"
+
+    def test_other_backend_with_no_request_returns_empty(self):
+        cfg = _make_conn_config()
+        out = _resolve_active_model_for_db(
+            VoiceMode.LOCAL, cfg, "npu_genie", llm_model_request=None,
+        )
+        assert out == ""
+
+
+# ─── persist_session_config_to_db (async DB write) ───────────────
+
+
+class TestPersistSessionConfigToDb:
+    @pytest.mark.asyncio
+    async def test_happy_path_writes_session_row(self):
+        db = MagicMock()
+        db.update_session = AsyncMock()
+        cfg = _make_conn_config(
+            ollama_model="ministral-3:3b",
+            system_prompt="(local prompt)",
+        )
+
+        await persist_session_config_to_db(
+            db,
+            session_id="sess-XYZ",
+            vmode=VoiceMode.LOCAL,
+            conn_config=cfg,
+            llm_backend="ollama",
+            llm_model_request="ministral-3:3b",
+        )
+
+        db.update_session.assert_awaited_once_with(
+            "sess-XYZ",
+            system_prompt="(local prompt)",
+            voice_mode=0,
+            llm_model="ministral-3:3b",
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_db_is_noop(self):
+        """Test paths or embedded usage may not have a DB wired."""
+        await persist_session_config_to_db(
+            None,
+            session_id="sess-X",
+            vmode=VoiceMode.LOCAL,
+            conn_config=_make_conn_config(),
+            llm_backend="ollama",
+            llm_model_request=None,
+        )
+        # no exception, no call
+
+    @pytest.mark.asyncio
+    async def test_no_session_id_is_noop(self):
+        """Boot race — no session has been created yet."""
+        db = MagicMock()
+        db.update_session = AsyncMock()
+
+        for empty in (None, ""):
+            await persist_session_config_to_db(
+                db,
+                session_id=empty,
+                vmode=VoiceMode.LOCAL,
+                conn_config=_make_conn_config(),
+                llm_backend="ollama",
+                llm_model_request=None,
+            )
+
+        db.update_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_db_exception_is_logged_not_raised(self):
+        """A failed DB write must NOT block the in-memory pipeline
+        swap — the in-memory state IS the runtime source of truth."""
+        db = MagicMock()
+        db.update_session = AsyncMock(side_effect=RuntimeError("DB down"))
+
+        # Must NOT raise.
+        await persist_session_config_to_db(
+            db,
+            session_id="sess-X",
+            vmode=VoiceMode.LOCAL,
+            conn_config=_make_conn_config(),
+            llm_backend="ollama",
+            llm_model_request=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_long_llm_model_truncated_to_128(self):
+        """Pin the [:128] guard — the DB column is bounded."""
+        db = MagicMock()
+        db.update_session = AsyncMock()
+        long_id = "a" * 200  # 200 chars
+        cfg = _make_conn_config(openrouter_model=long_id)
+
+        await persist_session_config_to_db(
+            db,
+            session_id="sess-X",
+            vmode=VoiceMode.CLOUD,
+            conn_config=cfg,
+            llm_backend="openrouter",
+            llm_model_request=None,
+        )
+
+        kwargs = db.update_session.await_args.kwargs
+        assert len(kwargs["llm_model"]) == 128
+        assert kwargs["llm_model"] == "a" * 128
+
+
+# ─── apply_swap_config_to_conn (sync conn_config mutation) ───────
+
+
+class TestApplySwapConfigToConn:
+    def test_stamps_backend_names(self):
+        cfg = _make_conn_config()
+        cfg.stt.backend = "(was)"
+        cfg.tts.backend = "(was)"
+        cfg.llm.backend = "(was)"
+
+        apply_swap_config_to_conn(
+            cfg,
+            vmode=VoiceMode.LOCAL,
+            stt_backend="moonshine",
+            tts_backend="piper",
+            llm_backend="ollama",
+        )
+
+        assert cfg.stt.backend == "moonshine"
+        assert cfg.tts.backend == "piper"
+        assert cfg.llm.backend == "ollama"
+
+    def test_local_does_not_propagate_api_keys(self):
+        cfg = _make_conn_config(openrouter_api_key="sk-test", openrouter_url="https://X")
+        # Pre-call: STT/TTS subconfigs have their own (empty) keys.
+        cfg.stt.openrouter_api_key = ""
+        cfg.tts.openrouter_api_key = ""
+
+        apply_swap_config_to_conn(
+            cfg,
+            vmode=VoiceMode.LOCAL,
+            stt_backend="moonshine",
+            tts_backend="piper",
+            llm_backend="ollama",
+        )
+
+        # No propagation in LOCAL mode.
+        assert cfg.stt.openrouter_api_key == ""
+        assert cfg.tts.openrouter_api_key == ""
+
+    def test_hybrid_propagates_api_keys(self):
+        cfg = _make_conn_config(openrouter_api_key="sk-test", openrouter_url="https://X")
+        cfg.stt.openrouter_api_key = ""
+        cfg.tts.openrouter_api_key = ""
+
+        apply_swap_config_to_conn(
+            cfg,
+            vmode=VoiceMode.HYBRID,
+            stt_backend="openrouter",
+            tts_backend="openrouter",
+            llm_backend="ollama",
+        )
+
+        assert cfg.stt.openrouter_api_key == "sk-test"
+        assert cfg.stt.openrouter_url == "https://X"
+        assert cfg.tts.openrouter_api_key == "sk-test"
+        assert cfg.tts.openrouter_url == "https://X"
+
+    def test_cloud_propagates_api_keys(self):
+        cfg = _make_conn_config(openrouter_api_key="sk-test", openrouter_url="https://X")
+
+        apply_swap_config_to_conn(
+            cfg,
+            vmode=VoiceMode.CLOUD,
+            stt_backend="openrouter",
+            tts_backend="openrouter",
+            llm_backend="openrouter",
+        )
+
+        assert cfg.stt.openrouter_api_key == "sk-test"
+        assert cfg.tts.openrouter_api_key == "sk-test"
+
+    def test_tc_with_cloud_stt_propagates_api_keys(self):
+        """TinkerClaw mode that opted into cloud STT/TTS via the
+        'cloud' suffix needs the API keys propagated even though
+        vmode.needs_cloud_stt_tts() is False for TC."""
+        cfg = _make_conn_config(openrouter_api_key="sk-tc", openrouter_url="https://X")
+
+        apply_swap_config_to_conn(
+            cfg,
+            vmode=VoiceMode.TINKERCLAW,
+            stt_backend="openrouter",  # cloud-suffix override
+            tts_backend="openrouter",
+            llm_backend="tinkerclaw",
+        )
+
+        assert cfg.stt.openrouter_api_key == "sk-tc"
+        assert cfg.tts.openrouter_api_key == "sk-tc"
+
+    def test_tc_with_local_stt_does_not_propagate(self):
+        """TinkerClaw default (local STT/TTS) doesn't need the
+        OpenRouter API key for STT/TTS subconfigs."""
+        cfg = _make_conn_config(openrouter_api_key="sk-tc", openrouter_url="https://X")
+        cfg.stt.openrouter_api_key = ""
+
+        apply_swap_config_to_conn(
+            cfg,
+            vmode=VoiceMode.TINKERCLAW,
+            stt_backend="moonshine",  # local default
+            tts_backend="piper",
+            llm_backend="tinkerclaw",
+        )
+
+        # No propagation when STT is local.
+        assert cfg.stt.openrouter_api_key == ""
+
+    def test_returns_none(self):
+        """Pure mutation; no return value."""
+        cfg = _make_conn_config()
+        out = apply_swap_config_to_conn(
+            cfg,
+            vmode=VoiceMode.LOCAL,
+            stt_backend="moonshine",
+            tts_backend="piper",
+            llm_backend="ollama",
+        )
+        assert out is None


### PR DESCRIPTION
## What

**Eighth** Wave 22a-style sub-handler extract from \`_handle_config_update\` (after #214/215/216/217/218/219/220).

Pulls the post-validation, pre-swap finalization steps out of \`_handle_config_update\` into [\`dragon_voice/config_finalize.py\`](dragon_voice/config_finalize.py).

## Two functions, one module

| Function | Type | Purpose |
|---|---|---|
| \`await persist_session_config_to_db(db, ...)\` | async | Write new system_prompt + voice_mode + llm_model onto session DB row |
| \`apply_swap_config_to_conn(conn_config, ...)\` | sync | Stamp backend names + propagate OpenRouter API key for cloud-STT/TTS modes |

Both run AFTER validation + backend selection, BEFORE the actual swap. Keeping them in one module makes the natural call site one logical unit:

\`\`\`python
await persist_session_config_to_db(...)
apply_swap_config_to_conn(...)
await swap_pipeline_and_conversation_backends(...)
\`\`\`

## Failure isolation

\`persist_session_config_to_db\` swallows DB exceptions with a WARNING log — matches pre-extract behaviour where a failed session row update did NOT block the in-memory pipeline swap (the in-memory state IS the runtime source of truth; the DB row is for cross-session resume — never block the swap on a failed write).

## Tests

[\`tests/test_config_finalize.py\`](tests/test_config_finalize.py) — 17 tests across three classes:

**\`TestResolveActiveModelForDb\`** (5 tests) — pins the active-model resolver including the **divergence** from \`config_update_ack._resolve_active_model\`: the DB persist path falls back to the user's requested \`llm_model\` when the chosen backend isn't openrouter / TC / ollama (matching pre-extract behaviour at server.py:2218).

**\`TestPersistSessionConfigToDb\`** (5 tests):
| # | Branch | Pinned |
|---|---|---|
| 1 | Happy path | update_session called with right kwargs |
| 2 | No DB | No-op (test paths, embedded usage) |
| 3 | No session_id (None or "") | No-op (boot race) |
| 4 | DB exception | Logged at WARNING, NOT raised |
| 5 | llm_model > 128 chars | Truncated (column bound) |

**\`TestApplySwapConfigToConn\`** (7 tests):
| # | Branch | Pinned |
|---|---|---|
| 1 | Backend names always stamped | conn_config.{stt,tts,llm}.backend updated |
| 2 | LOCAL | NO API key propagation |
| 3 | HYBRID | API key + URL propagated to STT and TTS |
| 4 | CLOUD | API key + URL propagated |
| 5 | TC with cloud STT (substring override) | API key propagated |
| 6 | TC default (local STT) | NO propagation |
| 7 | Returns None | Pure mutation |

## server.py shrink

| Metric | Value |
|---|---|
| This PR | 2499 → 2483 LOC (−16 net) |
| Cumulative round-2 | 2714 → 2483 LOC (−231, **−8.5 %**) |

## _handle_config_update progress

**Eight** sub-responsibilities now extracted across 8 PRs (#214/215/216/217/218/219/220/this).

\`_handle_config_update\`'s remaining inline body is now **~150 LOC** — top-of-function rate-limit guard + voice_mode parse + the trailing call-site chain to all eight extracted helpers. **The function is now a thin orchestrator.**

The remaining giants in server.py are:
* \`_handle_register\` (522 LOC) — next target for round 3
* \`_handle_text_body\` (438 LOC) — also a round-3 candidate

Both prime targets for similar decomposition.

## Verification

\`\`\`
\$ python3 -m pytest tests/test_config_finalize.py -v
17 passed in 0.02s

\$ python3 -m pytest tests/ --ignore=tests/audit -q
790 passed, 108 subtests passed, 1 skipped, 0 failed in 11.22s

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \\
    dragon_voice/ tests/
All checks passed!
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)