### PR TITLE
refactor(server): extract text-path LLM receipt + TC zero-cost receipt to text_path_receipt module

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -40,6 +40,10 @@ from dragon_voice.empty_response_wrap import maybe_synthesize_empty_response_wra
 from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
+from dragon_voice.text_path_receipt import (
+    emit_text_path_llm_receipt,
+    emit_tinkerclaw_zero_cost_receipt,
+)
 from dragon_voice.tool_event_emitter import ToolEventEmitter
 from dragon_voice.media.store import MediaStore
 from dragon_voice.media.pipeline import MediaPipeline
@@ -1461,42 +1465,17 @@ class VoiceServer:
             if not ws.closed:
                 await ws.send_json({"type": "llm_done", "llm_ms": 0, "text": response_text})
 
-            # v4·D connectivity polish: emit a zero-cost receipt on the
-            # TinkerClaw bypass path so the chat bubble gets stamped
-            # ("claw-agent · FREE") instead of no stamp at all.  TC turns
-            # don't expose token counts the way OpenRouter does; we just
-            # surface the engine name so transparency-per-bubble still
-            # holds.
-            if not ws.closed:
-                # Wave 8 audit #2 (A4/F3/J12): the first-turn fallback was
-                # the bare string "tinkerclaw" which shows up in chat
-                # bubbles as a generic stamp until the gateway populates
-                # `_model`. Fall back to the LLMConfig default
-                # ("minimax/MiniMax-M2.5") when both `name` and `_model`
-                # are empty so the first bubble stamp is still honest.
-                inner = getattr(llm, "_model", "") or ""
-                conf_default = getattr(conn_cfg.llm, "tinkerclaw_model", "") or ""
-                tc_model = (
-                    inner
-                    or getattr(llm, "name", None)
-                    or conf_default
-                    or "minimax/MiniMax-M2.5"
-                )
-                try:
-                    await ws.send_json({
-                        "type": "receipt",
-                        "stage": "llm",
-                        "model": tc_model,
-                        "prompt_tokens": 0,
-                        "completion_tokens": 0,
-                        "total_tokens": 0,
-                        "cost_mils": 0,          # TC bills to its own gateway
-                        "llm_ms": 0,
-                        "retried": False,
-                        "retry_reason": "",
-                    })
-                except Exception:
-                    logger.debug("TC receipt emit failed", exc_info=True)
+            # SOLID-audit follow-up: TC zero-cost receipt extracted to
+            # text_path_receipt.emit_tinkerclaw_zero_cost_receipt.
+            # Same model-name resolution priority chain
+            # (_model → name → config_default → minimax fallback) is
+            # pinned by 4 dedicated tests.
+            await emit_tinkerclaw_zero_cost_receipt(
+                ws,
+                llm=llm,
+                tinkerclaw_model_default=getattr(conn_cfg.llm, "tinkerclaw_model", "") or "",
+                safe_send_json=self._safe_send_json,
+            )
 
             # SOLID-audit follow-up: rich media detection extracted to
             # rich_media_emit.emit_rich_media_for_text_turn (dedup with
@@ -1694,49 +1673,18 @@ class VoiceServer:
 
             logger.info("Text response on session %s: %s", session_id, response_text[:80])
 
