### PR TITLE
refactor(server): extract Surface register + Scheduler replay (~30 LOC) to surface_register

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -37,6 +37,7 @@ from dragon_voice.session_handshake import (
     replay_session_message_tail,
 )
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
+from dragon_voice.surface_register import register_surface_and_replay_scheduler
 from dragon_voice.media.store import MediaStore
 from dragon_voice.media.pipeline import MediaPipeline
 from dragon_voice.vision_capability import emit_vision_capability
@@ -1101,43 +1102,19 @@ class VoiceServer:
         conn_state["registered"] = True
         conn_state["response_mode"] = "always_speak"  # voice device gets TTS
 
-        # v4·D Phase 4g: register this connection's surface with the
-        # shared SurfaceManager.  Skills dispatch widget_* emissions
-        # through here and widget_action events route back via
-        # handle_action().
-        # v4·D audit P1: route surface + tool-event sends through the
-        # _safe_send_json helper so a transient close mid-widget-emit
-        # doesn't bubble into the WS handler and tear the session down.
-        if self._surface_mgr is not None:
-            async def _surface_send(msg: dict):
-                if not ws.closed:
-                    await self._safe_send_json(ws, msg)
-            await self._surface_mgr.register_session(session_id, _surface_send, caps=conn_state.get("widget_capabilities"))
-
-        # Phase 5 ε2 (issue #131): replay any queued offline
-        # notifications for this device.  Hook fires AFTER
-        # SurfaceManager.register_session so the scheduler manager
-        # can find a live Tab5Surface for this session.  Best-effort:
-        # a queue-drain failure logs a warning but doesn't block
-        # registration (the user's reminders just stay queued for
-        # the next register).
-        scheduler_mgr = getattr(self, "_scheduler_mgr", None)
-        if scheduler_mgr is not None:
-            try:
-                replayed = await scheduler_mgr.replay_queued_for_device(
-                    device_id,
-                )
-                if replayed > 0:
-                    logger.info(
-                        "Scheduler offline-queue replay: delivered %d "
-                        "frame(s) to %s on session %s",
-                        replayed, device_id, session_id,
-                    )
-            except Exception as e:
-                logger.warning(
-                    "Scheduler offline-queue replay failed for %s: %s",
-                    device_id, e,
-                )
+        # SOLID-audit follow-up: Surface + Scheduler wiring extracted
+        # to surface_register.register_surface_and_replay_scheduler.
+        # Hook ordering (register before replay) is preserved + pinned
+        # by a dedicated test.
+        await register_surface_and_replay_scheduler(
+            ws,
+            surface_mgr=self._surface_mgr,
+            scheduler_mgr=getattr(self, "_scheduler_mgr", None),
+            session_id=session_id,
+            device_id=device_id,
+            widget_capabilities=conn_state.get("widget_capabilities"),
+            safe_send_json=self._safe_send_json,
+        )
 
         # Store tool event callbacks per-connection (NOT on shared conversation engine)
         if self._tool_registry:

