### PR TITLE
refactor(server): dedup empty-response wrap out of both _handle_text_body branches

### DIFF
--- a/dragon_voice/empty_response_wrap.py
+++ b/dragon_voice/empty_response_wrap.py
@@ -1,0 +1,143 @@
+"""Empty-response guard — synthesize a fallback when the LLM
+produced no usable text but tools fired (or, optionally, an
+apology when nothing produced anything).
+
+Wave 23 SOLID-audit follow-up — second sub-extract from
+`_handle_text_body` (round 4, after rich_media_emit #227).
+
+## Why this matters
+
+Several model classes can produce empty / near-empty user-visible
+text after a turn:
+
+  * **FC-trained local models** (xLAM, distil-functiongemma,
+    LFM2.5-Nova) emit tool calls then stop — leaving the user-
+    visible text empty after the parser strips the markup.
+    Without a wrap, Tab5 sees `llm` with empty text and silently
+    drops the chat bubble.
+  * **TinkerClaw / MiniMax** halts after a failed tool call
+    without formulating a user-facing reply.
+
+`tools/response_wrap.py` provides:
+
+  * `looks_like_useful_text(s)` — True iff `s` has more than just
+    bracket-noise / residual XML / whitespace.  #75 phase 1b
+    refinement of the older "strict empty" check.
+  * `synthesize_wrap(tool_calls)` — picks a per-tool template
+    ("Got it — magenta.", "Searched: 5 results", etc.) from the
+    most-recent tool fire.
+
+This module is the WS-handler-side glue that decides:
+
+  1. Is the response text useful?  Return it as-is.
+  2. Did any tools fire?  Synthesize a wrap, send it, return it.
+  3. Did the caller pass a `fallback_when_no_tools`?  Send that,
+     return it.
+  4. Otherwise: return the (probably empty) original — let the
+     caller's `llm_done` emit handle the empty case however it
+     wants.
+
+## Pre-extract behaviour preserved exactly
+
+  * **TinkerClaw branch** — calls with
+    `fallback_when_no_tools="Sorry, I couldn't generate a response..."`
+    so the apology fires when no tools fired (legacy W15-H09).
+  * **Local ConvEngine branch** — calls with
+    `fallback_when_no_tools=None` so empty-with-no-tools just
+    falls through (matches pre-extract semantics).
+
+The two branches diverged historically — pinned by tests so a
+future "let's unify them" refactor doesn't silently change one
+or the other.
+
+## API
+
+```python
+response_text = await maybe_synthesize_empty_response_wrap(
+    ws,
+    response_text=response_text,
+    tool_calls=conn_state.get("tool_calls_this_turn") or [],
+    safe_send_json=self._safe_send_json,
+    log_label="tc",                                       # or "local"
+    fallback_when_no_tools="Sorry, ...",                  # or None
+)
+```
+
+Returns the (possibly new) response text.  The caller assigns it
+back so any downstream consumer (TTS synth, receipt emit, log
+line) sees the wrap-or-original.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable, Optional
+
+from aiohttp import web
+
+from dragon_voice.tools.response_wrap import looks_like_useful_text, synthesize_wrap
+
+logger = logging.getLogger(__name__)
+
+
+SafeSendJson = Callable[[web.WebSocketResponse, dict], Awaitable[bool]]
+
+
+async def maybe_synthesize_empty_response_wrap(
+    ws: web.WebSocketResponse,
+    *,
+    response_text: str,
+    tool_calls: list,
+    safe_send_json: SafeSendJson,
+    log_label: str = "local",
+    fallback_when_no_tools: Optional[str] = None,
+) -> str:
+    """If `response_text` isn't useful (#75 phase 1b heuristic),
+    synthesize a wrap from `tool_calls` and emit it as an `llm`
+    frame.  Return the new text the caller should treat as the
+    LLM response.
+
+    Returns `response_text` unchanged when:
+      * `looks_like_useful_text(response_text)` is True (happy path),
+      * OR no tools fired AND `fallback_when_no_tools` is None
+        (legacy local-path behaviour — let empty pass through).
+
+    Args:
+        ws: Open WebSocket to Tab5.
+        response_text: The post-stream LLM response text.
+        tool_calls: The per-turn `tool_calls_this_turn` tracker
+            list (from `conn_state`).  Empty list means no tools
+            fired this turn.
+        safe_send_json: WS-send callable.
+        log_label: Prefix for log lines so post-extract you can
+            tell TC vs local-path wraps apart in the journal.
+        fallback_when_no_tools: When set, sent as the apology
+            text when no tools fired.  When None (local-path
+            default), empty-with-no-tools falls through silently.
+    """
+    if looks_like_useful_text(response_text):
+        return response_text
+
+    wrap_text: Optional[str] = None
+    if tool_calls:
+        wrap_text = synthesize_wrap(tool_calls)
+        logger.info(
+            "#75 phase 1b: %s text path produced near-empty LLM text "
+            "(%r) but %d tool(s) fired — emitting template wrap (%d chars)",
+            log_label, response_text[:30], len(tool_calls), len(wrap_text),
+        )
+    elif fallback_when_no_tools is not None:
+        wrap_text = fallback_when_no_tools
+        logger.warning(
+            "W15-H09: %s text path produced zero tokens — emitting fallback response",
+            log_label,
+        )
+
+    if wrap_text is None:
+        # Nothing to do — local-path semantics let the empty
+        # pass through; the caller's llm_done will fire with
+        # the empty text and Tab5 will drop the bubble.
+        return response_text
+
+    if not ws.closed:
+        await safe_send_json(ws, {"type": "llm", "text": wrap_text})
+    return wrap_text

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -36,6 +36,7 @@ from dragon_voice.session_handshake import (
     emit_session_start,
     replay_session_message_tail,
 )
+from dragon_voice.empty_response_wrap import maybe_synthesize_empty_response_wrap
 from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
@@ -1439,47 +1440,21 @@ class VoiceServer:
 
             response_text = "".join(full_response)
 
-            # Wave 15 W15-H09 + #75 phase 1b: empty-response guard.  When
-            # MiniMax / the TinkerClaw agent halts after a failed tool
-            # call without formulating a user-facing reply, OR when an
-            # FC-trained local model (xLAM, functiongemma, …) only
-            # emitted tool calls with no natural-language wrap, we'd
-            # otherwise send llm_done with text="" and Tab5 silently
-            # drops the chat bubble.
-            #
-            # Preference order:
-            #   1. If any tool fired this turn, synthesise a per-tool
-            #      template wrap from `conn_state["tool_calls_this_turn"]`
-            #      (response_wrap.synthesize_wrap).  Fast, deterministic,
-            #      describes what actually ran — users get a useful ack
-            #      like "Got it — magenta." rather than a frustrating
-            #      "Sorry, I couldn't generate a response."
-            #   2. Fall through to the legacy W15-H09 generic apology
-            #      when there were zero tool fires (e.g. real LLM error).
-            # #75 phase 1b refinement: trigger wrap when reply is
-            # bracket-noise-only too, not just strict-empty.  See
-            # looks_like_useful_text above for the heuristic.
-            if not looks_like_useful_text(response_text):
-                tool_calls = conn_state.get("tool_calls_this_turn") or []
-                if tool_calls:
-                    fallback = synthesize_wrap(tool_calls)
-                    logger.info(
-                        "#75 phase 1b: TC path produced near-empty LLM text "
-                        "(%r) but %d tool(s) fired — emitting template wrap (%d chars)",
-                        response_text[:30], len(tool_calls), len(fallback),
-                    )
-                else:
-                    fallback = (
-                        "Sorry, I couldn't generate a response for that. "
-                        "Please try rephrasing, or try again in a moment."
-                    )
-                    logger.warning(
-                        "W15-H09: TinkerClaw text path produced zero tokens — "
-                        "emitting fallback response"
-                    )
-                if not ws.closed:
-                    await ws.send_json({"type": "llm", "text": fallback})
-                response_text = fallback
+            # SOLID-audit follow-up: empty-response guard extracted to
+            # empty_response_wrap.maybe_synthesize_empty_response_wrap.
+            # TC semantics: pass fallback_when_no_tools="Sorry, ..."
+            # so the W15-H09 apology fires when zero tools fired.
+            response_text = await maybe_synthesize_empty_response_wrap(
+                ws,
+                response_text=response_text,
+                tool_calls=conn_state.get("tool_calls_this_turn") or [],
+                safe_send_json=self._safe_send_json,
+                log_label="tc",
+                fallback_when_no_tools=(
+                    "Sorry, I couldn't generate a response for that. "
+                    "Please try rephrasing, or try again in a moment."
+                ),
+            )
 
             logger.info("TinkerClaw text response (%d chars): %s",
                         len(response_text), response_text[:80])
@@ -1604,25 +1579,19 @@ class VoiceServer:
 
             response_text = _TOOL_RE_LOCAL.sub("", "".join(full_response))
 
-            # #75 phase 1b: if the local model fired tools but never
-            # produced user-facing text (common with FC-trained small
-            # models like xLAM that emit tool calls then stop), wrap
-            # the tool results in a templated natural-language ack so
-            # Tab5 doesn't render an empty bubble.  Same intent as the
-            # TC-path guard above, just applied to the local/conversation
-            # engine flow.
-            if not looks_like_useful_text(response_text):
-                tool_calls = conn_state.get("tool_calls_this_turn") or []
-                if tool_calls:
-                    wrap = synthesize_wrap(tool_calls)
-                    logger.info(
-                        "#75 phase 1b: local text path emitted near-empty text "
-                        "(%r) with %d tool fire(s) — sending template wrap (%d chars)",
-                        response_text[:30], len(tool_calls), len(wrap),
-                    )
-                    if not ws.closed:
-                        await ws.send_json({"type": "llm", "text": wrap})
-                    response_text = wrap
+            # SOLID-audit follow-up: same empty-response guard as
+            # the TC path above, but with fallback_when_no_tools=None
+            # to preserve the local-path semantics where empty +
+            # no tools just falls through (the legacy "let it pass"
+            # behaviour — Tab5 drops the empty bubble silently).
+            response_text = await maybe_synthesize_empty_response_wrap(
+                ws,
+                response_text=response_text,
+                tool_calls=conn_state.get("tool_calls_this_turn") or [],
+                safe_send_json=self._safe_send_json,
+                log_label="local",
+                fallback_when_no_tools=None,
+            )
 
             if not ws.closed:
                 await ws.send_json({"type": "llm_done", "llm_ms": 0})

--- a/tests/test_empty_response_wrap.py
+++ b/tests/test_empty_response_wrap.py
@@ -1,0 +1,243 @@
+"""Tests for ``dragon_voice.empty_response_wrap.maybe_synthesize_empty_response_wrap``.
+
+Pin every branch of the empty-response guard.
+
+The two original call sites (TC bypass + local ConvEngine path)
+diverged historically:
+
+  * TC: passes `fallback_when_no_tools="Sorry, ..."` so the
+    apology fires when no tools fired (W15-H09 legacy).
+  * Local: passes `fallback_when_no_tools=None` so empty-with-
+    no-tools just falls through.
+
+These tests pin BOTH semantics so a future "let's unify them"
+refactor doesn't silently change one branch.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.empty_response_wrap import maybe_synthesize_empty_response_wrap
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    return ws
+
+
+def _make_safe_send_json() -> AsyncMock:
+    return AsyncMock(return_value=True)
+
+
+# ─── Happy path: useful text passes through ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_useful_text_passes_through_unchanged():
+    """Standard happy path: LLM produced useful prose; the guard
+    is a no-op."""
+    ws = _make_ws()
+    send = _make_safe_send_json()
+
+    out = await maybe_synthesize_empty_response_wrap(
+        ws,
+        response_text="Hello, the time is 12:30 PM.",
+        tool_calls=[],
+        safe_send_json=send,
+        log_label="local",
+    )
+
+    assert out == "Hello, the time is 12:30 PM."
+    send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_useful_text_with_tools_still_passes_through():
+    """Even when tools fired, useful text means we keep the LLM's
+    prose — the wrap only kicks in for empty/junk responses."""
+    ws = _make_ws()
+    send = _make_safe_send_json()
+
+    out = await maybe_synthesize_empty_response_wrap(
+        ws,
+        response_text="Stored your fact: chair is magenta.",
+        tool_calls=[{"tool": "remember", "args": {"fact": "chair is magenta"}}],
+        safe_send_json=send,
+        log_label="local",
+    )
+
+    assert out == "Stored your fact: chair is magenta."
+    send.assert_not_awaited()
+
+
+# ─── Empty + tools fired → synthesize wrap ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_empty_with_tools_synthesizes_wrap():
+    """The xLAM / functiongemma case: tool fired, empty user-
+    visible reply.  Synthesize a per-tool wrap and send it."""
+    ws = _make_ws()
+    send = _make_safe_send_json()
+
+    out = await maybe_synthesize_empty_response_wrap(
+        ws,
+        response_text="",
+        tool_calls=[
+            {"tool": "remember", "args": {"fact": "magenta"}, "result": "stored"},
+        ],
+        safe_send_json=send,
+        log_label="local",
+    )
+
+    # Returned a non-empty wrap string
+    assert out != ""
+    assert isinstance(out, str)
+    # Sent via safe_send_json as an llm frame
+    send.assert_awaited_once()
+    payload = send.await_args.args[1]
+    assert payload["type"] == "llm"
+    assert payload["text"] == out
+
+
+@pytest.mark.asyncio
+async def test_bracket_noise_with_tools_treated_as_empty():
+    """#75 phase 1b: response that's just bracket noise should
+    trigger the wrap, not pass through as 'useful'."""
+    ws = _make_ws()
+    send = _make_safe_send_json()
+
+    out = await maybe_synthesize_empty_response_wrap(
+        ws,
+        response_text="<>",  # bracket noise only
+        tool_calls=[{"tool": "datetime", "args": {}, "result": "12:30"}],
+        safe_send_json=send,
+        log_label="local",
+    )
+    # Wrap fired
+    assert out != "<>"
+    send.assert_awaited_once()
+
+
+# ─── Empty + no tools, no fallback → pass through (LOCAL semantics) ─
+
+
+@pytest.mark.asyncio
+async def test_empty_no_tools_no_fallback_passes_through():
+    """LOCAL path semantics: empty text + no tools + no fallback
+    → return unchanged.  Caller's llm_done emits empty text;
+    Tab5 drops the bubble.  Pinned so a future "always send
+    something" refactor doesn't silently flip this branch."""
+    ws = _make_ws()
+    send = _make_safe_send_json()
+
+    out = await maybe_synthesize_empty_response_wrap(
+        ws,
+        response_text="",
+        tool_calls=[],
+        safe_send_json=send,
+        log_label="local",
+        fallback_when_no_tools=None,
+    )
+
+    assert out == ""
+    send.assert_not_awaited()
+
+
+# ─── Empty + no tools + fallback set → apology (TC semantics) ────
+
+
+@pytest.mark.asyncio
+async def test_empty_no_tools_with_fallback_sends_apology():
+    """TC path semantics: empty + no tools + fallback_when_no_tools
+    set → send the apology and return it."""
+    ws = _make_ws()
+    send = _make_safe_send_json()
+    apology = "Sorry, I couldn't generate a response for that."
+
+    out = await maybe_synthesize_empty_response_wrap(
+        ws,
+        response_text="",
+        tool_calls=[],
+        safe_send_json=send,
+        log_label="tc",
+        fallback_when_no_tools=apology,
+    )
+
+    assert out == apology
+    send.assert_awaited_once()
+    payload = send.await_args.args[1]
+    assert payload["type"] == "llm"
+    assert payload["text"] == apology
+
+
+# ─── ws.closed handling ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ws_closed_skips_send_but_still_returns_wrap():
+    """If ws.closed is True, the wrap is still returned (so any
+    downstream consumer like TTS / receipt sees the synthesised
+    text) but the WS send is skipped."""
+    ws = _make_ws(closed=True)
+    send = _make_safe_send_json()
+
+    out = await maybe_synthesize_empty_response_wrap(
+        ws,
+        response_text="",
+        tool_calls=[{"tool": "remember", "args": {"fact": "x"}}],
+        safe_send_json=send,
+        log_label="local",
+    )
+
+    assert out != ""  # wrap returned
+    send.assert_not_awaited()  # but no send
+
+
+# ─── log_label provenance ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_log_label_distinguishes_tc_vs_local(caplog):
+    """The log_label parameter discriminates TC vs local in logs.
+    Caplog should see 'tc' when we pass log_label='tc'."""
+    import logging
+    caplog.set_level(logging.INFO, logger="dragon_voice.empty_response_wrap")
+    ws = _make_ws()
+
+    await maybe_synthesize_empty_response_wrap(
+        ws,
+        response_text="",
+        tool_calls=[{"tool": "datetime", "args": {}, "result": "12:30"}],
+        safe_send_json=_make_safe_send_json(),
+        log_label="tc",
+    )
+
+    matched = [r for r in caplog.records if "tc text path" in r.getMessage().lower()]
+    assert matched, f"no log lines mentioned 'tc text path': {[r.getMessage() for r in caplog.records]}"
+
+
+@pytest.mark.asyncio
+async def test_w15_h09_log_warning_on_no_tools_fallback(caplog):
+    """The W15-H09 fallback path logs at WARNING, not INFO —
+    pinned so an ops watcher can still distinguish 'wrap from
+    tools' (informational) from 'fallback apology' (warning)."""
+    import logging
+    caplog.set_level(logging.WARNING, logger="dragon_voice.empty_response_wrap")
+    ws = _make_ws()
+
+    await maybe_synthesize_empty_response_wrap(
+        ws,
+        response_text="",
+        tool_calls=[],
+        safe_send_json=_make_safe_send_json(),
+        log_label="tc",
+        fallback_when_no_tools="Sorry, ...",
+    )
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "expected at least one WARNING log line"
+    assert any("W15-H09" in r.getMessage() for r in warnings)


