### PR TITLE
refactor(server): extract vision-turn handler (~108 LOC) to vision_turn module

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -40,6 +40,7 @@ from dragon_voice.empty_response_wrap import maybe_synthesize_empty_response_wra
 from dragon_voice.text_path_tts import synthesize_and_stream_text_response
 from dragon_voice.tinkerclaw_text_path import handle_tinkerclaw_text_path
 from dragon_voice.local_text_stream import stream_local_text_with_tool_filter
+from dragon_voice.vision_turn import handle_vision_turn
 from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
@@ -1715,104 +1716,23 @@ class VoiceServer:
         memory injection, tool-calling, and (most importantly) the
         multimodal user message is persisted so subsequent text turns can
         still see the image (cross-modal continuity).
+
+        SOLID-audit follow-up: vision-turn body extracted to
+        vision_turn.handle_vision_turn.  That module owns: media-id
+        lookup, capability-driven vision check, per-turn tool
+        tracker reset, ConvEngine streaming with the keepalive
+        wrap, the #75 Phase 1b empty-reply wrap, and the always-
+        llm_done invariant.
         """
-        media_id = cmd.get("media_id", "")
-        text = cmd.get("text", "What's in this image?")
-        session_id = conn_state.get("session_id", "")
-
-        image_path = await self._media_store.get_path(media_id)
-        if not image_path:
-            if not ws.closed:
-                await ws.send_json(error_event(
-                    code="media_not_found",
-                    message="Image not found — please retake the photo.",
-                    severity=Severity.TRANSIENT, scope=Scope.MEDIA,
-                ))
-            return
-
-        # #183 PR 3: capability-driven vision check.  Replaces the old
-        # substring check on the model name.  Works uniformly for all
-        # backend types — single-backend setups query the active model's
-        # declared caps; router setups query the union of caps available
-        # in the current tier.
-        from dragon_voice.llm.base import Modality
-        conv = conn_state.get("conversation") or self._conversation
-        llm_backend = getattr(conv, "_llm", None) if conv else None
-        if not llm_backend:
-            if not ws.closed:
-                await ws.send_json(error_event(
-                    code="no_llm_available",
-                    message="No language model is configured.  Check Settings.",
-                    severity=Severity.FATAL, scope=Scope.LLM,
-                ))
-            return
-        if Modality.VISION not in llm_backend.capabilities:
-            if not ws.closed:
-                await ws.send_json(error_event(
-                    code="vision_unsupported",
-                    message="Image analysis needs a vision-capable model.",
-                    severity=Severity.FATAL, scope=Scope.LLM,
-                ))
-            return
-
-        # #75 phase 1b: reset per-turn tool tracker on this path too.
-        conn_state["tool_calls_this_turn"] = []
-
-        # #183 PR 3: route through ConversationEngine.process_text_stream
-        # with media_id set — ConvEngine persists the multimodal user
-        # message via MessageStore (encoded with the multimodal marker)
-        # and on context build hydrates it back to an OpenAI image_url
-        # content array.  Tools, memory, and cross-modal continuity all
-        # work the same as text turns.
-        full_response = []
-        try:
-            async with self._ws_keepalive_during_inference(ws, label="vision"):
-                async for token in conv.process_text_stream(
-                    session_id=session_id,
-                    text=text,
-                    input_mode="vision",
-                    media_id=media_id,
-                ):
-                    full_response.append(token)
-                    if not ws.closed:
-                        await ws.send_json({"type": "llm", "text": token})
-        except Exception as e:
-            logger.error("user_media LLM failed: %s", e)
-            if not ws.closed:
-                # Phase 3 γ1: was raw `str(e)` — leaked Python exception
-                # text (e.g. "list index out of range") into Tab5's voice
-                # caption.  Now a stable, user-friendly message keyed by
-                # `vision_failed`; cause kept in the server log only.
-                await ws.send_json(error_event(
-                    code="vision_failed",
-                    message="Image analysis failed — please try again.",
-                    severity=Severity.TRANSIENT,
-                    scope=Scope.LLM,
-                ))
-            return
-
-        # #75 phase 1b: vision path gets the same empty-reply guard as
-        # the text paths.  Multimodal models can fire a tool (e.g.
-        # `note` to save a snapshot caption) and stop without text.
-        if not looks_like_useful_text("".join(full_response)):
-            tool_calls = conn_state.get("tool_calls_this_turn") or []
-            if tool_calls:
-                wrap = synthesize_wrap(tool_calls)
-                logger.info(
-                    "#75 phase 1b: vision path emitted near-empty text with "
-                    "%d tool fire(s) — sending template wrap (%d chars)",
-                    len(tool_calls), len(wrap),
-                )
-                if not ws.closed:
-                    await ws.send_json({"type": "llm", "text": wrap})
-                full_response.append(wrap)
-
-        if not ws.closed:
-            await ws.send_json({"type": "llm_done", "llm_ms": 0})
-
-        # ConversationEngine already persisted the assistant response
-        # via process_text_stream (look for `add_message(role="assistant"
-        # ...)` in conversation.py).  No second persist needed here.
+        await handle_vision_turn(
+            ws,
+            cmd=cmd,
+            conn_state=conn_state,
+            conversation=self._conversation,
+            media_store=self._media_store,
+            ws_keepalive=self._ws_keepalive_during_inference,
+            safe_send_json=self._safe_send_json,
+        )
 
     async def _handle_disconnect(self, conn_state: dict) -> None:
         """Handle WebSocket disconnect: pause session, mark device offline."""

--- a/dragon_voice/vision_turn.py
+++ b/dragon_voice/vision_turn.py
@@ -1,0 +1,212 @@
+"""Vision-turn handler — Tab5 photo upload → LLM analysis.
+
+Wave 23 SOLID-audit follow-up — seventh sub-extract from the
+`_handle_*` family in server.py (round 4, after the six
+sub-extracts from `_handle_text_body`).
+
+When Tab5 sends a `user_media` WS frame (camera photo for
+multimodal LLM analysis), Dragon needs to:
+
+  1. Resolve the media_id to a disk path via MediaStore.
+  2. Check the active LLM advertises Modality.VISION (#183 PR 3
+     capability-driven check, replacing the old name-substring
+     heuristic that broke for fleet/router setups).
+  3. Reset the per-turn tool tracker (#75 Phase 1b — vision
+     turns can fire tools too).
+  4. Stream the vision turn through ConversationEngine
+     (`process_text_stream(input_mode="vision", media_id=…)`)
+     with the WS PING keepalive so Tab5's PONG-watch doesn't
+     trip on a 30-90 s vision generation.
+  5. Apply the #75 Phase 1b empty-reply wrap when the model
+     fires a tool (e.g. `note` to save a snapshot caption) and
+     stops without text.
+  6. Emit `llm_done`.
+
+Pre-extract this whole chain lived inline in
+`VoiceServer._handle_user_media` (~108 LOC).  Now lives here so
+the WS handler family in `server.py` stays focused on the
+dispatch surface.
+
+## API
+
+```python
+await handle_vision_turn(
+    ws,
+    *,
+    cmd,
+    conn_state,
+    conversation,
+    media_store,
+    ws_keepalive,
+    safe_send_json,
+) -> None
+```
+
+`media_store` is the `MediaStore` instance (used for the
+`get_path(media_id)` lookup).  `conversation` falls back to
+the server's default ConvEngine when conn_state doesn't carry a
+per-connection one.  `ws_keepalive` and `safe_send_json` follow
+the same DIP pattern used by the round-4 text-path extracts.
+
+## Default prompt
+
+When Tab5 omits `text` from the `user_media` frame, we default
+to "What's in this image?" — pre-extract this was hardcoded
+inline; lifted to module-level so a future config knob (per-
+device caption prompts) has a single place to wire in.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from aiohttp import web
+
+from dragon_voice.errors import Scope, Severity, error_event
+from dragon_voice.tools.response_wrap import looks_like_useful_text, synthesize_wrap
+
+logger = logging.getLogger(__name__)
+
+
+SafeSendJson = Callable[[web.WebSocketResponse, dict], Awaitable[bool]]
+WsKeepaliveFactory = Callable[..., Any]
+
+
+# Default caption prompt when Tab5 omits `text` from the user_media
+# frame.  Tab5 firmware does send a prompt today, but the inline
+# fallback predates that contract.
+_DEFAULT_VISION_PROMPT = "What's in this image?"
+
+
+async def handle_vision_turn(
+    ws: web.WebSocketResponse,
+    *,
+    cmd: dict,
+    conn_state: dict,
+    conversation: Optional[Any],     # ConversationEngine (Optional)
+    media_store: Any,                # MediaStore
+    ws_keepalive: WsKeepaliveFactory,
+    safe_send_json: SafeSendJson,
+) -> None:
+    """Handle a Tab5 `user_media` (image-upload) frame.
+
+    Routes the multimodal turn through ConversationEngine so the
+    user message persists with the multimodal marker (cross-modal
+    continuity — a follow-up text turn can still see the photo).
+
+    Three terminal early returns:
+      * Missing media (Tab5 sent a stale media_id) → `media_not_found`.
+      * No active LLM at all → `no_llm_available` (FATAL).
+      * Active LLM doesn't advertise VISION capability →
+        `vision_unsupported` (FATAL).
+
+    Mid-turn LLM exception → `vision_failed` (TRANSIENT).  The raw
+    exception text is kept in the server log only; the WS frame
+    carries a stable user-friendly message so Tab5's caption
+    surface doesn't show "list index out of range".
+
+    Always emits `llm_done` on the success path so Tab5 can leave
+    the SPEAKING / GENERATING UI state.
+    """
+    media_id = cmd.get("media_id", "")
+    text = cmd.get("text", _DEFAULT_VISION_PROMPT)
+    session_id = conn_state.get("session_id", "")
+
+    image_path = await media_store.get_path(media_id)
+    if not image_path:
+        if not ws.closed:
+            await ws.send_json(error_event(
+                code="media_not_found",
+                message="Image not found — please retake the photo.",
+                severity=Severity.TRANSIENT, scope=Scope.MEDIA,
+            ))
+        return
+
+    # #183 PR 3: capability-driven vision check.  Replaces the old
+    # substring check on the model name.  Works uniformly for all
+    # backend types — single-backend setups query the active
+    # model's declared caps; router setups query the union of caps
+    # available in the current tier.
+    from dragon_voice.llm.base import Modality
+    conv = conn_state.get("conversation") or conversation
+    llm_backend = getattr(conv, "_llm", None) if conv else None
+    if not llm_backend:
+        if not ws.closed:
+            await ws.send_json(error_event(
+                code="no_llm_available",
+                message="No language model is configured.  Check Settings.",
+                severity=Severity.FATAL, scope=Scope.LLM,
+            ))
+        return
+    if Modality.VISION not in llm_backend.capabilities:
+        if not ws.closed:
+            await ws.send_json(error_event(
+                code="vision_unsupported",
+                message="Image analysis needs a vision-capable model.",
+                severity=Severity.FATAL, scope=Scope.LLM,
+            ))
+        return
+
+    # #75 phase 1b: reset per-turn tool tracker on this path too.
+    conn_state["tool_calls_this_turn"] = []
+
+    # #183 PR 3: route through ConversationEngine.process_text_stream
+    # with media_id set — ConvEngine persists the multimodal user
+    # message via MessageStore (encoded with the multimodal marker)
+    # and on context build hydrates it back to an OpenAI image_url
+    # content array.  Tools, memory, and cross-modal continuity
+    # all work the same as text turns.
+    full_response: list[str] = []
+    try:
+        async with ws_keepalive(ws, label="vision"):
+            async for token in conv.process_text_stream(
+                session_id=session_id,
+                text=text,
+                input_mode="vision",
+                media_id=media_id,
+            ):
+                full_response.append(token)
+                if not ws.closed:
+                    await ws.send_json({"type": "llm", "text": token})
+    except Exception as e:
+        logger.error("user_media LLM failed: %s", e)
+        if not ws.closed:
+            # Phase 3 γ1: was raw `str(e)` — leaked Python exception
+            # text (e.g. "list index out of range") into Tab5's voice
+            # caption.  Now a stable, user-friendly message keyed by
+            # `vision_failed`; cause kept in the server log only.
+            await ws.send_json(error_event(
+                code="vision_failed",
+                message="Image analysis failed — please try again.",
+                severity=Severity.TRANSIENT,
+                scope=Scope.LLM,
+            ))
+        return
+
+    # #75 phase 1b: vision path gets the same empty-reply guard as
+    # the text paths.  Multimodal models can fire a tool (e.g.
+    # `note` to save a snapshot caption) and stop without text.
+    if not looks_like_useful_text("".join(full_response)):
+        tool_calls = conn_state.get("tool_calls_this_turn") or []
+        if tool_calls:
+            wrap = synthesize_wrap(tool_calls)
+            logger.info(
+                "#75 phase 1b: vision path emitted near-empty text with "
+                "%d tool fire(s) — sending template wrap (%d chars)",
+                len(tool_calls), len(wrap),
+            )
+            if not ws.closed:
+                await ws.send_json({"type": "llm", "text": wrap})
+            full_response.append(wrap)
+
+    if not ws.closed:
+        await ws.send_json({"type": "llm_done", "llm_ms": 0})
+
+    # ConversationEngine already persisted the assistant response
+    # via process_text_stream (look for `add_message(role="assistant"
+    # ...)` in conversation.py).  No second persist needed here.
+
+    # `safe_send_json` is accepted on the API for parity with the
+    # round-4 text-path extracts and for future extension (e.g. an
+    # F5 vision-receipt frame); pre-extract code didn't use it.
+    _ = safe_send_json