-            # Phase 3 per-turn receipt for text-path turns. Voice-path
-            # receipts are emitted from pipeline._process_utterance; the
-            # text path reaches the LLM via ConversationEngine directly
-            # and bypasses pipeline entirely, so we emit here too.
-            try:
-                convo = conn_state.get("conversation") or self._conversation
-                cur_llm = getattr(convo, "_llm", None)
-                # Wave 21b (#204): isinstance(SupportsUsage) over hasattr —
-                # closes the "model='llm'" silent fallback for backends like
-                # `dual` and `tinkerclaw` that lacked get_last_usage entirely.
-                from dragon_voice.llm.base import SupportsUsage
-                if cur_llm is not None and isinstance(cur_llm, SupportsUsage):
-                    usage = cur_llm.get_last_usage()
-                    if usage and usage.get("total_tokens"):
-                        from dragon_voice.llm.openrouter_llm import price_for_model
-                        cost_mils = price_for_model(
-                            usage["model"],
-                            usage.get("prompt_tokens", 0),
-                            usage.get("completion_tokens", 0),
-                        )
-                        if not ws.closed:
-                            await ws.send_json({
-                                "type":              "receipt",
-                                "stage":             "llm",
-                                "model":             usage["model"],
-                                "prompt_tokens":     usage.get("prompt_tokens", 0),
-                                "completion_tokens": usage.get("completion_tokens", 0),
-                                "total_tokens":      usage.get("total_tokens", 0),
-                                "cost_mils":         cost_mils,
-                                # v4·D Gauntlet G2 surface retries
-                                "retried":           bool(usage.get("retried", False)),
-                                "retry_reason":      usage.get("retry_reason", ""),
-                            })
-                        logger.info(
-                            "Receipt emitted (text): model=%s tok=%d+%d=%d cost_mils=%d",
-                            usage["model"],
-                            usage.get("prompt_tokens", 0),
-                            usage.get("completion_tokens", 0),
-                            usage.get("total_tokens", 0),
-                            cost_mils,
-                        )
-            except Exception:
-                logger.exception("Text-path receipt emit failed")
+            # SOLID-audit follow-up: Phase 3 per-turn receipt
+            # extracted to text_path_receipt.emit_text_path_llm_receipt.
+            # Voice-path receipts are emitted from
+            # pipeline._process_utterance; the text path reaches the
+            # LLM via ConversationEngine directly and bypasses
+            # pipeline entirely, so we emit here too.
+            convo = conn_state.get("conversation") or self._conversation
+            await emit_text_path_llm_receipt(
+                ws,
+                conversation=convo,
+                safe_send_json=self._safe_send_json,
+            )
 
         except Exception:
             logger.exception("Text processing error on session %s", session_id)

