### PR TITLE
refactor(server): extract WS keepalive task (~60 LOC closure) to ws_keepalive module

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -42,6 +42,7 @@ from dragon_voice.tinkerclaw_text_path import handle_tinkerclaw_text_path
 from dragon_voice.local_text_stream import stream_local_text_with_tool_filter
 from dragon_voice.vision_turn import handle_vision_turn
 from dragon_voice.ws_voice_admission import check_ws_voice_admission
+from dragon_voice.ws_keepalive import run_ws_keepalive
 from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
@@ -570,75 +571,25 @@ class VoiceServer:
         peer = request.remote or "unknown"
         logger.info("WebSocket connected: %s (ws_id=%s)", peer, ws_id)
 
-        # Server-side keepalive: ping every 15s to prevent ngrok idle timeout.
-        # ngrok drops WS connections after ~30s of silence. Detects dead
-        # connections via send-failure counter + response timeout (US-DQ20).
-        _keepalive_running = True
-        # Shared flag: last time ANY message was received from the client.
-        # Updated in the main message loop; read by the keepalive task.
+        # SOLID-audit follow-up: server-side keepalive task
+        # extracted to ws_keepalive.run_ws_keepalive.  That module
+        # owns: 15s JSON-pong loop (ngrok counts data frames),
+        # 5s send-timeout per ping (US-DQ05 GIL-contention guard),
+        # 3-consecutive-failure WS-close threshold (US-DQ20).
+        # See module docstring for the 195 s dead-detection budget
+        # tuned around #75 LLM-flap and Tab5's pingpong window.
+        _keepalive_stop = asyncio.Event()
+        _keepalive_task = asyncio.create_task(
+            run_ws_keepalive(ws, ws_id=ws_id, stop_event=_keepalive_stop)
+        )
+
+        # Shared flag: last time ANY message was received from the
+        # client.  Updated in the main message loop; left for
+        # potential future silence-check use (the old 30s silence
+        # check was removed when Tab5 migrated to
+        # esp_websocket_client whose control frames don't surface
+        # to the message loop).
         _last_client_msg_time = time.monotonic()
-
-        async def _ws_keepalive():
-            nonlocal _last_client_msg_time
-            fail_count = 0
-            while _keepalive_running and not ws.closed:
-                await asyncio.sleep(15)  # 15s < ngrok's ~30s idle threshold
-                if ws.closed or not _keepalive_running:
-                    break
-                # Send JSON pong (data frame) — ngrok counts data frames as activity.
-                # 5s timeout prevents sends from blocking indefinitely when the
-                # event loop is delayed by GIL contention from inference (US-DQ05).
-                try:
-                    await asyncio.wait_for(
-                        ws.send_json({"type": "pong"}), timeout=5.0
-                    )
-                    fail_count = 0
-                except asyncio.TimeoutError:
-                    fail_count += 1
-                    logger.warning(
-                        "Keepalive send timed out for %s (%d/3) — event loop may be blocked",
-                        ws_id, fail_count,
-                    )
-                    if fail_count >= 3:
-                        logger.warning("Keepalive: 3 consecutive timeouts, closing WS %s", ws_id)
-                        try:
-                            await ws.close()
-                        except Exception:
-                            pass
-                        break
-                    continue
-                except Exception:
-                    fail_count += 1
-                    logger.warning("Keepalive send failed for %s (%d/3)", ws_id, fail_count)
-                    if fail_count >= 3:
-                        logger.warning("Keepalive: 3 consecutive send failures, closing WS %s", ws_id)
-                        try:
-                            await ws.close()
-                        except Exception:
-                            pass
-                        break
-                    continue
-
-                # NOTE: The old 30s "no client message" silence check was removed.
-                # Tab5 migrated to esp_websocket_client (voice.c commit 3af34b0) which
-                # uses WS-level PING/PONG control frames at 15s interval. Control
-                # frames do NOT update _last_client_msg_time (aiohttp handles them
-                # internally and they never surface to the message loop), so the
-                # silence check produced a 30-45s false-positive close every cycle.
-                # Liveness is now detected by: (1) WS-level ping/pong timeout on
-                # Tab5 side (Tab5's voice.c sets ping_interval_sec=15 +
-                # pingpong_timeout_sec=180, so worst-case idle dead-detect ≈ 195 s
-                # — deliberately wide to tolerate slow Ollama LLM turns without
-                # tearing the WS during a legit thinking window), (2) this task's
-                # send-failure counter above (3 consecutive send failures), and
-                # (3) TCP RST propagation.  Audit D1 (#137) flagged "45 s
-                # detection latency" but the actual budget is 195 s — the 45 s
-                # number was from a pre-#75 iteration and the comment is stale.
-                # Lowering the PONG budget below ~120 s reintroduces the LLM-flap
-                # class #75 was built to fix.
-                # _last_client_msg_time is left as-is for potential future use.
-
-        _keepalive_task = asyncio.create_task(_ws_keepalive())
 
         # Connection state — populated after register.
         #
