### PR TITLE
refactor(server): extract clear command handler (~33 LOC) to clear_handler module

### DIFF
--- a/dragon_voice/clear_handler.py
+++ b/dragon_voice/clear_handler.py
@@ -1,0 +1,118 @@
+"""Tab5 `clear` WS command handler.
+
+Wave 23 SOLID-audit follow-up — twelfth sub-extract from the
+WS-handler family in server.py (round 4 spillover, after the
+eleven prior extracts #227-#237).
+
+When Tab5 sends a `clear` frame (user hit "clear chat"), the
+server has to:
+
+  1. Wipe the in-memory pipeline conversation history.
+  2. End the current DB session and create a fresh one (so the
+     next LLM call gets an empty context — no leaked history
+     from the prior chat).
+  3. Update `conn_state["session_id"]` to the new session.
+  4. Send a `session_start` frame so Tab5 can switch its chat
+     view to the new session.
+
+Pre-extract this 33-LOC handler lived inline in
+`_handle_ws_voice`'s cmd_type dispatch.  Now lives here so the
+dispatch table stays a flat one-liner per command.
+
+## API
+
+```python
+await handle_clear_command(
+    ws,
+    *,
+    ws_id,
+    conn_state,
+    session_mgr,
+) -> None
+```
+
+`session_mgr` is the SessionManager singleton.  When it (or the
+old session id) is missing, the in-memory clear still runs but
+the DB-session swap is skipped — preserves the pre-extract
+behaviour for boot races and test paths.
+
+## #56 closure (preserved verbatim)
+
+`session_mgr.create_session()` returns a single dict — NOT a
+`(dict, bool)` tuple.  That's `get_or_create_session`.  The
+old tuple-unpack raised `ValueError` and tore down the WS
+handler, leaving Tab5 in RECONNECTING with a blank chat view.
+The single-dict shape is preserved here and pinned by the
+happy-path test.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_clear_command(
+    ws: web.WebSocketResponse,
+    *,
+    ws_id: str,
+    conn_state: dict,
+    session_mgr: Optional[Any],   # SessionManager (Optional in test paths)
+) -> None:
+    """Handle a Tab5 `clear` WS frame.
+
+    In-memory clear always runs (when a pipeline is attached).
+    DB-session swap runs only when both `session_mgr` and the
+    current `session_id` are available — preserves the pre-
+    extract behaviour for boot races and test paths.
+
+    Side effects:
+      * `pipeline.clear_history()` invoked when attached.
+      * `session_mgr.end_session(old_sid)` ends the old session.
+      * `session_mgr.create_session(device_id, session_type)`
+        creates a fresh one; the new id is written back to
+        `conn_state["session_id"]`.
+      * `session_start` WS frame emitted with the new session id.
+
+    The `session_start` frame carries `resumed=False` and
+    `message_count=0` so Tab5's chat view starts empty.
+    """
+    pipeline = conn_state.get("pipeline")
+    if pipeline:
+        pipeline.clear_history()
+
+    # End current session and create a fresh one (clears DB context).
+    old_sid = conn_state.get("session_id")
+    device_id = conn_state.get("device_id")
+    if old_sid and session_mgr:
+        await session_mgr.end_session(old_sid)
+        # closes #56: create_session returns a single dict,
+        # NOT a (dict, bool) tuple — that's
+        # get_or_create_session.  The old tuple-unpack raised
+        # ValueError and tore down the WS handler, leaving Tab5
+        # in RECONNECTING with a blank chat view.  Symptom:
+        # every /chat returned 'voice not connected' until
+        # next reconnect.
+        session = await session_mgr.create_session(
+            device_id=device_id, session_type="conversation",
+        )
+        conn_state["session_id"] = session["id"]
+        logger.info(
+            "Connection %s: history cleared, new session %s",
+            ws_id, session["id"],
+        )
+        if not ws.closed:
+            await ws.send_json({
+                "type": "session_start",
+                "session_id": session["id"],
+                "device_id": device_id,
+                "resumed": False,
+                "message_count": 0,
+            })
+    else:
+        logger.info(
+            "Connection %s: conversation history cleared", ws_id,
+        )

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -45,6 +45,7 @@ from dragon_voice.ws_voice_admission import check_ws_voice_admission
 from dragon_voice.ws_keepalive import run_ws_keepalive
 from dragon_voice.binary_frame_dispatch import dispatch_binary_frame
 from dragon_voice.cancel_handler import handle_cancel_command
+from dragon_voice.clear_handler import handle_clear_command
 from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
@@ -718,38 +719,19 @@ class VoiceServer:
                                     await pipeline.start_processing()
 
                     elif cmd_type == "clear":
-                        pipeline = conn_state.get("pipeline")
-                        if pipeline:
-                            pipeline.clear_history()
-                        # End current session and create a fresh one (clears DB context)
-                        old_sid = conn_state.get("session_id")
-                        device_id = conn_state.get("device_id")
-                        if old_sid and self._session_mgr:
-                            await self._session_mgr.end_session(old_sid)
-                            # closes #56: create_session returns a single dict,
-                            # NOT a (dict, bool) tuple — that's
-                            # get_or_create_session.  The old tuple-unpack
-                            # raised ValueError and tore down the WS handler,
-                            # leaving Tab5 dead after a 'clear' + mode-swap
-                            # sequence.  Symptom: Tab5 sat in RECONNECTING and
-                            # every /chat returned 'voice not connected' with
-                            # a blank chat view.
-                            session = await self._session_mgr.create_session(
-                                device_id=device_id, session_type="conversation"
-                            )
-                            conn_state["session_id"] = session["id"]
-                            logger.info("Connection %s: history cleared, new session %s",
-                                        ws_id, session["id"])
-                            if not ws.closed:
-                                await ws.send_json({
-                                    "type": "session_start",
-                                    "session_id": session["id"],
-                                    "device_id": device_id,
-                                    "resumed": False,
-                                    "message_count": 0,
-                                })
-                        else:
-                            logger.info("Connection %s: conversation history cleared", ws_id)
+                        # SOLID-audit follow-up: clear chain extracted
+                        # to clear_handler.handle_clear_command.  That
+                        # module owns: pipeline.clear_history,
+                        # end_session + create_session DB swap (with
+                        # the #56 single-dict-return contract pinned),
+                        # conn_state.session_id update, and the
+                        # session_start emit.
+                        await handle_clear_command(
+                            ws,
+                            ws_id=ws_id,
+                            conn_state=conn_state,
+                            session_mgr=self._session_mgr,
+                        )
 
                     elif cmd_type == "cancel":
                         # SOLID-audit follow-up: cancel chain extracted

--- a/tests/test_clear_handler.py
+++ b/tests/test_clear_handler.py
@@ -1,0 +1,213 @@
+"""Tests for ``dragon_voice.clear_handler``.
+
+Pin every branch + the #56 single-dict create_session contract.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.clear_handler import handle_clear_command
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    ws.send_json = AsyncMock()
+    return ws
+
+
+def _make_pipeline() -> MagicMock:
+    p = MagicMock()
+    p.clear_history = MagicMock()
+    return p
+
+
+def _make_session_mgr(*, new_sid: str = "new-session-id") -> MagicMock:
+    mgr = MagicMock()
+    mgr.end_session = AsyncMock()
+    mgr.create_session = AsyncMock(return_value={"id": new_sid})
+    return mgr
+
+
+# ─── Pipeline clear ──────────────────────────────────────────
+
+
+class TestPipelineClear:
+    @pytest.mark.asyncio
+    async def test_pipeline_clear_history_invoked_when_attached(self):
+        ws = _make_ws()
+        pipeline = _make_pipeline()
+        session_mgr = _make_session_mgr()
+
+        await handle_clear_command(
+            ws,
+            ws_id="ws1",
+            conn_state={
+                "pipeline": pipeline,
+                "session_id": "old-sid",
+                "device_id": "dev1",
+            },
+            session_mgr=session_mgr,
+        )
+
+        pipeline.clear_history.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_pipeline_skips_clear(self):
+        """Boot race: clear arrives before register attached
+        the pipeline.  Must not crash."""
+        ws = _make_ws()
+        session_mgr = _make_session_mgr()
+
+        await handle_clear_command(
+            ws,
+            ws_id="ws2",
+            conn_state={
+                "session_id": "old-sid",
+                "device_id": "dev2",
+            },
+            session_mgr=session_mgr,
+        )
+        # No assertion — just must not raise.
+
+
+# ─── DB session swap ─────────────────────────────────────────
+
+
+class TestSessionSwap:
+    @pytest.mark.asyncio
+    async def test_full_swap_emits_session_start(self):
+        ws = _make_ws()
+        pipeline = _make_pipeline()
+        session_mgr = _make_session_mgr(new_sid="fresh-123")
+        conn_state = {
+            "pipeline": pipeline,
+            "session_id": "old-sid",
+            "device_id": "tab5-A",
+        }
+
+        await handle_clear_command(
+            ws,
+            ws_id="ws3",
+            conn_state=conn_state,
+            session_mgr=session_mgr,
+        )
+
+        # Old session ended
+        session_mgr.end_session.assert_awaited_once_with("old-sid")
+        # New session created with the right kwargs
+        session_mgr.create_session.assert_awaited_once_with(
+            device_id="tab5-A", session_type="conversation",
+        )
+        # conn_state updated to the new session id
+        assert conn_state["session_id"] == "fresh-123"
+        # session_start frame emitted with the right shape
+        ws.send_json.assert_awaited_once()
+        frame = ws.send_json.await_args.args[0]
+        assert frame["type"] == "session_start"
+        assert frame["session_id"] == "fresh-123"
+        assert frame["device_id"] == "tab5-A"
+        assert frame["resumed"] is False
+        assert frame["message_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_no_session_mgr_skips_db_swap(self):
+        """Test path / boot race — no session manager available.
+        Pipeline clear still runs; DB swap silently skipped."""
+        ws = _make_ws()
+        pipeline = _make_pipeline()
+
+        await handle_clear_command(
+            ws,
+            ws_id="ws4",
+            conn_state={
+                "pipeline": pipeline,
+                "session_id": "old",
+                "device_id": "d",
+            },
+            session_mgr=None,
+        )
+
+        pipeline.clear_history.assert_called_once()
+        # No session_start emitted (no swap to announce)
+        ws.send_json.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_old_session_id_skips_db_swap(self):
+        """Pre-register clear (no session yet) — pipeline clear
+        still runs; DB swap silently skipped."""
+        ws = _make_ws()
+        pipeline = _make_pipeline()
+        session_mgr = _make_session_mgr()
+
+        await handle_clear_command(
+            ws,
+            ws_id="ws5",
+            conn_state={
+                "pipeline": pipeline,
+                # no session_id
+                "device_id": "d",
+            },
+            session_mgr=session_mgr,
+        )
+
+        session_mgr.end_session.assert_not_awaited()
+        session_mgr.create_session.assert_not_awaited()
+        ws.send_json.assert_not_awaited()
+
+
+# ─── #56 closure pin: single-dict create_session ─────────────
+
+
+class TestSingleDictCreateSessionContract:
+    @pytest.mark.asyncio
+    async def test_single_dict_return_shape(self):
+        """#56 closure: create_session returns a single dict with
+        an "id" key.  NOT a (dict, bool) tuple — that's
+        get_or_create_session.  The old tuple-unpack raised
+        ValueError and tore down the WS handler.  Pin the
+        contract so a future refactor can't drift."""
+        ws = _make_ws()
+        session_mgr = _make_session_mgr(new_sid="contract-id")
+
+        await handle_clear_command(
+            ws,
+            ws_id="ws6",
+            conn_state={"session_id": "old", "device_id": "d"},
+            session_mgr=session_mgr,
+        )
+
+        # If create_session returned a tuple, the [\"id\"] index
+        # would have raised KeyError on the tuple — meaning the
+        # session_start frame would never have been emitted.
+        ws.send_json.assert_awaited_once()
+        assert ws.send_json.await_args.args[0]["session_id"] == "contract-id"
+
+
+# ─── ws.closed skip ──────────────────────────────────────────
+
+
+class TestWsClosedSkip:
+    @pytest.mark.asyncio
+    async def test_closed_ws_skips_session_start_emit(self):
+        """ws closed mid-handler — DB swap still runs (per
+        pre-extract behaviour: the swap is a fact-of-life that
+        must persist regardless of the WS state) but session_start
+        frame is skipped."""
+        ws = _make_ws(closed=True)
+        session_mgr = _make_session_mgr()
+
+        await handle_clear_command(
+            ws,
+            ws_id="ws7",
+            conn_state={"session_id": "old", "device_id": "d"},
+            session_mgr=session_mgr,
+        )
+
+        # DB swap still happened
+        session_mgr.end_session.assert_awaited_once()
+        session_mgr.create_session.assert_awaited_once()
+        # But no frame emitted
+        ws.send_json.assert_not_awaited()


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **twelfth sub-extract** from the WS-handler family in server.py (round 4 spillover, after the eleven prior extracts #227-#237).

When Tab5 sends a \`clear\` frame (user hit \"clear chat\"), the server wipes the in-memory pipeline conversation history, ends the current DB session, creates a fresh one, and emits \`session_start\` so Tab5 can switch its chat view. Pre-extract this 33-LOC handler lived inline in \`_handle_ws_voice\`'s cmd_type dispatch.

### Behaviour preserved verbatim

- \`pipeline.clear_history()\` invoked when a pipeline is attached; silently skipped on boot races.
- DB-session swap runs only when both \`session_mgr\` and the current \`session_id\` are available.
- \`session_start\` frame emitted with \`resumed=False\` + \`message_count=0\`.
- ws-closed mid-handler: DB swap still runs (must persist), frame emit is skipped.

### #56 closure pinned

\`session_mgr.create_session()\` returns a single dict — NOT a \`(dict, bool)\` tuple (that's \`get_or_create_session\`). The old tuple-unpack raised ValueError and tore down the WS handler, leaving Tab5 in RECONNECTING with a blank chat view. The single-dict shape is preserved here and pinned by a dedicated test.

### Test coverage

7 tests spanning pipeline-clear branches (attached, no-pipeline boot race), DB-swap branches (full swap with frame emit, no session_mgr, no old session_id), the #56 single-dict contract pin, and the ws-closed mid-handler emit-skip path.

### Diff stats

| Metric | Before | After | Δ |
|---|---|---|---|
| \`server.py\` LOC | 1660 | 1642 | **-18** |
| \`server.py\` LOC (cumulative across 28-PR series, since #211) | 2714 | 1642 | **-39.5%** |

## Test plan

- [x] \`python3 -m pytest tests/test_clear_handler.py -v\` → 7 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → 988 passed, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)