### PR TITLE
refactor(server): extract tool-event closures (~176 LOC) to ToolEventEmitter class

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -38,6 +38,7 @@ from dragon_voice.session_handshake import (
 )
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
+from dragon_voice.tool_event_emitter import ToolEventEmitter
 from dragon_voice.media.store import MediaStore
 from dragon_voice.media.pipeline import MediaPipeline
 from dragon_voice.vision_capability import emit_vision_capability
@@ -1116,182 +1117,31 @@ class VoiceServer:
             safe_send_json=self._safe_send_json,
         )
 
-        # Store tool event callbacks per-connection (NOT on shared conversation engine)
+        # SOLID-audit follow-up: tool-event callbacks (the three
+        # async closures `_on_tool_call`, `_on_tool_result`,
+        # `_on_tool_error`) extracted to ToolEventEmitter — a small
+        # stateful class that captures the per-connection state
+        # (ws, conn_state, session_id, safe_send_json, emit_legacy)
+        # at construction and exposes the three callbacks as methods.
+        # Pre-extract this was ~176 LOC of inline closures with all
+        # the β-arch pair-emit + tracker bookkeeping + web_search
+        # auto-widget logic intertwined; now it's 19 unit tests
+        # pinning every branch.
         if self._tool_registry:
-            # β-arch (issue #123): adapter so emit_progress_pair (which
-            # takes an OnEvent: Callable[[dict], Awaitable[None]]) can
-            # use the existing _safe_send_json swallow.  Returning
-            # True/False from the helper is harmless — the pair helper
-            # awaits but discards the return.
-            async def _emit_via_ws(ev: dict) -> None:
-                await self._safe_send_json(ws, ev)
-
-            # Read the bus transition flag once at registration time —
-            # not hot-reloaded.
-            _emit_legacy = bool(getattr(
-                conn_state.get("config"),
-                "progress_bus_emit_legacy",
-                True,
-            ))
-
-            async def _on_tool_call(call):
-                # #75 phase 1b: pre-register the call + args in the
-                # per-turn tracker so `_on_tool_result` can merge the
-                # result into the same record.  The wrap synthesiser
-                # reads both sides (e.g. `remember` needs the `fact`
-                # from args to write "Got it — {fact}.").
-                try:
-                    conn_state.setdefault("tool_calls_this_turn", []).append({
-                        "tool": call.get("tool"),
-                        "args": call.get("args") or {},
-                    })
-                except Exception:
-                    logger.debug("tool_calls_this_turn pre-register suppressed", exc_info=True)
-                # Wave 12 — agent_log recording happens at the
-                # ToolRegistry.execute chokepoint (tools/registry.py)
-                # so it captures every invocation regardless of
-                # caller (WS, REST /tools/{name}/execute, dashboard).
-                # No need to record here.
-                if not ws.closed:
-                    # β-arch (issue #123): pair-emit — legacy
-                    # `tool_call` for unmodified Tab5 + new
-                    # progress.tool.start with the same payload nested.
-                    await emit_progress_pair(
-                        _emit_via_ws,
-                        legacy={
-                            "type": "tool_call",
-                            "tool": call["tool"],
-                            "args": call["args"],
-                        },
-                        phase=Phase.TOOL,
-                        stage=Stage.START,
-                        payload={"tool": call["tool"], "args": call["args"]},
-                        emit_legacy=_emit_legacy,
-                    )
-
-            async def _on_tool_result(result):
-                if ws.closed:
-                    return
-                # β-arch (issue #123): pair-emit — legacy
-                # `tool_result` (with all result fields spread at top
-                # level) + new progress.tool.done with the same fields
-                # nested in payload for the unified bus.
-                await emit_progress_pair(
-                    _emit_via_ws,
-                    legacy={"type": "tool_result", **result},
-                    phase=Phase.TOOL,
-                    stage=Stage.DONE,
-                    payload={
-                        "tool": result.get("tool"),
-                        "result": result.get("result"),
-                        "execution_ms": result.get("execution_ms"),
-                    },
-                    emit_legacy=_emit_legacy,
-                )
-                # #75 phase 1b: merge result into the most-recent
-                # pre-registered call for this tool name (fills the
-                # FIRST pending slot so same-tool-twice-in-one-turn
-                # still maps 1:1).  If no pre-register exists (some
-                # code paths emit tool_result only), append the bare
-                # result so the wrap still has something to describe.
-                try:
-                    tracker = conn_state.setdefault("tool_calls_this_turn", [])
-                    merged = False
-                    for rec in tracker:
-                        if rec.get("tool") == result.get("tool") and "result" not in rec:
-                            rec["result"] = result.get("result")
-                            rec["execution_ms"] = result.get("execution_ms")
-                            merged = True
-                            break
-                    if not merged:
-                        tracker.append(result)
-                except Exception:
-                    logger.debug("tool_calls_this_turn merge suppressed", exc_info=True)
-                # Wave 12 — agent_log close happens at the
-                # ToolRegistry.execute chokepoint, not here.
-                # v4·D Phase 4c: auto-emit widget_list for web_search results
-                # so the Tab5 home live-slot surfaces the top hits without
-                # the LLM having to orchestrate a widget call itself.
-                try:
-                    if result.get("tool") == "web_search":
-                        payload = result.get("result") or {}
-                        hits = payload.get("results") or []
-                        query = payload.get("query", "")
-                        items = []
-                        for r in hits[:5]:
-                            t = str(r.get("title") or r.get("snippet") or "")[:79]
-                            if not t:
-                                continue
-                            items.append({"text": t, "value": ""})
-                        if items:
-                            await ws.send_json({
-                                "type": "widget_list",
-                                "skill_id": "web_search",
-                                "card_id": f"ws_{session_id[:8]}",
-                                "title": (query[:60] or "Web results"),
-                                "tone": "info",
-                                "priority": 70,
-                                "items": items,
-                            })
-                except Exception:
-                    logger.debug("widget_list auto-emit failed", exc_info=True)
-
-            async def _on_tool_error(err: dict):
-                """γ2-M1 (issue #104): emit a structured tool error
-                frame when the parser swallows malformed JSON args.
-
-                Pre-fix the failure was a silent `logger.warning` —
-                the LLM continued without firing the tool and the
-                user saw an empty/generic reply with zero signal that
-                anything was attempted.  Now we surface a TRANSIENT
-                error in the TOOL scope so Tab5 (γ2-H8) can render a
-                non-blocking toast.
-
-                Audit B4 (#137): the err dict's `code` and `message`
-                fields are honoured so ConvEngine can signal e.g.
-                `tool_call_limit_reached` distinct from the original
-                `tool_args_invalid` parse failure.  Default codes
-                preserve back-compat with callers that pre-date B4.
-
-                The raw args are deliberately NOT included in the
-                user-facing message — they may contain prompt-injection
-                content from the LLM and Tab5's caption isn't a safe
-                place to render arbitrary text.  Server log already
-                carries the full failure for ops debugging.
-                """
-                if ws.closed:
-                    return
-                tool_name = err.get("name") or "(unknown)"
-                code = err.get("code") or "tool_args_invalid"
-                message = err.get("message") or (
-                    f"Tool '{tool_name}' had invalid arguments — skipped."
-                )
-                # β-arch (issue #123): pair-emit — legacy γ1 error
-                # frame (already structured per #102) + new
-                # progress.tool.error frame for the unified bus.
-                # Both carry the same code/message/severity/scope
-                # so γ2-H8 routing applies regardless of which
-                # frame Tab5 reads.
-                await emit_progress_pair(
-                    _emit_via_ws,
-                    legacy=error_event(
-                        code=code,
-                        message=message,
-                        severity=Severity.TRANSIENT,
-                        scope=Scope.TOOL,
-                    ),
-                    phase=Phase.TOOL,
-                    stage=Stage.ERROR,
-                    code=code,
-                    message=message,
-                    severity=Severity.TRANSIENT,
-                    scope=Scope.TOOL,
-                    emit_legacy=_emit_legacy,
-                )
-
-            conn_state["on_tool_call"] = _on_tool_call
-            conn_state["on_tool_result"] = _on_tool_result
-            conn_state["on_tool_error"] = _on_tool_error
+            tool_emitter = ToolEventEmitter(
+                ws=ws,
+                conn_state=conn_state,
+                session_id=session_id,
+                safe_send_json=self._safe_send_json,
+                emit_legacy=bool(getattr(
+                    conn_state.get("config"),
+                    "progress_bus_emit_legacy",
+                    True,
+                )),
+            )
+            conn_state["on_tool_call"] = tool_emitter.on_tool_call
+            conn_state["on_tool_result"] = tool_emitter.on_tool_result
+            conn_state["on_tool_error"] = tool_emitter.on_tool_error
 
         # SOLID-audit follow-up: session_start emit + session_messages
         # replay extracted to session_handshake module.  Both run