--- a/tests/test_vision_turn.py
+++ b/tests/test_vision_turn.py
@@ -1,0 +1,442 @@
+"""Tests for ``dragon_voice.vision_turn``.
+
+Pin every branch of the vision-turn handler so a future
+refactor can't drift on:
+
+  * Missing media → `media_not_found` (TRANSIENT/MEDIA)
+  * No active LLM → `no_llm_available` (FATAL/LLM)
+  * LLM lacking VISION cap → `vision_unsupported` (FATAL/LLM)
+  * Mid-stream LLM exception → `vision_failed` + early return
+    (no stray `llm_done` after a failed turn)
+  * Happy path → llm tokens → llm_done
+  * Per-turn tool tracker reset
+  * Default prompt fallback when Tab5 omits `text`
+  * #75 Phase 1b empty-reply wrap on tool-only turns
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.errors import Scope, Severity
+from dragon_voice.llm.base import Modality
+from dragon_voice.vision_turn import handle_vision_turn
+
+
+# ─── Test helpers ─────────────────────────────────────────────
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    ws.send_json = AsyncMock()
+    return ws
+
+
+def _make_safe_send_json() -> AsyncMock:
+    return AsyncMock(return_value=True)
+
+
+@asynccontextmanager
+async def _noop_keepalive(ws, *, label: str):
+    yield
+
+
+def _make_keepalive_factory():
+    calls: list[dict] = []
+
+    @asynccontextmanager
+    async def _factory(ws, *, label: str):
+        calls.append({"label": label, "ws": ws})
+        yield
+
+    _factory.calls = calls  # type: ignore[attr-defined]
+    return _factory
+
+
+def _make_media_store(*, path: str | None = "/tmp/img.jpg") -> MagicMock:
+    store = MagicMock()
+    store.get_path = AsyncMock(return_value=path)
+    return store
+
+
+def _make_llm(*, has_vision: bool = True) -> MagicMock:
+    llm = MagicMock()
+    if has_vision:
+        llm.capabilities = frozenset({Modality.TEXT, Modality.VISION})
+    else:
+        llm.capabilities = frozenset({Modality.TEXT})
+    return llm
+
+
+def _make_conversation(
+    *,
+    llm: Any | None = None,
+    tokens: list[str] | None = None,
+    raises: Exception | None = None,
+) -> MagicMock:
+    convo = MagicMock()
+    convo._llm = llm
+    captured: dict = {}
+
+    async def _stream(**kwargs):
+        captured.update(kwargs)
+        if raises is not None:
+            raise raises
+        for tok in (tokens or []):
+            yield tok
+
+    convo.process_text_stream = _stream
+    convo._captured = captured  # type: ignore[attr-defined]
+    return convo
+
+
+def _emitted_types(ws: MagicMock) -> list[str]:
+    return [c.args[0].get("type") for c in ws.send_json.call_args_list]
+
+
+def _emitted_codes(ws: MagicMock) -> list[str]:
+    """Error codes from any error_event frames sent on ws."""
+    out = []
+    for c in ws.send_json.call_args_list:
+        payload = c.args[0]
+        if payload.get("type") == "error":
+            out.append(payload.get("code"))
+    return out
+
+
+# ─── Error branches ───────────────────────────────────────────
+
+
+class TestMissingMedia:
+    @pytest.mark.asyncio
+    async def test_media_not_found_emits_transient_media_error(self):
+        ws = _make_ws()
+        store = _make_media_store(path=None)  # not found
+        convo = _make_conversation(llm=_make_llm())
+
+        await handle_vision_turn(
+            ws,
+            cmd={"media_id": "stale-id"},
+            conn_state={"session_id": "s1"},
+            conversation=convo,
+            media_store=store,
+            ws_keepalive=_noop_keepalive,
+            safe_send_json=_make_safe_send_json(),
+        )
+
+        assert "error" in _emitted_types(ws)
+        assert _emitted_codes(ws) == ["media_not_found"]
+        # No llm/llm_done frames emitted
+        assert "llm" not in _emitted_types(ws)
+        assert "llm_done" not in _emitted_types(ws)
+
+
+class TestNoLLM:
+    @pytest.mark.asyncio
+    async def test_no_active_llm_emits_fatal_llm_error(self):
+        ws = _make_ws()
+        store = _make_media_store()
+        # Conversation exists but `._llm` is None (post-shutdown).
+        convo = MagicMock()
+        convo._llm = None
+
+        await handle_vision_turn(
+            ws,
+            cmd={"media_id": "abc"},
+            conn_state={"session_id": "s1"},
+            conversation=convo,
+            media_store=store,
+            ws_keepalive=_noop_keepalive,
+            safe_send_json=_make_safe_send_json(),
+        )
+
+        assert _emitted_codes(ws) == ["no_llm_available"]
+        # Severity check
+        sev = ws.send_json.call_args_list[0].args[0]["severity"]
+        assert sev == Severity.FATAL.value
+
+
+class TestVisionUnsupported:
+    @pytest.mark.asyncio
+    async def test_text_only_llm_emits_fatal_vision_unsupported(self):
+        ws = _make_ws()
+        store = _make_media_store()
+        convo = _make_conversation(llm=_make_llm(has_vision=False))
+
+        await handle_vision_turn(
+            ws,
+            cmd={"media_id": "abc"},
+            conn_state={"session_id": "s1"},
+            conversation=convo,
+            media_store=store,
+            ws_keepalive=_noop_keepalive,
+            safe_send_json=_make_safe_send_json(),
+        )
+
+        assert _emitted_codes(ws) == ["vision_unsupported"]
+        sev = ws.send_json.call_args_list[0].args[0]["severity"]
+        assert sev == Severity.FATAL.value
+        scope = ws.send_json.call_args_list[0].args[0]["scope"]
+        assert scope == Scope.LLM.value
+
+
+# ─── Happy path ──────────────────────────────────────────────
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_streams_tokens_then_llm_done(self):
+        ws = _make_ws()
+        store = _make_media_store()
+        convo = _make_conversation(
+            llm=_make_llm(),
+            tokens=["A ", "red ", "chair."],
+        )
+        keepalive = _make_keepalive_factory()
+        conn_state = {"session_id": "s1"}
+
+        await handle_vision_turn(
+            ws,
+            cmd={"media_id": "img-42", "text": "describe"},
+            conn_state=conn_state,
+            conversation=convo,
+            media_store=store,
+            ws_keepalive=keepalive,
+            safe_send_json=_make_safe_send_json(),
+        )
+
+        # Per-turn tool tracker was reset
+        assert conn_state["tool_calls_this_turn"] == []
+
+        # 3 llm tokens then 1 llm_done
+        types = _emitted_types(ws)
+        assert types == ["llm", "llm", "llm", "llm_done"]
+        # Joined text
+        joined = "".join(
+            c.args[0].get("text", "") for c in ws.send_json.call_args_list
+            if c.args[0].get("type") == "llm"
+        )
+        assert joined == "A red chair."
+
+        # ConvEngine got vision + media_id set
+        cap = convo._captured
+        assert cap["session_id"] == "s1"
+        assert cap["text"] == "describe"
+        assert cap["input_mode"] == "vision"
+        assert cap["media_id"] == "img-42"
+
+        # Keepalive was wrapped with label="vision"
+        assert keepalive.calls == [{"label": "vision", "ws": ws}]
+
+    @pytest.mark.asyncio
+    async def test_default_prompt_when_text_missing(self):
+        ws = _make_ws()
+        store = _make_media_store()
+        convo = _make_conversation(llm=_make_llm(), tokens=[])
+
+        await handle_vision_turn(
+            ws,
+            cmd={"media_id": "img"},  # no `text`
+            conn_state={"session_id": "s"},
+            conversation=convo,
+            media_store=store,
+            ws_keepalive=_noop_keepalive,
+            safe_send_json=_make_safe_send_json(),
+        )
+
+        assert convo._captured["text"] == "What's in this image?"
+
+
+# ─── Conversation override from conn_state ───────────────────
+
+
+class TestConversationOverride:
+    @pytest.mark.asyncio
+    async def test_per_connection_conv_takes_precedence_over_default(self):
+        """If `conn_state["conversation"]` is set (per-connection
+        ConvEngine), it must be used over the server default."""
+        ws = _make_ws()
+        store = _make_media_store()
+        per_conn_llm = _make_llm()
+        per_conn_convo = _make_conversation(llm=per_conn_llm, tokens=["x"])
+
+        # Default convo has a NON-vision LLM — if we wrongly used
+        # the default, the call would hit `vision_unsupported`.
+        default_convo = _make_conversation(llm=_make_llm(has_vision=False))
+
+        await handle_vision_turn(
+            ws,
+            cmd={"media_id": "img"},
+            conn_state={
+                "session_id": "s",
+                "conversation": per_conn_convo,
+            },
+            conversation=default_convo,
+            media_store=store,
+            ws_keepalive=_noop_keepalive,
+            safe_send_json=_make_safe_send_json(),
+        )
+
+        # Happy path emitted, not the unsupported error
+        codes = _emitted_codes(ws)
+        assert "vision_unsupported" not in codes
+        assert "llm_done" in _emitted_types(ws)
+
+
+# ─── Mid-turn exception ──────────────────────────────────────
+
+
+class TestMidTurnException:
+    @pytest.mark.asyncio
+    async def test_llm_exception_emits_vision_failed_and_returns(self):
+        """Mid-stream RuntimeError → emits vision_failed + early
+        return.  No stray `llm_done` after a failed turn."""
+        ws = _make_ws()
+        store = _make_media_store()
+        convo = _make_conversation(
+            llm=_make_llm(),
+            raises=RuntimeError("model crashed"),
+        )
+
+        await handle_vision_turn(
+            ws,
+            cmd={"media_id": "img"},
+            conn_state={"session_id": "s"},
+            conversation=convo,
+            media_store=store,
+            ws_keepalive=_noop_keepalive,
+            safe_send_json=_make_safe_send_json(),
+        )
+
+        codes = _emitted_codes(ws)
+        assert "vision_failed" in codes
+        # Pin the early return: no llm_done frame after the error
+        assert "llm_done" not in _emitted_types(ws)
+
+    @pytest.mark.asyncio
+    async def test_error_message_does_not_leak_python_exception_text(self):
+        """Phase 3 γ1 closure — the user-facing message must NOT
+        be `str(e)`.  Pre-fix this leaked things like
+        'list index out of range' into Tab5's voice caption."""
+        ws = _make_ws()
+        store = _make_media_store()
+        convo = _make_conversation(
+            llm=_make_llm(),
+            raises=IndexError("list index out of range"),
+        )
+
+        await handle_vision_turn(
+            ws,
+            cmd={"media_id": "img"},
+            conn_state={"session_id": "s"},
+            conversation=convo,
+            media_store=store,
+            ws_keepalive=_noop_keepalive,
+            safe_send_json=_make_safe_send_json(),
+        )
+
+        msg = next(
+            c.args[0]["message"] for c in ws.send_json.call_args_list
+            if c.args[0].get("code") == "vision_failed"
+        )
+        assert "list index out of range" not in msg
+        assert "Image analysis failed" in msg
+
+
+# ─── #75 Phase 1b empty-reply wrap ───────────────────────────
+
+
+class TestEmptyReplyWrap:
+    @pytest.mark.asyncio
+    async def test_empty_text_with_tool_fire_synthesizes_wrap(self):
+        """When LLM emitted near-empty text but a tool fired, the
+        #75 Phase 1b wrap synthesizes a template ack so Tab5
+        doesn't get an empty bubble."""
+        ws = _make_ws()
+        store = _make_media_store()
+        convo = _make_conversation(
+            llm=_make_llm(),
+            tokens=[],  # no text
+        )
+        # Simulate ConversationEngine pushing a tool call into
+        # conn_state during process_text_stream — we pre-populate
+        # to mimic the post-stream state.
+        conn_state = {
+            "session_id": "s",
+            "tool_calls_this_turn": [{"name": "note", "args": {}}],
+        }
+
+        # process_text_stream wipes tool_calls_this_turn=[], so we
+        # need to repopulate after process_text_stream returns.
+        # Patch the convo to set tool_calls after stream exits.
+        async def _stream_then_record(**kwargs):
+            # Stream nothing
+            return
+            yield  # pragma: no cover
+
+        # We can't easily re-set conn_state mid-stream from inside
+        # the convo mock without reaching back into kwargs.  The
+        # simpler path: pre-populate AFTER the handler resets it
+        # by patching the wrap entry conditions.  Easiest: mock
+        # `looks_like_useful_text` + `synthesize_wrap`.
+        from unittest.mock import patch
+
+        with patch(
+            "dragon_voice.vision_turn.looks_like_useful_text",
+            return_value=False,
+        ), patch(
+            "dragon_voice.vision_turn.synthesize_wrap",
+            return_value="Saved note.",
+        ):
+            # Re-set tool_calls_this_turn AFTER the handler clears
+            # it on entry.  We do this by overriding the convo's
+            # process_text_stream to set the conn_state entry
+            # mid-stream.
+            async def _stream_set_tool(**kwargs):
+                conn_state["tool_calls_this_turn"] = [
+                    {"name": "note", "args": {}}
+                ]
+                return
+                yield  # pragma: no cover
+            convo.process_text_stream = _stream_set_tool
+
+            await handle_vision_turn(
+                ws,
+                cmd={"media_id": "img"},
+                conn_state=conn_state,
+                conversation=convo,
+                media_store=store,
+                ws_keepalive=_noop_keepalive,
+                safe_send_json=_make_safe_send_json(),
+            )
+
+        # Wrap text was sent as an llm frame BEFORE llm_done
+        sent = ws.send_json.call_args_list
+        types = [c.args[0].get("type") for c in sent]
+        assert types == ["llm", "llm_done"]
+        assert sent[0].args[0]["text"] == "Saved note."
+
+    @pytest.mark.asyncio
+    async def test_empty_text_no_tool_fire_skips_wrap(self):
+        """Empty text + zero tools → just llm_done (no wrap).
+        Pre-extract this was the silent fallthrough."""
+        ws = _make_ws()
+        store = _make_media_store()
+        convo = _make_conversation(llm=_make_llm(), tokens=[])
+
+        await handle_vision_turn(
+            ws,
+            cmd={"media_id": "img"},
+            conn_state={"session_id": "s"},
+            conversation=convo,
+            media_store=store,
+            ws_keepalive=_noop_keepalive,
+            safe_send_json=_make_safe_send_json(),
+        )
+
+        # Just llm_done — no wrap llm frame
+        assert _emitted_types(ws) == ["llm_done"]


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **seventh sub-extract** from the \`_handle_*\` family in server.py (round 4 spillover after the six sub-extracts from \`_handle_text_body\` #227-#232).

The vision-turn body (~108 LOC pre-extract) handled Tab5 camera-photo uploads end-to-end: media-id lookup, capability-driven vision check, per-turn tool tracker reset, ConvEngine streaming with the PING keepalive, the #75 Phase 1b empty-reply wrap, and the always-\`llm_done\` invariant. Now lives in its own dedicated module.

### Behaviour preserved verbatim

- Default prompt \`\"What's in this image?\"\` when Tab5 omits \`text\`
- Missing media → \`media_not_found\` (TRANSIENT/MEDIA)
- No active LLM at all → \`no_llm_available\` (FATAL/LLM)
- LLM lacking VISION cap → \`vision_unsupported\` (FATAL/LLM) via #183 PR 3 capability-driven check (not name substring)
- Per-turn tool tracker reset (#75 Phase 1b)
- \`_ws_keepalive_during_inference(label=\"vision\")\` wraps the ConvEngine token stream
- Per-connection conversation override (\`conn_state[\"conversation\"]\`) takes precedence over the server default
- Mid-stream LLM exception → \`vision_failed\` (TRANSIENT/LLM, Phase 3 γ1 — message NEVER leaks Python exception text); early return so no stray \`llm_done\` after a failure
- \`looks_like_useful_text\` + \`synthesize_wrap\` empty-reply fallback (only when at least one tool fired)
- Always-\`llm_done\` on success path

### DIP

- \`media_store\`, \`conversation\`, \`ws_keepalive\`, \`safe_send_json\` all passed in.
- \`safe_send_json\` is currently unused but accepted for parity with the round-4 text-path extracts and for future extension (e.g. an F5 vision-receipt frame).

### Test coverage

10 new tests in \`tests/test_vision_turn.py\` spanning:

- Missing media error
- No active LLM error (FATAL)
- Vision-unsupported error (FATAL)
- Happy path (3 tokens → llm_done)
- Default prompt fallback when Tab5 omits \`text\`
- Per-connection conversation override (catches the wrong-default bug)
- Mid-stream RuntimeError → vision_failed + early return
- Phase 3 γ1: error message does NOT leak Python exception text
- #75 Phase 1b empty-reply wrap on tool-only turns
- Empty + zero tools = silent llm_done (no wrap)

### Diff stats

| Metric | Before | After | Δ |
|---|---|---|---|
| \`server.py\` LOC | 1900 | 1820 | **-80** |
| \`server.py\` LOC (cumulative across 23-PR series, since #211) | 2714 | 1820 | **-32.9%** |

## Test plan

- [x] \`python3 -m pytest tests/test_vision_turn.py -v\` → 10 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → 930 passed, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)