--- a/dragon_voice/surface_register.py
+++ b/dragon_voice/surface_register.py
@@ -1,0 +1,124 @@
+"""Surface registration + scheduler offline-queue replay.
+
+Wave 23 SOLID-audit follow-up — fourth sub-handler extract from
+`_handle_register` (round 3, after stale_conn_eviction #222,
+device_upsert #223, session_handshake #224).
+
+Owns the two post-session-create hooks that wire a fresh
+connection into the cross-cutting infrastructure:
+
+  * **Surface registration** — register the connection's WS-send
+    callback with the shared SurfaceManager so skills can dispatch
+    `widget_*` emissions through it and `widget_action` events
+    route back via `handle_action`.
+
+  * **Scheduler offline-queue replay** — drain any notifications
+    that were queued while the device was offline and deliver
+    them now that a live Tab5Surface exists for this session.
+
+Both are best-effort wiring with explicit failure isolation —
+a SurfaceManager hiccup or a scheduler-replay failure must not
+block device registration.
+
+## API
+
+```python
+await register_surface_and_replay_scheduler(
+    ws,
+    *,
+    surface_mgr,
+    scheduler_mgr,
+    session_id,
+    device_id,
+    widget_capabilities,
+    safe_send_json,
+) -> None
+```
+
+No return value — both hooks are fire-and-forget side effects.
+
+## Hook ordering
+
+The replay MUST fire AFTER `SurfaceManager.register_session` so
+the scheduler manager can find a live Tab5Surface for this
+session when delivering queued frames.  This invariant is
+encoded in the function body (the two calls are sequential)
+and pinned by a dedicated test.
+
+## DIP
+
+`surface_mgr`, `scheduler_mgr`, and `safe_send_json` are passed
+in.  The whole module compiles without importing `VoiceServer`.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+SafeSendJson = Callable[[web.WebSocketResponse, dict], Awaitable[bool]]
+
+
+async def register_surface_and_replay_scheduler(
+    ws: web.WebSocketResponse,
+    *,
+    surface_mgr: Optional[Any],        # SurfaceManager
+    scheduler_mgr: Optional[Any],      # SchedulerManager
+    session_id: str,
+    device_id: str,
+    widget_capabilities: Optional[dict],
+    safe_send_json: SafeSendJson,
+) -> None:
+    """Wire a fresh connection into Surface + Scheduler.
+
+    Two hooks fire in order:
+
+      1. ``surface_mgr.register_session(session_id, send, caps=...)``
+         where ``send`` is a closure routing through
+         `safe_send_json` so widget emissions get the same
+         transport-close swallow policy as the rest of the WS
+         path.  Skipped when `surface_mgr` is None (test paths).
+
+      2. ``scheduler_mgr.replay_queued_for_device(device_id)`` —
+         delivers any notifications queued while the device was
+         offline.  Failures swallowed with WARNING; the user's
+         reminders just stay queued for the next register.
+         Skipped when `scheduler_mgr` is None.
+
+    Hook order is important: replay happens AFTER register so the
+    scheduler can find a live Tab5Surface for this session when
+    delivering the queued frames.
+    """
+    if surface_mgr is not None:
+        async def _surface_send(msg: dict) -> None:
+            # v4·D audit P1: route surface sends through
+            # _safe_send_json so a transient close mid-widget-emit
+            # doesn't bubble into the WS handler and tear the
+            # session down.
+            if not ws.closed:
+                await safe_send_json(ws, msg)
+        await surface_mgr.register_session(
+            session_id, _surface_send, caps=widget_capabilities,
+        )
+
+    # Phase 5 ε2 (issue #131): replay any queued offline notifications
+    # for this device.  Best-effort: a queue-drain failure logs a
+    # warning but doesn't block registration.
+    if scheduler_mgr is not None:
+        try:
+            replayed = await scheduler_mgr.replay_queued_for_device(device_id)
+            if replayed > 0:
+                logger.info(
+                    "Scheduler offline-queue replay: delivered %d "
+                    "frame(s) to %s on session %s",
+                    replayed, device_id, session_id,
+                )
+        except Exception as e:
+            logger.warning(
+                "Scheduler offline-queue replay failed for %s: %s",
+                device_id, e,
+            )

--- a/tests/test_surface_register.py
+++ b/tests/test_surface_register.py
@@ -1,0 +1,255 @@
+"""Tests for ``dragon_voice.surface_register``.
+
+Pin every branch:
+
+  1. Both managers None → no-op.
+  2. surface_mgr only → register_session called; replay skipped.
+  3. scheduler_mgr only → register_session skipped; replay called.
+  4. Both wired, happy path → register first, then replay.
+  5. surface_mgr.register_session passes the send closure that
+     routes through safe_send_json (NOT a raw ws.send_json).
+  6. The send closure short-circuits when ws.closed is True.
+  7. scheduler_mgr.replay_queued_for_device raises → swallowed
+     with WARNING log.
+  8. Replay returns >0 → logged at INFO; replay returns 0 → silent.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.surface_register import register_surface_and_replay_scheduler
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    return ws
+
+
+def _make_safe_send_json() -> AsyncMock:
+    return AsyncMock(return_value=True)
+
+
+def _make_surface_mgr() -> MagicMock:
+    sm = MagicMock()
+    sm.register_session = AsyncMock()
+    return sm
+
+
+def _make_scheduler_mgr(returns: int = 0, raises: Exception | None = None) -> MagicMock:
+    sm = MagicMock()
+    if raises is not None:
+        sm.replay_queued_for_device = AsyncMock(side_effect=raises)
+    else:
+        sm.replay_queued_for_device = AsyncMock(return_value=returns)
+    return sm
+
+
+# ─── No-managers branch ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_both_managers_none_is_noop():
+    ws = _make_ws()
+    send = _make_safe_send_json()
+
+    await register_surface_and_replay_scheduler(
+        ws,
+        surface_mgr=None,
+        scheduler_mgr=None,
+        session_id="sess-X",
+        device_id="dev-A",
+        widget_capabilities=None,
+        safe_send_json=send,
+    )
+    send.assert_not_awaited()
+
+
+# ─── Surface-only ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_surface_mgr_only_register_called_replay_skipped():
+    ws = _make_ws()
+    surface = _make_surface_mgr()
+
+    await register_surface_and_replay_scheduler(
+        ws,
+        surface_mgr=surface,
+        scheduler_mgr=None,
+        session_id="sess-X",
+        device_id="dev-A",
+        widget_capabilities={"types": ["live"]},
+        safe_send_json=_make_safe_send_json(),
+    )
+
+    surface.register_session.assert_awaited_once()
+    args, kwargs = surface.register_session.await_args
+    assert args[0] == "sess-X"
+    assert kwargs["caps"] == {"types": ["live"]}
+
+
+# ─── Scheduler-only ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_scheduler_mgr_only_replay_called_register_skipped():
+    ws = _make_ws()
+    scheduler = _make_scheduler_mgr(returns=3)
+
+    await register_surface_and_replay_scheduler(
+        ws,
+        surface_mgr=None,
+        scheduler_mgr=scheduler,
+        session_id="sess-X",
+        device_id="dev-A",
+        widget_capabilities=None,
+        safe_send_json=_make_safe_send_json(),
+    )
+    scheduler.replay_queued_for_device.assert_awaited_once_with("dev-A")
+
+
+# ─── Happy path: both wired, ordering matters ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_register_called_before_replay():
+    """The replay MUST happen AFTER surface register so the
+    scheduler can find a live Tab5Surface for the session.  Pin
+    the ordering so a future refactor can't reverse it."""
+    ws = _make_ws()
+    surface = _make_surface_mgr()
+    scheduler = _make_scheduler_mgr(returns=1)
+
+    # Track call order via a shared list.
+    order: list[str] = []
+    surface.register_session = AsyncMock(side_effect=lambda *a, **kw: order.append("register"))
+    scheduler.replay_queued_for_device = AsyncMock(side_effect=lambda *a, **kw: order.append("replay"))
+
+    await register_surface_and_replay_scheduler(
+        ws,
+        surface_mgr=surface,
+        scheduler_mgr=scheduler,
+        session_id="sess-X",
+        device_id="dev-A",
+        widget_capabilities={"types": ["live"]},
+        safe_send_json=_make_safe_send_json(),
+    )
+
+    assert order == ["register", "replay"]
+
+
+# ─── Send closure routes through safe_send_json ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_closure_routes_through_safe_send_json():
+    """The closure passed to surface_mgr.register_session must
+    route through safe_send_json (which handles transport-close
+    swallow), NOT through raw ws.send_json."""
+    ws = _make_ws()
+    send = _make_safe_send_json()
+    captured_closure = None
+
+    surface = MagicMock()
+    async def capture_register(session_id, closure, **kwargs):
+        nonlocal captured_closure
+        captured_closure = closure
+    surface.register_session = AsyncMock(side_effect=capture_register)
+
+    await register_surface_and_replay_scheduler(
+        ws,
+        surface_mgr=surface,
+        scheduler_mgr=None,
+        session_id="sess-X",
+        device_id="dev-A",
+        widget_capabilities=None,
+        safe_send_json=send,
+    )
+
+    # Now invoke the captured closure and verify it routes through
+    # safe_send_json.
+    assert captured_closure is not None
+    await captured_closure({"type": "widget_live", "card_id": "c1"})
+    send.assert_awaited_once()
+    payload = send.await_args.args[1]
+    assert payload == {"type": "widget_live", "card_id": "c1"}
+
+
+@pytest.mark.asyncio
+async def test_send_closure_skips_when_ws_closed():
+    """Captured closure should short-circuit when ws.closed is
+    True — avoid spurious log noise from the safe_send_json layer."""
+    ws = _make_ws(closed=True)
+    send = _make_safe_send_json()
+    captured_closure = None
+
+    surface = MagicMock()
+    async def capture_register(session_id, closure, **kwargs):
+        nonlocal captured_closure
+        captured_closure = closure
+    surface.register_session = AsyncMock(side_effect=capture_register)
+
+    await register_surface_and_replay_scheduler(
+        ws,
+        surface_mgr=surface,
+        scheduler_mgr=None,
+        session_id="sess-X",
+        device_id="dev-A",
+        widget_capabilities=None,
+        safe_send_json=send,
+    )
+
+    assert captured_closure is not None
+    await captured_closure({"type": "widget_live"})
+    # Closed → no send attempted.
+    send.assert_not_awaited()
+
+
+# ─── Scheduler failure isolation ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_scheduler_replay_failure_swallowed():
+    """A queue-drain failure must NOT block registration —
+    user's reminders just stay queued for the next register."""
+    ws = _make_ws()
+    surface = _make_surface_mgr()
+    scheduler = _make_scheduler_mgr(raises=RuntimeError("DB busy"))
+
+    # Must NOT raise.
+    await register_surface_and_replay_scheduler(
+        ws,
+        surface_mgr=surface,
+        scheduler_mgr=scheduler,
+        session_id="sess-X",
+        device_id="dev-A",
+        widget_capabilities=None,
+        safe_send_json=_make_safe_send_json(),
+    )
+
+    # Surface still registered (happens BEFORE the replay).
+    surface.register_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_replay_zero_is_silent():
+    """When the scheduler reports 0 replayed frames, we don't
+    log a confusing 'delivered 0 frames' message — pinned by
+    only logging when replayed > 0."""
+    ws = _make_ws()
+    scheduler = _make_scheduler_mgr(returns=0)
+
+    # Must NOT raise + not log spam.
+    await register_surface_and_replay_scheduler(
+        ws,
+        surface_mgr=None,
+        scheduler_mgr=scheduler,
+        session_id="sess-X",
+        device_id="dev-A",
+        widget_capabilities=None,
+        safe_send_json=_make_safe_send_json(),
+    )
+    scheduler.replay_queued_for_device.assert_awaited_once()


