### PR TITLE
refactor(server): extract stop command handler (~30 LOC) to stop_handler module

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -46,6 +46,7 @@ from dragon_voice.ws_keepalive import run_ws_keepalive
 from dragon_voice.binary_frame_dispatch import dispatch_binary_frame
 from dragon_voice.cancel_handler import handle_cancel_command
 from dragon_voice.clear_handler import handle_clear_command
+from dragon_voice.stop_handler import handle_stop_command
 from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
@@ -690,33 +691,23 @@ class VoiceServer:
                                 await pipeline.process_segment()
 
                     elif cmd_type == "stop":
-                        pipeline = conn_state.get("pipeline")
-                        if pipeline:
-                            mode = conn_state.get("mode", "ask")
-                            buf_size = len(pipeline._audio_buffer) + len(pipeline._segment_buffer)
-                            logger.info("Connection %s: stop (mode=%s, buffer=%d bytes)", ws_id, mode, buf_size)
-                            async with conn_lock:  # US-P10: serialize with text
-                                if mode == "dictate":
-                                    transcript = await pipeline.finish_dictation()
-                                    # Auto-save dictation to Dragon notes DB
-                                    if transcript and len(transcript.strip()) > 10 and self._notes_svc:
-                                        try:
-                                            note = await self._notes_svc.create_from_text(
-                                                transcript.strip(), title=""
-                                            )
-                                            logger.info("Auto-created note %s from dictation (%d chars)",
-                                                        note.id, len(transcript))
-                                            if not ws.closed:
-                                                await ws.send_json({
-                                                    "type": "note_created",
-                                                    "note_id": note.id,
-                                                    "title": note.title,
-                                                    "transcript": transcript[:200],
-                                                })
-                                        except Exception as e:
-                                            logger.error("Failed to auto-create dictation note: %s", e)
-                                else:
-                                    await pipeline.start_processing()
+                        # SOLID-audit follow-up: stop chain extracted
+                        # to stop_handler.handle_stop_command.  That
+                        # module owns: pipeline.finish_dictation OR
+                        # start_processing dispatch by mode, the
+                        # >10-char dictation auto-note gate, the
+                        # create_from_text failure swallow, the
+                        # 200-char transcript truncation in the
+                        # note_created frame, and the conn_lock
+                        # serialise (US-P10) with concurrent text
+                        # cmd handlers.
+                        await handle_stop_command(
+                            ws,
+                            ws_id=ws_id,
+                            conn_state=conn_state,
+                            conn_lock=conn_lock,
+                            notes_svc=self._notes_svc,
+                        )
 
                     elif cmd_type == "clear":
                         # SOLID-audit follow-up: clear chain extracted

