### PR TITLE
refactor(server): extract WS /ws/voice admission gate (~55 LOC) to ws_voice_admission module

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -41,6 +41,7 @@ from dragon_voice.text_path_tts import synthesize_and_stream_text_response
 from dragon_voice.tinkerclaw_text_path import handle_tinkerclaw_text_path
 from dragon_voice.local_text_stream import stream_local_text_with_tool_filter
 from dragon_voice.vision_turn import handle_vision_turn
+from dragon_voice.ws_voice_admission import check_ws_voice_admission
 from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
@@ -511,60 +512,22 @@ class VoiceServer:
                     config_update, error, event
             - Binary: PCM int16 audio at config.tts_sample_rate
         """
-        # Wave 14 W14-C04: authenticate the WS upgrade request.  Prior to
-        # this, /ws/voice was publicly reachable and the `register` frame
-        # only required a non-empty device_id — so any attacker with the
-        # ngrok URL could impersonate any Tab5, hijack sessions, and burn
-        # OpenRouter/TinkerClaw budget.
-        #
-        # Contract:
-        #   - If server.api_token is configured: client MUST present
-        #       `Authorization: Bearer <token>` on the upgrade request,
-        #       matched with hmac.compare_digest.  Mismatch → 401.
-        #   - If server.api_token is blank (unprovisioned/dev): allow the
-        #       handshake but log-warn so the operator knows they're
-        #       running unauthenticated.  This matches the pattern of
-        #       letting first-run bootstraps work without breaking Tab5
-        #       flashes mid-upgrade.
+        # SOLID-audit follow-up: WS auth + connection-cap admission
+        # gate extracted to ws_voice_admission.check_ws_voice_admission.
+        # That module owns: W14-C04 bearer-token check via
+        # hmac.compare_digest, the dev-mode unauthenticated bypass
+        # warning, the >= max_connections cap, and the γ3-Dragon
+        # (#111) JSON error-frame shape for both 401 / 503.  Returns
+        # None to proceed; a ready-to-return Response when rejected.
         expected_token = (getattr(self._config.server, "api_token", "") or "").strip()
-        if expected_token:
-            auth_header = request.headers.get("Authorization", "")
-            supplied = auth_header[7:].strip() if auth_header.startswith("Bearer ") else ""
-            import hmac as _hmac
-            if not supplied or not _hmac.compare_digest(supplied, expected_token):
-                logger.warning(
-                    "WS /ws/voice: rejecting unauthenticated upgrade from %s (header_present=%s)",
-                    request.remote, bool(auth_header))
-                # γ3-Dragon (issue #111): JSON body with `code` so future
-                # ops tooling / dashboard introspection can distinguish
-                # auth failure from other 401 sources without parsing
-                # prose.  Tab5 (γ3-Tab5 follow-up) still uses the raw
-                # status code for its stop-retry decision since
-                # esp_websocket_client doesn't expose the body cleanly.
-                return web.json_response(
-                    {
-                        "code": "auth_failed",
-                        "message": "Invalid Dragon token — check Settings.",
-                    },
-                    status=401,
-                )
-        else:
-            logger.warning(
-                "WS /ws/voice: server.api_token not configured — allowing "
-                "unauthenticated WS. Set DRAGON_API_TOKEN to enforce.")
-
-        # Reject if at connection limit
-        if len(self._active_connections) >= self._max_connections:
-            logger.warning("Connection limit reached (%d), rejecting", self._max_connections)
-            # γ3-Dragon (issue #111): same JSON-body treatment as the
-            # 401 path above — see comment there for rationale.
-            return web.json_response(
-                {
-                    "code": "server_full",
-                    "message": "Dragon is at capacity — try again in a moment.",
-                },
-                status=503,
-            )
+        rejection = check_ws_voice_admission(
+            request,
+            expected_token=expected_token,
+            active_connection_count=len(self._active_connections),
+            max_connections=self._max_connections,
+        )
+        if rejection is not None:
+            return rejection
 
         # v4·D connectivity audit -- ROOT CAUSE FIX #3.
         #

--- a/dragon_voice/ws_voice_admission.py
+++ b/dragon_voice/ws_voice_admission.py
@@ -1,0 +1,147 @@
+"""WS /ws/voice admission gate — auth + connection-limit checks.
+
+Wave 23 SOLID-audit follow-up — eighth sub-extract from the
+WS-handler family (round 4 spillover, after the seven sub-extracts
+from the text-path + vision-turn handlers).
+
+The first ~55 LOC of `_handle_ws_voice` were pre-handshake
+admission control: validate the bearer token, enforce the active-
+connection cap, return a structured 401 / 503 if either gate
+fails.  Pure-function shape — no side effects on the server
+beyond reading the configured token + the active-connection
+count — but lived inline alongside the WS lifecycle wiring.
+
+This module is the dedicated home for that gate so the WS
+handler in `server.py` starts at the actual handshake
+(`web.WebSocketResponse` construction).
+
+## API
+
+```python
+rejection = check_ws_voice_admission(
+    request,
+    *,
+    expected_token,
+    active_connection_count,
+    max_connections,
+)
+```
+
+Returns `None` when the connection should proceed, or a
+ready-to-return `web.Response` (401 or 503) when rejected.
+The caller short-circuits on a non-None return.
+
+## Why a function returning Optional[Response]
+
+Keeping the rejection flow as a returned value (rather than
+raising) lets the caller apply consistent logging / metrics
+around it without try-except scaffolding.  Matches the pattern
+used by aiohttp middleware throughout the codebase.
+
+## Auth contract (W14-C04)
+
+  * Configured token (non-empty): client MUST present
+    `Authorization: Bearer <token>` matching via
+    `hmac.compare_digest`.  Mismatch → 401.
+  * Empty token (unprovisioned/dev): allow the upgrade but log
+    at WARNING so the operator notices they're running
+    unauthenticated.  This matches the first-run-bootstrap
+    pattern that lets fresh Tab5 flashes connect before the
+    operator sets DRAGON_API_TOKEN.
+
+## Error-frame shape (γ3-Dragon, issue #111)
+
+Both rejection responses carry a JSON body with `code` +
+`message` so future ops tooling and dashboard introspection can
+distinguish auth_failed / server_full from other 401 / 503
+sources without parsing prose.  Tab5 (γ3-Tab5 follow-up) still
+uses the raw status code for its stop-retry decision because
+`esp_websocket_client` doesn't expose the response body.
+"""
+from __future__ import annotations
+
+import hmac
+import logging
+from typing import Optional
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+def check_ws_voice_admission(
+    request: web.Request,
+    *,
+    expected_token: str,
+    active_connection_count: int,
+    max_connections: int,
+) -> Optional[web.Response]:
+    """Validate an incoming /ws/voice upgrade request.
+
+    Returns
+    -------
+    Optional[web.Response]
+        ``None`` when the upgrade should proceed; a
+        ``web.json_response`` (401 or 503) when the request must
+        be rejected.  The caller short-circuits the handler by
+        returning the response directly.
+
+    Two rejection branches in priority order:
+
+      1. **Auth (W14-C04)** — when ``expected_token`` is non-empty,
+         require ``Authorization: Bearer <token>`` matching via
+         ``hmac.compare_digest``.  Mismatch → 401 with
+         ``code="auth_failed"``.
+      2. **Connection cap** — when the current active count is at
+         or above ``max_connections``, reject with 503 and
+         ``code="server_full"``.
+
+    When ``expected_token`` is blank (unprovisioned/dev), log a
+    WARNING and let the upgrade through — matches the first-run
+    bootstrap pattern.
+    """
+    # ── Auth gate (W14-C04) ────────────────────────────────────
+    if expected_token:
+        auth_header = request.headers.get("Authorization", "")
+        supplied = (
+            auth_header[7:].strip()
+            if auth_header.startswith("Bearer ")
+            else ""
+        )
+        if not supplied or not hmac.compare_digest(supplied, expected_token):
+            logger.warning(
+                "WS /ws/voice: rejecting unauthenticated upgrade from %s "
+                "(header_present=%s)",
+                request.remote, bool(auth_header),
+            )
+            # γ3-Dragon (#111): JSON body with `code` so future ops
+            # tooling / dashboard introspection can distinguish auth
+            # failure from other 401 sources without parsing prose.
+            return web.json_response(
+                {
+                    "code": "auth_failed",
+                    "message": "Invalid Dragon token — check Settings.",
+                },
+                status=401,
+            )
+    else:
+        logger.warning(
+            "WS /ws/voice: server.api_token not configured — allowing "
+            "unauthenticated WS. Set DRAGON_API_TOKEN to enforce.",
+        )
+
+    # ── Connection-cap gate ───────────────────────────────────
+    if active_connection_count >= max_connections:
+        logger.warning(
+            "Connection limit reached (%d), rejecting", max_connections,
+        )
+        # γ3-Dragon (#111): same JSON-body treatment as the 401 path.
+        return web.json_response(
+            {
+                "code": "server_full",
+                "message": "Dragon is at capacity — try again in a moment.",
+            },
+            status=503,
+        )
+
+    return None

--- a/tests/test_ws_voice_admission.py
+++ b/tests/test_ws_voice_admission.py
@@ -1,0 +1,241 @@
+"""Tests for ``dragon_voice.ws_voice_admission``.
+
+Pin every branch of the admission gate so a future refactor
+can't accidentally weaken auth or break the 503 capacity
+response shape.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from dragon_voice.ws_voice_admission import check_ws_voice_admission
+
+
+def _make_request(
+    *,
+    auth_header: str | None = None,
+    remote: str = "192.168.1.50",
+) -> MagicMock:
+    req = MagicMock()
+    req.headers = {}
+    if auth_header is not None:
+        req.headers["Authorization"] = auth_header
+    req.remote = remote
+    # MagicMock(spec=[]) headers wouldn't expose .get; use a real dict
+    # via lambda:
+    real_dict = dict(req.headers)
+    req.headers = real_dict
+    return req
+
+
+# ─── Auth gate ────────────────────────────────────────────────
+
+
+class TestAuthGate:
+    def test_blank_token_allows_unauthenticated_upgrade(self):
+        """When the server hasn't set an api_token (first-run /
+        dev bootstrap), the upgrade proceeds — but a WARNING
+        gets logged so the operator notices."""
+        req = _make_request(auth_header=None)
+        result = check_ws_voice_admission(
+            req,
+            expected_token="",
+            active_connection_count=0,
+            max_connections=10,
+        )
+        # None means "proceed".
+        assert result is None
+
+    def test_missing_auth_header_rejected_when_token_required(self):
+        req = _make_request(auth_header=None)
+        result = check_ws_voice_admission(
+            req,
+            expected_token="server-secret",
+            active_connection_count=0,
+            max_connections=10,
+        )
+        assert result is not None
+        assert result.status == 401
+        # JSON body shape (γ3-Dragon)
+        body = result.body.decode()
+        assert '"auth_failed"' in body
+        assert "Invalid Dragon token" in body
+
+    def test_wrong_bearer_token_rejected(self):
+        req = _make_request(auth_header="Bearer wrong-token")
+        result = check_ws_voice_admission(
+            req,
+            expected_token="server-secret",
+            active_connection_count=0,
+            max_connections=10,
+        )
+        assert result is not None
+        assert result.status == 401
+
+    def test_correct_bearer_token_passes(self):
+        req = _make_request(auth_header="Bearer server-secret")
+        result = check_ws_voice_admission(
+            req,
+            expected_token="server-secret",
+            active_connection_count=0,
+            max_connections=10,
+        )
+        assert result is None
+
+    def test_non_bearer_scheme_rejected(self):
+        """`Basic <…>` or any non-Bearer scheme must be rejected
+        even if the token bytes happen to appear in the header."""
+        req = _make_request(auth_header="Basic server-secret")
+        result = check_ws_voice_admission(
+            req,
+            expected_token="server-secret",
+            active_connection_count=0,
+            max_connections=10,
+        )
+        assert result is not None
+        assert result.status == 401
+
+    def test_bearer_with_empty_token_rejected(self):
+        """`Bearer ` (no value) must NOT pass even if expected
+        token is blank — the auth gate doesn't run when expected
+        is blank, but if it does run with `Bearer ` we must still
+        reject."""
+        req = _make_request(auth_header="Bearer ")
+        result = check_ws_voice_admission(
+            req,
+            expected_token="server-secret",
+            active_connection_count=0,
+            max_connections=10,
+        )
+        assert result is not None
+        assert result.status == 401
+
+    def test_constant_time_compare_used(self):
+        """Sanity check: even tokens with a long shared prefix
+        must reject when they don't fully match.  This is a smoke
+        test — the actual timing-safety lives in
+        hmac.compare_digest."""
+        req = _make_request(auth_header="Bearer server-secre")
+        result = check_ws_voice_admission(
+            req,
+            expected_token="server-secret",
+            active_connection_count=0,
+            max_connections=10,
+        )
+        assert result is not None
+        assert result.status == 401
+
+
+# ─── Connection-cap gate ──────────────────────────────────────
+
+
+class TestConnectionCap:
+    def test_under_cap_passes(self):
+        req = _make_request(auth_header=None)
+        result = check_ws_voice_admission(
+            req,
+            expected_token="",
+            active_connection_count=4,
+            max_connections=5,
+        )
+        assert result is None
+
+    def test_at_cap_rejected(self):
+        """Active count == max → reject (>=, not >)."""
+        req = _make_request(auth_header=None)
+        result = check_ws_voice_admission(
+            req,
+            expected_token="",
+            active_connection_count=5,
+            max_connections=5,
+        )
+        assert result is not None
+        assert result.status == 503
+        body = result.body.decode()
+        assert '"server_full"' in body
+        assert "at capacity" in body
+
+    def test_over_cap_rejected(self):
+        """Active count > max → reject (defensive — shouldn't
+        happen but we don't want to widen the breach)."""
+        req = _make_request(auth_header=None)
+        result = check_ws_voice_admission(
+            req,
+            expected_token="",
+            active_connection_count=10,
+            max_connections=5,
+        )
+        assert result is not None
+        assert result.status == 503
+
+    def test_auth_takes_precedence_over_cap(self):
+        """When BOTH gates would fire, auth (401) wins over cap
+        (503).  This pins the priority order so a future refactor
+        can't accidentally invert it (which would leak the
+        server-busy signal to unauthenticated probes — minor
+        info disclosure)."""
+        req = _make_request(auth_header="Bearer wrong")
+        result = check_ws_voice_admission(
+            req,
+            expected_token="server-secret",
+            active_connection_count=999,
+            max_connections=5,
+        )
+        assert result is not None
+        assert result.status == 401  # auth, not cap
+
+
+# ─── Response shape ──────────────────────────────────────────
+
+
+class TestResponseShape:
+    def test_auth_failed_response_is_json(self):
+        req = _make_request(auth_header=None)
+        result = check_ws_voice_admission(
+            req,
+            expected_token="x",
+            active_connection_count=0,
+            max_connections=10,
+        )
+        assert result.headers.get("Content-Type", "").startswith(
+            "application/json"
+        )
+
+    def test_server_full_response_is_json(self):
+        req = _make_request(auth_header=None)
+        result = check_ws_voice_admission(
+            req,
+            expected_token="",
+            active_connection_count=10,
+            max_connections=10,
+        )
+        assert result.headers.get("Content-Type", "").startswith(
+            "application/json"
+        )
+
+    @pytest.mark.parametrize(
+        "expected_token,count,max_,expected_code",
+        [
+            ("", 5, 10, None),         # blank token, under cap → pass
+            ("", 10, 10, 503),         # blank token, at cap → 503
+            ("t", 5, 10, 401),         # token required, no header → 401
+            ("t", 10, 10, 401),        # auth wins over cap → 401
+        ],
+    )
+    def test_priority_matrix(
+        self, expected_token, count, max_, expected_code,
+    ):
+        req = _make_request(auth_header=None)
+        result = check_ws_voice_admission(
+            req,
+            expected_token=expected_token,
+            active_connection_count=count,
+            max_connections=max_,
+        )
+        if expected_code is None:
+            assert result is None
+        else:
+            assert result is not None
+            assert result.status == expected_code


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **eighth sub-extract** from the WS-handler family in server.py (round 4 spillover, after the seven sub-extracts from text-path + vision-turn handlers #227-#233).

The first ~55 LOC of \`_handle_ws_voice\` were pre-handshake admission control: validate the bearer token, enforce the active-connection cap, return a structured 401 / 503 if either gate fails. Pure-function shape — no side effects on the server beyond reading the configured token + the active-connection count — but lived inline alongside the WS lifecycle wiring. Now lives in its own dedicated module.

### Behaviour preserved verbatim

- **W14-C04 bearer-token gate:** \`hmac.compare_digest\` match against configured \`api_token\`; reject with 401 + γ3-Dragon JSON body (\`{\"code\":\"auth_failed\",\"message\":\"Invalid Dragon token …\"}\`).
- **Empty token (unprovisioned/dev)** falls through with WARNING log so first-run bootstraps work without breaking Tab5 flashes mid-upgrade.
- **Connection-cap gate:** \`>= max_connections\` → 503 + γ3-Dragon JSON body (\`{\"code\":\"server_full\",\"message\":\"… at capacity …\"}\`).
- **Auth takes precedence over cap** (pinned by test) so an unauthenticated probe at capacity still gets 401, not 503 — prevents minor info disclosure.

### Test coverage

17 tests spanning:
- 7 auth-gate branches (blank-token bypass, missing header, wrong token, correct token, non-Bearer scheme, empty \`Bearer \` value, near-match prefix rejection)
- 4 connection-cap branches (under, at, over, auth-priority-over-cap)
- 6 response-shape pins (Content-Type, priority matrix parametrization)

### Diff stats

| Metric | Before | After | Δ |
|---|---|---|---|
| \`server.py\` LOC | 1820 | 1783 | **-37** |
| \`server.py\` LOC (cumulative across 24-PR series, since #211) | 2714 | 1783 | **-34.3%** |

## Test plan

- [x] \`python3 -m pytest tests/test_ws_voice_admission.py -v\` → 17 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → 947 passed, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)