@@ -976,8 +927,11 @@ class VoiceServer:
         except Exception:
             logger.exception("WebSocket handler error for %s", ws_id)
         finally:
-            # Stop keepalive
-            _keepalive_running = False
+            # Stop keepalive — set the event for a clean exit on
+            # the next wake; cancel for the harder-edged interrupt
+            # of the in-flight asyncio.sleep.  Both are wired so
+            # the task can't outlive the handler.
+            _keepalive_stop.set()
             _keepalive_task.cancel()
             # Clean up: pause session, mark device offline, shut down pipeline
             await self._handle_disconnect(conn_state)

--- a/dragon_voice/ws_keepalive.py
+++ b/dragon_voice/ws_keepalive.py
@@ -1,0 +1,172 @@
+"""Server-side WS keepalive task for the /ws/voice connection.
+
+Wave 23 SOLID-audit follow-up — ninth sub-extract from the
+WS-handler family in server.py (round 4 spillover, after the
+eight prior extracts).
+
+The keepalive task pings every 15 s with a JSON `pong` data
+frame to prevent ngrok's ~30 s idle drop, and tears the WS
+down if 3 consecutive pings fail (send timeout or send error).
+Pre-extract this lived as a closure inside `_handle_ws_voice`
+that captured `_keepalive_running`, `ws`, and `ws_id` from the
+outer scope.
+
+This module is the dedicated home for that task.
+
+## API
+
+```python
+stop_event = asyncio.Event()
+task = asyncio.create_task(
+    run_ws_keepalive(ws, ws_id="ws42", stop_event=stop_event)
+)
+# ... main loop ...
+stop_event.set()    # signal clean stop
+task.cancel()       # interrupt the in-flight sleep
+```
+
+## Why a JSON `pong` data frame, not a WS-level PING
+
+ngrok counts only data frames as activity for its idle-drop
+heuristic.  A WS-level PING (which aiohttp's `heartbeat=…`
+config emits) keeps the kernel-side TCP connection warm but
+does NOT update ngrok's app-level activity counter — so an
+otherwise quiet connection still gets dropped after ~30 s
+unless there's a data frame on the wire.  This task is the
+only thing standing between a slow LLM thinking window and a
+mid-turn flap.
+
+## Failure semantics
+
+Three consecutive send timeouts (5 s each) OR three
+consecutive send exceptions → close the WS.  This is the
+"event loop blocked + dead peer" detector — when inference
+holds the GIL too long, sends start failing, and we'd rather
+end the WS cleanly than leak the connection until OOM.
+
+## Dead-detection budget (wider than you'd expect)
+
+Worst-case server-side dead-WS detection ≈ 195 s, set by Tab5's
+`pingpong_timeout_sec=180` plus the 15 s ping interval.  This is
+deliberately wide to tolerate slow Ollama LLM turns without
+tearing the WS during a legit thinking window.  Lowering the
+PONG budget below ~120 s reintroduces the LLM-flap class
+issue #75 was built to fix.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+# Default tuning constants.  Lifted to module level so a future
+# config knob (per-deployment ngrok vs LAN tuning) has one
+# canonical place to wire in.
+_DEFAULT_INTERVAL_S = 15.0       # 15 s < ngrok's ~30 s idle threshold
+_DEFAULT_SEND_TIMEOUT_S = 5.0    # send-timeout per ping
+_DEFAULT_MAX_FAILURES = 3        # close WS after 3 consecutive fails
+
+
+async def run_ws_keepalive(
+    ws: web.WebSocketResponse,
+    *,
+    ws_id: str,
+    stop_event: Optional[asyncio.Event] = None,
+    interval_s: float = _DEFAULT_INTERVAL_S,
+    send_timeout_s: float = _DEFAULT_SEND_TIMEOUT_S,
+    max_consecutive_failures: int = _DEFAULT_MAX_FAILURES,
+) -> None:
+    """Run the keepalive loop until the WS closes, the stop
+    event is set, or the failure threshold trips.
+
+    Parameters
+    ----------
+    ws:
+        The aiohttp WebSocketResponse to ping.
+    ws_id:
+        Connection identifier for log lines.
+    stop_event:
+        Optional asyncio.Event the caller sets to signal a
+        clean stop.  ``task.cancel()`` is the harder-edged
+        alternative.  When omitted, the only stop conditions are
+        ``ws.closed`` becoming true or the failure threshold.
+    interval_s:
+        Seconds between pings.  Defaults to 15 s — must be less
+        than ngrok's ~30 s idle threshold and the Tab5 PONG
+        watchdog window.
+    send_timeout_s:
+        Seconds to wait for each ping send to complete.  When
+        the event loop is blocked by inference holding the GIL,
+        sends can hang indefinitely; this bounds the pathology.
+    max_consecutive_failures:
+        Number of consecutive ping failures (timeouts OR
+        exceptions) before closing the WS.
+
+    Returns when:
+      * ``ws.closed`` is True at the start of an iteration, OR
+      * ``stop_event`` is set, OR
+      * The failure counter hits ``max_consecutive_failures``.
+
+    Always closes the WS on the failure-threshold path; never
+    raises.
+    """
+    fail_count = 0
+    while not ws.closed:
+        if stop_event is not None and stop_event.is_set():
+            return
+        await asyncio.sleep(interval_s)
+        if ws.closed:
+            return
+        if stop_event is not None and stop_event.is_set():
+            return
+
+        # Send a JSON `pong` data frame — ngrok counts data
+        # frames as activity.  send_timeout_s prevents the send
+        # from blocking indefinitely when the event loop is
+        # delayed by GIL contention from inference (US-DQ05).
+        try:
+            await asyncio.wait_for(
+                ws.send_json({"type": "pong"}),
+                timeout=send_timeout_s,
+            )
+            fail_count = 0
+        except asyncio.TimeoutError:
+            fail_count += 1
+            logger.warning(
+                "Keepalive send timed out for %s (%d/%d) — "
+                "event loop may be blocked",
+                ws_id, fail_count, max_consecutive_failures,
+            )
+            if fail_count >= max_consecutive_failures:
+                logger.warning(
+                    "Keepalive: %d consecutive timeouts, closing WS %s",
+                    max_consecutive_failures, ws_id,
+                )
+                try:
+                    await ws.close()
+                except Exception:
+                    pass
+                return
+            continue
+        except Exception:
+            fail_count += 1
+            logger.warning(
+                "Keepalive send failed for %s (%d/%d)",
+                ws_id, fail_count, max_consecutive_failures,
+            )
+            if fail_count >= max_consecutive_failures:
+                logger.warning(
+                    "Keepalive: %d consecutive send failures, closing WS %s",
+                    max_consecutive_failures, ws_id,
+                )
+                try:
+                    await ws.close()
+                except Exception:
+                    pass
+                return
+            continue

--- a/tests/test_ws_keepalive.py
+++ b/tests/test_ws_keepalive.py
@@ -1,0 +1,316 @@
+"""Tests for ``dragon_voice.ws_keepalive``.
+
+Pin every loop-exit branch and the failure-counter reset
+behaviour so a future refactor can't drift on:
+
+  * Stop-event-set early exit (before sleep, after sleep)
+  * ws.closed early exit (before sleep, after sleep)
+  * Successful send → fail_count resets
+  * Timeout under threshold → continue
+  * 3 timeouts → close + return
+  * Send-exception under threshold → continue
+  * 3 send-exceptions → close + return
+  * Successful send AFTER timeouts resets the counter
+  * Tiny interval used in tests so we don't sit in real sleeps
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.ws_keepalive import run_ws_keepalive
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    return ws
+
+
+# ─── Stop-event branches ───────────────────────────────────────
+
+
+class TestStopEvent:
+    @pytest.mark.asyncio
+    async def test_stop_event_set_before_first_iteration_returns_immediately(self):
+        ws = _make_ws()
+        stop = asyncio.Event()
+        stop.set()
+
+        await run_ws_keepalive(
+            ws, ws_id="ws1", stop_event=stop,
+            interval_s=0.001,
+        )
+
+        ws.send_json.assert_not_awaited()
+        ws.close.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_stop_event_set_during_sleep_returns_after_sleep(self):
+        """Caller sets stop_event while we're sleeping; we should
+        notice on wake and return without sending another ping."""
+        ws = _make_ws()
+        stop = asyncio.Event()
+
+        async def _set_stop_after_short_delay():
+            await asyncio.sleep(0.005)
+            stop.set()
+
+        # Start the stopper concurrently — stash the ref to keep
+        # the task alive past this scope (RUF006).
+        _stopper = asyncio.create_task(_set_stop_after_short_delay())
+
+        await run_ws_keepalive(
+            ws, ws_id="ws2", stop_event=stop,
+            interval_s=0.02,  # > stopper delay
+        )
+
+        # We may have sent zero pings (stop fired before first
+        # interval elapsed); we definitely shouldn't have closed.
+        ws.close.assert_not_awaited()
+        _ = _stopper  # silence unused; the ref itself is the point
+
+
+# ─── ws.closed branches ────────────────────────────────────────
+
+
+class TestWsClosed:
+    @pytest.mark.asyncio
+    async def test_ws_closed_at_start_returns_immediately(self):
+        ws = _make_ws(closed=True)
+        await run_ws_keepalive(
+            ws, ws_id="ws3", stop_event=asyncio.Event(),
+            interval_s=0.001,
+        )
+        ws.send_json.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_ws_closes_during_sleep(self):
+        """ws.closed flips to True mid-sleep; on wake we notice
+        and return without sending."""
+        ws = _make_ws(closed=False)
+
+        async def _close_ws():
+            await asyncio.sleep(0.005)
+            ws.closed = True
+
+        _closer = asyncio.create_task(_close_ws())  # noqa: F841 (RUF006: keep ref alive)
+
+        await run_ws_keepalive(
+            ws, ws_id="ws4",
+            interval_s=0.02,
+        )
+        _ = _closer  # silence unused; the reference itself is the point
+
+        ws.send_json.assert_not_awaited()
+
+
+# ─── Happy path ───────────────────────────────────────────────
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_sends_ping_then_continues(self):
+        """One successful ping, then close ws to break the loop."""
+        ws = _make_ws()
+        send_count = 0
+
+        async def _send_then_close(payload):
+            nonlocal send_count
+            send_count += 1
+            if send_count >= 2:
+                ws.closed = True
+
+        ws.send_json.side_effect = _send_then_close
+
+        await run_ws_keepalive(
+            ws, ws_id="ws5",
+            interval_s=0.001,
+        )
+
+        # 2 pings sent (the second one set ws.closed; the next
+        # iteration's `if ws.closed: return` exits cleanly).
+        assert ws.send_json.await_count == 2
+        for c in ws.send_json.await_args_list:
+            assert c.args[0] == {"type": "pong"}
+        # Clean exit — no close() call (only failure-threshold
+        # path closes the WS from inside the loop).
+        ws.close.assert_not_awaited()
+
+
+# ─── Timeout branch ───────────────────────────────────────────
+
+
+class TestTimeoutFailures:
+    @pytest.mark.asyncio
+    async def test_one_timeout_increments_then_continues(self):
+        """One timeout under threshold → continue, don't close."""
+        ws = _make_ws()
+        call_count = 0
+
+        async def _send(payload):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Hang long enough to trigger the wait_for timeout
+                await asyncio.sleep(10)
+            elif call_count == 2:
+                # Second call: succeed and close ws to exit
+                ws.closed = True
+
+        ws.send_json.side_effect = _send
+
+        await run_ws_keepalive(
+            ws, ws_id="ws6",
+            interval_s=0.001,
+            send_timeout_s=0.005,
+            max_consecutive_failures=3,
+        )
+
+        # 2 send attempts — first timed out, second succeeded
+        assert ws.send_json.await_count == 2
+        # No close — failure counter reset to 0 after the second
+        ws.close.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_three_consecutive_timeouts_close_ws(self):
+        """3 timeouts in a row → close + return."""
+        ws = _make_ws()
+
+        async def _hang(payload):
+            await asyncio.sleep(10)  # will time out
+
+        ws.send_json.side_effect = _hang
+
+        await run_ws_keepalive(
+            ws, ws_id="ws7",
+            interval_s=0.001,
+            send_timeout_s=0.005,
+            max_consecutive_failures=3,
+        )
+
+        # Exactly 3 timeouts fired the close.
+        assert ws.send_json.await_count == 3
+        ws.close.assert_awaited_once()
+
+
+# ─── Send-exception branch ────────────────────────────────────
+
+
+class TestSendExceptionFailures:
+    @pytest.mark.asyncio
+    async def test_one_exception_increments_then_continues(self):
+        ws = _make_ws()
+        call_count = 0
+
+        async def _send(payload):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ConnectionResetError("peer gone")
+            elif call_count == 2:
+                ws.closed = True  # exit cleanly
+
+        ws.send_json.side_effect = _send
+
+        await run_ws_keepalive(
+            ws, ws_id="ws8",
+            interval_s=0.001,
+            max_consecutive_failures=3,
+        )
+
+        assert ws.send_json.await_count == 2
+        ws.close.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_three_consecutive_exceptions_close_ws(self):
+        ws = _make_ws()
+        ws.send_json.side_effect = ConnectionResetError("dead")
+
+        await run_ws_keepalive(
+            ws, ws_id="ws9",
+            interval_s=0.001,
+            max_consecutive_failures=3,
+        )
+
+        assert ws.send_json.await_count == 3
+        ws.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_close_failure_does_not_propagate(self):
+        """When ws.close() itself raises, we still return cleanly
+        (the WS is dead anyway; we don't want the keepalive task
+        to crash and leak the connection record)."""
+        ws = _make_ws()
+        ws.send_json.side_effect = RuntimeError("dead")
+        ws.close.side_effect = RuntimeError("close also broken")
+
+        # Must not raise.
+        await run_ws_keepalive(
+            ws, ws_id="ws10",
+            interval_s=0.001,
+            max_consecutive_failures=2,
+        )
+
+
+# ─── Counter-reset across mixed failures ──────────────────────
+
+
+class TestCounterResetOnSuccess:
+    @pytest.mark.asyncio
+    async def test_success_after_two_failures_resets_counter(self):
+        """Sequence: timeout, timeout, success, exception, exception,
+        exception → only the last 3-in-a-row exception streak fires
+        the close.  This pins the consecutive-failures semantic
+        (not a cumulative counter)."""
+        ws = _make_ws()
+        seq = iter([
+            "timeout", "timeout", "success",
+            "exc", "exc", "exc",
+        ])
+
+        async def _send(payload):
+            kind = next(seq)
+            if kind == "timeout":
+                await asyncio.sleep(10)
+            elif kind == "success":
+                return  # success
+            elif kind == "exc":
+                raise RuntimeError("boom")
+
+        ws.send_json.side_effect = _send
+
+        await run_ws_keepalive(
+            ws, ws_id="ws11",
+            interval_s=0.001,
+            send_timeout_s=0.005,
+            max_consecutive_failures=3,
+        )
+
+        # 6 send attempts: 2 timeouts + 1 success + 3 exceptions
+        assert ws.send_json.await_count == 6
+        # Close fired by the 3-exception streak (success reset
+        # after the 2 timeouts so the streak count is per-tail).
+        ws.close.assert_awaited_once()
+
+
+# ─── Default tuning constants ─────────────────────────────────
+
+
+class TestDefaultTuning:
+    def test_defaults_match_pre_extract_constants(self):
+        """Pin the default tuning so a future refactor can't
+        accidentally regress the 15s/5s/3 trio that ngrok-vs-LLM
+        latency was tuned around (#75 + US-DQ05 + US-DQ20)."""
+        from dragon_voice.ws_keepalive import (
+            _DEFAULT_INTERVAL_S,
+            _DEFAULT_MAX_FAILURES,
+            _DEFAULT_SEND_TIMEOUT_S,
+        )
+        assert _DEFAULT_INTERVAL_S == 15.0
+        assert _DEFAULT_SEND_TIMEOUT_S == 5.0
+        assert _DEFAULT_MAX_FAILURES == 3


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **ninth sub-extract** from the WS-handler family in server.py (round 4 spillover, after the eight prior extracts #227-#234).

The keepalive task pings every 15 s with a JSON \`pong\` data frame to prevent ngrok's ~30 s idle drop, and tears the WS down if 3 consecutive pings fail (send timeout or send exception). Pre-extract this lived as a 60-LOC closure inside \`_handle_ws_voice\` that captured \`_keepalive_running\`, \`ws\`, and \`ws_id\` from the outer scope. Now lives in its own dedicated module.

### Behaviour preserved verbatim

- 15 s sleep interval (< ngrok ~30 s idle threshold)
- JSON \`{\"type\": \"pong\"}\` data frame (ngrok counts data frames as activity; WS-level PING wouldn't update its counter)
- 5 s send-timeout per ping (US-DQ05 — guards against event-loop blocked by GIL contention from inference)
- 3-consecutive-failure WS-close threshold (US-DQ20)
- Both timeout and exception paths increment the counter
- Successful send resets the counter (so failures must be consecutive, not cumulative)
- \`ws.close()\` failure on the close path is swallowed (the WS is dead anyway)

### API improvement

Replaced the \`_keepalive_running\` nonlocal with an \`asyncio.Event\` passed in by the caller. Caller does \`stop_event.set()\` for a clean exit on the next wake plus \`task.cancel()\` for the harder-edged interrupt of the in-flight sleep. Both wired in the \`_handle_ws_voice\` finally block so the task can't outlive the handler.

### Test coverage

12 tests spanning:
- Stop-event branches (set before first iteration, set during sleep)
- ws.closed branches (closed at start, closes during sleep)
- Happy path (sends pong frames)
- Timeout branches (one then continue, three closes WS)
- Exception branches (one then continue, three closes WS)
- ws.close() failure swallow
- Counter reset on success after failures
- Default tuning constant pin (15s/5s/3 — must not regress)

### Diff stats

| Metric | Before | After | Δ |
|---|---|---|---|
| \`server.py\` LOC | 1783 | 1737 | **-46** |
| \`server.py\` LOC (cumulative across 25-PR series, since #211) | 2714 | 1737 | **-36.0%** |

## Test plan

- [x] \`python3 -m pytest tests/test_ws_keepalive.py -v\` → 12 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → 959 passed, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)