### PR TITLE
refactor(server): extract cancel command handler (~60 LOC) to cancel_handler module

### DIFF
--- a/dragon_voice/cancel_handler.py
+++ b/dragon_voice/cancel_handler.py
@@ -1,0 +1,152 @@
+"""Tab5 `cancel` WS command handler.
+
+Wave 23 SOLID-audit follow-up — eleventh sub-extract from the
+WS-handler family in server.py (round 4 spillover, after the
+ten prior extracts #227-#236).
+
+When Tab5 sends a `cancel` frame mid-turn (user hit STOP), the
+server has to:
+
+  1. Cancel any in-flight handler task in the `text`, `media`,
+     or `config` slots (Phase 1 / issue #91).
+  2. Cancel the voice pipeline (audit A1 / #137 — also kills
+     in-flight Piper subproc since text path can call
+     `_tts.synthesize` directly outside `_processing`).
+  3. Discard any scheduler-fired widgets that deferred during
+     this turn (audit B1 / #165 — user cancelled, the deferred
+     reminder should also disappear).
+  4. Send a `cancel_ack` so Tab5 has positive feedback that the
+     cancel landed (Tab5 already transitions to READY locally
+     on cancel-send; the ack is the protocol-clean half).
+
+Pre-extract this 60-LOC handler lived inline in
+`_handle_ws_voice`'s cmd_type dispatch.  Now lives here so the
+dispatch table stays a flat one-liner per command.
+
+## API
+
+```python
+await handle_cancel_command(
+    ws,
+    *,
+    ws_id,
+    conn_state,
+    surface_mgr,
+    safe_send_json,
+) -> None
+```
+
+`surface_mgr` is the SurfaceManager singleton (used for the
+deferred-widget discard).  `safe_send_json` follows the same
+DIP pattern used by the round-4 text-path extracts.
+
+## What's intentionally NOT in this module
+
+The actual task lifecycle (which task lives in which slot,
+when slots get populated, when they get cleared on completion)
+is the dispatcher's responsibility — this module just walks
+the slots and cancels.  Adding a new slot is a one-line
+change here AND in the dispatcher; the audit's WsDispatcher
+follow-up will collapse both.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+SafeSendJson = Callable[[web.WebSocketResponse, dict], Awaitable[bool]]
+
+
+# Handler-task slots cancelled on a `cancel` frame.  Order is
+# the legacy walk order (text → media → config); preserved for
+# log-line stability.
+_CANCEL_SLOTS = ("text", "media", "config")
+
+
+async def handle_cancel_command(
+    ws: web.WebSocketResponse,
+    *,
+    ws_id: str,
+    conn_state: dict,
+    surface_mgr: Optional[Any],      # SurfaceManager (Optional in test paths)
+    safe_send_json: SafeSendJson,
+) -> None:
+    """Handle a Tab5 `cancel` WS frame.
+
+    Walks the `text` / `media` / `config` handler-task slots,
+    cancels any in-flight pipeline, discards deferred widgets,
+    and sends `cancel_ack` with the per-source breakdown.
+
+    Side effects (per pre-extract behaviour):
+      * `conn_state["handler_tasks"][slot]` set to ``None`` for
+        any cancelled slot (so the dispatcher knows the slot is
+        free again).
+      * `pipeline.cancel()` invoked when a pipeline is attached
+        (idempotent — safe even when nothing is in flight).
+      * `surface_mgr.discard_deferred(session_id)` invoked when
+        both surface manager and session id are available.
+
+    The `cancel_ack` payload always carries a `cancelled` list
+    even when nothing was cancelled — Tab5 uses an empty list
+    as a signal that the cancel arrived but found nothing in
+    flight (e.g. user hit STOP after the turn already finished).
+    """
+    cancelled_what: list[str] = []
+    handler_tasks = conn_state.setdefault("handler_tasks", {})
+    pipeline = conn_state.get("pipeline")
+
+    # ── Cancel in-flight handler tasks ──────────────────────
+    for slot in _CANCEL_SLOTS:
+        t = handler_tasks.get(slot)
+        if t and not t.done():
+            t.cancel()
+            try:
+                await t
+            except (asyncio.CancelledError, Exception):
+                # Task may have raised mid-cancel; the task
+                # itself logged at the relevant level.  Don't
+                # propagate to the WS loop or the loop dies.
+                pass
+            handler_tasks[slot] = None
+            cancelled_what.append(slot)
+
+    # ── Cancel the pipeline (audit A1 / #137) ───────────────
+    # Always invoked — text path calls pipeline._tts.synthesize
+    # directly (see _handle_text), so a Piper subprocess can be
+    # alive even when no handler-task slot was occupied or
+    # _processing is False.  pipeline.cancel() is idempotent.
+    if pipeline:
+        logger.info("Connection %s: cancel → pipeline.cancel", ws_id)
+        await pipeline.cancel()
+        cancelled_what.append("pipeline")
+
+    # ── Discard deferred scheduler widgets (audit B1 / #165) ─
+    # User cancelled the turn, so any reminder that fired during
+    # it should also disappear (a fresh fire cycle will pop on
+    # the next turn-idle window if the scheduler still wants to
+    # deliver it).
+    sid = conn_state.get("session_id")
+    if surface_mgr is not None and sid:
+        dropped = surface_mgr.discard_deferred(sid)
+        if dropped:
+            logger.info(
+                "Connection %s: cancel → discarded %d deferred widget(s)",
+                ws_id, dropped,
+            )
+            cancelled_what.append(f"deferred:{dropped}")
+
+    # ── Send cancel_ack ─────────────────────────────────────
+    # Tab5 transitions to READY locally on cancel-send and may
+    # otherwise see late `llm` tokens that were already in TCP
+    # flight.  Tab5-side fix at voice.c:752 covers the late-
+    # token case directly; this ack is the protocol-clean half.
+    await safe_send_json(ws, {
+        "type": "cancel_ack",
+        "cancelled": cancelled_what,
+    })

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -44,6 +44,7 @@ from dragon_voice.vision_turn import handle_vision_turn
 from dragon_voice.ws_voice_admission import check_ws_voice_admission
 from dragon_voice.ws_keepalive import run_ws_keepalive
 from dragon_voice.binary_frame_dispatch import dispatch_binary_frame
+from dragon_voice.cancel_handler import handle_cancel_command
 from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
@@ -751,65 +752,20 @@ class VoiceServer:
                             logger.info("Connection %s: conversation history cleared", ws_id)
 
                     elif cmd_type == "cancel":
-                        # Phase 1 (issue #91): cancel needs to reach in-flight
-                        # text/media handler tasks too, not just the voice
-                        # pipeline.  Today text/media are awaited inline above
-                        # which blocks the WS read loop — a cancel frame from
-                        # Tab5 sits in the TCP buffer until the inline await
-                        # returns, by which point the response has already
-                        # finished and Tab5 sees the cancelled tokens
-                        # materialise after the user gave up.
-                        pipeline = conn_state.get("pipeline")
-                        cancelled_what: list[str] = []
-                        handler_tasks = conn_state.setdefault("handler_tasks", {})
-                        for slot in ("text", "media", "config"):
-                            t = handler_tasks.get(slot)
-                            if t and not t.done():
-                                t.cancel()
-                                try:
-                                    await t
-                                except (asyncio.CancelledError, Exception):
-                                    # task may have raised mid-cancel; we
-                                    # logged it; don't propagate to the WS
-                                    # loop or the loop dies on us
-                                    pass
-                                handler_tasks[slot] = None
-                                cancelled_what.append(slot)
-                        # Always cancel the pipeline.  The text path calls
-                        # pipeline._tts.synthesize() directly (see _handle_text),
-                        # so a Piper subprocess can be alive even when no
-                        # handler-task slot was occupied or _processing is False.
-                        # pipeline.cancel() is idempotent.  (audit A1, #137)
-                        if pipeline:
-                            logger.info("Connection %s: cancel → pipeline.cancel", ws_id)
-                            await pipeline.cancel()
-                            cancelled_what.append("pipeline")
-                        # Audit B1 (#165): also drop any scheduler-fired
-                        # widgets that deferred during this turn — user
-                        # cancelled the turn, so any reminder that fired
-                        # during it should also disappear (a fresh fire
-                        # cycle will pop on the next turn-idle window if
-                        # the scheduler still wants to deliver it).
-                        sid = conn_state.get("session_id")
-                        if self._surface_mgr is not None and sid:
-                            dropped = self._surface_mgr.discard_deferred(sid)
-                            if dropped:
-                                logger.info(
-                                    "Connection %s: cancel → discarded %d deferred widget(s)",
-                                    ws_id, dropped,
-                                )
-                                cancelled_what.append(f"deferred:{dropped}")
-                        # Send ack so Tab5 has a positive signal that cancel
-                        # landed — matters because Tab5 transitions to READY
-                        # locally on cancel-send and may otherwise see late
-                        # `llm` tokens that were already in TCP flight.
-                        # Tab5-side fix at voice.c:752 covers the late-token
-                        # case directly; this ack is the protocol-clean half
-                        # of the same change.
-                        await self._safe_send_json(ws, {
-                            "type": "cancel_ack",
-                            "cancelled": cancelled_what,
-                        })
+                        # SOLID-audit follow-up: cancel chain extracted
+                        # to cancel_handler.handle_cancel_command.  That
+                        # module owns: in-flight handler-task cancel
+                        # (text/media/config slots), pipeline.cancel
+                        # (audit A1 / #137 — idempotent), deferred-widget
+                        # discard (audit B1 / #165), and the cancel_ack
+                        # emit with per-source breakdown.
+                        await handle_cancel_command(
+                            ws,
+                            ws_id=ws_id,
+                            conn_state=conn_state,
+                            surface_mgr=self._surface_mgr,
+                            safe_send_json=self._safe_send_json,
+                        )
 
                     elif cmd_type == "text":
                         # Phase 1 (issue #91): spawn as a task so the WS read

--- a/tests/test_cancel_handler.py
+++ b/tests/test_cancel_handler.py
@@ -1,0 +1,346 @@
+"""Tests for ``dragon_voice.cancel_handler``.
+
+Pin every step of the cancel chain so a future refactor can't
+accidentally drop the in-flight task cancel, the pipeline kill,
+the deferred-widget discard, or the cancel_ack.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.cancel_handler import handle_cancel_command
+
+
+def _make_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    return ws
+
+
+def _make_safe_send_json() -> AsyncMock:
+    return AsyncMock(return_value=True)
+
+
+def _make_pipeline() -> MagicMock:
+    p = MagicMock()
+    p.cancel = AsyncMock()
+    return p
+
+
+def _make_inflight_task() -> asyncio.Task:
+    """A real asyncio.Task that hangs forever — we'll cancel it."""
+    async def _hang():
+        await asyncio.sleep(60)
+    return asyncio.create_task(_hang())
+
+
+# ─── No-op (nothing to cancel) ────────────────────────────────
+
+
+class TestNoOp:
+    @pytest.mark.asyncio
+    async def test_no_tasks_no_pipeline_no_widgets_still_acks(self):
+        """User hit STOP after the turn already finished — nothing
+        in flight, but we still send `cancel_ack` with an empty
+        list so Tab5 has a positive signal."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+
+        await handle_cancel_command(
+            ws,
+            ws_id="ws1",
+            conn_state={"session_id": "s1"},
+            surface_mgr=None,
+            safe_send_json=send,
+        )
+
+        send.assert_awaited_once()
+        ack = send.await_args.args[1]
+        assert ack["type"] == "cancel_ack"
+        assert ack["cancelled"] == []
+
+
+# ─── Handler-task cancellation ────────────────────────────────
+
+
+class TestHandlerTaskCancel:
+    @pytest.mark.asyncio
+    async def test_cancels_inflight_text_task_and_clears_slot(self):
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        text_task = _make_inflight_task()
+        handler_tasks = {"text": text_task, "media": None, "config": None}
+
+        await handle_cancel_command(
+            ws,
+            ws_id="ws2",
+            conn_state={
+                "session_id": "s",
+                "handler_tasks": handler_tasks,
+            },
+            surface_mgr=None,
+            safe_send_json=send,
+        )
+
+        # Task was cancelled
+        assert text_task.cancelled()
+        # Slot reset to None (so dispatcher knows it's free)
+        assert handler_tasks["text"] is None
+        # cancel_ack lists the slot
+        ack = send.await_args.args[1]
+        assert "text" in ack["cancelled"]
+
+    @pytest.mark.asyncio
+    async def test_cancels_all_three_slots_in_order(self):
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        text_t = _make_inflight_task()
+        media_t = _make_inflight_task()
+        config_t = _make_inflight_task()
+        handler_tasks = {"text": text_t, "media": media_t, "config": config_t}
+
+        await handle_cancel_command(
+            ws,
+            ws_id="ws3",
+            conn_state={
+                "session_id": "s",
+                "handler_tasks": handler_tasks,
+            },
+            surface_mgr=None,
+            safe_send_json=send,
+        )
+
+        for t in (text_t, media_t, config_t):
+            assert t.cancelled()
+
+        # Order pinned: text, media, config (legacy walk order
+        # — preserved for log-line stability).
+        ack = send.await_args.args[1]
+        assert ack["cancelled"][:3] == ["text", "media", "config"]
+
+    @pytest.mark.asyncio
+    async def test_done_task_is_skipped(self):
+        """A task that already finished must NOT get cancelled
+        (idempotent on completed tasks)."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+
+        async def _quick():
+            return "done"
+
+        finished = asyncio.create_task(_quick())
+        await asyncio.sleep(0)  # let it complete
+        assert finished.done()
+
+        handler_tasks = {"text": finished}
+
+        await handle_cancel_command(
+            ws,
+            ws_id="ws4",
+            conn_state={
+                "session_id": "s",
+                "handler_tasks": handler_tasks,
+            },
+            surface_mgr=None,
+            safe_send_json=send,
+        )
+
+        ack = send.await_args.args[1]
+        assert "text" not in ack["cancelled"]
+        # Slot left as-is (caller's lifecycle responsibility)
+        assert handler_tasks["text"] is finished
+
+    @pytest.mark.asyncio
+    async def test_task_raising_during_await_does_not_propagate(self):
+        """A task that raises a non-CancelledError mid-cancel must
+        be swallowed — propagating would tear down the WS read
+        loop (preserved verbatim from pre-extract)."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+
+        async def _raises_after_cancel():
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                raise RuntimeError("boom on cancel") from None
+
+        bad = asyncio.create_task(_raises_after_cancel())
+        # Let it start
+        await asyncio.sleep(0)
+        handler_tasks = {"text": bad}
+
+        # Must NOT raise.
+        await handle_cancel_command(
+            ws,
+            ws_id="ws5",
+            conn_state={
+                "session_id": "s",
+                "handler_tasks": handler_tasks,
+            },
+            surface_mgr=None,
+            safe_send_json=send,
+        )
+
+        ack = send.await_args.args[1]
+        assert "text" in ack["cancelled"]
+        assert handler_tasks["text"] is None
+
+
+# ─── Pipeline cancel ──────────────────────────────────────────
+
+
+class TestPipelineCancel:
+    @pytest.mark.asyncio
+    async def test_pipeline_cancel_invoked_when_attached(self):
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        pipeline = _make_pipeline()
+
+        await handle_cancel_command(
+            ws,
+            ws_id="ws6",
+            conn_state={"session_id": "s", "pipeline": pipeline},
+            surface_mgr=None,
+            safe_send_json=send,
+        )
+
+        pipeline.cancel.assert_awaited_once()
+        ack = send.await_args.args[1]
+        assert "pipeline" in ack["cancelled"]
+
+    @pytest.mark.asyncio
+    async def test_pipeline_cancel_skipped_when_not_attached(self):
+        """Boot race: cancel arrives before register set up the
+        pipeline.  Must not crash."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+
+        await handle_cancel_command(
+            ws,
+            ws_id="ws7",
+            conn_state={"session_id": "s"},
+            surface_mgr=None,
+            safe_send_json=send,
+        )
+
+        ack = send.await_args.args[1]
+        assert "pipeline" not in ack["cancelled"]
+
+
+# ─── Deferred-widget discard (audit B1 / #165) ───────────────
+
+
+class TestDeferredWidgetDiscard:
+    @pytest.mark.asyncio
+    async def test_discard_invoked_when_surface_mgr_and_session(self):
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        surface_mgr = MagicMock()
+        surface_mgr.discard_deferred = MagicMock(return_value=2)
+
+        await handle_cancel_command(
+            ws,
+            ws_id="ws8",
+            conn_state={"session_id": "s-active"},
+            surface_mgr=surface_mgr,
+            safe_send_json=send,
+        )
+
+        surface_mgr.discard_deferred.assert_called_once_with("s-active")
+        ack = send.await_args.args[1]
+        # cancelled list reports the count via "deferred:N"
+        assert "deferred:2" in ack["cancelled"]
+
+    @pytest.mark.asyncio
+    async def test_zero_dropped_omits_from_ack(self):
+        """When discard_deferred returns 0, the ack list must NOT
+        contain a `deferred:0` entry (preserved verbatim — keeps
+        the ack list focused on what actually got dropped)."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        surface_mgr = MagicMock()
+        surface_mgr.discard_deferred = MagicMock(return_value=0)
+
+        await handle_cancel_command(
+            ws,
+            ws_id="ws9",
+            conn_state={"session_id": "s"},
+            surface_mgr=surface_mgr,
+            safe_send_json=send,
+        )
+
+        ack = send.await_args.args[1]
+        assert not any(c.startswith("deferred:") for c in ack["cancelled"])
+
+    @pytest.mark.asyncio
+    async def test_no_surface_mgr_skips_discard(self):
+        ws = _make_ws()
+        send = _make_safe_send_json()
+
+        await handle_cancel_command(
+            ws,
+            ws_id="ws10",
+            conn_state={"session_id": "s"},
+            surface_mgr=None,
+            safe_send_json=send,
+        )
+
+        ack = send.await_args.args[1]
+        assert not any(c.startswith("deferred:") for c in ack["cancelled"])
+
+    @pytest.mark.asyncio
+    async def test_no_session_id_skips_discard(self):
+        """Cancel arrived before register completed — no session
+        to scope the discard against.  Must skip silently."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        surface_mgr = MagicMock()
+        surface_mgr.discard_deferred = MagicMock()
+
+        await handle_cancel_command(
+            ws,
+            ws_id="ws11",
+            conn_state={},  # no session_id
+            surface_mgr=surface_mgr,
+            safe_send_json=send,
+        )
+
+        surface_mgr.discard_deferred.assert_not_called()
+
+
+# ─── cancel_ack always sent ──────────────────────────────────
+
+
+class TestCancelAck:
+    @pytest.mark.asyncio
+    async def test_full_breakdown_in_ack(self):
+        """End-to-end: tasks + pipeline + deferred all reported
+        in the same `cancelled` list."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        text_t = _make_inflight_task()
+        pipeline = _make_pipeline()
+        surface_mgr = MagicMock()
+        surface_mgr.discard_deferred = MagicMock(return_value=3)
+
+        await handle_cancel_command(
+            ws,
+            ws_id="ws12",
+            conn_state={
+                "session_id": "s",
+                "pipeline": pipeline,
+                "handler_tasks": {"text": text_t},
+            },
+            surface_mgr=surface_mgr,
+            safe_send_json=send,
+        )
+
+        ack = send.await_args.args[1]
+        assert ack["type"] == "cancel_ack"
+        assert "text" in ack["cancelled"]
+        assert "pipeline" in ack["cancelled"]
+        assert "deferred:3" in ack["cancelled"]


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **eleventh sub-extract** from the WS-handler family in server.py (round 4 spillover, after the ten prior extracts #227-#236).

When Tab5 sends a \`cancel\` frame mid-turn (user hit STOP), the server walks the in-flight handler-task slots, kills the pipeline, drops deferred widgets, and acks. Pre-extract this 60-LOC handler lived inline in \`_handle_ws_voice\`'s cmd_type dispatch.

### Behaviour preserved verbatim

- Iterates \`text\` → \`media\` → \`config\` slots in legacy walk order (preserved for log-line stability). Cancel + await each in-flight task; CancelledError + plain Exception both swallowed so a buggy task doesn't tear down the WS read loop. Slot reset to \`None\` so dispatcher knows it's free again.
- Done tasks skipped (idempotent on completed tasks; slot left as-is for the caller's lifecycle to clean up).
- Pipeline cancel always fires when a pipeline is attached (audit A1 / #137 — text path calls \`_tts.synthesize\` directly outside \`_processing\`, so a Piper subprocess can be alive even when no slot was occupied). \`pipeline.cancel()\` is idempotent.
- Deferred-widget discard via \`surface_mgr.discard_deferred(sid)\` (audit B1 / #165) — only when both surface manager and session id are available. Zero-dropped is omitted from the ack list (preserves the \"report only what changed\" semantic).
- \`cancel_ack\` always emitted, even when nothing was cancelled — Tab5 uses an empty list as a positive signal that cancel landed.

### DIP

\`surface_mgr\` + \`safe_send_json\` passed in (no reach back into \`self\`).

### Test coverage

12 tests spanning:
- No-op case (nothing in flight, still acks)
- All three handler-task slots cancelling in order
- Done-task skip
- Mid-cancel exception swallow
- Pipeline cancel attached/unattached
- Deferred-widget discard with surface_mgr present/absent, session-id present/absent
- Zero-dropped omission from ack
- Full breakdown end-to-end

### Diff stats

| Metric | Before | After | Δ |
|---|---|---|---|
| \`server.py\` LOC | 1704 | 1660 | **-44** |
| \`server.py\` LOC (cumulative across 27-PR series, since #211) | 2714 | 1660 | **-38.8%** |

## Test plan

- [x] \`python3 -m pytest tests/test_cancel_handler.py -v\` → 12 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → 981 passed, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)