--- a/dragon_voice/stop_handler.py
+++ b/dragon_voice/stop_handler.py
@@ -1,0 +1,165 @@
+"""Tab5 `stop` WS command handler.
+
+Wave 23 SOLID-audit follow-up — thirteenth sub-extract from
+the WS-handler family in server.py (round 4 spillover, after
+the twelve prior extracts #227-#238).
+
+When Tab5 sends a `stop` frame (mic released after PTT or
+dictation finished), the server has to:
+
+  1. **Dictate mode** — call `pipeline.finish_dictation()` which
+     runs STT + post-processing.  When the transcript is
+     non-trivial (>10 chars), auto-save it as a Dragon note via
+     `notes_svc.create_from_text()` and emit a `note_created`
+     frame so Tab5 can show the freshly-saved note.
+  2. **Ask / other modes** — call `pipeline.start_processing()`
+     which runs the STT → LLM → TTS chain on the buffered audio.
+
+Both branches run inside the per-connection `conn_lock`
+(US-P10) so they serialise against text-cmd processing on the
+same connection.
+
+Pre-extract this 30-LOC handler lived inline in
+`_handle_ws_voice`'s cmd_type dispatch.  Now lives here so
+the dispatch table stays a flat one-liner per command.
+
+## API
+
+```python
+await handle_stop_command(
+    ws,
+    *,
+    ws_id,
+    conn_state,
+    conn_lock,
+    notes_svc,
+) -> None
+```
+
+`conn_lock` is the per-connection `asyncio.Lock` (US-P10).
+`notes_svc` is the NotesService singleton — when missing or
+when the dictation transcript is too short to be useful (≤10
+chars), the note auto-create silently skips.
+
+## Why >10 char transcript gate
+
+Dictation post-processing on a near-empty buffer can produce
+filler like " " or "Uh." or " uhh." after Whisper's silence
+trim.  Persisting these as notes would clutter the notes view
+without value.  The 10-char floor is a proxy for "the user
+actually said something dictatable".
+
+## Why try/except around create_from_text
+
+Note auto-create failure (DB hiccup, embedder timeout) MUST
+NOT fail the stop command — the dictation transcript already
+landed via `finish_dictation`'s `dictation_summary` frame, and
+the note is a "while we're here, also save it" convenience.
+Logged at ERROR for ops visibility but never re-raised.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Optional
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+# Dictation transcripts shorter than this are filler (silence
+# trim residue); skip the note auto-save.
+_MIN_DICTATION_CHARS_FOR_NOTE = 10
+
+
+async def handle_stop_command(
+    ws: web.WebSocketResponse,
+    *,
+    ws_id: str,
+    conn_state: dict,
+    conn_lock: asyncio.Lock,
+    notes_svc: Optional[Any],   # NotesService (Optional in test paths)
+) -> None:
+    """Handle a Tab5 `stop` WS frame.
+
+    No-op when the pipeline isn't attached yet (boot race).
+
+    Mode dispatch:
+      * ``dictate`` → `pipeline.finish_dictation()` + auto-note
+        when transcript is >10 chars and notes_svc is available.
+      * ``ask`` (or anything else) → `pipeline.start_processing()`
+        — runs the STT → LLM → TTS chain on the buffered audio.
+
+    Both branches run inside ``conn_lock`` so they serialise
+    against any concurrent text-cmd handler on the same
+    connection (US-P10).
+    """
+    pipeline = conn_state.get("pipeline")
+    if not pipeline:
+        return
+
+    mode = conn_state.get("mode", "ask")
+    buf_size = (
+        len(pipeline._audio_buffer)
+        + len(pipeline._segment_buffer)
+    )
+    logger.info(
+        "Connection %s: stop (mode=%s, buffer=%d bytes)",
+        ws_id, mode, buf_size,
+    )
+
+    async with conn_lock:  # US-P10: serialise with text
+        if mode == "dictate":
+            transcript = await pipeline.finish_dictation()
+            await _maybe_auto_create_note(
+                ws,
+                transcript=transcript,
+                notes_svc=notes_svc,
+            )
+        else:
+            await pipeline.start_processing()
+
+
+async def _maybe_auto_create_note(
+    ws: web.WebSocketResponse,
+    *,
+    transcript: Optional[str],
+    notes_svc: Optional[Any],
+) -> None:
+    """Auto-save the dictation transcript as a Dragon note +
+    emit `note_created`.  Silently skips on:
+
+      * No transcript / whitespace-only.
+      * Transcript too short (≤10 chars — filler from silence
+        trim).
+      * No notes service available (test path / boot race).
+
+    Failure to create the note is caught + logged at ERROR but
+    never re-raised — the transcript already landed via the
+    pipeline's `dictation_summary` frame; the note is a
+    "while we're here, also save it" convenience.
+    """
+    if not transcript:
+        return
+    stripped = transcript.strip()
+    if len(stripped) <= _MIN_DICTATION_CHARS_FOR_NOTE:
+        return
+    if notes_svc is None:
+        return
+
+    try:
+        note = await notes_svc.create_from_text(stripped, title="")
+        logger.info(
+            "Auto-created note %s from dictation (%d chars)",
+            note.id, len(transcript),
+        )
+        if not ws.closed:
+            await ws.send_json({
+                "type": "note_created",
+                "note_id": note.id,
+                "title": note.title,
+                "transcript": transcript[:200],
+            })
+    except Exception as e:
+        logger.error("Failed to auto-create dictation note: %s", e)

--- a/tests/test_stop_handler.py
+++ b/tests/test_stop_handler.py
@@ -1,0 +1,321 @@
+"""Tests for ``dragon_voice.stop_handler``.
+
+Pin every branch + the >10-char dictation-note gate.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.stop_handler import handle_stop_command
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    ws.send_json = AsyncMock()
+    return ws
+
+
+def _make_pipeline(
+    *,
+    transcript: str = "",
+    audio_buffer_len: int = 0,
+    segment_buffer_len: int = 0,
+) -> MagicMock:
+    p = MagicMock()
+    p._audio_buffer = bytearray(audio_buffer_len)
+    p._segment_buffer = bytearray(segment_buffer_len)
+    p.finish_dictation = AsyncMock(return_value=transcript)
+    p.start_processing = AsyncMock()
+    return p
+
+
+def _make_notes_svc(*, note_id: str = "note-1", title: str = "T") -> MagicMock:
+    svc = MagicMock()
+    note = MagicMock()
+    note.id = note_id
+    note.title = title
+    svc.create_from_text = AsyncMock(return_value=note)
+    return svc
+
+
+# ─── No-pipeline boot race ────────────────────────────────────
+
+
+class TestNoPipeline:
+    @pytest.mark.asyncio
+    async def test_no_pipeline_is_silent_noop(self):
+        ws = _make_ws()
+        await handle_stop_command(
+            ws,
+            ws_id="ws1",
+            conn_state={},  # no pipeline
+            conn_lock=asyncio.Lock(),
+            notes_svc=_make_notes_svc(),
+        )
+        # Nothing happened; no frame.
+        ws.send_json.assert_not_awaited()
+
+
+# ─── Ask mode ─────────────────────────────────────────────────
+
+
+class TestAskMode:
+    @pytest.mark.asyncio
+    async def test_ask_mode_calls_start_processing(self):
+        ws = _make_ws()
+        pipeline = _make_pipeline()
+
+        await handle_stop_command(
+            ws,
+            ws_id="ws2",
+            conn_state={"pipeline": pipeline, "mode": "ask"},
+            conn_lock=asyncio.Lock(),
+            notes_svc=_make_notes_svc(),
+        )
+
+        pipeline.start_processing.assert_awaited_once()
+        pipeline.finish_dictation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unknown_mode_falls_through_to_start_processing(self):
+        """Modes other than 'dictate' default to ask-mode behaviour
+        (including missing or unrecognised values)."""
+        ws = _make_ws()
+        pipeline = _make_pipeline()
+
+        await handle_stop_command(
+            ws,
+            ws_id="ws3",
+            conn_state={"pipeline": pipeline},  # no mode key
+            conn_lock=asyncio.Lock(),
+            notes_svc=_make_notes_svc(),
+        )
+
+        pipeline.start_processing.assert_awaited_once()
+
+
+# ─── Dictate mode ─────────────────────────────────────────────
+
+
+class TestDictateMode:
+    @pytest.mark.asyncio
+    async def test_dictate_mode_calls_finish_dictation(self):
+        ws = _make_ws()
+        pipeline = _make_pipeline(transcript="A long enough transcript")
+
+        await handle_stop_command(
+            ws,
+            ws_id="ws4",
+            conn_state={"pipeline": pipeline, "mode": "dictate"},
+            conn_lock=asyncio.Lock(),
+            notes_svc=_make_notes_svc(),
+        )
+
+        pipeline.finish_dictation.assert_awaited_once()
+        pipeline.start_processing.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dictate_long_transcript_creates_note_and_emits_frame(self):
+        ws = _make_ws()
+        pipeline = _make_pipeline(transcript="This is a real dictation.")
+        notes_svc = _make_notes_svc(note_id="note-42", title="Auto Title")
+
+        await handle_stop_command(
+            ws,
+            ws_id="ws5",
+            conn_state={"pipeline": pipeline, "mode": "dictate"},
+            conn_lock=asyncio.Lock(),
+            notes_svc=notes_svc,
+        )
+
+        notes_svc.create_from_text.assert_awaited_once()
+        ws.send_json.assert_awaited_once()
+        frame = ws.send_json.await_args.args[0]
+        assert frame["type"] == "note_created"
+        assert frame["note_id"] == "note-42"
+        assert frame["title"] == "Auto Title"
+        # Transcript truncated to 200 chars
+        assert frame["transcript"] == "This is a real dictation."
+
+    @pytest.mark.asyncio
+    async def test_dictate_short_transcript_skips_note(self):
+        """≤10 chars → silence-trim residue / filler.  Skip the
+        note auto-save so the notes view doesn't fill with junk."""
+        ws = _make_ws()
+        pipeline = _make_pipeline(transcript="uhh")  # 3 chars
+        notes_svc = _make_notes_svc()
+
+        await handle_stop_command(
+            ws,
+            ws_id="ws6",
+            conn_state={"pipeline": pipeline, "mode": "dictate"},
+            conn_lock=asyncio.Lock(),
+            notes_svc=notes_svc,
+        )
+
+        notes_svc.create_from_text.assert_not_awaited()
+        # No note_created frame
+        ws.send_json.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dictate_whitespace_only_transcript_skips_note(self):
+        ws = _make_ws()
+        pipeline = _make_pipeline(transcript="   \n\t   ")
+        notes_svc = _make_notes_svc()
+
+        await handle_stop_command(
+            ws,
+            ws_id="ws7",
+            conn_state={"pipeline": pipeline, "mode": "dictate"},
+            conn_lock=asyncio.Lock(),
+            notes_svc=notes_svc,
+        )
+
+        notes_svc.create_from_text.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dictate_empty_transcript_skips_note(self):
+        ws = _make_ws()
+        pipeline = _make_pipeline(transcript="")
+        notes_svc = _make_notes_svc()
+
+        await handle_stop_command(
+            ws,
+            ws_id="ws8",
+            conn_state={"pipeline": pipeline, "mode": "dictate"},
+            conn_lock=asyncio.Lock(),
+            notes_svc=notes_svc,
+        )
+
+        notes_svc.create_from_text.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dictate_no_notes_svc_skips_note(self):
+        """No notes service (test path / boot race) → finish_dictation
+        still runs but auto-note silently skips."""
+        ws = _make_ws()
+        pipeline = _make_pipeline(transcript="A long enough transcript")
+
+        await handle_stop_command(
+            ws,
+            ws_id="ws9",
+            conn_state={"pipeline": pipeline, "mode": "dictate"},
+            conn_lock=asyncio.Lock(),
+            notes_svc=None,
+        )
+
+        pipeline.finish_dictation.assert_awaited_once()
+        # No note_created frame
+        ws.send_json.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dictate_create_from_text_failure_is_swallowed(self):
+        """Note auto-create failure (DB hiccup, embedder timeout)
+        MUST NOT fail the stop command — the transcript already
+        landed via the pipeline's dictation_summary frame."""
+        ws = _make_ws()
+        pipeline = _make_pipeline(transcript="This is a real dictation.")
+        notes_svc = MagicMock()
+        notes_svc.create_from_text = AsyncMock(
+            side_effect=RuntimeError("DB down"),
+        )
+
+        # Must NOT raise.
+        await handle_stop_command(
+            ws,
+            ws_id="ws10",
+            conn_state={"pipeline": pipeline, "mode": "dictate"},
+            conn_lock=asyncio.Lock(),
+            notes_svc=notes_svc,
+        )
+
+        # No note_created emitted on the failure path
+        ws.send_json.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dictate_ws_closed_skips_frame_emit_but_creates_note(self):
+        """When ws closes between create_from_text and frame emit,
+        the note is still saved (it's persisted DB state) but the
+        frame isn't sent."""
+        ws = _make_ws(closed=True)
+        pipeline = _make_pipeline(transcript="A long enough transcript")
+        notes_svc = _make_notes_svc()
+
+        await handle_stop_command(
+            ws,
+            ws_id="ws11",
+            conn_state={"pipeline": pipeline, "mode": "dictate"},
+            conn_lock=asyncio.Lock(),
+            notes_svc=notes_svc,
+        )
+
+        # Note still created (DB persistence)
+        notes_svc.create_from_text.assert_awaited_once()
+        # But no frame emitted (ws closed)
+        ws.send_json.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dictate_transcript_truncated_to_200_chars(self):
+        """The note_created frame's transcript is capped at 200
+        chars to keep the WS payload small.  Pin the cap so a
+        future refactor can't accidentally send the full text."""
+        long_transcript = "x" * 500
+        ws = _make_ws()
+        pipeline = _make_pipeline(transcript=long_transcript)
+        notes_svc = _make_notes_svc()
+
+        await handle_stop_command(
+            ws,
+            ws_id="ws12",
+            conn_state={"pipeline": pipeline, "mode": "dictate"},
+            conn_lock=asyncio.Lock(),
+            notes_svc=notes_svc,
+        )
+
+        frame = ws.send_json.await_args.args[0]
+        assert len(frame["transcript"]) == 200
+
+
+# ─── conn_lock serialisation ──────────────────────────────────
+
+
+class TestConnLockHeld:
+    @pytest.mark.asyncio
+    async def test_conn_lock_acquired_during_processing(self):
+        """The lock MUST be held across the start_processing /
+        finish_dictation call so a concurrent text cmd handler
+        can't interleave (US-P10)."""
+        ws = _make_ws()
+        pipeline = _make_pipeline()
+        lock = asyncio.Lock()
+
+        # Hold the lock externally; the handler should wait
+        # for it before calling start_processing.
+        await lock.acquire()
+        call_count = {"n": 0}
+
+        async def _record(*args, **kwargs):
+            call_count["n"] += 1
+
+        pipeline.start_processing.side_effect = _record
+
+        # Schedule the handler — it should block on the lock.
+        task = asyncio.create_task(
+            handle_stop_command(
+                ws,
+                ws_id="ws13",
+                conn_state={"pipeline": pipeline, "mode": "ask"},
+                conn_lock=lock,
+                notes_svc=None,
+            )
+        )
+        await asyncio.sleep(0.01)
+        assert call_count["n"] == 0  # blocked on lock
+
+        lock.release()
+        await task
+        assert call_count["n"] == 1


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **thirteenth sub-extract** from the WS-handler family in server.py (round 4 spillover, after the twelve prior extracts #227-#238).

When Tab5 sends a \`stop\` frame (mic released after PTT or dictation finished), the server runs the right pipeline call based on mode and (for dictation) optionally auto-saves the transcript as a Dragon note. Pre-extract this 30-LOC handler lived inline in \`_handle_ws_voice\`'s cmd_type dispatch.

### Behaviour preserved verbatim

- No-op when pipeline isn't attached yet (boot race)
- Mode dispatch:
  - \`dictate\` → \`pipeline.finish_dictation()\`
  - anything else (incl. missing) → \`pipeline.start_processing()\`
- Both branches run inside \`conn_lock\` (US-P10) so they serialise against concurrent text-cmd handlers
- Dictation auto-note gates: empty / whitespace-only → skip; ≤10-char → skip (silence-trim residue); missing notes_svc → skip
- \`notes_svc.create_from_text\` failure swallowed at ERROR — the transcript already landed via the pipeline's \`dictation_summary\` frame; the note auto-create is a \"while we're here\" convenience
- \`note_created\` frame: truncates transcript to 200 chars to keep the WS payload small (pinned by test)
- ws-closed mid-handler: note still persists to DB (it's fact-of-life) but the frame emit is skipped

### Test coverage

13 tests spanning no-pipeline boot race, ask-mode + unknown-mode-fallthrough → start_processing, dictate happy path, all four note-skip branches (short, whitespace, empty, no notes_svc), create_from_text failure swallow, ws-closed mid-handler frame skip, 200-char truncation pin, and the conn_lock-held-during-processing US-P10 serialisation pin.

### Diff stats

| Metric | Before | After | Δ |
|---|---|---|---|
| \`server.py\` LOC | 1642 | 1633 | **-9** |
| \`server.py\` LOC (cumulative across 29-PR series, since #211) | 2714 | 1633 | **-39.8%** |

## Test plan

- [x] \`python3 -m pytest tests/test_stop_handler.py -v\` → 13 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → **1001 passed**, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)