### PR TITLE
refactor(server): dedup rich-media emit out of both _handle_text_body branches

### DIFF
--- a/dragon_voice/rich_media_emit.py
+++ b/dragon_voice/rich_media_emit.py
@@ -1,0 +1,156 @@
+"""Post-LLM rich media detection + emission for text-path turns.
+
+Wave 23 SOLID-audit follow-up — first sub-handler extract from
+`_handle_text_body` (round 4, after round 1+2+3 decomposed
+`_handle_config_update` and `_handle_register`).
+
+Pre-extract this helper was duplicated TWICE inside
+`_handle_text_body`:
+
+  * Once in the TinkerClaw bypass branch (server.py:1525-1553).
+  * Once in the ConversationEngine path (server.py:1646-1681).
+
+Both copies were ~28 LOC of nearly-identical code: scan the
+LLM response for renderable code-blocks / tables / image URLs,
+emit a `media_rendering: start` progress signal so Tab5 doesn't
+perceive the 1-3 s render as a stalled reply (Audit D4, #137),
+strip the rendered content from the text, then emit each media
+event.
+
+The two copies differ only in log labels and one defensive
+check.  This module collapses them into one entry point with a
+`log_label` parameter for log-line provenance.
+
+## API
+
+```python
+await emit_rich_media_for_text_turn(
+    ws,
+    *,
+    response_text,
+    media_pipeline,
+    session_id,
+    safe_send_json,
+    log_label="local",     # or "tc" for the TinkerClaw branch
+) -> None
+```
+
+No return value — all side effects flow through the WS.
+
+## Behavior
+
+  1. If `media_pipeline` is None or `response_text` is empty → no-op.
+  2. If `media_pipeline.has_renderable_content(response_text)` is
+     True AND `ws` is open → send `{"type": "media_rendering",
+     "stage": "start"}` so Tab5 shows the user a rendering hint.
+  3. Run `media_pipeline.process_response(response_text, session_id)`.
+     If it raises → log + swallow (UX nice-to-have, not session
+     correctness).
+  4. If the pipeline returned media events:
+     a. Strip the rendered content from the text and send a
+        `text_update` BEFORE the media events (Audit D6 — Tab5's
+        last-bubble targeting still points at the text bubble
+        when the clear arrives).
+     b. Emit each media event in order.
+
+## DIP
+
+`media_pipeline` and `safe_send_json` are passed in.  Module
+compiles without importing `VoiceServer`.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+SafeSendJson = Callable[[web.WebSocketResponse, dict], Awaitable[bool]]
+
+
+async def emit_rich_media_for_text_turn(
+    ws: web.WebSocketResponse,
+    *,
+    response_text: str,
+    media_pipeline: Optional[Any],     # MediaPipeline
+    session_id: str,
+    safe_send_json: SafeSendJson,
+    log_label: str = "local",
+) -> None:
+    """Detect + emit rich media for a completed LLM text response.
+
+    No-op when:
+      * `media_pipeline` is None (test paths, embedded usage).
+      * `response_text` is empty.
+
+    Failure isolation:
+      All exceptions inside the media-pipeline call are caught +
+      logged at WARNING.  Rich-media detection is UX nice-to-have;
+      a failed render must not block the next chat turn.
+
+    Args:
+        ws: Open WebSocket to Tab5.
+        response_text: The full LLM response text to scan.
+        media_pipeline: MediaPipeline instance (Optional — None is
+            no-op for test paths).
+        session_id: Session id (for media-cache key namespacing).
+        safe_send_json: WS-send callable (passed in for DIP — used
+            for the `media_rendering` progress signal which goes
+            through the swallow helper).  The actual media event
+            emission uses `ws.send_json` direct because failures
+            there are caught by the outer try/except.
+        log_label: Prefix for log lines so post-extract you can
+            still tell TC vs local-path media events apart in the
+            journal.  Default `"local"`; pass `"tc"` from the
+            TinkerClaw bypass branch.
+    """
+    if not response_text or media_pipeline is None:
+        return
+
+    # Audit D4 (#137): emit progress BEFORE rendering so Tab5
+    # doesn't perceive the 1-3 s code-block render as a stalled
+    # reply.  Goes through safe_send_json to swallow transport
+    # close mid-reply.
+    if not ws.closed and media_pipeline.has_renderable_content(response_text):
+        await safe_send_json(ws, {
+            "type": "media_rendering",
+            "stage": "start",
+        })
+
+    try:
+        media_events = await media_pipeline.process_response(
+            response_text, session_id,
+        )
+        logger.info(
+            "MediaPipeline (%s): %d event(s) for response len=%d",
+            log_label, len(media_events), len(response_text),
+        )
+        if media_events:
+            # Audit D6: send text_update BEFORE media events.  Tab5's
+            # ui_chat_update_last_message targets the *last* chat
+            # bubble.  If we send media first, the image becomes
+            # "last" and the empty-string text_update would remove
+            # the wrong row.  text_update first clears the streamed
+            # markdown bubble; media events then append the
+            # rendered JPEG below.
+            cleaned = media_pipeline.strip_rendered_content(
+                response_text, media_events,
+            )
+            logger.info(
+                "strip_rendered_content (%s): %d→%d chars",
+                log_label, len(response_text), len(cleaned),
+            )
+            if not ws.closed:
+                await ws.send_json({"type": "text_update", "text": cleaned})
+                logger.info(
+                    "Sent text_update (D6 %s) with %d chars",
+                    log_label, len(cleaned),
+                )
+        for event in media_events:
+            if not ws.closed:
+                await ws.send_json(event)
+    except Exception as e:
+        logger.warning("Media detection (%s) failed: %s", log_label, e)

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -36,6 +36,7 @@ from dragon_voice.session_handshake import (
     emit_session_start,
     replay_session_message_tail,
 )
+from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
 from dragon_voice.tool_event_emitter import ToolEventEmitter
@@ -1522,35 +1523,18 @@ class VoiceServer:
                 except Exception:
                     logger.debug("TC receipt emit failed", exc_info=True)
 
-            # Rich media detection for TinkerClaw responses too.
-            # Audit D4 (#137): emit a progress signal BEFORE rendering
-            # if there's renderable content, so Tab5 doesn't perceive
-            # the 1-3 s code-block render as a stalled reply.
-            if full_response and self._media_pipeline:
-                if not ws.closed and self._media_pipeline.has_renderable_content(response_text):
-                    await self._safe_send_json(ws, {
-                        "type": "media_rendering",
-                        "stage": "start",
-                    })
-                try:
-                    media_events = await self._media_pipeline.process_response(
-                        response_text, session_id
-                    )
-                    # Audit D6 (TC path): send text_update BEFORE media events
-                    # so Tab5's last-bubble targeting still points at the
-                    # text bubble when the clear arrives.
-                    if media_events:
-                        logger.info("Sent %d media events for TinkerClaw response", len(media_events))
-                        cleaned = self._media_pipeline.strip_rendered_content(response_text, media_events)
-                        logger.info("Text stripped: %d→%d chars", len(response_text), len(cleaned))
-                        if not ws.closed:
-                            await ws.send_json({"type": "text_update", "text": cleaned})
-                            logger.info("Sent text_update (D6 TC) with %d chars", len(cleaned))
-                    for event in media_events:
-                        if not ws.closed:
-                            await ws.send_json(event)
-                except Exception as e:
-                    logger.warning("TinkerClaw media detection failed: %s", e)
+            # SOLID-audit follow-up: rich media detection extracted to
+            # rich_media_emit.emit_rich_media_for_text_turn (dedup with
+            # the local-path branch below).
+            if full_response:
+                await emit_rich_media_for_text_turn(
+                    ws,
+                    response_text=response_text,
+                    media_pipeline=self._media_pipeline,
+                    session_id=session_id,
+                    safe_send_json=self._safe_send_json,
+                    log_label="tc",
+                )
 
             return
 
@@ -1643,42 +1627,20 @@ class VoiceServer:
             if not ws.closed:
                 await ws.send_json({"type": "llm_done", "llm_ms": 0})
 
-            # Rich media detection — scan response for image/chart/map references.
-            # Audit D6: send text_update BEFORE media events. Tab5's
-            # ui_chat_update_last_message targets the *last* chat bubble. If
-            # we send media first, the image becomes "last" and the empty-
-            # string text_update removes the wrong row. text_update first
-            # clears the streamed markdown bubble; media events then append
-            # the rendered JPEG below.
+            # SOLID-audit follow-up: rich media detection extracted to
+            # rich_media_emit.emit_rich_media_for_text_turn (dedup with
+            # the TC bypass branch above).  Audit D6 ordering invariant
+            # (text_update BEFORE media events) is preserved + pinned
+            # by tests/test_rich_media_emit.py.
             if full_response:
-                # Audit D4 (#137): emit progress before render so Tab5
-                # doesn't perceive the 1-3 s code-block render as a
-                # stalled reply.
-                if not ws.closed and self._media_pipeline.has_renderable_content(response_text):
-                    await self._safe_send_json(ws, {
-                        "type": "media_rendering",
-                        "stage": "start",
-                    })
-                try:
-                    media_events = await self._media_pipeline.process_response(
-                        response_text, session_id
-                    )
-                    logger.info("MediaPipeline: %d event(s) for response len=%d",
-                                len(media_events), len(response_text))
-                    if media_events:
-                        cleaned = self._media_pipeline.strip_rendered_content(
-                            response_text, media_events
-                        )
-                        logger.info("strip_rendered_content: %d->%d chars",
-                                    len(response_text), len(cleaned))
-                        if not ws.closed:
-                            await ws.send_json({"type": "text_update", "text": cleaned})
-                            logger.info("Sent text_update (D6) with %d chars", len(cleaned))
-                    for event in media_events:
-                        if not ws.closed:
-                            await ws.send_json(event)
-                except Exception as e:
-                    logger.warning("Media detection failed: %s", e)
+                await emit_rich_media_for_text_turn(
+                    ws,
+                    response_text=response_text,
+                    media_pipeline=self._media_pipeline,
+                    session_id=session_id,
+                    safe_send_json=self._safe_send_json,
+                    log_label="local",
+                )
 
             # Synthesize TTS for the text response (only if response_mode != match_input)
             # match_input = text in, text out. always_speak = always TTS.

--- a/tests/test_d_tier_polish.py
+++ b/tests/test_d_tier_polish.py
@@ -69,16 +69,23 @@ def test_system_endpoint_includes_inference_executor_block() -> None:
 def test_text_path_emits_media_rendering_progress_before_render() -> None:
     """Pin via source inspection so a refactor that drops the progress
     emit re-opens the perceived-stall window between llm_done and
