### PR TITLE
refactor(server): extract session_start + session_messages replay (~79 LOC) to session_handshake

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -32,6 +32,10 @@ from dragon_voice.config_swap_guards import validate_config_swap_prereqs
 from dragon_voice.config_update_ack import emit_config_update_ack
 from dragon_voice.conn_state import ConnState
 from dragon_voice.device_upsert import upsert_device_with_collision_guard
+from dragon_voice.session_handshake import (
+    emit_session_start,
+    replay_session_message_tail,
+)
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.media.store import MediaStore
 from dragon_voice.media.pipeline import MediaPipeline
@@ -1312,41 +1316,23 @@ class VoiceServer:
             conn_state["on_tool_result"] = _on_tool_result
             conn_state["on_tool_error"] = _on_tool_error
 
-        # Send session_start IMMEDIATELY — before slow pipeline init.
-        # Use _safe_send_json so a transient transport close (the Tab5
-        # register-before-receive-task-running race, refs #31 + TT #76)
-        # doesn't propagate an exception up to the WS handler and force
-        # a session pause. If the send drops, the client will reconnect
-        # shortly and we'll replay session_start on the next handshake.
-        # #183 PR 3: include `fleet_summary` so Tab5 firmware can
-        # advertise vision/video/audio caps dynamically without a
-        # hardcoded substring lookup.  Only present when the router is
-        # active; legacy single-backend deployments emit the same
-        # session_start as today.
-        session_start_config = {
-            "stt": conn_config.stt.backend,
-            "tts": conn_config.tts.backend,
-            "llm": conn_config.llm.backend,
-            "tts_sample_rate": conn_config.audio.input_sample_rate,
-            "response_mode": "match_input",
-            "system_prompt": conn_config.llm.system_prompt,
-        }
-        # Wave 22b (#202): use ConversationEngine.fleet_summary() instead
-        # of reaching into _conversation._llm with isinstance().
-        if self._conversation:
-            summary = self._conversation.fleet_summary(conn_state.get("voice_mode", 0))
-            if summary is not None:
-                session_start_config["fleet_summary"] = summary
-        if not await self._safe_send_json(ws, {
-            "type": "session_start",
-            "session_id": session_id,
-            "device_id": device_id,
-            "resumed": resumed,
-            "message_count": session.get("message_count", 0),
-            "config": session_start_config,
-        }):
-            logger.info("session_start send dropped on %s — client likely reconnecting", ws_id)
-            return
+        # SOLID-audit follow-up: session_start emit + session_messages
+        # replay extracted to session_handshake module.  Both run
+        # BEFORE the slow pipeline init so Tab5 sees the session
+        # confirmed even if Moonshine takes 2 s to load.
+        if not await emit_session_start(
+            ws,
+            session_id=session_id,
+            device_id=device_id,
+            resumed=resumed,
+            message_count=session.get("message_count", 0),
+            ws_id=ws_id,
+            conn_config=conn_config,
+            conversation=self._conversation,
+            voice_mode=conn_state.get("voice_mode", 0),
+            safe_send_json=self._safe_send_json,
+        ):
+            return  # transport drop — Tab5 will reconnect
 
         logger.info(
             "Device %s registered on session %s (resumed=%s, ws_id=%s)",
@@ -1355,42 +1341,14 @@ class VoiceServer:
 
         # Audit C8/K15 (2026-04-20): on resume, replay the tail of the
         # message history so Tab5 chat can rehydrate its local store.
-        # Previously session_start carried only message_count and Tab5
-        # had to fetch via REST (which it never did) -- so a reconnect
-        # lost the conversation from the user's view even though it was
-        # on disk. Cap at 20 messages (most recent) to keep the WS frame
-        # small; Tab5 can still fetch full history via
-        # /api/v1/sessions/{id}/messages.
-        if resumed and self._message_store is not None:
-            try:
-                msgs = await self._message_store.get_messages(
-                    session_id, limit=20, offset=0
-                )
-                # Return the LAST 20 (get_messages returns ascending, so
-                # slice the tail).
-                tail = msgs[-20:] if len(msgs) > 20 else msgs
-                items = []
-                for m in tail:
-                    role = m.get("role")
-                    content = m.get("content")
-                    if not role or not content:
-                        continue
-                    items.append({
-                        "role": role,
-                        "content": content,
-                        "timestamp": m.get("created_at"),
-                    })
-                if items and not await self._safe_send_json(ws, {
-                    "type": "session_messages",
-                    "session_id": session_id,
-                    "items": items,
-                }):
-                    logger.info("session_messages replay dropped on %s", ws_id)
-                else:
-                    logger.info("Replayed %d messages for session %s",
-                                len(items), session_id)
-            except Exception as e:
-                logger.warning("session_messages replay failed: %s", e)
+        if resumed:
+            await replay_session_message_tail(
+                ws,
+                session_id=session_id,
+                ws_id=ws_id,
+                message_store=self._message_store,
+                safe_send_json=self._safe_send_json,
+            )
 
         # Reset conn_config to local defaults before pipeline init.
         # Tab5 will immediately send config_update with its actual mode,

--- a/dragon_voice/session_handshake.py
+++ b/dragon_voice/session_handshake.py
@@ -1,0 +1,202 @@
+"""Session-handshake WS messages — `session_start` + `session_messages`.
+
+Wave 23 SOLID-audit follow-up — third sub-handler extract from
+`_handle_register` (round 3, after stale_conn_eviction #222 and
+device_upsert #223).
+
+Owns the two WS frames Tab5 receives RIGHT AFTER the device row is
+upserted but BEFORE the slow voice pipeline initializes:
+
+  * `session_start` — confirm the session id, the resume state,
+    the message count, and the active backend triple + (when
+    router-active) the per-modality fleet summary.
+  * `session_messages` — on resume, replay the tail of the
+    message history so Tab5 chat can rehydrate its local store
+    (Audit C8/K15, 2026-04-20).
+
+## API
+
+Two functions in one module — same shape as `config_finalize.py`
+which paired the DB-persist + conn-config-mutate steps.  Keeps
+the natural call-site one logical block.
+
+```python
+ok = await emit_session_start(
+    ws,
+    *,
+    session_id, device_id, resumed, message_count, ws_id,
+    conn_config, conversation, voice_mode,
+    safe_send_json,
+) -> bool
+```
+
+Returns ``True`` iff the send succeeded.  Returns ``False`` if
+`safe_send_json` reported a transport drop — the caller MUST
+short-circuit out of `_handle_register` (Tab5 will reconnect and
+we'll replay session_start fresh on the next handshake).
+
+```python
+await replay_session_message_tail(
+    ws,
+    *,
+    session_id, ws_id,
+    message_store,
+    safe_send_json,
+    limit=20,
+) -> None
+```
+
+No-op when `message_store` is None or no messages exist.
+Failures are logged at WARNING level and swallowed — replay is a
+nice-to-have UX feature, not a session correctness invariant.
+
+## DIP
+
+`safe_send_json`, `conversation`, `message_store` are all passed
+in.  The module compiles without importing `VoiceServer`.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+SafeSendJson = Callable[[web.WebSocketResponse, dict], Awaitable[bool]]
+
+# Cap on the message tail we replay on resume.  20 is small enough
+# to keep the WS frame under any practical buffer threshold while
+# giving Tab5 enough context to rehydrate the visible chat scroll.
+# Larger histories can be fetched via /api/v1/sessions/{id}/messages.
+_REPLAY_TAIL_LIMIT = 20
+
+
+async def emit_session_start(
+    ws: web.WebSocketResponse,
+    *,
+    session_id: str,
+    device_id: str,
+    resumed: bool,
+    message_count: int,
+    ws_id: str,
+    conn_config: Any,                  # VoiceConfig
+    conversation: Optional[Any],       # ConversationEngine
+    voice_mode: int,
+    safe_send_json: SafeSendJson,
+) -> bool:
+    """Send the `session_start` WS frame to Tab5.
+
+    Pre-extract the build was inline in `_handle_register` at
+    server.py:1326-1349 with the `fleet_summary` inclusion logic
+    duplicated from `config_update_ack.emit_config_update_ack`
+    (PR #220).  Sharing the fleet-summary lookup behind
+    `ConversationEngine.fleet_summary` (Wave 22b, PR #207) keeps
+    both call sites in sync.
+
+    Returns ``True`` iff `safe_send_json` reported success.
+    Returns ``False`` if the send was dropped (transport
+    half-closed mid-handshake) — caller MUST short-circuit out
+    of `_handle_register`; Tab5 will reconnect and replay
+    `session_start` fresh on the next handshake.
+    """
+    config_payload: dict = {
+        "stt": conn_config.stt.backend,
+        "tts": conn_config.tts.backend,
+        "llm": conn_config.llm.backend,
+        "tts_sample_rate": conn_config.audio.input_sample_rate,
+        "response_mode": "match_input",
+        "system_prompt": conn_config.llm.system_prompt,
+    }
+
+    # Wave 22b (#202): use ConversationEngine.fleet_summary() instead
+    # of reaching into _conversation._llm with isinstance().  Same
+    # pattern as config_update_ack.emit_config_update_ack (PR #220).
+    if conversation is not None:
+        summary = conversation.fleet_summary(voice_mode)
+        if summary is not None:
+            config_payload["fleet_summary"] = summary
+
+    sent = await safe_send_json(ws, {
+        "type": "session_start",
+        "session_id": session_id,
+        "device_id": device_id,
+        "resumed": resumed,
+        "message_count": message_count,
+        "config": config_payload,
+    })
+
+    if not sent:
+        logger.info("session_start send dropped on %s — client likely reconnecting", ws_id)
+
+    return sent
+
+
+async def replay_session_message_tail(
+    ws: web.WebSocketResponse,
+    *,
+    session_id: str,
+    ws_id: str,
+    message_store: Optional[Any],     # MessageStore
+    safe_send_json: SafeSendJson,
+    limit: int = _REPLAY_TAIL_LIMIT,
+) -> None:
+    """Audit C8/K15 (2026-04-20): on resume, replay the tail of
+    the message history so Tab5 chat can rehydrate its local
+    store.  Pre-fix `session_start` carried only `message_count`
+    and Tab5 had to fetch via REST (which it never did) — so a
+    reconnect lost the conversation from the user's view even
+    though it was on disk.
+
+    No-op when:
+      * `message_store` is None (test paths)
+      * no messages exist for `session_id`
+      * every message has empty role/content (defensive — pre-
+        extract code skipped these inline)
+
+    Failures are caught + logged at WARNING and swallowed — replay
+    is a UX nice-to-have, not a session correctness invariant.
+    Tab5 can still fetch full history via REST.
+
+    `limit` defaults to 20 to keep the WS frame small.
+    """
+    if message_store is None:
+        return
+
+    try:
+        msgs = await message_store.get_messages(session_id, limit=limit, offset=0)
+        # Return the LAST `limit` (get_messages returns ascending,
+        # so slice the tail).
+        tail = msgs[-limit:] if len(msgs) > limit else msgs
+
+        items = []
+        for m in tail:
+            role = m.get("role")
+            content = m.get("content")
+            if not role or not content:
+                continue
+            items.append({
+                "role": role,
+                "content": content,
+                "timestamp": m.get("created_at"),
+            })
+
+        if not items:
+            return  # nothing useful to replay
+
+        sent = await safe_send_json(ws, {
+            "type": "session_messages",
+            "session_id": session_id,
+            "items": items,
+        })
+        if not sent:
+            logger.info("session_messages replay dropped on %s", ws_id)
+        else:
+            logger.info(
+                "Replayed %d messages for session %s",
+                len(items), session_id,
+            )
+    except Exception as e:
+        logger.warning("session_messages replay failed: %s", e)

--- a/tests/test_session_handshake.py
+++ b/tests/test_session_handshake.py
@@ -1,0 +1,372 @@
+"""Tests for ``dragon_voice.session_handshake``.
+
+Two surfaces:
+
+  * ``emit_session_start`` — async sender for the post-register
+    handshake frame.  Pin payload shape, fleet_summary inclusion
+    contract, drop-on-send-fail return semantics.
+
+  * ``replay_session_message_tail`` — async optional replay of
+    the message tail on session resume.  Pin no-op branches
+    (no message_store, empty store, all-skipped messages) and
+    failure-isolation (store raises → logged + swallowed).
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.session_handshake import (
+    emit_session_start,
+    replay_session_message_tail,
+)
+
+
+def _make_ws() -> MagicMock:
+    ws = MagicMock()
+    return ws
+
+
+def _make_safe_send_json(returns: bool = True) -> AsyncMock:
+    return AsyncMock(return_value=returns)
+
+
+def _make_conn_config(
+    *,
+    stt: str = "moonshine",
+    tts: str = "piper",
+    llm: str = "ollama",
+    sample_rate: int = 16000,
+    system_prompt: str = "(local)",
+) -> MagicMock:
+    cfg = MagicMock()
+    cfg.stt.backend = stt
+    cfg.tts.backend = tts
+    cfg.llm.backend = llm
+    cfg.audio.input_sample_rate = sample_rate
+    cfg.llm.system_prompt = system_prompt
+    return cfg
+
+
+def _make_conv_with_summary(summary):
+    conv = MagicMock()
+    conv.fleet_summary = MagicMock(return_value=summary)
+    return conv
+
+
+# ─── emit_session_start ──────────────────────────────────────────
+
+
+class TestEmitSessionStart:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_true_with_full_payload(self):
+        ws = _make_ws()
+        cfg = _make_conn_config()
+        send = _make_safe_send_json(returns=True)
+
+        out = await emit_session_start(
+            ws,
+            session_id="sess-XYZ",
+            device_id="dev-A",
+            resumed=False,
+            message_count=0,
+            ws_id="ws-1",
+            conn_config=cfg,
+            conversation=None,
+            voice_mode=0,
+            safe_send_json=send,
+        )
+
+        assert out is True
+        send.assert_awaited_once()
+        envelope = send.await_args.args[1]
+        assert envelope["type"] == "session_start"
+        assert envelope["session_id"] == "sess-XYZ"
+        assert envelope["device_id"] == "dev-A"
+        assert envelope["resumed"] is False
+        assert envelope["message_count"] == 0
+
+        cfg_payload = envelope["config"]
+        assert cfg_payload == {
+            "stt": "moonshine",
+            "tts": "piper",
+            "llm": "ollama",
+            "tts_sample_rate": 16000,
+            "response_mode": "match_input",
+            "system_prompt": "(local)",
+        }
+        # No fleet_summary key when conversation is None.
+        assert "fleet_summary" not in cfg_payload
+
+    @pytest.mark.asyncio
+    async def test_resumed_session_carries_message_count(self):
+        ws = _make_ws()
+        send = _make_safe_send_json()
+
+        await emit_session_start(
+            ws,
+            session_id="sess-XYZ",
+            device_id="dev-A",
+            resumed=True,
+            message_count=42,
+            ws_id="ws-1",
+            conn_config=_make_conn_config(),
+            conversation=None,
+            voice_mode=0,
+            safe_send_json=send,
+        )
+
+        envelope = send.await_args.args[1]
+        assert envelope["resumed"] is True
+        assert envelope["message_count"] == 42
+
+    @pytest.mark.asyncio
+    async def test_router_active_includes_fleet_summary(self):
+        """When ConversationEngine.fleet_summary returns a dict
+        (CapabilityAwareRouter active), it MUST land in the
+        config payload so Tab5 can render its capability chips
+        without a fresh config_update."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        fleet = {
+            "text":     "ministral-3:3b",
+            "vision":   "qwen/qwen3.6-flash",
+            "video":    None,
+            "audio_in": None,
+            "audio_out": None,
+            "tool_calling": "ministral-3:3b",
+        }
+        conv = _make_conv_with_summary(fleet)
+
+        await emit_session_start(
+            ws,
+            session_id="sess-XYZ",
+            device_id="dev-A",
+            resumed=False,
+            message_count=0,
+            ws_id="ws-1",
+            conn_config=_make_conn_config(),
+            conversation=conv,
+            voice_mode=2,
+            safe_send_json=send,
+        )
+
+        cfg_payload = send.await_args.args[1]["config"]
+        assert cfg_payload["fleet_summary"] == fleet
+        # Asked with the right voice_mode int
+        conv.fleet_summary.assert_called_once_with(2)
+
+    @pytest.mark.asyncio
+    async def test_non_router_omits_fleet_summary_field(self):
+        """Single-backend configurations return None from
+        fleet_summary; the field MUST be omitted (not present-
+        with-null) so Tab5 firmware that uses missing-field
+        semantics keeps working."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        conv = _make_conv_with_summary(None)
+
+        await emit_session_start(
+            ws,
+            session_id="sess-XYZ",
+            device_id="dev-A",
+            resumed=False,
+            message_count=0,
+            ws_id="ws-1",
+            conn_config=_make_conn_config(),
+            conversation=conv,
+            voice_mode=0,
+            safe_send_json=send,
+        )
+        cfg_payload = send.await_args.args[1]["config"]
+        assert "fleet_summary" not in cfg_payload
+
+    @pytest.mark.asyncio
+    async def test_send_drop_returns_false(self):
+        """If safe_send_json reports drop (transport half-closed),
+        return False so the caller short-circuits — Tab5 will
+        reconnect and we'll replay session_start fresh."""
+        ws = _make_ws()
+        send = _make_safe_send_json(returns=False)
+
+        out = await emit_session_start(
+            ws,
+            session_id="sess-XYZ",
+            device_id="dev-A",
+            resumed=False,
+            message_count=0,
+            ws_id="ws-1",
+            conn_config=_make_conn_config(),
+            conversation=None,
+            voice_mode=0,
+            safe_send_json=send,
+        )
+        assert out is False
+
+
+# ─── replay_session_message_tail ─────────────────────────────────
+
+
+class TestReplaySessionMessageTail:
+    @pytest.mark.asyncio
+    async def test_no_message_store_is_noop(self):
+        """During boot or test paths, message_store may be None."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+
+        await replay_session_message_tail(
+            ws,
+            session_id="sess-X",
+            ws_id="ws-1",
+            message_store=None,
+            safe_send_json=send,
+        )
+
+        send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_empty_store_skips_send(self):
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        store = MagicMock()
+        store.get_messages = AsyncMock(return_value=[])
+
+        await replay_session_message_tail(
+            ws,
+            session_id="sess-X",
+            ws_id="ws-1",
+            message_store=store,
+            safe_send_json=send,
+        )
+
+        store.get_messages.assert_awaited_once()
+        send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_happy_path_sends_session_messages_envelope(self):
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        store = MagicMock()
+        store.get_messages = AsyncMock(return_value=[
+            {"role": "user", "content": "hello", "created_at": "2026-05-01T12:00"},
+            {"role": "assistant", "content": "hi there", "created_at": "2026-05-01T12:01"},
+        ])
+
+        await replay_session_message_tail(
+            ws,
+            session_id="sess-XYZ",
+            ws_id="ws-1",
+            message_store=store,
+            safe_send_json=send,
+        )
+
+        send.assert_awaited_once()
+        envelope = send.await_args.args[1]
+        assert envelope["type"] == "session_messages"
+        assert envelope["session_id"] == "sess-XYZ"
+        assert len(envelope["items"]) == 2
+        assert envelope["items"][0] == {
+            "role": "user",
+            "content": "hello",
+            "timestamp": "2026-05-01T12:00",
+        }
+
+    @pytest.mark.asyncio
+    async def test_messages_with_missing_role_or_content_skipped(self):
+        """Defensive: pre-extract code skipped messages with
+        empty role/content (legacy tool-result frames etc.).
+        Pin that filter."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        store = MagicMock()
+        store.get_messages = AsyncMock(return_value=[
+            {"role": "user", "content": "valid"},
+            {"role": "", "content": "no role"},          # skipped
+            {"role": "assistant", "content": ""},         # skipped
+            {"role": None, "content": "still no role"},   # skipped
+            {"role": "user", "content": "also valid"},
+        ])
+
+        await replay_session_message_tail(
+            ws,
+            session_id="sess-X",
+            ws_id="ws-1",
+            message_store=store,
+            safe_send_json=send,
+        )
+
+        envelope = send.await_args.args[1]
+        assert len(envelope["items"]) == 2
+        contents = [i["content"] for i in envelope["items"]]
+        assert contents == ["valid", "also valid"]
+
+    @pytest.mark.asyncio
+    async def test_all_messages_skipped_no_send(self):
+        """If every message is filtered out, don't send an empty
+        session_messages envelope."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        store = MagicMock()
+        store.get_messages = AsyncMock(return_value=[
+            {"role": "", "content": "x"},
+            {"role": None, "content": "y"},
+        ])
+
+        await replay_session_message_tail(
+            ws,
+            session_id="sess-X",
+            ws_id="ws-1",
+            message_store=store,
+            safe_send_json=send,
+        )
+        send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_store_exception_logged_not_raised(self):
+        """If the store raises (DB down, schema migration in
+        progress), log + swallow.  Replay is a nice-to-have."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        store = MagicMock()
+        store.get_messages = AsyncMock(side_effect=RuntimeError("DB busy"))
+
+        # Must NOT raise.
+        await replay_session_message_tail(
+            ws,
+            session_id="sess-X",
+            ws_id="ws-1",
+            message_store=store,
+            safe_send_json=send,
+        )
+
+    @pytest.mark.asyncio
+    async def test_long_history_truncated_to_limit(self):
+        """A 100-message history should be capped to the most-recent 20."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        store = MagicMock()
+        msgs = [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg-{i}"}
+            for i in range(100)
+        ]
+        # Note: get_messages is itself called with limit=20, so the
+        # limit truncation happens at the DB layer.  The post-call
+        # tail-slice is defence-in-depth.  We mock get_messages to
+        # return ALL 100 to exercise the slice.
+        store.get_messages = AsyncMock(return_value=msgs)
+
+        await replay_session_message_tail(
+            ws,
+            session_id="sess-X",
+            ws_id="ws-1",
+            message_store=store,
+            safe_send_json=send,
+            limit=20,
+        )
+
+        envelope = send.await_args.args[1]
+        # Last 20 of msg-0..msg-99 = msg-80..msg-99
+        assert len(envelope["items"]) == 20
+        assert envelope["items"][0]["content"] == "msg-80"
+        assert envelope["items"][-1]["content"] == "msg-99"


### PR DESCRIPTION
## What

Round 3 PR-C — third sub-handler extract from \`_handle_register\` (after [#222](https://github.com/lorcan35/TinkerBox/pull/222) stale-conn eviction and [#223](https://github.com/lorcan35/TinkerBox/pull/223) device upsert).

Pulls the post-register handshake frames out of the inline ~79-LOC chain at server.py:1315-1393 into [\`dragon_voice/session_handshake.py\`](dragon_voice/session_handshake.py).

## Two functions, one module

Same shape as \`config_finalize.py\` (PR #221) — paired functions that run as one logical block in the caller.

\`\`\`python
ok = await emit_session_start(ws, *, session_id, device_id,
                              resumed, message_count, ws_id,
                              conn_config, conversation,
                              voice_mode, safe_send_json) -> bool
await replay_session_message_tail(ws, *, session_id, ws_id,
                                  message_store, safe_send_json,
                                  limit=20) -> None
\`\`\`

\`emit_session_start\` returns False on send drop so the caller can short-circuit out of \`_handle_register\` (Tab5 will reconnect and we replay session_start fresh). \`replay_session_message_tail\` is fire-and-forget — exceptions logged + swallowed because replay is UX nice-to-have, not session correctness.

## fleet_summary lookup deduped

Both \`emit_session_start\` (this PR) and \`emit_config_update_ack\` (PR #220) include the optional \`fleet_summary\` block. Pre-extract the include logic was duplicated — now both go through \`ConversationEngine.fleet_summary\` (Wave 22b, [#207](https://github.com/lorcan35/TinkerBox/pull/207)) so the two call sites stay in sync automatically.

## Tests

[\`tests/test_session_handshake.py\`](tests/test_session_handshake.py) — 12 tests across two classes:

**\`TestEmitSessionStart\`** (5 tests):
| # | Branch | Pinned |
|---|---|---|
| 1 | Happy path | Full envelope shape match |
| 2 | Resumed session | message_count carried |
| 3 | Router-active | fleet_summary in payload |
| 4 | Non-router | fleet_summary key OMITTED |
| 5 | Send drop | Returns False |

**\`TestReplaySessionMessageTail\`** (7 tests):
| # | Branch | Pinned |
|---|---|---|
| 1 | No message_store | No-op |
| 2 | Empty store | Skip send |
| 3 | Happy path | session_messages envelope with items array |
| 4 | Messages with missing role/content | Skipped (defensive filter) |
| 5 | All messages skipped | No send |
| 6 | Store exception | Logged + swallowed |
| 7 | Long history (>20) | Tail-truncated to limit |

## server.py shrink

| Metric | Value |
|---|---|
| This PR | 2424 → 2382 LOC (−42 net) |
| Cumulative round 1+2+3 | 2714 → 2382 LOC (−332, **−12.2 %**) |

## _handle_register progress

| Sub-responsibility | LOC | Status |
|---|---|---|
| Validate device_id | ~11 | inline, fine |
| P13 stale-conn eviction | ~57 | extracted #222 |
| Device DB upsert + D2 | ~34 | extracted #223 |
| Widget caps pluck + add_event | ~18 | inline, small |
| Session create/resume + conn_state init | ~14 | inline, small |
| Surface mgr + scheduler replay | ~30 | next candidate |
| Tool callback closures | ~176 | biggest remaining |
| **session_start + session_messages** | ~79 | extracted (this PR) |
| Pipeline init + create + codec neg | ~75 | tightly coupled |

\`_handle_register\` is now ~370 LOC. Tool callback closures (~176) are the biggest remaining win — but they're stateful async closures over \`ws\`, \`conn_state\`, \`_emit_legacy\`, \`_emit_via_ws\` and need careful design (likely a small \`ToolEventEmitter\` class) before extraction.

## Verification

\`\`\`
\$ python3 -m pytest tests/test_session_handshake.py -v
12 passed in 0.09s

\$ python3 -m pytest tests/ --ignore=tests/audit -q
820 passed, 108 subtests passed, 1 skipped, 0 failed in 11.18s

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \\
    dragon_voice/ tests/
All checks passed!
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)