### PR DESCRIPTION
## What

Round 3 PR-D — fourth sub-handler extract from \`_handle_register\` (after [#222](https://github.com/lorcan35/TinkerBox/pull/222) stale-conn eviction, [#223](https://github.com/lorcan35/TinkerBox/pull/223) device upsert, [#224](https://github.com/lorcan35/TinkerBox/pull/224) session_handshake).

Pulls the post-session-create infrastructure-wiring chunk out of the inline ~30-LOC chain at server.py:1104-1140 into [\`dragon_voice/surface_register.py\`](dragon_voice/surface_register.py).

## What moved

Two hooks that fire AFTER session create / conn_state init:

1. **Surface registration** — \`surface_mgr.register_session(session_id, send_closure, caps=widget_caps)\` where \`send_closure\` routes through \`safe_send_json\` (the v4·D audit P1 fix that protects widget emissions from transport-close exceptions).
2. **Scheduler offline-queue replay** — drain notifications queued while the device was offline (Phase 5 ε2, [#131](https://github.com/lorcan35/TinkerBox/pull/131)). Failure-isolated with WARNING log.

## Hook ordering pinned

The replay MUST happen AFTER surface register so the scheduler can find a live Tab5Surface for this session when delivering queued frames. Pre-extract this was a comment-only invariant — now it's pinned by a dedicated test (\`test_register_called_before_replay\`) that asserts the call order can't silently flip.

## API

\`\`\`python
await register_surface_and_replay_scheduler(
    ws,
    *,
    surface_mgr,        # Optional
    scheduler_mgr,      # Optional
    session_id,
    device_id,
    widget_capabilities,
    safe_send_json,
) -> None
\`\`\`

Both managers are Optional — None paths are no-ops (test scaffolding, embedded usage).

## Tests

[\`tests/test_surface_register.py\`](tests/test_surface_register.py) — 8 tests pinning every branch:

| # | Branch | Pinned |
|---|---|---|
| 1 | Both managers None | No-op |
| 2 | surface_mgr only | Register called; replay skipped |
| 3 | scheduler_mgr only | Replay called; register skipped |
| 4 | Both wired | **Register fires BEFORE replay (ordering pin)** |
| 5 | Send closure routes through safe_send_json | NOT raw ws.send_json (captured-closure pattern verifies actual call path) |
| 6 | Send closure short-circuits when ws.closed | No spurious sends |
| 7 | Scheduler.replay_queued_for_device raises | Swallowed; surface_mgr.register_session still runs first |
| 8 | Replay returns 0 | Silent (no spammy \"delivered 0\" log) |

## server.py shrink

| Metric | Value |
|---|---|
| This PR | 2382 → 2359 LOC (−23 net) |
| Cumulative round 1+2+3 | 2714 → 2359 LOC (−355, **−13.1 %**) |

## _handle_register progress

| Sub-responsibility | LOC | Status |
|---|---|---|
| Validate device_id | ~11 | inline guard |
| P13 stale-conn eviction | ~57 | extracted #222 |
| Device DB upsert + D2 | ~34 | extracted #223 |
| Widget caps pluck + add_event | ~18 | inline, small |
| Session create/resume + conn_state init | ~14 | inline, small |
| **Surface mgr + scheduler replay** | ~30 | extracted (this PR) |
| Tool callback closures | ~176 | biggest remaining (round-3 finale) |
| session_start + session_messages | ~79 | extracted #224 |
| Pipeline init reset + create + codec neg | ~75 | tightly coupled |

\`_handle_register\` is now ~340 LOC. Tool callback closures (~176) are the natural next-and-last big extract.

## Verification

\`\`\`
\$ python3 -m pytest tests/test_surface_register.py -v
8 passed in 0.08s

\$ python3 -m pytest tests/ --ignore=tests/audit -q
828 passed, 108 subtests passed, 1 skipped, 0 failed in 11.34s

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \\
    dragon_voice/ tests/
All checks passed!
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)