-    media frames.  Audit B1 (#165) extracted the body to
-    `_handle_text_body`; the emit lives there now."""
+    media frames.  Audit B1 (#165) originally extracted the body
+    to `_handle_text_body`; the SOLID round-4 refactor extracted
+    the emit one step further to
+    `rich_media_emit.emit_rich_media_for_text_turn` — the
+    inspection chases it there now.
+
+    See `tests/test_rich_media_emit.py` for the full behavioural
+    pinning of the emit function."""
     import inspect
-    from dragon_voice.server import VoiceServer
-    src = inspect.getsource(VoiceServer._handle_text_body)
+    from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
+    src = inspect.getsource(emit_rich_media_for_text_turn)
     assert "has_renderable_content(response_text)" in src, (
-        "_handle_text_body must guard the progress emit on has_renderable_content"
+        "emit_rich_media_for_text_turn must guard the progress emit on "
+        "has_renderable_content"
     )
     assert '"media_rendering"' in src and '"start"' in src, (
-        "_handle_text_body must emit type=media_rendering, stage=start"
+        "emit_rich_media_for_text_turn must emit type=media_rendering, stage=start"
     )
 
 

--- a/tests/test_rich_media_emit.py
+++ b/tests/test_rich_media_emit.py
@@ -1,0 +1,256 @@
+"""Tests for ``dragon_voice.rich_media_emit.emit_rich_media_for_text_turn``.
+
+Pin every branch of the dedup'd rich-media emission helper.  Two
+groups of tests:
+
+  * No-op branches: empty response_text, missing media_pipeline,
+    failure isolation.
+  * Happy-path emission: media_rendering progress signal, text_update
+    BEFORE media events (Audit D6 ordering invariant), every
+    media event sent.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    ws.send_json = AsyncMock()
+    return ws
+
+
+def _make_safe_send_json() -> AsyncMock:
+    return AsyncMock(return_value=True)
+
+
+def _make_pipeline(
+    *,
+    has_renderable: bool = True,
+    media_events: list | None = None,
+    cleaned_text: str = "",
+    process_raises: Exception | None = None,
+) -> MagicMock:
+    p = MagicMock()
+    p.has_renderable_content = MagicMock(return_value=has_renderable)
+    if process_raises is not None:
+        p.process_response = AsyncMock(side_effect=process_raises)
+    else:
+        p.process_response = AsyncMock(return_value=media_events or [])
+    p.strip_rendered_content = MagicMock(return_value=cleaned_text)
+    return p
+
+
+# ─── No-op branches ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_empty_response_text_is_noop():
+    ws = _make_ws()
+    pipe = _make_pipeline()
+    send = _make_safe_send_json()
+
+    await emit_rich_media_for_text_turn(
+        ws,
+        response_text="",
+        media_pipeline=pipe,
+        session_id="sess-X",
+        safe_send_json=send,
+    )
+
+    pipe.has_renderable_content.assert_not_called()
+    pipe.process_response.assert_not_called()
+    send.assert_not_awaited()
+    ws.send_json.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_media_pipeline_is_noop():
+    """Embedded usage / test paths may not have a MediaPipeline."""
+    ws = _make_ws()
+    send = _make_safe_send_json()
+
+    await emit_rich_media_for_text_turn(
+        ws,
+        response_text="Some response with code blocks",
+        media_pipeline=None,
+        session_id="sess-X",
+        safe_send_json=send,
+    )
+
+    send.assert_not_awaited()
+    ws.send_json.assert_not_awaited()
+
+
+# ─── media_rendering progress signal ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_renderable_content_emits_media_rendering_start():
+    """When content is renderable, send media_rendering:start
+    BEFORE the actual render so Tab5 shows a hint."""
+    ws = _make_ws()
+    pipe = _make_pipeline(has_renderable=True, media_events=[])
+    send = _make_safe_send_json()
+
+    await emit_rich_media_for_text_turn(
+        ws,
+        response_text="Here's some code: ```python\nprint('x')\n```",
+        media_pipeline=pipe,
+        session_id="sess-X",
+        safe_send_json=send,
+    )
+
+    # The progress signal goes via safe_send_json
+    send.assert_awaited_once()
+    payload = send.await_args.args[1]
+    assert payload == {"type": "media_rendering", "stage": "start"}
+
+
+@pytest.mark.asyncio
+async def test_non_renderable_content_skips_media_rendering():
+    """Plain text response → no media_rendering signal."""
+    ws = _make_ws()
+    pipe = _make_pipeline(has_renderable=False, media_events=[])
+    send = _make_safe_send_json()
+
+    await emit_rich_media_for_text_turn(
+        ws,
+        response_text="Just plain text",
+        media_pipeline=pipe,
+        session_id="sess-X",
+        safe_send_json=send,
+    )
+    send.assert_not_awaited()  # no media_rendering signal
+
+
+@pytest.mark.asyncio
+async def test_ws_closed_skips_media_rendering_signal():
+    ws = _make_ws(closed=True)
+    pipe = _make_pipeline(has_renderable=True, media_events=[])
+    send = _make_safe_send_json()
+
+    await emit_rich_media_for_text_turn(
+        ws,
+        response_text="```python\n```",
+        media_pipeline=pipe,
+        session_id="sess-X",
+        safe_send_json=send,
+    )
+    send.assert_not_awaited()
+
+
+# ─── Audit D6 ordering invariant ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_text_update_sent_BEFORE_media_events():
+    """Audit D6 invariant: when there are media events, the
+    text_update (clearing the streamed markdown bubble) MUST be
+    sent BEFORE the media events (the rendered JPEGs).  Pin the
+    ordering with a captured-call list so a future refactor can't
+    silently flip it (which would cause Tab5 to delete the wrong
+    chat row)."""
+    ws = _make_ws()
+    pipe = _make_pipeline(
+        has_renderable=True,
+        media_events=[
+            {"type": "media", "url": "/api/media/abc.jpg"},
+            {"type": "media", "url": "/api/media/def.jpg"},
+        ],
+        cleaned_text="(cleaned)",
+    )
+
+    await emit_rich_media_for_text_turn(
+        ws,
+        response_text="```python\nprint(1)\n```\n```python\nprint(2)\n```",
+        media_pipeline=pipe,
+        session_id="sess-X",
+        safe_send_json=_make_safe_send_json(),
+    )
+
+    # Sequence of ws.send_json calls — the FIRST must be text_update,
+    # the rest must be the media events in order.
+    types = [c.args[0]["type"] for c in ws.send_json.await_args_list]
+    assert types == ["text_update", "media", "media"]
+    # And the cleaned text payload landed.
+    text_update = ws.send_json.await_args_list[0].args[0]
+    assert text_update["text"] == "(cleaned)"
+
+
+@pytest.mark.asyncio
+async def test_no_media_events_skips_text_update_too():
+    """If process_response returns no events, don't emit a
+    text_update — the original streamed text is fine as-is."""
+    ws = _make_ws()
+    pipe = _make_pipeline(media_events=[])
+
+    await emit_rich_media_for_text_turn(
+        ws,
+        response_text="No code blocks here",
+        media_pipeline=pipe,
+        session_id="sess-X",
+        safe_send_json=_make_safe_send_json(),
+    )
+
+    # No ws.send_json calls (only the safe_send_json may have fired).
+    ws.send_json.assert_not_awaited()
+
+
+# ─── Failure isolation ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_process_response_failure_is_logged_not_raised():
+    """A pipeline.process_response exception must NOT propagate —
+    rich media is UX nice-to-have."""
+    ws = _make_ws()
+    pipe = _make_pipeline(process_raises=RuntimeError("Pillow blew up"))
+
+    # Must NOT raise.
+    await emit_rich_media_for_text_turn(
+        ws,
+        response_text="```py\n```",
+        media_pipeline=pipe,
+        session_id="sess-X",
+        safe_send_json=_make_safe_send_json(),
+    )
+
+    # No text_update or media events sent (the try/except caught
+    # before we could iterate).
+    ws.send_json.assert_not_awaited()
+
+
+# ─── log_label provenance ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_log_label_is_used_for_log_lines(caplog):
+    """The log_label parameter discriminates TC vs local in logs.
+    Caplog should see 'tc' when we pass log_label="tc"."""
+    import logging
+    caplog.set_level(logging.INFO, logger="dragon_voice.rich_media_emit")
+    ws = _make_ws()
+    pipe = _make_pipeline(
+        has_renderable=True,
+        media_events=[{"type": "media", "url": "/x"}],
+        cleaned_text="x",
+    )
+
+    await emit_rich_media_for_text_turn(
+        ws,
+        response_text="```\n```",
+        media_pipeline=pipe,
+        session_id="sess-X",
+        safe_send_json=_make_safe_send_json(),
+        log_label="tc",
+    )
+
+    # At least one log line must mention 'tc'
+    matched = [r for r in caplog.records if "(tc)" in r.getMessage()]
+    assert matched, f"no log lines mentioned (tc): {[r.getMessage() for r in caplog.records]}"


### PR DESCRIPTION
## What

**Round 4 starts on \`_handle_text_body\`** (442 LOC, the third giant after \`_handle_config_update\` and \`_handle_register\` were both decomposed in rounds 2+3).

First sub-extract: rich-media detection was **DUPLICATED** across the two branches of \`_handle_text_body\`:

* Once in the TinkerClaw bypass branch (server.py:1525-1553)
* Once in the ConversationEngine path (server.py:1646-1681)

Both copies were ~28 LOC of nearly-identical code. The two copies differed only in log labels and one defensive None-check.

This PR collapses them into one entry point in [\`dragon_voice/rich_media_emit.py\`](dragon_voice/rich_media_emit.py) with a \`log_label\` parameter for log-line provenance.

## API

\`\`\`python
await emit_rich_media_for_text_turn(
    ws,
    *,
    response_text,
    media_pipeline,
    session_id,
    safe_send_json,
    log_label=\"local\",     # or \"tc\" for the TinkerClaw branch
) -> None
\`\`\`

No-op when \`media_pipeline\` is None or \`response_text\` is empty. Failure isolation: pipeline.process_response exception → logged + swallowed (rich media is UX nice-to-have).

## Audit D6 ordering invariant (NEWLY PINNED)

The text_update MUST be sent BEFORE the media events. Pre-extract this was a comment (\"Tab5 targets the LAST chat bubble\"). Post-extract it's pinned by \`test_text_update_sent_BEFORE_media_events\` which captures the ws.send_json call list and asserts the sequence is \`[\"text_update\", \"media\", \"media\", ...]\`. **A future refactor that flips the order would cause Tab5 to delete the WRONG chat row; this test catches it immediately.**

## Tests

[\`tests/test_rich_media_emit.py\`](tests/test_rich_media_emit.py) — 9 tests:

| # | Branch | Pinned |
|---|---|---|
| 1 | Empty response_text | No-op |
| 2 | No media_pipeline | No-op |
| 3 | Renderable content | media_rendering:start emitted |
| 4 | Non-renderable content | No progress signal |
| 5 | ws.closed during signal | No spurious send |
| 6 | **Audit D6 ordering** | text_update BEFORE media (sequence pin) |
| 7 | No media events | text_update also skipped |
| 8 | process_response raises | Logged + swallowed |
| 9 | log_label provenance | \`\"tc\"\` lands in log records |

\`tests/test_d_tier_polish.py::test_text_path_emits_media_rendering_progress_before_render\` updated to chase the emit into its new home (still source-inspection based; complementary to the new behavioural tests).

## server.py shrink

| Metric | Value |
|---|---|
| This PR | 2209 → 2171 LOC (−38 net; ~57 LOC dup'd inline removed across two branches) |
| Cumulative round 1+2+3+4 | 2714 → 2171 LOC (−543, **−20.0 %**) — **broke the 20 % barrier** |

## _handle_text_body progress

| Sub-responsibility | Status |
|---|---|
| TinkerClaw bypass full path | ~140 LOC inline |
| ConvEngine streaming + tool-marker buffer | ~60 LOC |
| Empty-response wrap (DUP'd 2x) | ~30 LOC × 2 — next dedup |
| llm_done emit | trivial |
| **Rich media detection (DUP'd 2x)** | extracted (this PR) |
| TC zero-cost receipt | ~30 LOC TC-specific |
| TTS synthesis (local-only) | ~80 LOC — biggest remaining |
| Phase 3 LLM receipt (local-only) | ~30 LOC |

## Verification

\`\`\`
\$ python3 -m pytest tests/test_rich_media_emit.py -v
9 passed in 0.08s

\$ python3 -m pytest tests/ --ignore=tests/audit -q
856 passed, 108 subtests passed, 1 skipped, 0 failed in 11.43s

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \\
    dragon_voice/ tests/
All checks passed!
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)