### PR TITLE
refactor(server): extract device DB upsert + D2 collision guard (~34 LOC) to device_upsert

### DIFF
--- a/dragon_voice/device_upsert.py
+++ b/dragon_voice/device_upsert.py
@@ -1,0 +1,111 @@
+"""Device DB upsert with hardware_id collision handling.
+
+Wave 23 SOLID-audit follow-up — second sub-handler extract from
+`_handle_register` (round 3, after stale_conn_eviction #222).
+
+Owns the device-row upsert into the `devices` table and the
+**D2 audit fix** for `hardware_id` UNIQUE-constraint collisions:
+when a second `device_id` registers with a `hardware_id` that's
+already claimed by another device, send a γ-arch FATAL/DEVICE
+`hardware_id_collision` error to the client and signal the
+caller to short-circuit out of `_handle_register`.
+
+## Pre-extract behaviour
+
+The collision case used to bubble `sqlite3.IntegrityError` up to
+the WS handler and drop the connection with no Tab5 signal.  Tab5
+would auto-reconnect into the same eviction loop until someone
+manually intervened.
+
+Audit D2 (#137) fixed this by catching the IntegrityError
+specifically and emitting a γ-arch error_event.  This module is
+the single home for that fix.
+
+## API
+
+`await upsert_device_with_collision_guard(...) -> bool`
+
+Returns ``True`` iff the upsert succeeded.  Returns ``False`` if
+a `hardware_id` collision was detected — in which case the
+γ-arch error_event has already been sent to the WS and the
+caller MUST short-circuit out of `_handle_register`.
+
+Other (non-collision) IntegrityError types still raise — those
+are real bugs and the WS handler's outer try/except is the right
+place to catch them.
+
+## DIP
+
+`db` and `safe_send_json` are passed in.  The whole module
+compiles without importing `VoiceServer`.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+from typing import Any, Awaitable, Callable, Optional
+
+from aiohttp import web
+
+from dragon_voice.errors import Scope, Severity, error_event
+
+logger = logging.getLogger(__name__)
+
+
+SafeSendJson = Callable[[web.WebSocketResponse, dict], Awaitable[bool]]
+
+
+async def upsert_device_with_collision_guard(
+    ws: web.WebSocketResponse,
+    *,
+    db: Any,                          # Database
+    device_id: str,
+    hardware_id: str,
+    name: str = "",
+    firmware_ver: str = "",
+    platform: str = "",
+    capabilities: Optional[Any] = None,
+    safe_send_json: SafeSendJson,
+) -> bool:
+    """Upsert the device into the DB.  Returns True on success.
+
+    On `sqlite3.IntegrityError` mentioning `hardware_id`, sends a
+    γ-arch FATAL/DEVICE `hardware_id_collision` error to `ws` and
+    returns False so the caller can short-circuit out of register.
+
+    Other IntegrityError flavours are re-raised — those are real
+    bugs that the WS handler's outer try/except should surface.
+    """
+    try:
+        await db.upsert_device(
+            device_id=device_id,
+            hardware_id=hardware_id,
+            name=name,
+            firmware_ver=firmware_ver,
+            platform=platform,
+            capabilities=capabilities,
+        )
+    except sqlite3.IntegrityError as e:
+        # D2 audit (#137): the `devices` table has a UNIQUE constraint
+        # on `hardware_id`.  A second device_id claiming the same
+        # hardware_id is a collision the operator needs to resolve;
+        # signal it explicitly to the client rather than dropping the
+        # WS silently.
+        if "hardware_id" in str(e).lower():
+            logger.warning(
+                "D2 hardware_id collision: device_id=%s wanted hw=%s but "
+                "hw is already claimed by another device — rejecting register",
+                device_id, hardware_id,
+            )
+            if not ws.closed:
+                await safe_send_json(ws, error_event(
+                    code="hardware_id_collision",
+                    message="This hardware ID is already registered to another device.",
+                    severity=Severity.FATAL,
+                    scope=Scope.DEVICE,
+                ))
+            return False
+        # Non-collision IntegrityError: real bug, let the outer
+        # handler catch + log it.
+        raise
+    return True

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -31,6 +31,7 @@ from dragon_voice.config_swap import select_backends_for_mode
 from dragon_voice.config_swap_guards import validate_config_swap_prereqs
 from dragon_voice.config_update_ack import emit_config_update_ack
 from dragon_voice.conn_state import ConnState
+from dragon_voice.device_upsert import upsert_device_with_collision_guard
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.media.store import MediaStore
 from dragon_voice.media.pipeline import MediaPipeline
@@ -1046,40 +1047,22 @@ class VoiceServer:
             new_ws_id=ws_id,
         )
 
-        # Upsert device in DB.
-        #
-        # Audit D2 (#137): the `devices` table has a UNIQUE constraint on
-        # `hardware_id`, so a second `device_id` registering with a
-        # `hardware_id` that's already claimed raises sqlite3.IntegrityError
-        # which used to bubble up to the WS handler and drop the connection
-        # with no Tab5 signal.  Catch it specifically and emit a γ-arch
-        # FATAL/DEVICE error so the user sees what happened.
-        import sqlite3 as _sqlite3
-        try:
-            await self._db.upsert_device(
-                device_id=device_id,
-                hardware_id=hardware_id,
-                name=cmd.get("name", ""),
-                firmware_ver=cmd.get("firmware_ver", ""),
-                platform=cmd.get("platform", ""),
-                capabilities=cmd.get("capabilities"),
-            )
-        except _sqlite3.IntegrityError as e:
-            if "hardware_id" in str(e).lower():
-                logger.warning(
-                    "D2 hardware_id collision: device_id=%s wanted hw=%s but "
-                    "hw is already claimed by another device — rejecting register",
-                    device_id, hardware_id,
-                )
-                if not ws.closed:
-                    await self._safe_send_json(ws, error_event(
-                        code="hardware_id_collision",
-                        message="This hardware ID is already registered to another device.",
-                        severity=Severity.FATAL,
-                        scope=Scope.DEVICE,
-                    ))
-                return
-            raise
+        # SOLID-audit follow-up: device DB upsert + D2 collision guard
+        # extracted to device_upsert.upsert_device_with_collision_guard.
+        # Returns False when a hardware_id collision was caught (γ-arch
+        # error already sent); short-circuit out.
+        if not await upsert_device_with_collision_guard(
+            ws,
+            db=self._db,
+            device_id=device_id,
+            hardware_id=hardware_id,
+            name=cmd.get("name", ""),
+            firmware_ver=cmd.get("firmware_ver", ""),
+            platform=cmd.get("platform", ""),
+            capabilities=cmd.get("capabilities"),
+            safe_send_json=self._safe_send_json,
+        ):
+            return
 
         # v4·D audit P0 fix: expose the widget subset of client capabilities
         # on conn_state so skills can pull it via SurfaceManager and

--- a/tests/test_device_upsert.py
+++ b/tests/test_device_upsert.py
@@ -1,0 +1,202 @@
+"""Tests for ``dragon_voice.device_upsert.upsert_device_with_collision_guard``.
+
+Pin five branches of the D2 audit fix:
+
+  1. Happy path — db.upsert_device called with right args, returns True.
+  2. hardware_id collision → False, γ-arch FATAL/DEVICE error sent.
+  3. Non-collision IntegrityError → re-raised (real bug, not user-facing).
+  4. WS closed during collision → returns False without trying to send.
+  5. Generic exception types (not IntegrityError) → still raise (the
+     guard is specifically for hardware_id collision, not all errors).
+"""
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.device_upsert import upsert_device_with_collision_guard
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    return ws
+
+
+def _make_db(*, raises: Exception | None = None) -> MagicMock:
+    db = MagicMock()
+    if raises is not None:
+        db.upsert_device = AsyncMock(side_effect=raises)
+    else:
+        db.upsert_device = AsyncMock()
+    return db
+
+
+def _make_safe_send_json() -> AsyncMock:
+    return AsyncMock(return_value=True)
+
+
+@pytest.mark.asyncio
+async def test_happy_path_returns_true_with_correct_kwargs():
+    ws = _make_ws()
+    db = _make_db()
+    send = _make_safe_send_json()
+
+    out = await upsert_device_with_collision_guard(
+        ws,
+        db=db,
+        device_id="dev-A",
+        hardware_id="00:11:22:33:44:55",
+        name="Tab5 Living Room",
+        firmware_ver="0.7.1",
+        platform="esp32p4",
+        capabilities={"audio_codec": ["pcm", "opus"]},
+        safe_send_json=send,
+    )
+
+    assert out is True
+    db.upsert_device.assert_awaited_once_with(
+        device_id="dev-A",
+        hardware_id="00:11:22:33:44:55",
+        name="Tab5 Living Room",
+        firmware_ver="0.7.1",
+        platform="esp32p4",
+        capabilities={"audio_codec": ["pcm", "opus"]},
+    )
+    send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_hardware_id_collision_sends_gamma_error_and_returns_false():
+    """D2 audit fix anchor: collision triggers a structured
+    error_event with the canonical code 'hardware_id_collision'."""
+    ws = _make_ws()
+    db = _make_db(
+        raises=sqlite3.IntegrityError("UNIQUE constraint failed: devices.hardware_id"),
+    )
+    send = _make_safe_send_json()
+
+    out = await upsert_device_with_collision_guard(
+        ws,
+        db=db,
+        device_id="dev-DUP",
+        hardware_id="00:11:22:33:44:55",
+        safe_send_json=send,
+    )
+
+    assert out is False
+    send.assert_awaited_once()
+    payload = send.await_args.args[1]
+    assert payload.get("type") == "error"
+    assert payload.get("code") == "hardware_id_collision"
+    assert payload.get("severity") == "fatal"
+    assert payload.get("scope") == "device"
+
+
+@pytest.mark.asyncio
+async def test_non_collision_integrity_error_is_re_raised():
+    """An IntegrityError that's NOT about hardware_id is a real
+    bug; let it propagate to the outer handler instead of
+    silently swallowing as a collision."""
+    ws = _make_ws()
+    db = _make_db(
+        raises=sqlite3.IntegrityError("UNIQUE constraint failed: devices.device_id"),
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        await upsert_device_with_collision_guard(
+            ws,
+            db=db,
+            device_id="dev-A",
+            hardware_id="00:11:22:33:44:55",
+            safe_send_json=_make_safe_send_json(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_ws_closed_during_collision_returns_false_no_send():
+    """If the WS is already closed when the collision fires, we
+    return False but don't try to send (which would log spurious
+    transport errors)."""
+    ws = _make_ws(closed=True)
+    db = _make_db(
+        raises=sqlite3.IntegrityError("UNIQUE constraint failed: devices.hardware_id"),
+    )
+    send = _make_safe_send_json()
+
+    out = await upsert_device_with_collision_guard(
+        ws,
+        db=db,
+        device_id="dev-DUP",
+        hardware_id="00:11:22:33:44:55",
+        safe_send_json=send,
+    )
+
+    assert out is False
+    send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_non_integrity_exception_propagates():
+    """The guard is specifically for IntegrityError — generic
+    exceptions (e.g. operational/connection issues) should
+    propagate to the outer handler."""
+    ws = _make_ws()
+    db = _make_db(raises=RuntimeError("DB connection lost"))
+
+    with pytest.raises(RuntimeError, match="DB connection lost"):
+        await upsert_device_with_collision_guard(
+            ws,
+            db=db,
+            device_id="dev-A",
+            hardware_id="00:11:22:33:44:55",
+            safe_send_json=_make_safe_send_json(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_collision_message_case_insensitive():
+    """The collision detection lowercases the error string before
+    matching 'hardware_id' — pin the case-insensitive guard so a
+    future SQLite version emitting upper-case messages still gets
+    caught."""
+    ws = _make_ws()
+    db = _make_db(
+        raises=sqlite3.IntegrityError("UNIQUE constraint failed: HARDWARE_ID"),
+    )
+    send = _make_safe_send_json()
+
+    out = await upsert_device_with_collision_guard(
+        ws,
+        db=db,
+        device_id="dev-DUP",
+        hardware_id="00:11:22:33:44:55",
+        safe_send_json=send,
+    )
+    assert out is False
+    send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_default_kwargs_omit_optional_fields_as_empty():
+    """Calling without name/firmware_ver/platform should pass
+    empty strings to the DB (not None or omit) — match
+    pre-extract behaviour at server.py:1062-1065."""
+    ws = _make_ws()
+    db = _make_db()
+
+    await upsert_device_with_collision_guard(
+        ws,
+        db=db,
+        device_id="dev-A",
+        hardware_id="00:11:22:33:44:55",
+        safe_send_json=_make_safe_send_json(),
+    )
+
+    kwargs = db.upsert_device.await_args.kwargs
+    assert kwargs["name"] == ""
+    assert kwargs["firmware_ver"] == ""
+    assert kwargs["platform"] == ""
+    assert kwargs["capabilities"] is None


### PR DESCRIPTION
## What

Round 3 PR-B (sister of [#222](https://github.com/lorcan35/TinkerBox/pull/222) stale-conn eviction).  Pulls the device upsert + the **D2 audit fix** (hardware_id UNIQUE-constraint collision → γ-arch FATAL/DEVICE error_event) out of the inline ~34-LOC chain at server.py:1049-1082 into [\`dragon_voice/device_upsert.py\`](dragon_voice/device_upsert.py).

## D2 audit anchor

Pre-D2 ([#137](https://github.com/lorcan35/TinkerBox/pull/137)) the IntegrityError bubbled to the WS handler and the connection just dropped — Tab5 had no signal that the hardware_id was already claimed and would auto-reconnect into the same loop. D2 added the structured error_event; this extract makes the fix a **first-class testable function** instead of inline-and-easy-to-regress code.

## API

\`\`\`python
ok = await upsert_device_with_collision_guard(
    ws,
    db=self._db,
    device_id=...,
    hardware_id=...,
    name=..., firmware_ver=..., platform=..., capabilities=...,
    safe_send_json=self._safe_send_json,
) -> bool
\`\`\`

Returns \`True\` on success. Returns \`False\` only on a hardware_id collision — γ-arch error_event already sent; caller MUST short-circuit out.

Other (non-collision) IntegrityError types still raise — those are real bugs. Generic exceptions also propagate.

## Tests

[\`tests/test_device_upsert.py\`](tests/test_device_upsert.py) — 7 tests:

| # | Branch | Pinned |
|---|---|---|
| 1 | Happy path | True + correct DB kwargs |
| 2 | hardware_id collision | False + γ-arch FATAL/DEVICE error with code \"hardware_id_collision\" |
| 3 | Non-collision IntegrityError | Re-raised (real bug) |
| 4 | WS closed during collision | False, no send attempted |
| 5 | Generic non-IntegrityError | Propagates |
| 6 | Case-insensitive collision detection | Pinned so future SQLite version emitting upper-case messages still gets caught |
| 7 | Default kwargs | Match pre-extract behaviour (\"\" not None) |

## server.py shrink

| Metric | Value |
|---|---|
| This PR | 2441 → 2424 LOC (−17 net) |
| Cumulative round 1+2+3 | 2714 → 2424 LOC (−290, **−10.7 %**) |

## _handle_register progress

| Sub-responsibility | LOC | Status |
|---|---|---|
| Validate device_id | ~11 | inline guard, fine as-is |
| P13 stale-conn eviction | ~57 | extracted [#222](https://github.com/lorcan35/TinkerBox/pull/222) |
| **Device DB upsert + D2 collision** | ~34 | extracted (this PR) |
| Widget caps pluck + add_event | ~18 | inline, small |
| Session create/resume + conn_state init | ~14 | inline, small |
| Surface mgr + scheduler replay | ~30 | next-extract candidate |
| **Tool callback closures** | ~176 | biggest remaining; round-3-finale |
| session_start + session_messages replay | ~79 | next-extract candidate |
| Pipeline init reset + create + codec neg | ~75 | tightly coupled |

## Verification

\`\`\`
\$ python3 -m pytest tests/test_device_upsert.py -v
7 passed in 0.08s

\$ python3 -m pytest tests/ --ignore=tests/audit -q
808 passed, 108 subtests passed, 1 skipped, 0 failed in 11.48s

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \\
    dragon_voice/ tests/
All checks passed!
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)