### PR TITLE
refactor(server): extract binary frame dispatcher (~33 LOC) to binary_frame_dispatch module

### DIFF
--- a/dragon_voice/binary_frame_dispatch.py
+++ b/dragon_voice/binary_frame_dispatch.py
@@ -1,0 +1,128 @@
+"""Binary WS frame dispatcher — VID0 / AUD0 / raw PCM routing.
+
+Wave 23 SOLID-audit follow-up — tenth sub-extract from the
+WS-handler family in server.py (round 4 spillover, after the
+nine prior extracts #227-#235).
+
+Tab5 sends three flavours of binary frames over /ws/voice:
+
+  1. **VID0-tagged** — call-mode video frames (#175).  4-byte
+     magic header `"VID0"` + JPEG payload.  Routed to the video
+     relay handler which broadcasts to other connected clients.
+  2. **AUD0-tagged** — call-mode audio frames (#181 / TinkerTab
+     #272).  4-byte magic header `"AUD0"` + raw int16 PCM (or
+     OPUS).  Broadcast verbatim to peers; bypasses STT.
+  3. **Raw PCM** — the legacy unprefixed mic stream.  Falls
+     through to `pipeline.feed_audio()`.
+
+Pre-extract this 50-LOC dispatcher lived inline at the top of
+the `_handle_ws_voice` message loop.  Now lives here so the
+loop body in `server.py` stays focused on the protocol surface.
+
+## API
+
+```python
+await dispatch_binary_frame(
+    msg_data,
+    *,
+    conn_state,
+    active_connections,
+)
+```
+
+Three terminal cases:
+  * VID0 → forwarded to `video_upstream.get_handler().on_frame`
+  * AUD0 → broadcast to peer connections sharing a different
+           session_id, with per-peer drop on send failure
+  * Raw  → forwarded to `pipeline.feed_audio`
+
+The dispatcher is intentionally I/O-only (no state mutation on
+conn_state); side effects are all on the WS or the pipeline.
+
+## Why per-peer try/except on AUD0 broadcast
+
+A single dead peer connection in the fan-out shouldn't tear
+down the relay for every other listener.  Pre-extract the
+exception swallow was at DEBUG so call sessions stayed clean
+even when one Tab5 dropped.
+
+## Why no `pipeline` parameter
+
+`pipeline` is read fresh from `conn_state` per-frame because
+config-update mid-call may have hot-swapped the pipeline
+backend.  Capturing it at handler-entry would point at a stale
+backend after a swap.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def dispatch_binary_frame(
+    msg_data: bytes,
+    *,
+    conn_state: dict,
+    active_connections: dict,
+) -> None:
+    """Dispatch a single binary WS frame to the right handler.
+
+    Routing is by 4-byte magic prefix:
+
+      * ``"VID0"`` → video relay (`video_upstream.on_frame`)
+      * ``"AUD0"`` → call-audio fan-out to peer connections
+      * other     → `pipeline.feed_audio` (raw PCM mic stream)
+
+    All branches are no-ops when the prerequisite is missing
+    (no pipeline attached, no peers connected) so this function
+    is safe to call before / during / after the register handshake.
+    """
+    # Local imports preserve the pre-extract behaviour (these
+    # were imported inside the message loop, not at module top).
+    # Keeps test imports lightweight too — tests can stub these
+    # without paying the import cost up-front.
+    from dragon_voice.video_upstream import get_handler as _video_get_handler
+    from dragon_voice.video_upstream import parse_video_frame
+    from dragon_voice.audio_codec import peek_call_audio_magic
+
+    # ── #175: VID0-tagged video frame ─────────────────────
+    if parse_video_frame.peek(msg_data):
+        await _video_get_handler().on_frame(
+            session_id=conn_state.get("session_id", ""),
+            device_id=conn_state.get("device_id", ""),
+            wire_bytes=msg_data,
+            active_connections=active_connections,
+        )
+        return
+
+    # ── #181 / TinkerTab #272: AUD0 call-audio fan-out ─────
+    if peek_call_audio_magic(msg_data):
+        sender_sid = conn_state.get("session_id", "")
+        for c in list(active_connections.values()):
+            if c.get("session_id") == sender_sid:
+                continue
+            peer_ws = c.get("ws")
+            if peer_ws is None or peer_ws.closed:
+                continue
+            try:
+                await peer_ws.send_bytes(msg_data)
+            except Exception as e:
+                # One dead peer in the fan-out shouldn't tear the
+                # relay down for everyone else.  DEBUG so live
+                # call sessions don't spam ops at WARNING when a
+                # peer Tab5 drops mid-call.
+                logger.debug("call-audio relay drop: %s", e)
+        return
+
+    # ── Legacy raw PCM mic stream → pipeline ───────────────
+    # Note: feed_audio is NOT locked (US-P10) — it only appends
+    # to the audio buffer and the VAD check is lightweight.  The
+    # heavy processing (_process_utterance) is triggered via
+    # asyncio.create_task inside feed_audio and that task is
+    # serialized by the pipeline's own _processing flag.  Locking
+    # here would block audio ingestion during LLM/TTS processing.
+    pipeline: Any = conn_state.get("pipeline")
+    if pipeline:
+        await pipeline.feed_audio(msg_data)

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -43,6 +43,7 @@ from dragon_voice.local_text_stream import stream_local_text_with_tool_filter
 from dragon_voice.vision_turn import handle_vision_turn
 from dragon_voice.ws_voice_admission import check_ws_voice_admission
 from dragon_voice.ws_keepalive import run_ws_keepalive
+from dragon_voice.binary_frame_dispatch import dispatch_binary_frame
 from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
@@ -642,52 +643,18 @@ class VoiceServer:
                 _last_client_msg_time = time.monotonic()
 
                 if msg.type == WSMsgType.BINARY:
-                    # #175: video frames carry a 4-byte magic prefix
-                    # ("VID0").  Sniff the first bytes; if it matches,
-                    # route to the video handler instead of the audio
-                    # pipeline.  Audio frames are unprefixed raw PCM as
-                    # before, so absence of magic falls through to the
-                    # existing feed_audio path.
-                    from .video_upstream import parse_video_frame, get_handler as _vget
-                    if parse_video_frame.peek(msg.data):
-                        await _vget().on_frame(
-                            session_id=conn_state.get("session_id", ""),
-                            device_id=conn_state.get("device_id", ""),
-                            wire_bytes=msg.data,
-                            active_connections=self._active_connections,
-                        )
-                        continue
-
-                    # #181 / TinkerTab #272: in-call audio frames carry
-                    # the AUD0 magic.  Broadcast verbatim to other
-                    # connected clients and bypass STT — same model as
-                    # the video relay.  Bytes are raw int16 PCM (or
-                    # OPUS) inside; peers handle playback locally.
-                    from .audio_codec import peek_call_audio_magic
-                    if peek_call_audio_magic(msg.data):
-                        sender_sid = conn_state.get("session_id", "")
-                        for c in list(self._active_connections.values()):
-                            if c.get("session_id") == sender_sid:
-                                continue
-                            peer_ws = c.get("ws")
-                            if peer_ws is None or peer_ws.closed:
-                                continue
-                            try:
-                                await peer_ws.send_bytes(msg.data)
-                            except Exception as e:
-                                logger.debug("call-audio relay drop: %s", e)
-                        continue
-                    # Raw PCM audio data — forward to pipeline
-                    # Note: feed_audio is NOT locked (US-P10) — it only
-                    # appends to the audio buffer and the VAD check is
-                    # lightweight. The heavy processing (_process_utterance)
-                    # is triggered via asyncio.create_task inside feed_audio
-                    # and that task is serialized by the pipeline's own
-                    # _processing flag. Locking here would block audio
-                    # ingestion during LLM/TTS processing.
-                    pipeline = conn_state.get("pipeline")
-                    if pipeline:
-                        await pipeline.feed_audio(msg.data)
+                    # SOLID-audit follow-up: VID0 / AUD0 / raw PCM
+                    # routing extracted to
+                    # binary_frame_dispatch.dispatch_binary_frame.
+                    # That module owns: VID0 → video relay, AUD0 →
+                    # peer broadcast (sender excluded; closed peers
+                    # skipped; per-peer send failures swallowed at
+                    # DEBUG), raw PCM → pipeline.feed_audio.
+                    await dispatch_binary_frame(
+                        msg.data,
+                        conn_state=conn_state,
+                        active_connections=self._active_connections,
+                    )
 
                 elif msg.type == WSMsgType.TEXT:
                     try:

--- a/tests/test_binary_frame_dispatch.py
+++ b/tests/test_binary_frame_dispatch.py
@@ -1,0 +1,314 @@
+"""Tests for ``dragon_voice.binary_frame_dispatch``.
+
+Pin every routing branch + the per-peer dead-connection swallow
+on AUD0 fan-out.
+
+Test classes:
+
+  * ``TestVideoFrame`` — VID0-tagged → video_upstream.on_frame
+  * ``TestCallAudioBroadcast`` — AUD0-tagged → peer fan-out;
+    sender excluded; closed peers skipped; per-peer send
+    failures swallowed
+  * ``TestRawPCM`` — unprefixed → pipeline.feed_audio
+  * ``TestNoPipelineFallthrough`` — raw PCM with no pipeline
+    attached is a clean no-op (boot race)
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dragon_voice.binary_frame_dispatch import dispatch_binary_frame
+
+
+def _make_pipeline() -> MagicMock:
+    p = MagicMock()
+    p.feed_audio = AsyncMock()
+    return p
+
+
+def _make_peer_conn(*, session_id: str, ws_closed: bool = False) -> dict:
+    peer_ws = MagicMock()
+    peer_ws.closed = ws_closed
+    peer_ws.send_bytes = AsyncMock()
+    return {"session_id": session_id, "ws": peer_ws}
+
+
+# ─── VID0 routing ─────────────────────────────────────────────
+
+
+class TestVideoFrame:
+    @pytest.mark.asyncio
+    async def test_vid0_frame_routes_to_video_handler(self):
+        msg = b"VID0" + b"\x00" * 100  # any payload after magic
+
+        with patch(
+            "dragon_voice.video_upstream.parse_video_frame.peek",
+            return_value=True,
+        ), patch(
+            "dragon_voice.video_upstream.get_handler"
+        ) as get_h, patch(
+            "dragon_voice.audio_codec.peek_call_audio_magic",
+            return_value=False,
+        ):
+            handler = MagicMock()
+            handler.on_frame = AsyncMock()
+            get_h.return_value = handler
+
+            await dispatch_binary_frame(
+                msg,
+                conn_state={"session_id": "s1", "device_id": "d1"},
+                active_connections={},
+            )
+
+            handler.on_frame.assert_awaited_once()
+            kw = handler.on_frame.await_args.kwargs
+            assert kw["session_id"] == "s1"
+            assert kw["device_id"] == "d1"
+            assert kw["wire_bytes"] == msg
+
+    @pytest.mark.asyncio
+    async def test_vid0_frame_does_not_call_audio_or_pipeline(self):
+        """Pin the early return: VID0 → video handler ONLY.  No
+        peer fan-out, no pipeline.feed_audio."""
+        msg = b"VID0" + b"junk"
+        pipeline = _make_pipeline()
+
+        with patch(
+            "dragon_voice.video_upstream.parse_video_frame.peek",
+            return_value=True,
+        ), patch(
+            "dragon_voice.video_upstream.get_handler"
+        ) as get_h, patch(
+            "dragon_voice.audio_codec.peek_call_audio_magic",
+            return_value=False,
+        ) as audio_peek:
+            handler = MagicMock()
+            handler.on_frame = AsyncMock()
+            get_h.return_value = handler
+
+            await dispatch_binary_frame(
+                msg,
+                conn_state={"pipeline": pipeline, "session_id": "s"},
+                active_connections={},
+            )
+
+            # peek_call_audio_magic NOT consulted (we returned
+            # early on VID0).
+            audio_peek.assert_not_called()
+            pipeline.feed_audio.assert_not_awaited()
+
+
+# ─── AUD0 routing ─────────────────────────────────────────────
+
+
+class TestCallAudioBroadcast:
+    @pytest.mark.asyncio
+    async def test_aud0_broadcasts_to_other_peers_skipping_sender(self):
+        msg = b"AUD0" + b"\x01\x02\x03"
+        sender = _make_peer_conn(session_id="s-sender")
+        peer1 = _make_peer_conn(session_id="s-peer-1")
+        peer2 = _make_peer_conn(session_id="s-peer-2")
+
+        active = {
+            "ws-sender": sender,
+            "ws-peer-1": peer1,
+            "ws-peer-2": peer2,
+        }
+
+        with patch(
+            "dragon_voice.video_upstream.parse_video_frame.peek",
+            return_value=False,
+        ), patch(
+            "dragon_voice.audio_codec.peek_call_audio_magic",
+            return_value=True,
+        ):
+            await dispatch_binary_frame(
+                msg,
+                conn_state={"session_id": "s-sender"},
+                active_connections=active,
+            )
+
+        # Sender does NOT echo back to itself.
+        sender["ws"].send_bytes.assert_not_awaited()
+        # Both other peers received the frame verbatim.
+        peer1["ws"].send_bytes.assert_awaited_once_with(msg)
+        peer2["ws"].send_bytes.assert_awaited_once_with(msg)
+
+    @pytest.mark.asyncio
+    async def test_aud0_skips_closed_peers(self):
+        msg = b"AUD0" + b"x"
+        live_peer = _make_peer_conn(session_id="live")
+        dead_peer = _make_peer_conn(session_id="dead", ws_closed=True)
+
+        active = {"a": live_peer, "b": dead_peer}
+
+        with patch(
+            "dragon_voice.video_upstream.parse_video_frame.peek",
+            return_value=False,
+        ), patch(
+            "dragon_voice.audio_codec.peek_call_audio_magic",
+            return_value=True,
+        ):
+            await dispatch_binary_frame(
+                msg,
+                conn_state={"session_id": "sender"},
+                active_connections=active,
+            )
+
+        live_peer["ws"].send_bytes.assert_awaited_once_with(msg)
+        dead_peer["ws"].send_bytes.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_aud0_skips_peers_with_no_ws(self):
+        """Pre-register peer (ws=None) is silently skipped."""
+        msg = b"AUD0" + b"x"
+        peer_no_ws = {"session_id": "preregister", "ws": None}
+        live_peer = _make_peer_conn(session_id="live")
+
+        active = {"a": peer_no_ws, "b": live_peer}
+
+        with patch(
+            "dragon_voice.video_upstream.parse_video_frame.peek",
+            return_value=False,
+        ), patch(
+            "dragon_voice.audio_codec.peek_call_audio_magic",
+            return_value=True,
+        ):
+            await dispatch_binary_frame(
+                msg,
+                conn_state={"session_id": "sender"},
+                active_connections=active,
+            )
+
+        live_peer["ws"].send_bytes.assert_awaited_once_with(msg)
+
+    @pytest.mark.asyncio
+    async def test_aud0_one_peer_send_failure_does_not_break_fanout(self):
+        """A peer's send_bytes raising MUST NOT prevent the rest
+        of the fan-out.  Pin so a future refactor can't drop the
+        per-peer try/except."""
+        msg = b"AUD0" + b"x"
+        broken = _make_peer_conn(session_id="broken")
+        broken["ws"].send_bytes = AsyncMock(
+            side_effect=ConnectionResetError("peer left")
+        )
+        good = _make_peer_conn(session_id="good")
+
+        active = {"a": broken, "b": good}
+
+        with patch(
+            "dragon_voice.video_upstream.parse_video_frame.peek",
+            return_value=False,
+        ), patch(
+            "dragon_voice.audio_codec.peek_call_audio_magic",
+            return_value=True,
+        ):
+            # Must not raise.
+            await dispatch_binary_frame(
+                msg,
+                conn_state={"session_id": "sender"},
+                active_connections=active,
+            )
+
+        good["ws"].send_bytes.assert_awaited_once_with(msg)
+
+    @pytest.mark.asyncio
+    async def test_aud0_does_not_call_pipeline(self):
+        msg = b"AUD0" + b"x"
+        pipeline = _make_pipeline()
+
+        with patch(
+            "dragon_voice.video_upstream.parse_video_frame.peek",
+            return_value=False,
+        ), patch(
+            "dragon_voice.audio_codec.peek_call_audio_magic",
+            return_value=True,
+        ):
+            await dispatch_binary_frame(
+                msg,
+                conn_state={"session_id": "s", "pipeline": pipeline},
+                active_connections={},
+            )
+
+        pipeline.feed_audio.assert_not_awaited()
+
+
+# ─── Raw PCM routing ─────────────────────────────────────────
+
+
+class TestRawPCM:
+    @pytest.mark.asyncio
+    async def test_unprefixed_routes_to_pipeline_feed_audio(self):
+        msg = b"\x00\x01\x02\x03" * 16  # plausible raw PCM
+        pipeline = _make_pipeline()
+
+        with patch(
+            "dragon_voice.video_upstream.parse_video_frame.peek",
+            return_value=False,
+        ), patch(
+            "dragon_voice.audio_codec.peek_call_audio_magic",
+            return_value=False,
+        ):
+            await dispatch_binary_frame(
+                msg,
+                conn_state={"session_id": "s", "pipeline": pipeline},
+                active_connections={},
+            )
+
+        pipeline.feed_audio.assert_awaited_once_with(msg)
+
+
+# ─── No-pipeline fallthrough ─────────────────────────────────
+
+
+class TestNoPipelineFallthrough:
+    @pytest.mark.asyncio
+    async def test_raw_pcm_with_no_pipeline_is_silent_noop(self):
+        """Pre-register / boot race: pipeline not attached yet.
+        A raw PCM frame must NOT raise — silent no-op."""
+        msg = b"\x00\x01"
+
+        with patch(
+            "dragon_voice.video_upstream.parse_video_frame.peek",
+            return_value=False,
+        ), patch(
+            "dragon_voice.audio_codec.peek_call_audio_magic",
+            return_value=False,
+        ):
+            # Must not raise.
+            await dispatch_binary_frame(
+                msg,
+                conn_state={"session_id": "s"},  # no pipeline key
+                active_connections={},
+            )
+
+    @pytest.mark.asyncio
+    async def test_pipeline_read_fresh_per_frame(self):
+        """Pin the per-frame `conn_state.get("pipeline")` lookup
+        so a config-update mid-call (which hot-swaps the
+        pipeline) is reflected on the very next frame."""
+        msg = b"\x00\x01"
+        first = _make_pipeline()
+        second = _make_pipeline()
+        conn_state = {"session_id": "s", "pipeline": first}
+
+        with patch(
+            "dragon_voice.video_upstream.parse_video_frame.peek",
+            return_value=False,
+        ), patch(
+            "dragon_voice.audio_codec.peek_call_audio_magic",
+            return_value=False,
+        ):
+            await dispatch_binary_frame(
+                msg, conn_state=conn_state, active_connections={},
+            )
+            # Hot-swap mid-stream.
+            conn_state["pipeline"] = second
+            await dispatch_binary_frame(
+                msg, conn_state=conn_state, active_connections={},
+            )
+
+        first.feed_audio.assert_awaited_once_with(msg)
+        second.feed_audio.assert_awaited_once_with(msg)


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **tenth sub-extract** from the WS-handler family in server.py (round 4 spillover, after the nine prior extracts #227-#235).

Tab5 sends three flavours of binary WS frames; the in-loop dispatch was a 33-LOC if/elif chain at the top of \`_handle_ws_voice\`'s message loop:

- **VID0-tagged** → video relay (#175)
- **AUD0-tagged** → peer call-audio fan-out (#181 / TinkerTab #272)
- **raw PCM** → \`pipeline.feed_audio\` (legacy mic stream)

Now lives in its own dedicated module.

### Behaviour preserved verbatim

- VID0 routes to \`video_upstream.get_handler().on_frame\` with \`session_id\`, \`device_id\`, \`wire_bytes\`, \`active_connections\` kwargs
- AUD0 broadcasts verbatim to peers with a different \`session_id\`; sender excluded; closed peers skipped; \`ws=None\` peers (pre-register race) skipped
- Per-peer \`send_bytes\` failure swallowed at DEBUG so a single dead peer doesn't tear down the relay for the rest
- Raw PCM falls through to \`pipeline.feed_audio\` (no lock — keeps audio ingestion lightweight per US-P10)
- Pipeline read fresh per-frame so config-update mid-call hot-swaps reflect on the very next frame
- Silent no-op when raw PCM arrives pre-register (no pipeline yet) so boot races don't crash

### Test coverage

10 tests spanning:
- VID0 routing (correct handler call + no fall-through to audio/pipeline)
- AUD0 fan-out (sender excluded, closed peers skipped, ws=None skipped, per-peer failure swallow, no pipeline call)
- Raw-PCM routing
- No-pipeline silent no-op + per-frame pipeline lookup

### Diff stats

| Metric | Before | After | Δ |
|---|---|---|---|
| \`server.py\` LOC | 1737 | 1704 | **-33** |
| \`server.py\` LOC (cumulative across 26-PR series, since #211) | 2714 | 1704 | **-37.2%** |

## Test plan

- [x] \`python3 -m pytest tests/test_binary_frame_dispatch.py -v\` → 10 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → 969 passed, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)