### PR DESCRIPTION
## What

Round 4 PR-B (sister of [#227](https://github.com/lorcan35/TinkerBox/pull/227) rich_media_emit dedup). Pulls the W15-H09 + #75 phase 1b empty-response guard out of both branches of \`_handle_text_body\` into [\`dragon_voice/empty_response_wrap.py\`](dragon_voice/empty_response_wrap.py).

## What was duplicated

The same ~30-LOC guard appeared TWICE inline:

* **TC bypass branch** (server.py:1462-1482) — calls with the \`\"Sorry, I couldn't generate...\"\` apology fallback.
* **Local ConvEngine branch** (server.py:1614-1625) — has the wrap-with-tools branch but **NOT** the apology fallback (legacy semantics: empty + no tools just passes through).

The two branches diverged historically. This PR pins the divergence as an explicit \`fallback_when_no_tools: Optional[str]\` parameter so the difference is now a **first-class call-site choice**, not invisible code drift.

## API

\`\`\`python
response_text = await maybe_synthesize_empty_response_wrap(
    ws,
    response_text=response_text,
    tool_calls=conn_state.get(\"tool_calls_this_turn\") or [],
    safe_send_json=self._safe_send_json,
    log_label=\"tc\",                         # or \"local\"
    fallback_when_no_tools=\"Sorry, ...\",    # or None
) -> str
\`\`\`

Returns the (possibly new) response text. The caller assigns it back so any downstream consumer (TTS synth, receipt emit, log line) sees the wrap-or-original.

## Three semantic paths preserved

| Input | Action | Logging |
|---|---|---|
| Useful text | Return unchanged (happy path) | none |
| Empty + tools fired | Synthesize per-tool wrap, send \`llm\`, return wrap | INFO |
| Empty + no tools + fallback (TC) | Send fallback as \`llm\`, return it | **WARNING** (W15-H09 ops signal) |
| Empty + no tools + None (LOCAL) | Return original (probably empty); Tab5 drops bubble | none |

## Tests

[\`tests/test_empty_response_wrap.py\`](tests/test_empty_response_wrap.py) — 9 tests:

| # | Branch | Pinned |
|---|---|---|
| 1 | Useful text passes through | No send, no mutation |
| 2 | Useful text + tools | Still passes through |
| 3 | Empty + tools fired | Wrap synthesized + sent |
| 4 | Bracket-noise (#75 phase 1b) | Treated as empty |
| 5 | **LOCAL semantics** (empty + no tools + no fallback) | Pass through, no send — **divergence pinned** |
| 6 | **TC semantics** (empty + no tools + fallback) | Apology sent + returned |
| 7 | ws.closed | Wrap returned but send skipped |
| 8 | log_label TC vs local | Distinguishable in journal |
| 9 | W15-H09 fallback | Fires at WARNING level (ops can grep) |

## server.py shrink

| Metric | Value |
|---|---|
| This PR | 2171 → 2140 LOC (−31 net; ~50 LOC dup'd inline removed across both branches) |
| Cumulative round 1+2+3+4 | 2714 → 2140 LOC (−574, **−21.2 %**) |

## _handle_text_body progress

| Sub-responsibility | Status |
|---|---|
| TinkerClaw bypass full path | ~120 LOC inline (was ~170 pre-round-4) |
| ConvEngine streaming + tool-marker buffer | ~60 LOC |
| **Empty-response wrap (DUP'd 2x)** | extracted (this PR) |
| llm_done emit | trivial |
| **Rich media detection (DUP'd 2x)** | extracted #227 |
| TC zero-cost receipt | ~30 LOC TC-specific — next candidate |
| TTS synthesis (local-only) | ~80 LOC — biggest remaining |
| Phase 3 LLM receipt (local-only) | ~30 LOC |

\`_handle_text_body\` is now **~370 LOC** (down from 442).

## Verification

\`\`\`
\$ python3 -m pytest tests/test_empty_response_wrap.py -v
9 passed in 0.08s

\$ python3 -m pytest tests/ --ignore=tests/audit -q
865 passed, 108 subtests passed, 1 skipped, 0 failed in 11.26s

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \\
    dragon_voice/ tests/
All checks passed!
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)