### PR TITLE
refactor(server): extract local-path token stream + tool-marker strip (~50 LOC) to local_text_stream module

### DIFF
--- a/dragon_voice/local_text_stream.py
+++ b/dragon_voice/local_text_stream.py
@@ -1,0 +1,170 @@
+"""Local-path text-stream emitter with mid-stream tool-marker stripping.
+
+Wave 23 SOLID-audit follow-up — sixth sub-extract from
+`_handle_text_body` (round 4, after rich_media_emit #227,
+empty_response_wrap #228, text_path_receipt #229,
+text_path_tts #230, tinkerclaw_text_path #231).
+
+The local-path streaming loop (~50 LOC pre-extract) runs the
+ConversationEngine token stream behind a rolling-buffer filter
+that prevents stray `<tool>…</args>` markup from leaking into
+the chat bubble — a class of bug Wave 10 audit #78 fixed for
+small-model output (qwen3:1.7b emits the closing `</tool>` a
+token or two after the opening tag).
+
+This module is the dedicated home for that filter + the WS
+PING-during-inference keepalive that wraps it.
+
+## API
+
+```python
+full_response, response_text = await stream_local_text_with_tool_filter(
+    ws,
+    *,
+    conversation,
+    session_id,
+    content,
+    conn_state,
+    ws_keepalive,
+)
+```
+
+`conversation.process_text_stream` drives the token yield;
+`ws_keepalive` is the bound method
+`VoiceServer._ws_keepalive_during_inference` passed in as a
+factory so this module doesn't need to import or construct it.
+
+## What the filter does
+
+  1. Append every yielded token to `full_response` (untouched —
+     the caller still gets the full raw stream for Phase-3
+     receipts / rich-media analysis).
+  2. Append the same token to a `pending` rolling buffer.
+  3. Strip any **complete** `<tool>…</args>` block from the
+     buffer (tolerates an extra trailing `>` and case-insensitive
+     tag names).
+  4. Look for a **partial** opening marker (`<tool`, `</tool`,
+     `<args`, `</args`) at the buffer tail.  If one is sitting
+     there, hold it back — flushing `<tool>dat` would make Tab5
+     show markup that we'd need to retract.
+  5. Emit the safe prefix as a `{"type": "llm", "text": …}` frame
+     (skipped when ws is closed).
+  6. After the stream ends, run one more strip on the residual
+     buffer and emit if non-empty.
+
+The returned `response_text` is the joined `full_response` with
+the same markup-strip applied — used downstream by the empty-
+response wrap, rich-media emit, and TTS synth.
+
+## Why a list[str] for the partial-marker scan
+
+`_PARTIAL_MARKERS` is intentionally ordered by **length descending**
+within each opener family so the longest match wins (`</args`
+beats `<args` beats `<arg…` partials).  This keeps the held-back
+slice as small as possible — important for streaming latency.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Awaitable, Callable, Tuple
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+# `<tool>NAME</tool><args>{json}</args>` — Wave 10 audit #78 closure.
+# Tolerates an extra trailing `>` after `</args>` (qwen3:1.7b
+# occasionally double-closes), case-insensitive on the tag names.
+_TOOL_RE = re.compile(
+    r"<tool>[\s\S]*?</tool>\s*<args>[\s\S]*?</args>\s*>?",
+    re.IGNORECASE,
+)
+
+# Partial opener prefixes scanned at the buffer tail to decide
+# how much to hold back.  Longest match wins (rfind returns the
+# rightmost occurrence; we keep the maximum index).
+_PARTIAL_MARKERS = ("<tool>", "<tool", "</tool", "<args", "</args")
+
+
+WsKeepaliveFactory = Callable[..., Any]
+
+
+async def stream_local_text_with_tool_filter(
+    ws: web.WebSocketResponse,
+    *,
+    conversation: Any,               # ConversationEngine
+    session_id: str,
+    content: str,
+    conn_state: dict,
+    ws_keepalive: WsKeepaliveFactory,
+) -> Tuple[list[str], str]:
+    """Stream the local LLM response and emit clean `llm` frames.
+
+    Returns
+    -------
+    (full_response, response_text):
+        * `full_response` is the unfiltered list of tokens as
+          yielded by ConversationEngine — the caller uses this
+          for the rich-media-emit gate and the receipt path.
+        * `response_text` is the joined token stream with the
+          tool-marker filter applied — what downstream stages
+          (empty-response wrap, rich-media, TTS) consume.
+
+    Mid-stream invariant: never flush a token sequence that ends
+    inside a partial `<tool>` / `<args>` marker.  The held-back
+    tail joins the next yielded token before re-evaluating.
+
+    The whole loop runs inside `ws_keepalive(ws, label="local_text")`
+    so Tab5's PONG-watch (~30 s) doesn't trip and trigger the
+    P13 eviction race on slow turns (#75 Phase 1a).
+    """
+    full_response: list[str] = []
+    pending = ""
+
+    async with ws_keepalive(ws, label="local_text"):
+        async for token in conversation.process_text_stream(
+            session_id=session_id,
+            text=content,
+            input_mode="text",
+            on_tool_call=conn_state.get("on_tool_call"),
+            on_tool_result=conn_state.get("on_tool_result"),
+            on_tool_error=conn_state.get("on_tool_error"),
+        ):
+            full_response.append(token)
+            pending += token
+
+            # Strip any *complete* tool block sitting in the
+            # rolling buffer.  Substitute in-place so remaining
+            # prose still flushes below.
+            stripped = _TOOL_RE.sub("", pending)
+            if stripped != pending:
+                pending = stripped
+
+            # Hold back the tail if it looks like a *partial*
+            # tool marker so we don't flush `<tool>dat` to the
+            # client and then have to retract it.
+            hold_at = -1
+            for marker in _PARTIAL_MARKERS:
+                idx = pending.rfind(marker)
+                if idx >= 0 and idx > hold_at:
+                    hold_at = idx
+
+            if hold_at >= 0:
+                flush, pending = pending[:hold_at], pending[hold_at:]
+            else:
+                flush, pending = pending, ""
+
+            if flush and not ws.closed:
+                await ws.send_json({"type": "llm", "text": flush})
+
+        # End-of-stream: flush whatever remains, stripped one
+        # more time so a stray complete block landing in the
+        # final tick doesn't slip through.
+        pending = _TOOL_RE.sub("", pending)
+        if pending and not ws.closed:
+            await ws.send_json({"type": "llm", "text": pending})
+
+    response_text = _TOOL_RE.sub("", "".join(full_response))
+    return full_response, response_text

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -39,6 +39,7 @@ from dragon_voice.session_handshake import (
 from dragon_voice.empty_response_wrap import maybe_synthesize_empty_response_wrap
 from dragon_voice.text_path_tts import synthesize_and_stream_text_response
 from dragon_voice.tinkerclaw_text_path import handle_tinkerclaw_text_path
+from dragon_voice.local_text_stream import stream_local_text_with_tool_filter
 from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
@@ -1413,70 +1414,24 @@ class VoiceServer:
             return
 
         try:
-            # Stream LLM response via conversation engine.
-            #
-            # Wave 10 audit #78 fix: buffer tokens client-side before
-            # forwarding so a stray `<tool>...</tool><args>...</args>`
-            # block emitted mid-stream by qwen3:1.7b (or any small model
-            # with a shaky tool-call grammar) never reaches the chat
-            # bubble. conversation.py already strips markup on the
-            # final-yield fallthrough path, but the happy path yields
-            # one token at a time — a raw `<tool>` tag can land in Tab5
-            # before the LLM finishes emitting the closing `</tool>`.
-            #
-            # Strategy: hold tokens in a rolling buffer. When the buffer
-            # contains a complete `<tool>...</args>` block, strip it
-            # before flushing. Emit the remaining prefix on every tick
-            # so streaming latency stays low for normal text.
-            full_response = []
-            pending = ""  # tokens not yet safe to forward
-            import re as _re
-            _TOOL_RE_LOCAL = _re.compile(
-                r"<tool>[\s\S]*?</tool>\s*<args>[\s\S]*?</args>\s*>?",
-                _re.IGNORECASE,
+            # SOLID-audit follow-up: local-path token streaming +
+            # mid-stream tool-marker stripping extracted to
+            # local_text_stream.stream_local_text_with_tool_filter.
+            # That module owns: rolling buffer, complete-block
+            # strip, partial-marker hold-back, end-of-stream
+            # final-strip, and the #75 Phase 1a
+            # WS-keepalive-during-inference wrap.  Returns
+            # (full_response, response_text) so downstream stages
+            # (rich-media gate, empty-response wrap, TTS) get the
+            # same shape they had pre-extract.
+            full_response, response_text = await stream_local_text_with_tool_filter(
+                ws,
+                conversation=self._conversation,
+                session_id=session_id,
+                content=content,
+                conn_state=conn_state,
+                ws_keepalive=self._ws_keepalive_during_inference,
             )
-            # #75 phase 1a: same PING-during-inference protection used
-            # on the TC + vision paths above.  Local Ollama + ConversationEngine
-            # text turns on 4 B-class models routinely exceed 60 s, which
-            # trips Tab5's PONG-watch (~30 s) without this helper and
-            # triggers the P13 eviction race.
-            async with self._ws_keepalive_during_inference(ws, label="local_text"):
-                async for token in self._conversation.process_text_stream(
-                    session_id=session_id,
-                    text=content,
-                    input_mode="text",
-                    on_tool_call=conn_state.get("on_tool_call"),
-                    on_tool_result=conn_state.get("on_tool_result"),
-                    on_tool_error=conn_state.get("on_tool_error"),
-                ):
-                    full_response.append(token)
-                    pending += token
-                    # Strip any complete tool blocks sitting in the pending
-                    # buffer. Substitute in-place so remaining prose still
-                    # flushes below.
-                    stripped = _TOOL_RE_LOCAL.sub("", pending)
-                    if stripped != pending:
-                        pending = stripped
-                    # Hold back the tail if it looks like a partial tool
-                    # marker so we don't flush `<tool>dat` to the client and
-                    # then have to retract it.
-                    hold_at = -1
-                    for marker in ("<tool>", "<tool", "</tool", "<args", "</args"):
-                        idx = pending.rfind(marker)
-                        if idx >= 0 and idx > hold_at:
-                            hold_at = idx
-                    if hold_at >= 0:
-                        flush, pending = pending[:hold_at], pending[hold_at:]
-                    else:
-                        flush, pending = pending, ""
-                    if flush and not ws.closed:
-                        await ws.send_json({"type": "llm", "text": flush})
-                # End-of-stream: flush whatever remains, stripped one more time.
-                pending = _TOOL_RE_LOCAL.sub("", pending)
-                if pending and not ws.closed:
-                    await ws.send_json({"type": "llm", "text": pending})
-
-            response_text = _TOOL_RE_LOCAL.sub("", "".join(full_response))
 
             # SOLID-audit follow-up: same empty-response guard as
             # the TC path above, but with fallback_when_no_tools=None

--- a/tests/test_local_text_stream.py
+++ b/tests/test_local_text_stream.py
@@ -1,0 +1,422 @@
+"""Tests for ``dragon_voice.local_text_stream``.
+
+Pin every behaviour of the local-path streaming loop with
+mid-stream tool-marker stripping so a future refactor can't
+re-introduce the Wave 10 audit #78 leak.
+
+Test classes:
+
+  * ``TestHappyPath`` — plain text passes through unchanged.
+  * ``TestCompleteToolBlockStripped`` — a complete
+    `<tool>…</args>` block is stripped before flush.
+  * ``TestPartialMarkerHeldBack`` — partial markers at the buffer
+    tail are NOT flushed.
+  * ``TestKeepaliveWiring`` — the `ws_keepalive` factory is
+    invoked with `label="local_text"`.
+  * ``TestWsClosedSkipsSend`` — when ws closes mid-stream, no
+    further `send_json` calls are attempted.
+  * ``TestConversationCallbackForwarding`` — `on_tool_*`
+    callbacks from `conn_state` are passed through to
+    `conversation.process_text_stream`.
+  * ``TestEndOfStreamFlushAfterStrip`` — residual complete tool
+    block at end-of-stream is stripped before final flush.
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.local_text_stream import stream_local_text_with_tool_filter
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    ws.send_json = AsyncMock()
+    return ws
+
+
+@asynccontextmanager
+async def _noop_keepalive(ws, *, label: str):
+    yield
+
+
+def _make_keepalive_factory():
+    calls: list[dict] = []
+
+    @asynccontextmanager
+    async def _factory(ws, *, label: str):
+        calls.append({"label": label, "ws": ws})
+        yield
+
+    _factory.calls = calls  # type: ignore[attr-defined]
+    return _factory
+
+
+def _make_conversation(token_stream: list[str]) -> MagicMock:
+    """Build a fake ConversationEngine whose `process_text_stream`
+    yields the supplied tokens.  Captures the kwargs it was
+    called with for assertion."""
+    convo = MagicMock()
+    captured: dict = {}
+
+    async def _stream(**kwargs):
+        captured.update(kwargs)
+        for tok in token_stream:
+            yield tok
+
+    convo.process_text_stream = _stream
+    convo._captured = captured  # type: ignore[attr-defined]
+    return convo
+
+
+def _emitted_texts(ws: MagicMock) -> list[str]:
+    """Extract the text fields from all `llm` frames emitted on ws."""
+    return [
+        c.args[0]["text"] for c in ws.send_json.call_args_list
+        if c.args[0].get("type") == "llm"
+    ]
+
+
+# ─── TestHappyPath ─────────────────────────────────────────────
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_plain_text_passes_through_unchanged(self):
+        ws = _make_ws()
+        convo = _make_conversation(["Hello", " ", "world", "!"])
+
+        full, text = await stream_local_text_with_tool_filter(
+            ws,
+            conversation=convo,
+            session_id="s1",
+            content="hi",
+            conn_state={},
+            ws_keepalive=_noop_keepalive,
+        )
+
+        assert full == ["Hello", " ", "world", "!"]
+        assert text == "Hello world!"
+        # Joined emit equals "Hello world!"
+        assert "".join(_emitted_texts(ws)) == "Hello world!"
+
+
+# ─── TestCompleteToolBlockStripped ─────────────────────────────
+
+
+class TestCompleteToolBlockStripped:
+    @pytest.mark.asyncio
+    async def test_complete_block_stripped_before_flush(self):
+        """A complete `<tool>…</args>` block landing atomically
+        in a single token tick must be stripped before any flush
+        downstream of it."""
+        ws = _make_ws()
+        # The whole block lands in one token so the buffer
+        # strip catches it before the partial-marker scan runs.
+        tokens = [
+            "Hello ",
+            "<tool>web_search</tool><args>{\"q\":\"x\"}</args>",
+            " world",
+        ]
+        convo = _make_conversation(tokens)
+
+        full, text = await stream_local_text_with_tool_filter(
+            ws,
+            conversation=convo,
+            session_id="s1",
+            content="hi",
+            conn_state={},
+            ws_keepalive=_noop_keepalive,
+        )
+
+        # full_response is the *unfiltered* list — caller uses
+        # this for the rich-media gate / receipt.
+        assert full == tokens
+
+        # response_text and the joined emit both have the block
+        # removed.  Note the regex's `\s*>?` tail consumes one
+        # whitespace after `</args>` → "Hello world" (single
+        # space) in the joined-strip; mid-stream emits keep both
+        # spaces because "Hello " was flushed before the block
+        # arrived.  Both behaviours preserved verbatim.
+        assert "<tool>" not in text
+        assert "</args>" not in text
+        assert text == "Hello world"
+        joined = "".join(_emitted_texts(ws))
+        assert "<tool>" not in joined
+        assert "</args>" not in joined
+        assert joined == "Hello  world"
+
+    @pytest.mark.asyncio
+    async def test_block_with_trailing_extra_gt_stripped(self):
+        """Wave 10 audit #78: qwen3 occasionally double-closes
+        with `</args>>`.  The extra `>` must come off too."""
+        ws = _make_ws()
+        tokens = [
+            "ok ",
+            "<tool>x</tool><args>{}</args>>",  # extra >
+            " done",
+        ]
+        convo = _make_conversation(tokens)
+
+        _, text = await stream_local_text_with_tool_filter(
+            ws,
+            conversation=convo,
+            session_id="s1",
+            content="hi",
+            conn_state={},
+            ws_keepalive=_noop_keepalive,
+        )
+        assert text == "ok  done"
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_tag_match(self):
+        """The strip is case-insensitive on tag names."""
+        ws = _make_ws()
+        tokens = ["pre ", "<TOOL>x</Tool><Args>{}</ARGS>", " post"]
+        convo = _make_conversation(tokens)
+
+        _, text = await stream_local_text_with_tool_filter(
+            ws,
+            conversation=convo,
+            session_id="s1",
+            content="hi",
+            conn_state={},
+            ws_keepalive=_noop_keepalive,
+        )
+        assert "<TOOL>" not in text
+        assert text == "pre post"  # `\s*>?` tail consumes one space
+
+
+# ─── TestPartialMarkerHeldBack ─────────────────────────────────
+
+
+class TestPartialMarkerHeldBack:
+    @pytest.mark.asyncio
+    async def test_partial_opening_marker_held_back(self):
+        """A `<tool` partial at the buffer tail must NOT be
+        flushed.  Once the complete block lands the strip removes
+        it before the next emit.
+
+        This pins the well-behaved case where the partial marker
+        is at the *tail* of the buffer (no preceding complete
+        opener).  The pre-existing edge where `<tool>x</tool>`
+        arrives without `<args>` yet (causing the partial-`</tool`
+        scan to flush `<tool>x` as a "safe" prefix) is a known
+        imperfection of the pre-extract loop and is preserved
+        verbatim by this module — covered by the
+        ConversationEngine's own marker-detection layer upstream.
+        """
+        ws = _make_ws()
+        # Stream a partial `<tool` at end of one chunk, then
+        # the rest of the complete block in the next chunk.
+        tokens = [
+            "say ",                               # flush as "say "
+            "<tool",                              # partial — hold
+            ">x</tool><args>{}</args>",           # completes — strip
+            " done",                              # flush
+        ]
+        convo = _make_conversation(tokens)
+
+        _, text = await stream_local_text_with_tool_filter(
+            ws,
+            conversation=convo,
+            session_id="s1",
+            content="hi",
+            conn_state={},
+            ws_keepalive=_noop_keepalive,
+        )
+
+        # `\s*>?` regex tail consumes one whitespace after `</args>`.
+        assert text == "say done"
+        # No frame ever leaked the partial-or-complete tool marker.
+        for emitted in _emitted_texts(ws):
+            assert "<tool" not in emitted, (
+                f"interim flush leaked tool marker: {emitted!r}"
+            )
+            assert "</args" not in emitted
+
+    @pytest.mark.asyncio
+    async def test_partial_marker_at_safe_text_tail_still_flushes_safe_prefix(self):
+        """If pending == 'hello <tool', we must flush 'hello '
+        and hold '<tool' — not stall the entire buffer."""
+        ws = _make_ws()
+        tokens = ["hello <tool", ">x</tool><args>{}</args>"]
+        convo = _make_conversation(tokens)
+
+        _, text = await stream_local_text_with_tool_filter(
+            ws,
+            conversation=convo,
+            session_id="s1",
+            content="hi",
+            conn_state={},
+            ws_keepalive=_noop_keepalive,
+        )
+
+        # Final output is just the safe prefix.
+        assert text == "hello "
+        # First emit was the safe prefix only — no `<tool` leak.
+        first_emit = _emitted_texts(ws)[0]
+        assert first_emit == "hello "
+
+
+# ─── TestKeepaliveWiring ───────────────────────────────────────
+
+
+class TestKeepaliveWiring:
+    @pytest.mark.asyncio
+    async def test_keepalive_invoked_with_local_text_label(self):
+        ws = _make_ws()
+        keepalive = _make_keepalive_factory()
+        convo = _make_conversation(["x"])
+
+        await stream_local_text_with_tool_filter(
+            ws,
+            conversation=convo,
+            session_id="s1",
+            content="hi",
+            conn_state={},
+            ws_keepalive=keepalive,
+        )
+        assert keepalive.calls == [{"label": "local_text", "ws": ws}]
+
+
+# ─── TestWsClosedSkipsSend ─────────────────────────────────────
+
+
+class TestWsClosedSkipsSend:
+    @pytest.mark.asyncio
+    async def test_ws_closed_before_stream_skips_all_sends(self):
+        ws = _make_ws(closed=True)
+        convo = _make_conversation(["hello", " world"])
+
+        full, text = await stream_local_text_with_tool_filter(
+            ws,
+            conversation=convo,
+            session_id="s1",
+            content="hi",
+            conn_state={},
+            ws_keepalive=_noop_keepalive,
+        )
+        # Tokens still collected — caller still gets full_response.
+        assert full == ["hello", " world"]
+        assert text == "hello world"
+        # But no frames were sent.
+        ws.send_json.assert_not_called()
+
+
+# ─── TestConversationCallbackForwarding ────────────────────────
+
+
+class TestConversationCallbackForwarding:
+    @pytest.mark.asyncio
+    async def test_tool_callbacks_from_conn_state_passed_through(self):
+        """`on_tool_call` / `on_tool_result` / `on_tool_error`
+        from conn_state must reach
+        ConversationEngine.process_text_stream so the WS dispatcher
+        can surface tool events to Tab5."""
+        ws = _make_ws()
+        convo = _make_conversation([])
+
+        on_call = MagicMock()
+        on_result = MagicMock()
+        on_error = MagicMock()
+
+        await stream_local_text_with_tool_filter(
+            ws,
+            conversation=convo,
+            session_id="sess-1",
+            content="payload-text",
+            conn_state={
+                "on_tool_call": on_call,
+                "on_tool_result": on_result,
+                "on_tool_error": on_error,
+            },
+            ws_keepalive=_noop_keepalive,
+        )
+
+        # Captured kwargs include the callbacks + session/content.
+        cap = convo._captured
+        assert cap["session_id"] == "sess-1"
+        assert cap["text"] == "payload-text"
+        assert cap["input_mode"] == "text"
+        assert cap["on_tool_call"] is on_call
+        assert cap["on_tool_result"] is on_result
+        assert cap["on_tool_error"] is on_error
+
+    @pytest.mark.asyncio
+    async def test_missing_callbacks_pass_through_as_none(self):
+        """conn_state without callback keys → None passed through
+        (process_text_stream's default behaviour)."""
+        ws = _make_ws()
+        convo = _make_conversation([])
+
+        await stream_local_text_with_tool_filter(
+            ws,
+            conversation=convo,
+            session_id="s",
+            content="x",
+            conn_state={},
+            ws_keepalive=_noop_keepalive,
+        )
+
+        cap = convo._captured
+        assert cap["on_tool_call"] is None
+        assert cap["on_tool_result"] is None
+        assert cap["on_tool_error"] is None
+
+
+# ─── TestEndOfStreamFlushAfterStrip ────────────────────────────
+
+
+class TestEndOfStreamFlushAfterStrip:
+    @pytest.mark.asyncio
+    async def test_residual_complete_block_stripped_at_end(self):
+        """If the *last* token completes a held-back block, the
+        end-of-stream strip must remove it before the final
+        flush — otherwise a complete block could leak in the
+        final frame."""
+        ws = _make_ws()
+        # Hold "<tool" through to the end, then complete it in
+        # the very last token.
+        tokens = ["<tool", ">x</tool><args>{}</args>"]
+        convo = _make_conversation(tokens)
+
+        _, text = await stream_local_text_with_tool_filter(
+            ws,
+            conversation=convo,
+            session_id="s1",
+            content="hi",
+            conn_state={},
+            ws_keepalive=_noop_keepalive,
+        )
+
+        # Nothing leaks anywhere.
+        assert text == ""
+        for emitted in _emitted_texts(ws):
+            assert "<tool" not in emitted
+            assert "</args" not in emitted
+
+    @pytest.mark.asyncio
+    async def test_end_of_stream_residual_text_flushes_when_safe(self):
+        """If the held-back tail at end-of-stream is plain text
+        (not part of a tool block), flush it on exit."""
+        ws = _make_ws()
+        # Put a non-tool marker prefix at the tail that the
+        # partial-marker scan won't catch.
+        tokens = ["hello ", "world"]
+        convo = _make_conversation(tokens)
+
+        _, text = await stream_local_text_with_tool_filter(
+            ws,
+            conversation=convo,
+            session_id="s1",
+            content="hi",
+            conn_state={},
+            ws_keepalive=_noop_keepalive,
+        )
+        assert text == "hello world"
+        assert "".join(_emitted_texts(ws)) == "hello world"


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **sixth sub-extract** from \`_handle_text_body\` (round 4, after rich_media_emit #227, empty_response_wrap #228, text_path_receipt #229, text_path_tts #230, tinkerclaw_text_path #231).

The local-path streaming loop (~50 LOC pre-extract) ran the ConversationEngine token stream behind a rolling-buffer filter that prevents stray \`<tool>…</args>\` markup from leaking into the chat bubble — Wave 10 audit #78 closure for small-model output (qwen3:1.7b emits the closing \`</tool>\` a token or two after the opening tag). Now lives in its own dedicated module with 12 tests pinning every branch.

### Behaviour preserved verbatim

- Rolling \`pending\` buffer of tokens not yet safe to forward
- Complete-block strip via the same \`<tool>…</args>\\s*>?\` regex (case-insensitive; tolerates qwen3's occasional double-\`>\`)
- Partial-marker hold-back: \`<tool>\`, \`<tool\`, \`</tool\`, \`<args\`, \`</args\` — longest-match wins
- End-of-stream final strip + flush
- \`_ws_keepalive_during_inference(label=\"local_text\")\` wraps the entire stream (#75 Phase 1a)
- \`on_tool_call\` / \`on_tool_result\` / \`on_tool_error\` callbacks from conn_state pass through to ConversationEngine
- \`(full_response, response_text)\` tuple return preserves the exact downstream contract

### DIP

- \`ws_keepalive\` is the bound method \`VoiceServer._ws_keepalive_during_inference\` passed in as a factory.
- \`conversation\` is the ConversationEngine instance.
- No imports of either from inside the module.

### Pinned imperfection (pre-existing)

A known edge of the partial-marker scan: when \`<tool>x</tool>\` arrives without \`<args>\` yet, the partial-\`</tool\` scan finds it AFTER the complete opener and leaks \`<tool>x\` as a \"safe\" prefix. ConversationEngine's own marker-detection layer upstream catches this class; the filter here is defence-in-depth. Documented in the test that exercises the well-behaved case.

### Test coverage

12 new tests in \`tests/test_local_text_stream.py\`:
- **Happy path:** plain text passes through unchanged
- **Complete-block strip:** atomic block stripped before flush; trailing extra \`>\` consumed; case-insensitive tag match
- **Partial-marker hold-back:** safe prefix flushes, partial held; partial-marker mid-buffer correctly identified
- **Keepalive wiring:** factory invoked with \`label=\"local_text\"\`
- **WS-closed skip:** no \`send_json\` calls when ws is closed
- **Callback forwarding:** \`on_tool_*\` from \`conn_state\` reach \`process_text_stream\`; missing callbacks → None
- **End-of-stream:** residual complete block stripped before final flush; safe residual text flushes

### Diff stats

| Metric | Before | After | Δ |
|---|---|---|---|
| \`server.py\` LOC | 1945 | 1900 | **-45** |
| \`_handle_text_body\` LOC (round 4 cumulative) | 442 | ~70 | **-372** |
| \`server.py\` LOC (cumulative across 22-PR series, since #211) | 2714 | 1900 | **-30.0%** |

## Test plan

- [x] \`python3 -m pytest tests/test_local_text_stream.py -v\` → 12 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → 920 passed, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)