### PR TITLE
refactor(server): extract TinkerClaw text-path bypass (~100 LOC) to tinkerclaw_text_path module

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -38,6 +38,7 @@ from dragon_voice.session_handshake import (
 )
 from dragon_voice.empty_response_wrap import maybe_synthesize_empty_response_wrap
 from dragon_voice.text_path_tts import synthesize_and_stream_text_response
+from dragon_voice.tinkerclaw_text_path import handle_tinkerclaw_text_path
 from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
@@ -1387,110 +1388,28 @@ class VoiceServer:
     ) -> None:
         """Body of _handle_text, wrapped by the B1 turn-gate bracket above."""
 
-        # TinkerClaw mode: bypass ConversationEngine, use ConversationEngine's
-        # swapped LLM (not pipeline._llm which may be stale after swap race).
-        #
-        # ENC-1 (audit 2026-05-03): goes through the public `.llm`
-        # property instead of the private `_llm` attribute.  Behavior
-        # unchanged — the property is a thin pass-through.
+        # SOLID-audit follow-up: TinkerClaw bypass branch
+        # extracted to tinkerclaw_text_path.handle_tinkerclaw_text_path.
+        # That module owns: precondition gate (voice_mode 3 + live
+        # ConvEngine LLM), session-key set, thinking indicator,
+        # token streaming with #75 PING-during-inference keepalive,
+        # γ2-M6 (#106) DragonError fast-fail, empty-response wrap
+        # with W15-H09 apology fallback, llm_done, TC zero-cost
+        # receipt, and rich media emit (dedup with local path).
+        # Returns True when handled (we return); False when not in
+        # TC mode (we fall through to the local ConvEngine path).
         conn_cfg = conn_state.get("config")
-        if conn_cfg and conn_cfg.llm.backend == "tinkerclaw" and self._conversation and self._conversation.llm:
-            llm = self._conversation.llm
-            logger.info("_handle_text TinkerClaw bypass via ConvEngine LLM: %s", llm.name)
-            # Wave 21b (#204): isinstance(SupportsSessionKey) over hasattr.
-            from dragon_voice.llm.base import SupportsSessionKey
-            if isinstance(llm, SupportsSessionKey):
-                llm.set_session_key(conn_state.get("session_id", ""))
-
-            # Send a "thinking" indicator immediately to keep the WS alive.
-            # TinkerClaw agent can take 10-30s before first token (memory recall,
-            # skill execution). Without this, ngrok kills the idle connection.
-            if not ws.closed:
-                await ws.send_json({"type": "llm", "text": ""})
-
-            # #75 phase 1a: WS-level PING every 5 s while the LLM is
-            # generating.  Previously inlined here as `_keepalive()` at
-            # 10 s; now the shared helper lives on the class so the
-            # vision-upload path (below in _handle_user_media) gets the
-            # same protection instead of running bare.  5 s is safely
-            # under every Tab5 firmware's PONG-watch window (30–45 s);
-            # the outer `WebSocketResponse(heartbeat=60)` timer is too
-            # slow for a 90 s 4 B-class Ollama turn.  See docs/AUDIT.md
-            # "Local-mode gauntlet" for the observed P13-eviction race.
-            full_response = []
-            try:
-                async with self._ws_keepalive_during_inference(ws, label="tc_text"):
-                    async for token in llm.generate_stream_with_messages([
-                        {"role": "user", "content": text}
-                    ]):
-                        full_response.append(token)
-                        if not ws.closed:
-                            await ws.send_json({"type": "llm", "text": token})
-            except DragonError as e:
-                # γ2-M6 (issue #106): TC gateway pre-flight health check
-                # failed in ≤ 5 s.  Emit the structured γ1 error frame
-                # so Tab5 can surface a FATAL/GATEWAY banner — pre-fix
-                # the user waited the full 600 s sock_read timeout
-                # before the connection-error fallback fired.
-                logger.warning(
-                    "TC text path fast-failed: %s (code=%s)",
-                    e.message, e.code,
-                )
-                if not ws.closed:
-                    await self._safe_send_json(ws, e.to_event())
-                    await ws.send_json({
-                        "type": "llm_done", "llm_ms": 0, "text": "",
-                    })
-                return
-
-            response_text = "".join(full_response)
-
-            # SOLID-audit follow-up: empty-response guard extracted to
-            # empty_response_wrap.maybe_synthesize_empty_response_wrap.
-            # TC semantics: pass fallback_when_no_tools="Sorry, ..."
-            # so the W15-H09 apology fires when zero tools fired.
-            response_text = await maybe_synthesize_empty_response_wrap(
-                ws,
-                response_text=response_text,
-                tool_calls=conn_state.get("tool_calls_this_turn") or [],
-                safe_send_json=self._safe_send_json,
-                log_label="tc",
-                fallback_when_no_tools=(
-                    "Sorry, I couldn't generate a response for that. "
-                    "Please try rephrasing, or try again in a moment."
-                ),
-            )
-
-            logger.info("TinkerClaw text response (%d chars): %s",
-                        len(response_text), response_text[:80])
-            if not ws.closed:
-                await ws.send_json({"type": "llm_done", "llm_ms": 0, "text": response_text})
-
-            # SOLID-audit follow-up: TC zero-cost receipt extracted to
-            # text_path_receipt.emit_tinkerclaw_zero_cost_receipt.
-            # Same model-name resolution priority chain
-            # (_model → name → config_default → minimax fallback) is
-            # pinned by 4 dedicated tests.
-            await emit_tinkerclaw_zero_cost_receipt(
-                ws,
-                llm=llm,
-                tinkerclaw_model_default=getattr(conn_cfg.llm, "tinkerclaw_model", "") or "",
-                safe_send_json=self._safe_send_json,
-            )
-
-            # SOLID-audit follow-up: rich media detection extracted to
-            # rich_media_emit.emit_rich_media_for_text_turn (dedup with
-            # the local-path branch below).
-            if full_response:
-                await emit_rich_media_for_text_turn(
-                    ws,
-                    response_text=response_text,
-                    media_pipeline=self._media_pipeline,
-                    session_id=session_id,
-                    safe_send_json=self._safe_send_json,
-                    log_label="tc",
-                )
-
+        if await handle_tinkerclaw_text_path(
+            ws,
+            conn_state=conn_state,
+            conn_config=conn_cfg,
+            text=text,
+            session_id=session_id,
+            conversation=self._conversation,
+            media_pipeline=self._media_pipeline,
+            ws_keepalive=self._ws_keepalive_during_inference,
+            safe_send_json=self._safe_send_json,
+        ):
             return
 
         try:

--- a/dragon_voice/tinkerclaw_text_path.py
+++ b/dragon_voice/tinkerclaw_text_path.py
@@ -1,0 +1,248 @@
+"""TinkerClaw text-path bypass for the LLM turn.
+
+Wave 23 SOLID-audit follow-up — fifth sub-extract from
+`_handle_text_body` (round 4, after rich_media_emit #227,
+empty_response_wrap #228, text_path_receipt #229,
+text_path_tts #230).
+
+When `voice_mode=3` (TinkerClaw mode) is active, Dragon delegates
+the LLM call to the TinkerClaw gateway and bypasses the local
+ConversationEngine.process_text_stream path entirely.  The TC
+bypass branch (~100 LOC pre-extract) handles:
+
+  * ConvEngine LLM lookup + session-key set
+  * Empty "thinking" indicator (keeps WS alive while gateway
+    spins up — TC agent can take 10-30s before first token)
+  * Token streaming with `_ws_keepalive_during_inference` (so
+    Tab5's PONG-watch doesn't trip and trigger P13 eviction)
+  * γ2-M6 (#106) DragonError fast-fail with structured event
+  * Empty-response wrap (W15-H09 apology fallback when no tools
+    fired)
+  * `llm_done` emit
+  * TC zero-cost receipt (`emit_tinkerclaw_zero_cost_receipt`)
+  * Rich media emit (dedup with the local-path branch)
+
+This module is the dedicated home for that whole chain.
+
+## API
+
+```python
+handled = await handle_tinkerclaw_text_path(
+    ws,
+    *,
+    conn_state,
+    conn_config,
+    text,
+    session_id,
+    conversation,
+    media_pipeline,
+    ws_keepalive,
+    safe_send_json,
+) -> bool
+```
+
+Returns `True` when the TC bypass handled the turn (caller should
+return).  Returns `False` when not in TC mode (caller falls
+through to the local ConvEngine path).
+
+## DIP
+
+`ws_keepalive` is the bound method `VoiceServer._ws_keepalive_during_inference`
+passed in as a callable so this module doesn't need to import or
+construct the keepalive helper itself.  Same pattern used for
+`safe_send_json`.
+
+`conversation.llm` is reached through the public `.llm` property
+(closed via Wave 21b ENC-1 — was `._llm` pre-#204).
+
+## Why a precondition gate not a runtime check
+
+The caller decides TC vs local based on `conn_config.llm.backend`
+and the presence of `conversation.llm`.  The function then
+re-checks the same precondition so it remains safe to call as a
+"try TC first" guard without the caller duplicating the gate
+logic.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from aiohttp import web
+
+from dragon_voice.errors import DragonError
+from dragon_voice.empty_response_wrap import maybe_synthesize_empty_response_wrap
+from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
+from dragon_voice.text_path_receipt import emit_tinkerclaw_zero_cost_receipt
+
+logger = logging.getLogger(__name__)
+
+
+SafeSendJson = Callable[[web.WebSocketResponse, dict], Awaitable[bool]]
+# `ws_keepalive(ws, label=...) -> async context manager`.  Bound to
+# VoiceServer._ws_keepalive_during_inference at call time.
+WsKeepaliveFactory = Callable[..., Any]
+
+
+# Default fallback emitted when the gateway returned no usable text
+# AND no tools fired this turn.  W15-H09: gives the user a clear
+# "try again" instead of a silent dropped bubble.
+_TC_NO_TOOLS_FALLBACK = (
+    "Sorry, I couldn't generate a response for that. "
+    "Please try rephrasing, or try again in a moment."
+)
+
+
+def _is_tinkerclaw_mode(conn_config: Any, conversation: Any) -> bool:
+    """Return True iff this turn should bypass ConvEngine and go
+    through the TinkerClaw gateway.
+
+    Two conditions: voice_mode 3 wired the LLM as `tinkerclaw` AND
+    ConversationEngine has a live `.llm` reference (post-swap race
+    safety — `pipeline._llm` may be stale after a hot-swap).
+    """
+    if not conn_config:
+        return False
+    if conn_config.llm.backend != "tinkerclaw":
+        return False
+    if conversation is None or conversation.llm is None:
+        return False
+    return True
+
+
+async def handle_tinkerclaw_text_path(
+    ws: web.WebSocketResponse,
+    *,
+    conn_state: dict,
+    conn_config: Any,                # VoiceConfig (Optional in test paths)
+    text: str,
+    session_id: str,
+    conversation: Optional[Any],     # ConversationEngine (Optional)
+    media_pipeline: Optional[Any],   # MediaPipeline (Optional in test paths)
+    ws_keepalive: WsKeepaliveFactory,
+    safe_send_json: SafeSendJson,
+) -> bool:
+    """Run the TinkerClaw bypass branch of `_handle_text_body`.
+
+    Returns True when the TC path handled the turn (caller returns
+    immediately).  Returns False when not in TC mode (caller
+    proceeds to the local ConvEngine path).
+
+    On gateway fast-fail (DragonError from the pre-flight health
+    check, γ2-M6 / #106), emits the structured γ1 error_event +
+    `llm_done` so Tab5 surfaces a FATAL/GATEWAY banner instead of
+    waiting the full 600 s sock_read timeout.
+
+    Behaviour preserved verbatim from the pre-extract chain:
+      * `set_session_key` only when LLM implements SupportsSessionKey
+      * Empty `llm` frame as "thinking" indicator
+      * `_ws_keepalive_during_inference(label="tc_text")` wraps the
+        token stream
+      * Empty-response wrap with TC apology fallback (W15-H09)
+      * TC zero-cost receipt (`emit_tinkerclaw_zero_cost_receipt`)
+      * Rich media emit (only when LLM produced any tokens)
+    """
+    if not _is_tinkerclaw_mode(conn_config, conversation):
+        return False
+
+    # ENC-1 (audit 2026-05-03): goes through the public `.llm`
+    # property instead of the private `_llm` attribute.  Behavior
+    # unchanged — the property is a thin pass-through.
+    llm = conversation.llm
+    logger.info("_handle_text TinkerClaw bypass via ConvEngine LLM: %s", llm.name)
+
+    # Wave 21b (#204): isinstance(SupportsSessionKey) over hasattr.
+    from dragon_voice.llm.base import SupportsSessionKey
+    if isinstance(llm, SupportsSessionKey):
+        llm.set_session_key(conn_state.get("session_id", ""))
+
+    # Send a "thinking" indicator immediately to keep the WS alive.
+    # TinkerClaw agent can take 10-30s before first token (memory
+    # recall, skill execution).  Without this, ngrok kills the
+    # idle connection.
+    if not ws.closed:
+        await ws.send_json({"type": "llm", "text": ""})
+
+    # #75 phase 1a: WS-level PING every 5 s while the LLM is
+    # generating.  5 s is safely under every Tab5 firmware's
+    # PONG-watch window (30–45 s); the outer
+    # `WebSocketResponse(heartbeat=60)` timer is too slow for a
+    # 90 s 4 B-class Ollama turn.  See docs/AUDIT.md "Local-mode
+    # gauntlet" for the observed P13-eviction race.
+    full_response: list[str] = []
+    try:
+        async with ws_keepalive(ws, label="tc_text"):
+            async for token in llm.generate_stream_with_messages([
+                {"role": "user", "content": text}
+            ]):
+                full_response.append(token)
+                if not ws.closed:
+                    await ws.send_json({"type": "llm", "text": token})
+    except DragonError as e:
+        # γ2-M6 (issue #106): TC gateway pre-flight health check
+        # failed in ≤ 5 s.  Emit the structured γ1 error frame so
+        # Tab5 can surface a FATAL/GATEWAY banner — pre-fix the
+        # user waited the full 600 s sock_read timeout before the
+        # connection-error fallback fired.
+        logger.warning(
+            "TC text path fast-failed: %s (code=%s)",
+            e.message, e.code,
+        )
+        if not ws.closed:
+            await safe_send_json(ws, e.to_event())
+            await ws.send_json({
+                "type": "llm_done", "llm_ms": 0, "text": "",
+            })
+        return True
+
+    response_text = "".join(full_response)
+
+    # SOLID-audit follow-up: empty-response guard.
+    # TC semantics: pass fallback_when_no_tools so the W15-H09
+    # apology fires when zero tools fired this turn.
+    response_text = await maybe_synthesize_empty_response_wrap(
+        ws,
+        response_text=response_text,
+        tool_calls=conn_state.get("tool_calls_this_turn") or [],
+        safe_send_json=safe_send_json,
+        log_label="tc",
+        fallback_when_no_tools=_TC_NO_TOOLS_FALLBACK,
+    )
+
+    logger.info(
+        "TinkerClaw text response (%d chars): %s",
+        len(response_text), response_text[:80],
+    )
+    if not ws.closed:
+        await ws.send_json({
+            "type": "llm_done", "llm_ms": 0, "text": response_text,
+        })
+
+    # SOLID-audit follow-up: TC zero-cost receipt.
+    # Same model-name resolution priority chain
+    # (_model → name → config_default → minimax fallback) is
+    # pinned by the 4 dedicated tests in test_text_path_receipt.py.
+    await emit_tinkerclaw_zero_cost_receipt(
+        ws,
+        llm=llm,
+        tinkerclaw_model_default=getattr(
+            conn_config.llm, "tinkerclaw_model", "",
+        ) or "",
+        safe_send_json=safe_send_json,
+    )
+
+    # SOLID-audit follow-up: rich media detection (dedup with the
+    # local-path branch).  Only fires when the LLM actually
+    # produced tokens — avoids a no-op render when the gateway
+    # short-circuited.
+    if full_response:
+        await emit_rich_media_for_text_turn(
+            ws,
+            response_text=response_text,
+            media_pipeline=media_pipeline,
+            session_id=session_id,
+            safe_send_json=safe_send_json,
+            log_label="tc",
+        )
+
+    return True

--- a/tests/test_tinkerclaw_text_path.py
+++ b/tests/test_tinkerclaw_text_path.py
@@ -1,0 +1,546 @@
+"""Tests for ``dragon_voice.tinkerclaw_text_path``.
+
+Pin every branch of the TC bypass extract:
+
+  * ``TestPreconditionGate`` — non-TC modes return False (caller
+    falls through to local ConvEngine path).
+  * ``TestHappyPath`` — full chain: thinking-indicator → token
+    stream with keepalive → llm_done → zero-cost receipt → rich
+    media emit.
+  * ``TestSessionKey`` — `set_session_key` only fires when LLM
+    implements `SupportsSessionKey`.
+  * ``TestDragonErrorFastFail`` — γ2-M6 fast-fail emits structured
+    error_event + llm_done(0,"") and returns True (handled).
+  * ``TestEmptyResponseWrap`` — W15-H09 apology fires when zero
+    tools fired this turn.
+  * ``TestRichMediaGate`` — rich media emit skipped when LLM
+    returned zero tokens.
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dragon_voice.errors import DragonError, Scope, Severity
+from dragon_voice.tinkerclaw_text_path import handle_tinkerclaw_text_path
+
+
+# ─── Test helpers ───────────────────────────────────────────────
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    ws.send_json = AsyncMock()
+    return ws
+
+
+def _make_safe_send_json() -> AsyncMock:
+    return AsyncMock(return_value=True)
+
+
+@asynccontextmanager
+async def _noop_keepalive(ws, *, label: str):
+    """Stand-in for VoiceServer._ws_keepalive_during_inference."""
+    yield
+
+
+def _make_keepalive_factory():
+    """Returns a keepalive factory that records the label it was
+    called with so tests can assert ``label="tc_text"``."""
+    calls: list[dict] = []
+
+    @asynccontextmanager
+    async def _factory(ws, *, label: str):
+        calls.append({"label": label, "ws": ws})
+        yield
+
+    _factory.calls = calls  # type: ignore[attr-defined]
+    return _factory
+
+
+def _make_conn_config(
+    *,
+    backend: str = "tinkerclaw",
+    tinkerclaw_model: str = "",
+) -> MagicMock:
+    cfg = MagicMock()
+    cfg.llm.backend = backend
+    cfg.llm.tinkerclaw_model = tinkerclaw_model
+    return cfg
+
+
+def _make_llm(
+    *,
+    name: str = "tc_gateway",
+    inner_model: str = "",
+    tokens: list[str] | None = None,
+    raises: Exception | None = None,
+) -> MagicMock:
+    """Build a fake TC LLM.  `tokens` controls the streamed yield;
+    `raises` makes the stream raise mid-flight."""
+    llm = MagicMock()
+    llm.name = name
+    llm._model = inner_model
+
+    async def _stream(messages):
+        if raises is not None:
+            raise raises
+        for tok in (tokens or []):
+            yield tok
+
+    llm.generate_stream_with_messages = _stream
+    return llm
+
+
+def _make_conversation(llm: Any) -> MagicMock:
+    convo = MagicMock()
+    convo.llm = llm
+    return convo
+
+
+# ─── TestPreconditionGate ───────────────────────────────────────
+
+
+class TestPreconditionGate:
+    @pytest.mark.asyncio
+    async def test_returns_false_when_not_tc_mode(self):
+        """Non-TC backend returns False so the caller falls through
+        to the local ConvEngine path — no llm calls made."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        cfg = _make_conn_config(backend="ollama")  # NOT tinkerclaw
+        llm = _make_llm(tokens=["should-not-stream"])
+        convo = _make_conversation(llm)
+
+        handled = await handle_tinkerclaw_text_path(
+            ws,
+            conn_state={},
+            conn_config=cfg,
+            text="hello",
+            session_id="s1",
+            conversation=convo,
+            media_pipeline=None,
+            ws_keepalive=_noop_keepalive,
+            safe_send_json=send,
+        )
+        assert handled is False
+        ws.send_json.assert_not_called()
+        send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_conversation(self):
+        """No ConvEngine (test path / boot race) → False, no work."""
+        ws = _make_ws()
+        cfg = _make_conn_config(backend="tinkerclaw")
+
+        handled = await handle_tinkerclaw_text_path(
+            ws,
+            conn_state={},
+            conn_config=cfg,
+            text="hi",
+            session_id="s1",
+            conversation=None,
+            media_pipeline=None,
+            ws_keepalive=_noop_keepalive,
+            safe_send_json=_make_safe_send_json(),
+        )
+        assert handled is False
+        ws.send_json.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_conversation_has_no_llm(self):
+        """ConvEngine with `.llm = None` (post-shutdown) → False."""
+        ws = _make_ws()
+        cfg = _make_conn_config(backend="tinkerclaw")
+        convo = MagicMock()
+        convo.llm = None
+
+        handled = await handle_tinkerclaw_text_path(
+            ws,
+            conn_state={},
+            conn_config=cfg,
+            text="hi",
+            session_id="s1",
+            conversation=convo,
+            media_pipeline=None,
+            ws_keepalive=_noop_keepalive,
+            safe_send_json=_make_safe_send_json(),
+        )
+        assert handled is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_conn_config(self):
+        """No conn_config (early test path) → False."""
+        ws = _make_ws()
+        llm = _make_llm()
+        convo = _make_conversation(llm)
+
+        handled = await handle_tinkerclaw_text_path(
+            ws,
+            conn_state={},
+            conn_config=None,
+            text="hi",
+            session_id="s1",
+            conversation=convo,
+            media_pipeline=None,
+            ws_keepalive=_noop_keepalive,
+            safe_send_json=_make_safe_send_json(),
+        )
+        assert handled is False
+
+
+# ─── TestHappyPath ──────────────────────────────────────────────
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_full_chain_emits_thinking_tokens_done_receipt(self):
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        keepalive = _make_keepalive_factory()
+        cfg = _make_conn_config(
+            backend="tinkerclaw",
+            tinkerclaw_model="minimax/MiniMax-M2.5",
+        )
+        llm = _make_llm(
+            name="tc_gateway",
+            inner_model="minimax/MiniMax-M2.5",
+            tokens=["Hello", " ", "world"],
+        )
+        convo = _make_conversation(llm)
+        media_pipeline = MagicMock()
+
+        with patch(
+            "dragon_voice.tinkerclaw_text_path.emit_rich_media_for_text_turn",
+            new=AsyncMock(),
+        ) as rich:
+            handled = await handle_tinkerclaw_text_path(
+                ws,
+                conn_state={
+                    "session_id": "s-tc-1",
+                    "tool_calls_this_turn": [{"name": "any"}],  # tools fired → no apology
+                },
+                conn_config=cfg,
+                text="hello",
+                session_id="s-tc-1",
+                conversation=convo,
+                media_pipeline=media_pipeline,
+                ws_keepalive=keepalive,
+                safe_send_json=send,
+            )
+
+        assert handled is True
+
+        # Emitted frames: empty thinking + 3 tokens + llm_done + receipt
+        # (receipt goes through safe_send_json, not ws.send_json)
+        sent_types = [c.args[0]["type"] for c in ws.send_json.call_args_list]
+        assert sent_types == ["llm", "llm", "llm", "llm", "llm_done"]
+
+        # Token sequence: empty-string thinking, then "Hello", " ", "world"
+        sent_texts = [c.args[0].get("text") for c in ws.send_json.call_args_list]
+        assert sent_texts[0] == ""  # thinking
+        assert sent_texts[1:4] == ["Hello", " ", "world"]
+        # llm_done carries the joined text
+        assert sent_texts[4] == "Hello world"
+
+        # Receipt was sent through safe_send_json
+        receipt_call = send.await_args
+        assert receipt_call is not None
+        payload = receipt_call.args[1]
+        assert payload["type"] == "receipt"
+        assert payload["model"] == "minimax/MiniMax-M2.5"
+        assert payload["cost_mils"] == 0
+
+        # Rich media emit fired with the joined response
+        rich.assert_awaited_once()
+        rich_kw = rich.await_args.kwargs
+        assert rich_kw["response_text"] == "Hello world"
+        assert rich_kw["log_label"] == "tc"
+
+        # Keepalive called with label="tc_text"
+        assert keepalive.calls == [{"label": "tc_text", "ws": ws}]
+
+    @pytest.mark.asyncio
+    async def test_ws_closed_before_thinking_skips_send(self):
+        """If ws is closed before we emit the thinking indicator,
+        we skip the send but still try to stream (the keepalive +
+        token loop handle their own closed checks)."""
+        ws = _make_ws(closed=True)
+        send = _make_safe_send_json()
+        cfg = _make_conn_config(backend="tinkerclaw")
+        llm = _make_llm(tokens=[])  # no tokens
+        convo = _make_conversation(llm)
+
+        with patch(
+            "dragon_voice.tinkerclaw_text_path.emit_rich_media_for_text_turn",
+            new=AsyncMock(),
+        ):
+            handled = await handle_tinkerclaw_text_path(
+                ws,
+                conn_state={},
+                conn_config=cfg,
+                text="hi",
+                session_id="s1",
+                conversation=convo,
+                media_pipeline=MagicMock(),
+                ws_keepalive=_noop_keepalive,
+                safe_send_json=send,
+            )
+
+        assert handled is True
+        # No frames sent — ws was closed
+        ws.send_json.assert_not_called()
+
+
+# ─── TestSessionKey ─────────────────────────────────────────────
+
+
+class TestSessionKey:
+    @pytest.mark.asyncio
+    async def test_session_key_set_when_supported(self):
+        """LLM that implements SupportsSessionKey gets
+        `set_session_key(session_id)` called."""
+        from dragon_voice.llm.base import SupportsSessionKey
+
+        class _SkLLM:
+            name = "sk_llm"
+            _model = "x"
+
+            def set_session_key(self, key: str) -> None:
+                self.last_key = key
+
+            async def generate_stream_with_messages(self, messages):
+                return
+                yield  # pragma: no cover - empty generator
+
+        llm = _SkLLM()
+        assert isinstance(llm, SupportsSessionKey)
+
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        cfg = _make_conn_config(backend="tinkerclaw")
+        convo = _make_conversation(llm)
+
+        with patch(
+            "dragon_voice.tinkerclaw_text_path.emit_rich_media_for_text_turn",
+            new=AsyncMock(),
+        ):
+            await handle_tinkerclaw_text_path(
+                ws,
+                conn_state={"session_id": "sess-abc"},
+                conn_config=cfg,
+                text="hi",
+                session_id="sess-abc",
+                conversation=convo,
+                media_pipeline=MagicMock(),
+                ws_keepalive=_noop_keepalive,
+                safe_send_json=send,
+            )
+
+        assert llm.last_key == "sess-abc"
+
+    @pytest.mark.asyncio
+    async def test_no_session_key_set_when_unsupported(self):
+        """LLM lacking SupportsSessionKey does NOT get set_session_key
+        called.  (Pins the Wave 21b isinstance switch — used to be
+        a hasattr() that fired on backends like `dual` that exposed
+        the method via __getattr__ accidentally.)"""
+
+        class _NoSkLLM:
+            name = "nosk"
+            _model = "x"
+            # explicitly NO set_session_key method
+
+            async def generate_stream_with_messages(self, messages):
+                return
+                yield  # pragma: no cover
+
+        llm = _NoSkLLM()
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        cfg = _make_conn_config(backend="tinkerclaw")
+        convo = _make_conversation(llm)
+
+        # The function returning True without an AttributeError IS
+        # the pin — `set_session_key` was guarded by the isinstance
+        # check.  No assertion on the missing method needed.
+        with patch(
+            "dragon_voice.tinkerclaw_text_path.emit_rich_media_for_text_turn",
+            new=AsyncMock(),
+        ):
+            handled = await handle_tinkerclaw_text_path(
+                ws,
+                conn_state={"session_id": "s"},
+                conn_config=cfg,
+                text="hi",
+                session_id="s",
+                conversation=convo,
+                media_pipeline=MagicMock(),
+                ws_keepalive=_noop_keepalive,
+                safe_send_json=send,
+            )
+        assert handled is True
+
+
+# ─── TestDragonErrorFastFail ────────────────────────────────────
+
+
+class TestDragonErrorFastFail:
+    @pytest.mark.asyncio
+    async def test_dragon_error_emits_structured_event_and_returns_true(self):
+        """γ2-M6 (#106): TC gateway pre-flight fail → emit γ1
+        error_event via safe_send_json + llm_done(0,"") via
+        ws.send_json + return True (handled — caller MUST NOT
+        fall through to local path)."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        cfg = _make_conn_config(backend="tinkerclaw")
+        err = DragonError(
+            "TinkerClaw gateway is offline",
+            code="gateway_down",
+            severity=Severity.FATAL,
+            scope=Scope.LLM,
+        )
+        llm = _make_llm(raises=err)
+        convo = _make_conversation(llm)
+
+        handled = await handle_tinkerclaw_text_path(
+            ws,
+            conn_state={},
+            conn_config=cfg,
+            text="hi",
+            session_id="s1",
+            conversation=convo,
+            media_pipeline=MagicMock(),
+            ws_keepalive=_noop_keepalive,
+            safe_send_json=send,
+        )
+
+        assert handled is True
+
+        # Structured γ1 event went via safe_send_json
+        send.assert_awaited_once()
+        event_payload = send.await_args.args[1]
+        # to_event() shape — at minimum has the error code
+        assert event_payload.get("code") == "gateway_down"
+        assert event_payload.get("severity") == Severity.FATAL.value
+
+        # Then llm_done(0, "") went via ws.send_json (after the
+        # opening empty thinking frame)
+        sent_done = [
+            c.args[0] for c in ws.send_json.call_args_list
+            if c.args[0].get("type") == "llm_done"
+        ]
+        assert len(sent_done) == 1
+        assert sent_done[0]["llm_ms"] == 0
+        assert sent_done[0]["text"] == ""
+
+    @pytest.mark.asyncio
+    async def test_non_dragon_exception_does_not_swallow(self):
+        """A plain RuntimeError MUST propagate — only DragonError
+        gets the fast-fail wrap.  Caller's outer try/except handles
+        unexpected failures."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        cfg = _make_conn_config(backend="tinkerclaw")
+        llm = _make_llm(raises=RuntimeError("upstream blew up"))
+        convo = _make_conversation(llm)
+
+        with pytest.raises(RuntimeError, match="upstream blew up"):
+            await handle_tinkerclaw_text_path(
+                ws,
+                conn_state={},
+                conn_config=cfg,
+                text="hi",
+                session_id="s1",
+                conversation=convo,
+                media_pipeline=MagicMock(),
+                ws_keepalive=_noop_keepalive,
+                safe_send_json=send,
+            )
+
+
+# ─── TestEmptyResponseWrap ──────────────────────────────────────
+
+
+class TestEmptyResponseWrap:
+    @pytest.mark.asyncio
+    async def test_empty_response_no_tools_fires_apology(self):
+        """When LLM returned empty AND no tools fired → W15-H09
+        apology synthesized + emitted via llm_done.text."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        cfg = _make_conn_config(backend="tinkerclaw")
+        llm = _make_llm(tokens=[])  # zero tokens
+        convo = _make_conversation(llm)
+
+        with patch(
+            "dragon_voice.tinkerclaw_text_path.emit_rich_media_for_text_turn",
+            new=AsyncMock(),
+        ):
+            await handle_tinkerclaw_text_path(
+                ws,
+                conn_state={"tool_calls_this_turn": []},  # no tools
+                conn_config=cfg,
+                text="hi",
+                session_id="s1",
+                conversation=convo,
+                media_pipeline=MagicMock(),
+                ws_keepalive=_noop_keepalive,
+                safe_send_json=send,
+            )
+
+        # llm_done.text carries the W15-H09 apology
+        done_call = next(
+            c for c in ws.send_json.call_args_list
+            if c.args[0].get("type") == "llm_done"
+        )
+        assert "couldn't generate a response" in done_call.args[0]["text"]
+
+
+# ─── TestRichMediaGate ──────────────────────────────────────────
+
+
+class TestRichMediaGate:
+    @pytest.mark.asyncio
+    async def test_zero_tokens_skips_rich_media_emit(self):
+        """`if full_response:` gate — zero LLM tokens means no rich
+        media work to do.  The TC zero-cost receipt still fires."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        cfg = _make_conn_config(backend="tinkerclaw")
+        llm = _make_llm(tokens=[])  # zero tokens
+        convo = _make_conversation(llm)
+        media_pipeline = MagicMock()
+
+        with patch(
+            "dragon_voice.tinkerclaw_text_path.emit_rich_media_for_text_turn",
+            new=AsyncMock(),
+        ) as rich:
+            await handle_tinkerclaw_text_path(
+                ws,
+                conn_state={},
+                conn_config=cfg,
+                text="hi",
+                session_id="s1",
+                conversation=convo,
+                media_pipeline=media_pipeline,
+                ws_keepalive=_noop_keepalive,
+                safe_send_json=send,
+            )
+
+        rich.assert_not_awaited()
+
+        # But the TC zero-cost receipt still fires (sent via safe_send_json)
+        assert send.await_count >= 1
+        receipt = next(
+            (c.args[1] for c in send.await_args_list
+             if c.args[1].get("type") == "receipt"),
+            None,
+        )
+        assert receipt is not None
+        assert receipt["cost_mils"] == 0


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **fifth sub-extract** from `_handle_text_body` (round 4, after rich_media_emit #227, empty_response_wrap #228, text_path_receipt #229, text_path_tts #230).

When \`voice_mode=3\` (TinkerClaw mode) is active, Dragon delegates the LLM call to the TC gateway and bypasses the local \`ConversationEngine.process_text_stream\` path entirely. The TC bypass branch (~100 LOC pre-extract) handled the entire gateway-side turn; now lives in its own dedicated module with 12 dedicated tests pinning every branch.

### Behaviour preserved verbatim

- **Precondition gate:** voice_mode 3 + live ConvEngine LLM (post-swap-race safety — \`pipeline._llm\` may be stale after a hot-swap)
- **\`set_session_key\`** only when LLM implements \`SupportsSessionKey\` (Wave 21b #204 isinstance over hasattr)
- **Empty \`llm\` thinking indicator** (TC agent can take 10-30s before first token; ngrok kills idle connections without it)
- **\`_ws_keepalive_during_inference(label=\"tc_text\")\`** wraps the token stream so Tab5's PONG-watch (~30 s) doesn't trip P13
- **γ2-M6 (#106) DragonError fast-fail** emits structured γ1 \`error_event\` + \`llm_done(0,\"\")\` via \`safe_send_json\` — pre-fix the user waited the full 600 s sock_read timeout
- **Empty-response wrap** with W15-H09 apology fallback when zero tools fired this turn
- **\`llm_done\`** with joined text
- **TC zero-cost receipt** via \`emit_tinkerclaw_zero_cost_receipt\` (model-name resolution priority chain pinned by #229's tests)
- **Rich media emit** (gated on \`if full_response:\` so a no-token short-circuit skips the render)

### DIP

- \`ws_keepalive\` is the bound method \`VoiceServer._ws_keepalive_during_inference\` passed in as a callable — no need to import or construct the keepalive helper from inside the module.
- Same pattern for \`safe_send_json\`.
- Returns \`True\` when handled (caller returns); \`False\` when not in TC mode (caller falls through to local ConvEngine path). One-liner call site.

### Test coverage

12 new tests in \`tests/test_tinkerclaw_text_path.py\` spanning:

- **4 precondition no-op branches** (non-TC backend, no conversation, \`conversation.llm=None\`, no \`conn_config\`)
- **Full happy-path** emit chain (thinking → tokens → \`llm_done\` → receipt → rich-media)
- **ws-closed early skip**
- **SessionKey isinstance-vs-hasattr** distinction (Wave 21b pin)
- **DragonError fast-fail wrap** (γ2-M6 / #106): structured \`error_event\` + \`llm_done(0,\"\")\` + returns True
- **Non-DragonError propagation** (no swallowing — caller's outer try/except handles unexpected failures)
- **W15-H09 apology fallback** when zero tools fired
- **Zero-token rich-media gate** (skips emit when LLM short-circuited)

### Diff stats

| Metric | Before | After | Δ |
|---|---|---|---|
| \`server.py\` LOC | 2026 | 1945 | **-81** |
| \`_handle_text_body\` LOC (round 4 cumulative) | 442 | ~110 | **-332** |
| \`server.py\` LOC (cumulative across 21-PR series, since #211) | 2714 | 1945 | **-28.3%** |

## Test plan

- [x] \`python3 -m pytest tests/test_tinkerclaw_text_path.py -v\` → 12 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → 908 passed, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)