--- a/dragon_voice/text_path_receipt.py
+++ b/dragon_voice/text_path_receipt.py
@@ -1,0 +1,229 @@
+"""Per-turn `receipt` emission for the text-path LLM turns.
+
+Wave 23 SOLID-audit follow-up — third sub-extract from
+`_handle_text_body` (round 4, after rich_media_emit #227 and
+empty_response_wrap #228).
+
+The text-path receipts (vs voice-path receipts emitted from
+`pipeline._process_utterance`) are sent by `_handle_text_body`
+right after the LLM finishes streaming.  Two flavours:
+
+  * **Local path** — pulls token counts + cost from the active
+    LLM via the `SupportsUsage` protocol (Wave 21b PR #204) and
+    `price_for_model` (PR #210), then sends a `receipt` frame.
+  * **TinkerClaw bypass path** — TC bills to its own gateway so
+    Dragon doesn't have token counts; emits a zero-cost receipt
+    with just the model name so the chat bubble still gets
+    stamped ("claw-agent · FREE") instead of no stamp at all.
+
+This module is the dedicated home for both.
+
+## API
+
+```python
+await emit_text_path_llm_receipt(
+    ws,
+    *,
+    conversation,
+    safe_send_json,
+) -> None
+```
+
+Local-path receipt.  Reads token usage from `conversation.llm`
+(via `SupportsUsage`), computes cost via `price_for_model`,
+sends an `llm`-stage receipt.  Failures swallowed with WARNING
+log — receipt is informational, not session correctness.
+
+```python
+await emit_tinkerclaw_zero_cost_receipt(
+    ws,
+    *,
+    llm,
+    tinkerclaw_model_default,
+    safe_send_json,
+) -> None
+```
+
+TC-specific receipt.  Picks the model name (private `_model`
+first, then `.name`, then config default, then hardcoded
+`minimax/MiniMax-M2.5` last-resort) and sends a zero-cost
+receipt frame.
+
+## Design choices
+
+  * Both functions accept `safe_send_json` even though the
+    pre-extract code mostly used `ws.send_json` directly.  The
+    audit-D6-style transport-close swallow benefit applies to
+    these receipts too, even if the original code path was
+    "send and pray (with try/except)".
+  * The TC receipt's `_model` reach-through is preserved for
+    behavioural parity, with a TODO pointing at a future
+    `TinkerClawBackend.public_model_name()` accessor (audit
+    follow-up to ENC-1).
+  * The local receipt's `convo._llm` access is also preserved
+    pending a follow-up `ConversationEngine.get_last_usage()`
+    accessor (sister of `choose_vision_model` in PR #212).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+SafeSendJson = Callable[[web.WebSocketResponse, dict], Awaitable[bool]]
+
+
+# Last-resort fallback when neither the live LLM instance nor the
+# config carries a model name.  Matches Wave 8 audit #2 (A4/F3/J12)
+# pre-fix behaviour: the first turn after registration would
+# otherwise stamp the bubble with the bare string "tinkerclaw".
+_TC_MODEL_LAST_RESORT = "minimax/MiniMax-M2.5"
+
+
+async def emit_text_path_llm_receipt(
+    ws: web.WebSocketResponse,
+    *,
+    conversation: Optional[Any],     # ConversationEngine (Optional for tests)
+    safe_send_json: SafeSendJson,
+) -> None:
+    """Emit a `receipt` frame for the just-completed local
+    text-path LLM turn.
+
+    Voice-path receipts come from `pipeline._process_utterance`;
+    the text path reaches the LLM via ConversationEngine
+    directly and bypasses the pipeline entirely, so we emit
+    here too.
+
+    No-op when:
+      * `conversation` is None (test paths, embedded usage).
+      * The live LLM doesn't implement `SupportsUsage` (e.g.
+        backends like `dual` or `tinkerclaw` use a different
+        receipt path — see `emit_tinkerclaw_zero_cost_receipt`).
+      * `get_last_usage()` returns an empty / zero-token dict.
+
+    Failure isolation: any exception in the lookup or send
+    chain is caught + logged at ERROR with traceback.  A failed
+    receipt must NOT block the next text turn.
+    """
+    try:
+        if conversation is None:
+            return
+        # ENC-1 follow-up TODO: this still reaches into the
+        # private `_llm` attribute.  A future
+        # `ConversationEngine.get_last_usage()` accessor would
+        # close the SRP smell.  Behaviour-preserving for now.
+        cur_llm = getattr(conversation, "_llm", None)
+        if cur_llm is None:
+            return
+
+        # Wave 21b (#204): isinstance(SupportsUsage) over hasattr —
+        # closes the "model='llm'" silent fallback for backends
+        # like `dual` and `tinkerclaw` that lacked
+        # get_last_usage entirely.
+        from dragon_voice.llm.base import SupportsUsage
+        if not isinstance(cur_llm, SupportsUsage):
+            return
+
+        usage = cur_llm.get_last_usage()
+        if not usage or not usage.get("total_tokens"):
+            return
+
+        from dragon_voice.llm.openrouter_llm import price_for_model
+        cost_mils = price_for_model(
+            usage["model"],
+            usage.get("prompt_tokens", 0),
+            usage.get("completion_tokens", 0),
+        )
+
+        if not ws.closed:
+            await safe_send_json(ws, {
+                "type":              "receipt",
+                "stage":             "llm",
+                "model":             usage["model"],
+                "prompt_tokens":     usage.get("prompt_tokens", 0),
+                "completion_tokens": usage.get("completion_tokens", 0),
+                "total_tokens":      usage.get("total_tokens", 0),
+                "cost_mils":         cost_mils,
+                # v4·D Gauntlet G2: surface retries so the chat
+                # bubble can render a "RETRIED" chip when the
+                # OpenRouter retry path fired (context_trim or
+                # 429 backoff).
+                "retried":           bool(usage.get("retried", False)),
+                "retry_reason":      usage.get("retry_reason", ""),
+            })
+        logger.info(
+            "Receipt emitted (text): model=%s tok=%d+%d=%d cost_mils=%d",
+            usage["model"],
+            usage.get("prompt_tokens", 0),
+            usage.get("completion_tokens", 0),
+            usage.get("total_tokens", 0),
+            cost_mils,
+        )
+    except Exception:
+        logger.exception("Text-path receipt emit failed")
+
+
+async def emit_tinkerclaw_zero_cost_receipt(
+    ws: web.WebSocketResponse,
+    *,
+    llm: Any,
+    tinkerclaw_model_default: str,
+    safe_send_json: SafeSendJson,
+) -> None:
+    """v4·D connectivity polish: emit a zero-cost receipt on the
+    TinkerClaw bypass path so the chat bubble gets stamped
+    ("claw-agent · FREE") instead of no stamp at all.
+
+    TC turns don't expose token counts the way OpenRouter does;
+    we just surface the engine name so transparency-per-bubble
+    still holds.
+
+    ## Model-name resolution priority
+
+    Wave 8 audit #2 (A4/F3/J12) — the first-turn fallback used
+    to be the bare string "tinkerclaw" which shows up in chat
+    bubbles as a generic stamp until the gateway populates
+    `_model`.  Fall through this priority chain so the first
+    bubble stamp is still honest:
+
+      1. `llm._model` — the actual model the gateway loaded
+      2. `llm.name`   — the backend's display name
+      3. `tinkerclaw_model_default` — config default
+      4. `minimax/MiniMax-M2.5` — last-resort
+
+    Failure isolation: any send exception is logged at DEBUG
+    (not ERROR — receipt is purely informational on the TC path
+    where there's no token cost to surface).
+    """
+    if ws.closed:
+        return
+    try:
+        # ENC-1 follow-up TODO: `_model` is a private attr.
+        # Behaviour-preserving for now; a future
+        # TinkerClawBackend.public_model_name() accessor would
+        # close the SRP smell.
+        inner = getattr(llm, "_model", "") or ""
+        tc_model = (
+            inner
+            or getattr(llm, "name", None)
+            or tinkerclaw_model_default
+            or _TC_MODEL_LAST_RESORT
+        )
+        await safe_send_json(ws, {
+            "type":             "receipt",
+            "stage":            "llm",
+            "model":            tc_model,
+            "prompt_tokens":    0,
+            "completion_tokens": 0,
+            "total_tokens":     0,
+            "cost_mils":        0,          # TC bills to its own gateway
+            "llm_ms":           0,
+            "retried":          False,
+            "retry_reason":     "",
+        })
+    except Exception:
+        logger.debug("TC receipt emit failed", exc_info=True)

--- a/tests/test_text_path_receipt.py
+++ b/tests/test_text_path_receipt.py
@@ -1,0 +1,342 @@
+"""Tests for ``dragon_voice.text_path_receipt``.
+
+Two functions, two test classes:
+
+  * ``TestEmitTextPathLlmReceipt`` — local-path SupportsUsage
+    receipt.  Pin the no-op branches (None conv, no _llm,
+    non-SupportsUsage backend, empty usage) and the happy path
+    (full receipt frame with cost_mils + retried).
+
+  * ``TestEmitTinkerClawZeroCostReceipt`` — TC receipt.  Pin the
+    model-name resolution priority chain (4 fallback levels) and
+    the zero-cost frame shape.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.text_path_receipt import (
+    emit_text_path_llm_receipt,
+    emit_tinkerclaw_zero_cost_receipt,
+)
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    return ws
+
+
+def _make_safe_send_json() -> AsyncMock:
+    return AsyncMock(return_value=True)
+
+
+# ─── emit_text_path_llm_receipt ─────────────────────────────────
+
+
+class TestEmitTextPathLlmReceipt:
+    @pytest.mark.asyncio
+    async def test_none_conversation_is_noop(self):
+        ws = _make_ws()
+        send = _make_safe_send_json()
+
+        await emit_text_path_llm_receipt(
+            ws,
+            conversation=None,
+            safe_send_json=send,
+        )
+        send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_llm_attached_is_noop(self):
+        """During boot or post-shutdown, ConvEngine may have no
+        active LLM.  Pin the silent skip."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        conv = MagicMock(spec=[])  # no _llm attr at all
+        # MagicMock returns another mock by default; force None
+        # via spec=[]; getattr(conv, "_llm", None) returns None.
+
+        await emit_text_path_llm_receipt(
+            ws, conversation=conv, safe_send_json=send,
+        )
+        send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_supports_usage_backend_skips(self):
+        """A backend that doesn't implement SupportsUsage (e.g.
+        plain TinkerClaw, dual-model picker) MUST be silently
+        skipped — they have a different receipt path."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        # Plain backend with no get_last_usage method.
+        plain_backend = MagicMock(spec=[])
+        conv = MagicMock()
+        conv._llm = plain_backend
+
+        await emit_text_path_llm_receipt(
+            ws, conversation=conv, safe_send_json=send,
+        )
+        send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_empty_usage_skips(self):
+        """If get_last_usage returns empty / no total_tokens,
+        skip — Wave 21b silent-fallback closure."""
+        from dragon_voice.llm.base import LLMBackend, SupportsUsage
+
+        # Real subclass that satisfies SupportsUsage protocol
+        class _Backend:
+            def get_last_usage(self):
+                return {}  # empty
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        conv = MagicMock()
+        conv._llm = _Backend()
+        assert isinstance(_Backend(), SupportsUsage)
+
+        await emit_text_path_llm_receipt(
+            ws, conversation=conv, safe_send_json=send,
+        )
+        send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_zero_total_tokens_skips(self):
+        """A usage dict with total_tokens=0 means the LLM emitted
+        no real content (cancel? error?).  Skip the receipt so
+        the chat bubble doesn't get a useless 0-cost stamp."""
+        class _Backend:
+            def get_last_usage(self):
+                return {
+                    "model": "anthropic/claude-haiku-4.5",
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": 0,
+                }
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        conv = MagicMock()
+        conv._llm = _Backend()
+
+        await emit_text_path_llm_receipt(
+            ws, conversation=conv, safe_send_json=send,
+        )
+        send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_happy_path_emits_full_receipt(self):
+        class _Backend:
+            def get_last_usage(self):
+                return {
+                    "model": "anthropic/claude-haiku-4.5",
+                    "prompt_tokens": 100,
+                    "completion_tokens": 50,
+                    "total_tokens": 150,
+                }
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        conv = MagicMock()
+        conv._llm = _Backend()
+
+        await emit_text_path_llm_receipt(
+            ws, conversation=conv, safe_send_json=send,
+        )
+
+        send.assert_awaited_once()
+        payload = send.await_args.args[1]
+        assert payload["type"] == "receipt"
+        assert payload["stage"] == "llm"
+        assert payload["model"] == "anthropic/claude-haiku-4.5"
+        assert payload["prompt_tokens"] == 100
+        assert payload["completion_tokens"] == 50
+        assert payload["total_tokens"] == 150
+        # Cost computed via price_for_model — non-zero for haiku
+        assert payload["cost_mils"] > 0
+        assert payload["retried"] is False  # default
+        assert payload["retry_reason"] == ""
+
+    @pytest.mark.asyncio
+    async def test_retried_field_surfaced(self):
+        """v4·D Gauntlet G2: when usage carries retried=True
+        (context_trim or 429 backoff), the receipt MUST surface
+        it so Tab5 can render a 'RETRIED' chip."""
+        class _Backend:
+            def get_last_usage(self):
+                return {
+                    "model": "anthropic/claude-sonnet-4.6",
+                    "prompt_tokens": 200,
+                    "completion_tokens": 100,
+                    "total_tokens": 300,
+                    "retried": True,
+                    "retry_reason": "context_trim",
+                }
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        conv = MagicMock()
+        conv._llm = _Backend()
+
+        await emit_text_path_llm_receipt(
+            ws, conversation=conv, safe_send_json=send,
+        )
+        payload = send.await_args.args[1]
+        assert payload["retried"] is True
+        assert payload["retry_reason"] == "context_trim"
+
+    @pytest.mark.asyncio
+    async def test_ws_closed_skips_send(self):
+        class _Backend:
+            def get_last_usage(self):
+                return {"model": "x", "total_tokens": 100, "prompt_tokens": 50, "completion_tokens": 50}
+        ws = _make_ws(closed=True)
+        send = _make_safe_send_json()
+        conv = MagicMock()
+        conv._llm = _Backend()
+
+        await emit_text_path_llm_receipt(
+            ws, conversation=conv, safe_send_json=send,
+        )
+        send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_exception_in_usage_is_logged_not_raised(self):
+        """If get_last_usage raises (some backend bug), log +
+        swallow.  Receipt is informational."""
+        class _Backend:
+            def get_last_usage(self):
+                raise RuntimeError("usage tracker corrupt")
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        conv = MagicMock()
+        conv._llm = _Backend()
+
+        # Must NOT raise.
+        await emit_text_path_llm_receipt(
+            ws, conversation=conv, safe_send_json=send,
+        )
+
+
+# ─── emit_tinkerclaw_zero_cost_receipt ───────────────────────────
+
+
+class TestEmitTinkerClawZeroCostReceipt:
+    @pytest.mark.asyncio
+    async def test_picks_inner_model_first(self):
+        """Priority 1: llm._model takes precedence over name and
+        config default."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        llm = MagicMock()
+        llm._model = "loaded-model-A"
+        llm.name = "should-not-use-this"
+
+        await emit_tinkerclaw_zero_cost_receipt(
+            ws, llm=llm, tinkerclaw_model_default="default-model",
+            safe_send_json=send,
+        )
+        payload = send.await_args.args[1]
+        assert payload["model"] == "loaded-model-A"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_name_when_inner_empty(self):
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        llm = MagicMock()
+        llm._model = ""
+        llm.name = "name-fallback"
+
+        await emit_tinkerclaw_zero_cost_receipt(
+            ws, llm=llm, tinkerclaw_model_default="default-model",
+            safe_send_json=send,
+        )
+        payload = send.await_args.args[1]
+        assert payload["model"] == "name-fallback"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_default_when_name_empty(self):
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        llm = MagicMock()
+        llm._model = ""
+        llm.name = ""
+
+        await emit_tinkerclaw_zero_cost_receipt(
+            ws, llm=llm, tinkerclaw_model_default="config-default",
+            safe_send_json=send,
+        )
+        payload = send.await_args.args[1]
+        assert payload["model"] == "config-default"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_minimax_last_resort(self):
+        """When EVERY field is empty, last-resort fallback to
+        minimax/MiniMax-M2.5 keeps the bubble stamp from being
+        the bare 'tinkerclaw' string (Wave 8 audit #2 fix)."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        llm = MagicMock()
+        llm._model = ""
+        llm.name = ""
+
+        await emit_tinkerclaw_zero_cost_receipt(
+            ws, llm=llm, tinkerclaw_model_default="",
+            safe_send_json=send,
+        )
+        payload = send.await_args.args[1]
+        assert payload["model"] == "minimax/MiniMax-M2.5"
+
+    @pytest.mark.asyncio
+    async def test_zero_cost_frame_shape(self):
+        """The TC receipt MUST always carry zeros for token counts
+        + cost (TC bills to its own gateway).  Pin the wire shape
+        so a future change can't accidentally surface phantom
+        cost from the WS payload."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        llm = MagicMock()
+        llm._model = "minimax/MiniMax-M2.5"
+
+        await emit_tinkerclaw_zero_cost_receipt(
+            ws, llm=llm, tinkerclaw_model_default="",
+            safe_send_json=send,
+        )
+        payload = send.await_args.args[1]
+        assert payload["type"] == "receipt"
+        assert payload["stage"] == "llm"
+        assert payload["prompt_tokens"] == 0
+        assert payload["completion_tokens"] == 0
+        assert payload["total_tokens"] == 0
+        assert payload["cost_mils"] == 0
+        assert payload["llm_ms"] == 0
+        assert payload["retried"] is False
+        assert payload["retry_reason"] == ""
+
+    @pytest.mark.asyncio
+    async def test_ws_closed_skips_send(self):
+        ws = _make_ws(closed=True)
+        send = _make_safe_send_json()
+        llm = MagicMock()
+        llm._model = "anything"
+
+        await emit_tinkerclaw_zero_cost_receipt(
+            ws, llm=llm, tinkerclaw_model_default="",
+            safe_send_json=send,
+        )
+        send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_send_failure_swallowed_at_debug_level(self):
+        """TC receipt failure logs at DEBUG (purely informational
+        path) — pin so an ops watcher doesn't get noise from
+        every TC turn when a transport hiccups."""
+        ws = _make_ws()
+        send = AsyncMock(side_effect=ConnectionResetError("dead"))
+        llm = MagicMock()
+        llm._model = "x"
+
+        # Must NOT raise.
+        await emit_tinkerclaw_zero_cost_receipt(
+            ws, llm=llm, tinkerclaw_model_default="",
+            safe_send_json=send,
+        )


### PR DESCRIPTION
## What

Round 4 PR-C — third sub-extract from \`_handle_text_body\` (after [#227](https://github.com/lorcan35/TinkerBox/pull/227) rich_media_emit and [#228](https://github.com/lorcan35/TinkerBox/pull/228) empty_response_wrap).

Pulls **BOTH** text-path receipt emitters out of \`_handle_text_body\` into [\`dragon_voice/text_path_receipt.py\`](dragon_voice/text_path_receipt.py):

| Function | Source | Purpose |
|---|---|---|
| \`emit_text_path_llm_receipt\` | Local ConvEngine path | Pulls token counts + cost via SupportsUsage protocol (PR #204), computes via price_for_model (PR #210), full receipt with cost_mils + retried |
| \`emit_tinkerclaw_zero_cost_receipt\` | TC bypass path | TC bills to its own gateway; emits zero-cost frame with just the model name so chat bubble still gets stamped |

## Why one module, two functions

Both share the receipt-emit responsibility but diverge on data source (SupportsUsage vs hardcoded zeros) and the model-name resolution chain. Pre-extract they were ~50+30 LOC of inline code in two different spots in the same handler. Putting them in one module makes the receipt-emit responsibility a single discoverable unit.

## Model-name resolution (TC path)

Wave 8 audit #2 fix for the bare-\"tinkerclaw\" stamp problem — 4-level fallback chain:

1. \`llm._model\` — actual loaded model
2. \`llm.name\` — backend display name
3. \`tinkerclaw_model_default\` — config default
4. \`minimax/MiniMax-M2.5\` — last-resort

**Pinned by 4 dedicated tests** so the priority chain can't silently drift.

## ENC-1 follow-up TODOs preserved

Both emitters still reach into private \`_llm\` / \`_model\` attributes for behavioural parity. Each carries a TODO comment pointing at a future \`ConversationEngine.get_last_usage()\` and \`TinkerClawBackend.public_model_name()\` accessor (sister of \`choose_vision_model\` from PR #212). Those are separate, narrow follow-up PRs.

## Tests

[\`tests/test_text_path_receipt.py\`](tests/test_text_path_receipt.py) — 16 tests across 2 classes:

**\`TestEmitTextPathLlmReceipt\`** (9 tests) — every no-op branch (None conv, no _llm, non-SupportsUsage backend, empty usage, zero total_tokens) + happy path (full receipt) + retried surfacing (Gauntlet G2) + ws.closed + exception handling.

**\`TestEmitTinkerClawZeroCostReceipt\`** (7 tests) — 4 model-name resolution priority tests (one per fallback level, pinning the chain) + zero-cost frame shape pin + ws.closed + DEBUG-level send-failure (no ops noise per TC turn).

## server.py shrink

| Metric | Value |
|---|---|
| This PR | 2140 → 2088 LOC (−52 net; ~80 LOC of inline removed across both branches) |
| Cumulative round 1+2+3+4 | 2714 → 2088 LOC (−626, **−23.1 %**) |

## _handle_text_body progress

| Sub-responsibility | Status |
|---|---|
| TinkerClaw bypass full path | ~80 LOC inline (was ~170 pre-round-4) |
| ConvEngine streaming + tool-marker buffer | ~60 LOC |
| Empty-response wrap (DUP'd 2x) | extracted #228 |
| Rich media detection (DUP'd 2x) | extracted #227 |
| **TC zero-cost receipt** | extracted (this PR) |
| **Phase 3 LLM receipt (local-only)** | extracted (this PR) |
| TTS synthesis (local-only) | ~80 LOC — biggest remaining slice |

\`_handle_text_body\` is now **~290 LOC** (down from 442). **−34 % from round 4 alone.**

## Verification

\`\`\`
\$ python3 -m pytest tests/test_text_path_receipt.py -v
16 passed in 0.09s

\$ python3 -m pytest tests/ --ignore=tests/audit -q
881 passed, 108 subtests passed, 1 skipped, 0 failed in 11.33s

\$ ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 \\
    dragon_voice/ tests/
All checks passed!
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)