--- a/dragon_voice/tool_event_emitter.py
+++ b/dragon_voice/tool_event_emitter.py
@@ -1,0 +1,300 @@
+"""Per-connection tool-event emitter (β-arch + γ2-M1 + audit B4).
+
+Wave 23 SOLID-audit follow-up — fifth (and biggest) sub-handler
+extract from `_handle_register` (round 3, after stale_conn_eviction
+#222, device_upsert #223, session_handshake #224, surface_register
+#225).
+
+Pre-extract, three async closures (`_on_tool_call`,
+`_on_tool_result`, `_on_tool_error`) lived inline at server.py:1119-
+1294 (~176 LOC) capturing per-connection state via Python closure
+semantics.  They each combined β-arch pair-emit logic, per-turn
+tracker bookkeeping, transport-close swallow, and (for tool_result)
+the v4·D Phase 4c web_search auto-widget emission.
+
+This module turns the three closures into a single stateful class
+`ToolEventEmitter` that's constructed at register time with the
+per-connection state, and exposes the three callbacks as methods.
+
+## API
+
+```python
+emitter = ToolEventEmitter(
+    ws=ws,
+    conn_state=conn_state,
+    session_id=session_id,
+    safe_send_json=self._safe_send_json,
+    emit_legacy=bool(getattr(conn_state.get("config"),
+                              "progress_bus_emit_legacy", True)),
+)
+conn_state["on_tool_call"]   = emitter.on_tool_call
+conn_state["on_tool_result"] = emitter.on_tool_result
+conn_state["on_tool_error"]  = emitter.on_tool_error
+```
+
+After this PR, `_handle_register`'s tool-callback wiring shrinks
+from ~176 LOC of inline closures to ~10 LOC of `if self._tool_registry:
+emitter = ToolEventEmitter(...); conn_state["on_tool_*"] = emitter.on_tool_*`.
+
+## Why a class, not three free functions
+
+The three callbacks share state — the `ws`, `conn_state` ref,
+`session_id`, `safe_send_json`, and `emit_legacy` flag.  Pre-extract
+they were all closure variables.  Two equivalent options:
+
+  1. **Three free functions** taking all state as keyword args.
+     Verbose call sites; every call has to pass 5 positional args.
+  2. **Class** capturing state in `__init__`; methods take only the
+     event-specific arg.  Matches how the original closures
+     captured state via Python's lexical scoping.
+
+(2) is cleaner and matches existing patterns in
+`dragon_voice/handlers/` where stateful HTTP handlers are class-based.
+
+## DIP
+
+`ws`, `conn_state`, `safe_send_json` are passed in.  No
+VoiceServer reach-through.  The constructor records them; methods
+operate on the captured refs.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable
+
+from aiohttp import web
+
+from dragon_voice.errors import Scope, Severity, error_event
+from dragon_voice.progress import Phase, Stage
+from dragon_voice.progress_emit import emit_progress_pair
+
+logger = logging.getLogger(__name__)
+
+
+SafeSendJson = Callable[[web.WebSocketResponse, dict], Awaitable[bool]]
+
+
+class ToolEventEmitter:
+    """Owns the per-connection tool-event lifecycle.
+
+    Three async methods (`on_tool_call`, `on_tool_result`,
+    `on_tool_error`) implement the contract that
+    ConvEngine/ToolRegistry expect.  Each emits the β-arch
+    pair-frame (legacy + progress.tool.*) via
+    `emit_progress_pair` AND keeps the per-turn `tool_calls_this_turn`
+    tracker in sync so the wrap synthesiser can see the
+    call+args+result triple.
+
+    `on_tool_result` additionally auto-emits a `widget_list`
+    frame for `web_search` results so the Tab5 home live-slot
+    surfaces the top hits without the LLM having to orchestrate
+    a widget call itself (v4·D Phase 4c).
+    """
+
+    def __init__(
+        self,
+        *,
+        ws: web.WebSocketResponse,
+        conn_state: Any,                 # ConnState or dict
+        session_id: str,
+        safe_send_json: SafeSendJson,
+        emit_legacy: bool = True,
+    ) -> None:
+        self._ws = ws
+        self._conn_state = conn_state
+        self._session_id = session_id
+        self._safe_send_json = safe_send_json
+        self._emit_legacy = emit_legacy
+
+    # ── emit_progress_pair takes a Callable[[dict], Awaitable[None]]
+    #    that returns None (it awaits but discards).  Our
+    #    safe_send_json returns bool — wrap to match the signature.
+    async def _emit_via_ws(self, ev: dict) -> None:
+        await self._safe_send_json(self._ws, ev)
+
+    async def on_tool_call(self, call: dict) -> None:
+        """Called when ConvEngine fires a tool call.
+
+        Pre-registers the call+args in `conn_state["tool_calls_this_turn"]`
+        so `on_tool_result` can merge the result into the same record
+        (the wrap synthesiser reads both sides — e.g. `remember`
+        needs the `fact` from args to write "Got it — {fact}.").
+        """
+        # #75 phase 1b: pre-register the call + args in the per-turn
+        # tracker.
+        try:
+            self._conn_state.setdefault("tool_calls_this_turn", []).append({
+                "tool": call.get("tool"),
+                "args": call.get("args") or {},
+            })
+        except Exception:
+            logger.debug("tool_calls_this_turn pre-register suppressed", exc_info=True)
+
+        # Wave 12 — agent_log recording happens at the
+        # ToolRegistry.execute chokepoint (tools/registry.py) so it
+        # captures every invocation regardless of caller (WS, REST,
+        # dashboard).  No need to record here.
+        if self._ws.closed:
+            return
+
+        # β-arch (issue #123): pair-emit — legacy `tool_call` for
+        # unmodified Tab5 + new progress.tool.start with the same
+        # payload nested.
+        await emit_progress_pair(
+            self._emit_via_ws,
+            legacy={
+                "type": "tool_call",
+                "tool": call["tool"],
+                "args": call["args"],
+            },
+            phase=Phase.TOOL,
+            stage=Stage.START,
+            payload={"tool": call["tool"], "args": call["args"]},
+            emit_legacy=self._emit_legacy,
+        )
+
+    async def on_tool_result(self, result: dict) -> None:
+        """Called when a tool finishes executing.
+
+        Three things happen, in order:
+          1. β-arch pair-emit of the result frame.
+          2. Merge the result into the matching pre-registered call
+             in the per-turn tracker (or append bare if no pre-reg).
+          3. Auto-emit a `widget_list` frame for `web_search` hits
+             (v4·D Phase 4c).
+        """
+        if self._ws.closed:
+            return
+
+        # β-arch (issue #123): pair-emit — legacy `tool_result`
+        # (with all result fields spread at top level) + new
+        # progress.tool.done with the same fields nested in payload
+        # for the unified bus.
+        await emit_progress_pair(
+            self._emit_via_ws,
+            legacy={"type": "tool_result", **result},
+            phase=Phase.TOOL,
+            stage=Stage.DONE,
+            payload={
+                "tool": result.get("tool"),
+                "result": result.get("result"),
+                "execution_ms": result.get("execution_ms"),
+            },
+            emit_legacy=self._emit_legacy,
+        )
+
+        # #75 phase 1b: merge result into the most-recent
+        # pre-registered call for this tool name (fills the FIRST
+        # pending slot so same-tool-twice-in-one-turn still maps
+        # 1:1).  If no pre-register exists (some code paths emit
+        # tool_result only), append the bare result so the wrap
+        # still has something to describe.
+        try:
+            tracker = self._conn_state.setdefault("tool_calls_this_turn", [])
+            merged = False
+            for rec in tracker:
+                if rec.get("tool") == result.get("tool") and "result" not in rec:
+                    rec["result"] = result.get("result")
+                    rec["execution_ms"] = result.get("execution_ms")
+                    merged = True
+                    break
+            if not merged:
+                tracker.append(result)
+        except Exception:
+            logger.debug("tool_calls_this_turn merge suppressed", exc_info=True)
+
+        # Wave 12 — agent_log close happens at the
+        # ToolRegistry.execute chokepoint, not here.
+
+        # v4·D Phase 4c: auto-emit widget_list for web_search
+        # results so the Tab5 home live-slot surfaces the top hits
+        # without the LLM having to orchestrate a widget call itself.
+        try:
+            if result.get("tool") == "web_search":
+                await self._emit_web_search_widget_list(result)
+        except Exception:
+            logger.debug("widget_list auto-emit failed", exc_info=True)
+
+    async def _emit_web_search_widget_list(self, result: dict) -> None:
+        """Convert a `web_search` tool result into a `widget_list`
+        WS frame for the Tab5 home live-slot.
+
+        Picks the top 5 hits, truncates titles to 79 chars, and
+        emits via `ws.send_json` directly (NOT through
+        safe_send_json) — matches pre-extract behaviour where
+        this auto-emission was best-effort and any send failure
+        was caught by the outer try/except.
+        """
+        payload = result.get("result") or {}
+        hits = payload.get("results") or []
+        query = payload.get("query", "")
+        items = []
+        for r in hits[:5]:
+            t = str(r.get("title") or r.get("snippet") or "")[:79]
+            if not t:
+                continue
+            items.append({"text": t, "value": ""})
+        if not items:
+            return
+        await self._ws.send_json({
+            "type": "widget_list",
+            "skill_id": "web_search",
+            "card_id": f"ws_{self._session_id[:8]}",
+            "title": (query[:60] or "Web results"),
+            "tone": "info",
+            "priority": 70,
+            "items": items,
+        })
+
+    async def on_tool_error(self, err: dict) -> None:
+        """γ2-M1 (issue #104): emit a structured tool error frame
+        when the parser swallows malformed JSON args.
+
+        Pre-fix the failure was a silent `logger.warning` — the
+        LLM continued without firing the tool and the user saw an
+        empty/generic reply with zero signal that anything was
+        attempted.  Now we surface a TRANSIENT error in the TOOL
+        scope so Tab5 (γ2-H8) can render a non-blocking toast.
+
+        Audit B4 (#137): the err dict's `code` and `message`
+        fields are honoured so ConvEngine can signal e.g.
+        `tool_call_limit_reached` distinct from the original
+        `tool_args_invalid` parse failure.  Default codes preserve
+        back-compat with callers that pre-date B4.
+
+        The raw args are deliberately NOT included in the user-
+        facing message — they may contain prompt-injection content
+        from the LLM and Tab5's caption isn't a safe place to
+        render arbitrary text.  Server log already carries the
+        full failure for ops debugging.
+        """
+        if self._ws.closed:
+            return
+
+        tool_name = err.get("name") or "(unknown)"
+        code = err.get("code") or "tool_args_invalid"
+        message = err.get("message") or (
+            f"Tool '{tool_name}' had invalid arguments — skipped."
+        )
+
+        # β-arch (issue #123): pair-emit — legacy γ1 error frame
+        # (already structured per #102) + new progress.tool.error
+        # frame for the unified bus.  Both carry the same
+        # code/message/severity/scope so γ2-H8 routing applies
+        # regardless of which frame Tab5 reads.
+        await emit_progress_pair(
+            self._emit_via_ws,
+            legacy=error_event(
+                code=code,
+                message=message,
+                severity=Severity.TRANSIENT,
+                scope=Scope.TOOL,
+            ),
+            phase=Phase.TOOL,
+            stage=Stage.ERROR,
+            code=code,
+            message=message,
+            severity=Severity.TRANSIENT,
+            scope=Scope.TOOL,
+            emit_legacy=self._emit_legacy,
+        )

--- a/tests/test_tool_event_emitter.py
+++ b/tests/test_tool_event_emitter.py
@@ -1,0 +1,351 @@
+"""Tests for ``dragon_voice.tool_event_emitter.ToolEventEmitter``.
+
+Pin every branch of the three async methods + the per-turn tracker
+bookkeeping + the web_search auto-widget emit + the ws.closed
+short-circuits.
+
+Three groups of tests:
+
+  * `TestOnToolCall` — pre-register the call into tracker,
+    pair-emit, ws.closed skip.
+  * `TestOnToolResult` — pair-emit, tracker merge, web_search
+    widget auto-emit, ws.closed skip.
+  * `TestOnToolError` — γ2-M1 structured error pair-emit, B4
+    code/message override, ws.closed skip.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.tool_event_emitter import ToolEventEmitter
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    ws.send_json = AsyncMock()
+    return ws
+
+
+def _make_safe_send_json() -> AsyncMock:
+    return AsyncMock(return_value=True)
+
+
+def _make_emitter(*, closed: bool = False, conn_state: dict | None = None,
+                  emit_legacy: bool = True, session_id: str = "sess-XYZ"):
+    ws = _make_ws(closed=closed)
+    send = _make_safe_send_json()
+    state = conn_state if conn_state is not None else {}
+    em = ToolEventEmitter(
+        ws=ws,
+        conn_state=state,
+        session_id=session_id,
+        safe_send_json=send,
+        emit_legacy=emit_legacy,
+    )
+    return em, ws, send, state
+
+
+# ─── on_tool_call ────────────────────────────────────────────────
+
+
+class TestOnToolCall:
+    @pytest.mark.asyncio
+    async def test_pre_registers_call_in_tracker(self):
+        em, ws, send, state = _make_emitter()
+
+        await em.on_tool_call({"tool": "remember", "args": {"fact": "x"}})
+
+        # Pre-register lands in tool_calls_this_turn
+        assert state["tool_calls_this_turn"] == [
+            {"tool": "remember", "args": {"fact": "x"}},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_emits_pair_frame_legacy_plus_progress(self):
+        """When emit_legacy=True (default), pair-emits both the
+        legacy `tool_call` and the new `progress.tool.start`
+        frames."""
+        em, ws, send, state = _make_emitter(emit_legacy=True)
+
+        await em.on_tool_call({"tool": "datetime", "args": {}})
+
+        # Two sends: legacy + progress
+        assert send.await_count == 2
+        legacy = send.await_args_list[0].args[1]
+        progress = send.await_args_list[1].args[1]
+        assert legacy["type"] == "tool_call"
+        assert legacy["tool"] == "datetime"
+        assert progress.get("type") == "progress"
+
+    @pytest.mark.asyncio
+    async def test_emit_legacy_false_skips_legacy_frame(self):
+        em, ws, send, state = _make_emitter(emit_legacy=False)
+
+        await em.on_tool_call({"tool": "datetime", "args": {}})
+
+        # Only progress frame, no legacy.
+        assert send.await_count == 1
+        assert send.await_args.args[1].get("type") == "progress"
+
+    @pytest.mark.asyncio
+    async def test_ws_closed_skips_emit_but_still_pre_registers(self):
+        """Pre-extract behaviour: even if ws is closed, we still
+        update the tracker so the wrap synthesiser sees a complete
+        picture for the turn."""
+        em, ws, send, state = _make_emitter(closed=True)
+
+        await em.on_tool_call({"tool": "remember", "args": {"fact": "x"}})
+
+        # Tracker still updated.
+        assert state["tool_calls_this_turn"] == [
+            {"tool": "remember", "args": {"fact": "x"}},
+        ]
+        # No WS sends.
+        send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_args_none_normalized_to_empty_dict(self):
+        """Defensive: pre-extract used `call.get("args") or {}` to
+        avoid storing None in the tracker."""
+        em, ws, send, state = _make_emitter()
+        await em.on_tool_call({"tool": "datetime", "args": None})
+        assert state["tool_calls_this_turn"] == [
+            {"tool": "datetime", "args": {}},
+        ]
+
+
+# ─── on_tool_result ──────────────────────────────────────────────
+
+
+class TestOnToolResult:
+    @pytest.mark.asyncio
+    async def test_emits_pair_frame_with_result_fields(self):
+        em, ws, send, state = _make_emitter()
+
+        await em.on_tool_result({
+            "tool": "datetime",
+            "result": {"now": "2026-05-03T12:00"},
+            "execution_ms": 4,
+        })
+
+        # Two sends: legacy + progress.
+        assert send.await_count == 2
+        legacy = send.await_args_list[0].args[1]
+        # Legacy payload has all fields spread at top level.
+        assert legacy["type"] == "tool_result"
+        assert legacy["tool"] == "datetime"
+        assert legacy["result"] == {"now": "2026-05-03T12:00"}
+        assert legacy["execution_ms"] == 4
+
+    @pytest.mark.asyncio
+    async def test_merges_result_into_pre_registered_call(self):
+        """#75 phase 1b: merge result into the most-recent
+        pre-registered call for this tool name."""
+        em, ws, send, state = _make_emitter(
+            conn_state={"tool_calls_this_turn": [
+                {"tool": "remember", "args": {"fact": "X"}},  # pending
+            ]},
+        )
+
+        await em.on_tool_result({
+            "tool": "remember",
+            "result": {"stored": True},
+            "execution_ms": 12,
+        })
+
+        # The pre-registered call now has its result merged in.
+        record = state["tool_calls_this_turn"][0]
+        assert record == {
+            "tool": "remember",
+            "args": {"fact": "X"},
+            "result": {"stored": True},
+            "execution_ms": 12,
+        }
+
+    @pytest.mark.asyncio
+    async def test_same_tool_twice_maps_one_to_one(self):
+        """If a tool fires twice in one turn, the FIRST pending
+        slot gets the FIRST result; the second result merges into
+        the second pending slot."""
+        em, ws, send, state = _make_emitter(
+            conn_state={"tool_calls_this_turn": [
+                {"tool": "remember", "args": {"fact": "A"}},
+                {"tool": "remember", "args": {"fact": "B"}},
+            ]},
+        )
+
+        await em.on_tool_result({"tool": "remember", "result": "ok-A"})
+
+        # Only the FIRST pending slot got the result.
+        assert state["tool_calls_this_turn"][0].get("result") == "ok-A"
+        assert "result" not in state["tool_calls_this_turn"][1]
+
+    @pytest.mark.asyncio
+    async def test_no_pre_register_appends_bare_result(self):
+        """Some code paths emit tool_result without a prior
+        tool_call (test paths, REST execute).  The result still
+        lands in the tracker so the wrap has something to read."""
+        em, ws, send, state = _make_emitter()
+
+        result = {"tool": "calculator", "result": 42, "execution_ms": 1}
+        await em.on_tool_result(result)
+
+        assert state["tool_calls_this_turn"] == [result]
+
+    @pytest.mark.asyncio
+    async def test_web_search_auto_emits_widget_list(self):
+        """v4·D Phase 4c: when the tool is web_search, auto-emit
+        a widget_list frame so Tab5 home shows the top hits
+        without LLM orchestration."""
+        em, ws, send, state = _make_emitter(session_id="abc12345xyz")
+
+        await em.on_tool_result({
+            "tool": "web_search",
+            "result": {
+                "query": "claude opus pricing",
+                "results": [
+                    {"title": "Anthropic claude-opus-4.7 pricing"},
+                    {"title": "OpenRouter Opus rates"},
+                    {"title": "Pricing analysis"},
+                ],
+            },
+            "execution_ms": 234,
+        })
+
+        # Find the widget_list frame among the sends (legacy +
+        # progress + widget_list = 3 sends total).
+        widget_calls = [
+            c for c in ws.send_json.await_args_list
+            if c.args[0].get("type") == "widget_list"
+        ]
+        assert len(widget_calls) == 1
+        widget = widget_calls[0].args[0]
+        assert widget["skill_id"] == "web_search"
+        assert widget["card_id"].startswith("ws_")
+        assert widget["title"] == "claude opus pricing"
+        assert len(widget["items"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_web_search_no_results_skips_widget_emit(self):
+        em, ws, send, state = _make_emitter()
+        await em.on_tool_result({
+            "tool": "web_search",
+            "result": {"query": "x", "results": []},
+        })
+        widget_calls = [
+            c for c in ws.send_json.await_args_list
+            if c.args[0].get("type") == "widget_list"
+        ]
+        assert widget_calls == []
+
+    @pytest.mark.asyncio
+    async def test_non_web_search_does_not_auto_emit_widget(self):
+        em, ws, send, state = _make_emitter()
+        await em.on_tool_result({"tool": "datetime", "result": "now"})
+        widget_calls = [
+            c for c in ws.send_json.await_args_list
+            if c.args[0].get("type") == "widget_list"
+        ]
+        assert widget_calls == []
+
+    @pytest.mark.asyncio
+    async def test_ws_closed_short_circuits_everything(self):
+        """If ws is closed, NOTHING happens — no pair-emit, no
+        tracker mutation, no widget emit.  Pre-extract behaviour."""
+        em, ws, send, state = _make_emitter(closed=True)
+
+        await em.on_tool_result({"tool": "remember", "result": "x"})
+
+        send.assert_not_awaited()
+        assert state == {}  # no tracker mutation
+        ws.send_json.assert_not_awaited()
+
+
+# ─── on_tool_error ───────────────────────────────────────────────
+
+
+class TestOnToolError:
+    @pytest.mark.asyncio
+    async def test_default_code_and_message_when_err_minimal(self):
+        em, ws, send, state = _make_emitter()
+
+        await em.on_tool_error({"name": "foo"})
+
+        # Two sends: legacy γ1 error_event + progress.tool.error.
+        assert send.await_count == 2
+        legacy = send.await_args_list[0].args[1]
+        # Default code from the closure docstring.
+        assert legacy["code"] == "tool_args_invalid"
+        # Default message includes the tool name.
+        assert "foo" in legacy["message"]
+
+    @pytest.mark.asyncio
+    async def test_b4_code_and_message_override_honored(self):
+        """Audit B4 (#137): caller-supplied code + message override
+        the defaults.  ConvEngine uses this to signal e.g.
+        tool_call_limit_reached distinct from tool_args_invalid."""
+        em, ws, send, state = _make_emitter()
+
+        await em.on_tool_error({
+            "name": "foo",
+            "code": "tool_call_limit_reached",
+            "message": "Max 3 tool calls per turn — stopping.",
+        })
+
+        legacy = send.await_args_list[0].args[1]
+        assert legacy["code"] == "tool_call_limit_reached"
+        assert legacy["message"] == "Max 3 tool calls per turn — stopping."
+
+    @pytest.mark.asyncio
+    async def test_severity_and_scope_are_transient_tool(self):
+        em, ws, send, state = _make_emitter()
+        await em.on_tool_error({"name": "foo"})
+        legacy = send.await_args_list[0].args[1]
+        assert legacy["severity"] == "transient"
+        assert legacy["scope"] == "tool"
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_name_uses_placeholder(self):
+        em, ws, send, state = _make_emitter()
+        await em.on_tool_error({})  # no name field
+        legacy = send.await_args_list[0].args[1]
+        assert "(unknown)" in legacy["message"]
+
+    @pytest.mark.asyncio
+    async def test_ws_closed_skips_emit(self):
+        em, ws, send, state = _make_emitter(closed=True)
+        await em.on_tool_error({"name": "foo"})
+        send.assert_not_awaited()
+
+
+# ─── State capture invariant ─────────────────────────────────────
+
+
+class TestStateCapture:
+    """Pin that the emitter holds REFs (not copies) so mutations
+    via the conn_state path remain visible inside the emitter.
+    Pre-extract this was natural via Python closure semantics; the
+    class-based version must preserve it."""
+
+    @pytest.mark.asyncio
+    async def test_conn_state_mutation_visible_through_emitter(self):
+        state: dict = {}
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        em = ToolEventEmitter(
+            ws=ws,
+            conn_state=state,
+            session_id="sess-X",
+            safe_send_json=send,
+            emit_legacy=True,
+        )
+        # External mutation
+        state["tool_calls_this_turn"] = [
+            {"tool": "remember", "args": {"fact": "EXT"}},
+        ]
+        # Result merge sees the externally-added pending call.
+        await em.on_tool_result({"tool": "remember", "result": "OK"})
+        assert state["tool_calls_this_turn"][0]["result"] == "OK"


### PR DESCRIPTION
## What

**Round 3 finale** — fifth and biggest sub-handler extract from \`_handle_register\` (after [#222](https://github.com/lorcan35/TinkerBox/pull/222) stale-conn eviction, [#223](https://github.com/lorcan35/TinkerBox/pull/223) device upsert, [#224](https://github.com/lorcan35/TinkerBox/pull/224) session_handshake, [#225](https://github.com/lorcan35/TinkerBox/pull/225) surface_register).

Pulls the three async tool-event closures out of the inline ~176-LOC chain at server.py:1119-1294 into a single stateful class \`ToolEventEmitter\` in [\`dragon_voice/tool_event_emitter.py\`](dragon_voice/tool_event_emitter.py).

## Why a class, not three free functions

The three closures (\`_on_tool_call\`, \`_on_tool_result\`, \`_on_tool_error\`) shared **5 closure variables**: \`ws\`, \`conn_state\`, \`session_id\`, \`safe_send_json\`, \`emit_legacy\`. Pre-extract these were captured by Python's lexical scoping. Post-extract \`ToolEventEmitter.__init__\` records them and the three callbacks become methods.

Three free functions would force every call site to pass all 5 args every time — verbose. The class matches the existing pattern in \`dragon_voice/handlers/\` where stateful HTTP handlers are class-based.

## What's preserved (every audit / phase fix is pinned by tests)

* β-arch ([#123](https://github.com/lorcan35/TinkerBox/pull/123)) pair-emit on all three callbacks: legacy \`tool_call\`/\`tool_result\` frame + new \`progress.tool.*\` frame.
* \`_emit_legacy=False\` skips the legacy frame.
* [#75](https://github.com/lorcan35/TinkerBox/pull/75) phase 1b per-turn tracker bookkeeping (pre-register on call, merge on result, append-bare fallback).
* "Same-tool-twice-in-one-turn" 1:1 mapping invariant (FIRST pending slot gets the FIRST result).
* v4·D Phase 4c web_search auto-widget_list emit.
* γ2-M1 ([#104](https://github.com/lorcan35/TinkerBox/pull/104)) + audit B4 ([#137](https://github.com/lorcan35/TinkerBox/pull/137)) structured tool-error frame with caller-override of code + message.
* All ws.closed short-circuits (call: skip emit but **keep tracker**; result: skip everything; error: skip emit).

## Tests

[\`tests/test_tool_event_emitter.py\`](tests/test_tool_event_emitter.py) — 19 tests across 4 classes:

**\`TestOnToolCall\`** (5 tests)
**\`TestOnToolResult\`** (8 tests, including the same-tool-twice-1:1 invariant + the web_search auto-widget happy/no-results/non-web-search branches)
**\`TestOnToolError\`** (5 tests, including the audit-B4 code/message override)
**\`TestStateCapture\`** (1 test) — pin that the class holds REFs (not copies) so post-init external mutations to conn_state remain visible inside the emitter. Pre-extract this was natural via Python closure semantics; the class-based version must preserve it.

## server.py shrink

| Metric | Value |
|---|---|
| This PR | 2359 → 2209 LOC (**−150 LOC, biggest single shrink in the round-3 series**) |
| Cumulative round 1+2+3 | 2714 → 2209 LOC (−505, **−18.6 %**) |

## _handle_register progress

| Sub-responsibility | LOC | Status |
|---|---|---|
| Validate device_id | ~11 | inline |
| P13 stale-conn eviction | ~57 | extracted #222 |
| Device DB upsert + D2 | ~34 | extracted #223 |
| Widget caps pluck + add_event | ~18 | inline, small |
| Session create/resume + conn_state init | ~14 | inline, small |
| Surface mgr + scheduler replay | ~30 | extracted #225 |
| **Tool callback closures** | ~176 | extracted (this PR) |
| session_start + session_messages | ~79 | extracted #224 |
| Pipeline init reset + create + codec neg | ~75 | tightly coupled — last natural extract |

\`_handle_register\` is now **~190 LOC** (down from 522 — **−332, −63 %**) across 5 round-3 PRs. **The function is now a thin orchestrator.**

## Verification

\`\`\`
\$ python3 -m pytest tests/test_tool_event_emitter.py -v
19 passed in 0.09s

\$ python3 -m pytest tests/ --ignore=tests/audit -q
847 passed, 108 subtests passed, 1 skipped, 0 failed in 11.38s

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \\
    dragon_voice/ tests/
All checks passed!
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)