### PR TITLE
refactor(server): extract pipeline init + local-defaults reset (~50 LOC) to pipeline_init module

### DIFF
--- a/dragon_voice/pipeline_init.py
+++ b/dragon_voice/pipeline_init.py
@@ -1,0 +1,192 @@
+"""Voice pipeline construction + initialise for the register flow.
+
+Wave 23 SOLID-audit follow-up — fourteenth sub-extract from
+the WS-handler family in server.py (round 4 spillover, after
+the thirteen prior extracts #227-#239).
+
+After session_start lands and Tab5 sees the session confirmed,
+the register flow has to:
+
+  1. Reset `conn_config` to local defaults (Tab5 will send a
+     `config_update` immediately with its actual mode, so we
+     avoid initializing cloud backends only to swap them out).
+  2. Construct a `VoicePipeline` with the per-connection deps
+     (audio/event callbacks, conversation engine, session id,
+     media pipeline, backend pool, tool callbacks, surface mgr).
+  3. Call `initialize()` which loads Moonshine STT (~2 s on
+     ARM64) + warms the active TTS backend.
+  4. On init failure, emit a structured `pipeline_init_failed`
+     error event so Tab5 surfaces it in the voice caption.
+
+Pre-extract this 50-LOC chunk lived inline in
+`_handle_register`.  Now lives in its own dedicated module.
+
+## API
+
+```python
+pipeline = await build_and_initialize_pipeline(
+    ws,
+    *,
+    ws_id,
+    conn_config,
+    on_audio,
+    on_event,
+    conversation,
+    session_id,
+    media_pipeline,
+    backend_pool,
+    on_tool_call,
+    on_tool_result,
+    on_tool_error,
+    surface_mgr,
+    safe_send_json,
+)
+```
+
+Returns the live `VoicePipeline` on success, or `None` when
+init failed (caller short-circuits the rest of register).
+
+## Why local-defaults reset
+
+The configured `backend` field could be set to "openrouter" or
+"tinkerclaw" from a prior session's persisted config.  Building
+a Moonshine pipeline by hand would still try to wire the cloud
+STT/TTS even though the active mode is going to be Local on the
+fresh register.  Resetting STT/TTS to "moonshine"/"piper" + the
+LLM backend to its `local_backend` (or "ollama" fallback) means
+the post-register `config_update` from Tab5 is a no-op or a
+clean swap — never a "tear down half-built cloud + build local +
+build cloud again" round-trip.
+
+The condition `backend in ("openrouter", "tinkerclaw")` is
+deliberately narrow: local-but-non-ollama defaults like
+`lmstudio`, `npu_genie`, `dual` (PR #80), `router` (#185) are
+left as-is so the user's custom local config survives the
+reset.
+
+## Failure semantics
+
+Init failure → log at EXCEPTION (operator visible in journal),
+emit `pipeline_init_failed` (FATAL/SESSION) so Tab5 shows the
+banner, return None.  The raw exception text is NOT included in
+the user-facing message — Tab5's caption is 128 chars and we
+don't want Python tracebacks leaking to a non-developer user.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from aiohttp import web
+
+from dragon_voice.config import (
+    SYSTEM_PROMPT_LOCAL,
+    MAX_TOKENS_LOCAL,
+)
+from dragon_voice.errors import Scope, Severity, error_event
+from dragon_voice.pipeline import VoicePipeline
+
+logger = logging.getLogger(__name__)
+
+
+SafeSendJson = Callable[[web.WebSocketResponse, dict], Awaitable[bool]]
+
+
+# Cloud-backend names that trigger the LLM-backend reset.  Local
+# variants (ollama, lmstudio, npu_genie, dual, router) are left
+# as-is so user-customised local fleets survive the register.
+_CLOUD_LLM_BACKENDS = ("openrouter", "tinkerclaw")
+
+
+def _reset_conn_config_to_local_defaults(conn_config: Any) -> None:
+    """Mutate conn_config so the pipeline initialises with local
+    backends.  Tab5's post-register `config_update` will do the
+    actual mode swap — this just avoids building cloud and then
+    tearing it down.
+    """
+    conn_config.stt.backend = "moonshine"
+    conn_config.tts.backend = "piper"
+    if conn_config.llm.backend in _CLOUD_LLM_BACKENDS:
+        # Use the user's `local_backend` preference when set,
+        # else fall back to "ollama" — matches pre-extract.
+        conn_config.llm.backend = conn_config.llm.local_backend or "ollama"
+    conn_config.llm.system_prompt = SYSTEM_PROMPT_LOCAL
+    conn_config.llm.max_tokens = MAX_TOKENS_LOCAL
+
+
+async def build_and_initialize_pipeline(
+    ws: web.WebSocketResponse,
+    *,
+    ws_id: str,
+    conn_config: Any,                # VoiceConfig (deep-copied per connection)
+    on_audio: Callable[[bytes], Awaitable[None]],
+    on_event: Callable[[dict], Awaitable[None]],
+    conversation: Any,               # ConversationEngine
+    session_id: str,
+    media_pipeline: Optional[Any],   # MediaPipeline (Optional in tests)
+    backend_pool: Optional[Any],     # BackendPool (Optional)
+    on_tool_call: Optional[Callable] = None,
+    on_tool_result: Optional[Callable] = None,
+    on_tool_error: Optional[Callable] = None,
+    surface_mgr: Optional[Any] = None,
+    safe_send_json: Optional[SafeSendJson] = None,
+) -> Optional[VoicePipeline]:
+    """Build + initialise a VoicePipeline for a freshly-registered
+    session.  Returns the live pipeline on success, or ``None``
+    when init failed (caller MUST short-circuit the rest of
+    register).
+
+    Always resets ``conn_config`` to local defaults first
+    (see module docstring for the why), so the pipeline starts
+    on Moonshine/Piper/local-LLM regardless of whatever cloud
+    state was carried over from a prior session.
+
+    On init failure: logs the exception (operator visible in
+    journal), emits a FATAL ``pipeline_init_failed`` event so
+    Tab5 surfaces it in the voice caption, returns None.
+
+    Audit A2 (#142): tool callbacks (`on_tool_call`, etc.) are
+    passed through so voice turns surface tool indicators just
+    like text turns do.
+
+    Audit B1 (#165): `surface_mgr` is passed through so the
+    pipeline can gate scheduler-fired widgets behind LLM-token
+    interleave protection.
+    """
+    _reset_conn_config_to_local_defaults(conn_config)
+
+    pipeline = VoicePipeline(
+        conn_config, on_audio, on_event,
+        conversation_engine=conversation,
+        session_id=session_id,
+        media_pipeline=media_pipeline,
+        backend_pool=backend_pool,
+        on_tool_call=on_tool_call,
+        on_tool_result=on_tool_result,
+        on_tool_error=on_tool_error,
+        surface_mgr=surface_mgr,
+    )
+    try:
+        await pipeline.initialize()
+    except Exception:
+        logger.exception("Failed to initialize pipeline for %s", ws_id)
+        if not ws.closed:
+            # Don't leak the raw exception to the user — Tab5
+            # surfaces this in the voice caption.  Operator can
+            # see the actual exception in the journal via the
+            # logger.exception above.
+            err_frame = error_event(
+                code="pipeline_init_failed",
+                message="Voice pipeline failed to start.  Try reconnecting.",
+                severity=Severity.FATAL, scope=Scope.SESSION,
+            )
+            if safe_send_json is not None:
+                await safe_send_json(ws, err_frame)
+            else:
+                # Pre-extract path was raw ws.send_json; preserve
+                # for callers that haven't wired safe_send_json yet.
+                await ws.send_json(err_frame)
+        return None
+
+    logger.info("Pipeline ready for %s", ws_id)
+    return pipeline

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -47,6 +47,7 @@ from dragon_voice.binary_frame_dispatch import dispatch_binary_frame
 from dragon_voice.cancel_handler import handle_cancel_command
 from dragon_voice.clear_handler import handle_clear_command
 from dragon_voice.stop_handler import handle_stop_command
+from dragon_voice.pipeline_init import build_and_initialize_pipeline
 from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
@@ -1000,56 +1001,36 @@ class VoiceServer:
                 safe_send_json=self._safe_send_json,
             )
 
-        # Reset conn_config to local defaults before pipeline init.
-        # Tab5 will immediately send config_update with its actual mode,
-        # so this avoids initializing cloud backends only to swap them out.
-        # Only swap out when the configured backend is a cloud one — local
-        # backends (ollama, lmstudio, npu_genie, dual) are already what
-        # the user wants for mode 0/1, and re-pointing them at "ollama"
-        # silently breaks any local-but-non-ollama default (notably the
-        # dual-model pipeline added in #80).
-        conn_config.stt.backend = "moonshine"
-        conn_config.tts.backend = "piper"
-        if conn_config.llm.backend in ("openrouter", "tinkerclaw"):
-            conn_config.llm.backend = conn_config.llm.local_backend or "ollama"
-        conn_config.llm.system_prompt = SYSTEM_PROMPT_LOCAL
-        conn_config.llm.max_tokens = MAX_TOKENS_LOCAL
-
-        # NOW initialize the voice pipeline (slow: Moonshine load ~2s)
-        # This happens AFTER session_start is sent so Tab5 doesn't timeout.
-        # Audit A2 (#142): pass the per-conn tool callbacks built above so
-        # voice turns surface tool indicators just like text turns do.
-        pipeline = VoicePipeline(
-            conn_config, on_audio, on_event,
-            conversation_engine=self._conversation,
+        # SOLID-audit follow-up: pipeline construction +
+        # local-defaults reset + initialize + failure-emit
+        # extracted to pipeline_init.build_and_initialize_pipeline.
+        # That module owns: cloud-config-leakage protection
+        # (resets stt/tts/llm to local-tier when carrying over
+        # from a prior session), VoicePipeline construction with
+        # all per-connection deps (tool callbacks A2/#142,
+        # surface_mgr B1/#165), and the structured
+        # pipeline_init_failed FATAL emit on init failure.
+        # Returns the live pipeline on success, None on failure.
+        pipeline = await build_and_initialize_pipeline(
+            ws,
+            ws_id=ws_id,
+            conn_config=conn_config,
+            on_audio=on_audio,
+            on_event=on_event,
+            conversation=self._conversation,
             session_id=session_id,
             media_pipeline=self._media_pipeline,
             backend_pool=self._backend_pool,
             on_tool_call=conn_state.get("on_tool_call"),
             on_tool_result=conn_state.get("on_tool_result"),
             on_tool_error=conn_state.get("on_tool_error"),
-            # Audit B1 (#165): surface_mgr lets the pipeline gate
-            # scheduler-fired widgets so they don't interleave with
-            # LLM token frames.
             surface_mgr=self._surface_mgr,
+            safe_send_json=self._safe_send_json,
         )
-        try:
-            await pipeline.initialize()
-        except Exception as e:
-            logger.exception("Failed to initialize pipeline for %s", ws_id)
-            if not ws.closed:
-                # Don't leak the raw exception to the user — Tab5
-                # surfaces this in the voice caption.  Operator can
-                # see the actual `e` in the journal.
-                await ws.send_json(error_event(
-                    code="pipeline_init_failed",
-                    message="Voice pipeline failed to start.  Try reconnecting.",
-                    severity=Severity.FATAL, scope=Scope.SESSION,
-                ))
-            return
+        if pipeline is None:
+            return  # init failed; FATAL frame already emitted
 
         conn_state["pipeline"] = pipeline
-        logger.info("Pipeline ready for %s", ws_id)
 
         # #173 / TinkerTab #262: codec negotiation.  Tab5 advertises
         # capabilities.audio_codec = ["pcm", "opus"]; pick OPUS if both

--- a/tests/test_pipeline_init.py
+++ b/tests/test_pipeline_init.py
@@ -1,0 +1,407 @@
+"""Tests for ``dragon_voice.pipeline_init``.
+
+Pin every branch of the pipeline-build chain so a future
+refactor can't accidentally:
+  * Drop the local-defaults reset (would leave cloud state
+    leaking into the pipeline init)
+  * Leak Python exception text into Tab5's voice caption
+  * Rebuild VoicePipeline with the wrong tool callbacks
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dragon_voice.errors import Scope, Severity
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    ws.send_json = AsyncMock()
+    return ws
+
+
+def _make_safe_send_json() -> AsyncMock:
+    return AsyncMock(return_value=True)
+
+
+def _make_conn_config(
+    *,
+    stt: str = "openrouter",     # cloud — to be reset
+    tts: str = "openrouter",     # cloud — to be reset
+    llm: str = "openrouter",     # cloud — to be reset
+    local_backend: str = "ollama",
+) -> MagicMock:
+    cfg = MagicMock()
+    cfg.stt = MagicMock()
+    cfg.stt.backend = stt
+    cfg.tts = MagicMock()
+    cfg.tts.backend = tts
+    cfg.llm = MagicMock()
+    cfg.llm.backend = llm
+    cfg.llm.local_backend = local_backend
+    cfg.llm.system_prompt = ""
+    cfg.llm.max_tokens = 0
+    return cfg
+
+
+# ─── Local-defaults reset ────────────────────────────────────
+
+
+class TestLocalDefaultsReset:
+    """The cloud-config-leakage protection."""
+
+    @pytest.mark.asyncio
+    async def test_cloud_stt_reset_to_moonshine(self):
+        from dragon_voice.pipeline_init import build_and_initialize_pipeline
+        cfg = _make_conn_config(stt="openrouter")
+        with patch(
+            "dragon_voice.pipeline_init.VoicePipeline"
+        ) as VP:
+            VP.return_value.initialize = AsyncMock()
+            await build_and_initialize_pipeline(
+                _make_ws(),
+                ws_id="ws1",
+                conn_config=cfg,
+                on_audio=AsyncMock(),
+                on_event=AsyncMock(),
+                conversation=MagicMock(),
+                session_id="s",
+                media_pipeline=None,
+                backend_pool=None,
+            )
+        assert cfg.stt.backend == "moonshine"
+
+    @pytest.mark.asyncio
+    async def test_cloud_tts_reset_to_piper(self):
+        from dragon_voice.pipeline_init import build_and_initialize_pipeline
+        cfg = _make_conn_config(tts="openrouter")
+        with patch("dragon_voice.pipeline_init.VoicePipeline") as VP:
+            VP.return_value.initialize = AsyncMock()
+            await build_and_initialize_pipeline(
+                _make_ws(),
+                ws_id="ws2",
+                conn_config=cfg,
+                on_audio=AsyncMock(),
+                on_event=AsyncMock(),
+                conversation=MagicMock(),
+                session_id="s",
+                media_pipeline=None,
+                backend_pool=None,
+            )
+        assert cfg.tts.backend == "piper"
+
+    @pytest.mark.asyncio
+    async def test_cloud_llm_reset_to_local_backend(self):
+        from dragon_voice.pipeline_init import build_and_initialize_pipeline
+        cfg = _make_conn_config(llm="openrouter", local_backend="lmstudio")
+        with patch("dragon_voice.pipeline_init.VoicePipeline") as VP:
+            VP.return_value.initialize = AsyncMock()
+            await build_and_initialize_pipeline(
+                _make_ws(),
+                ws_id="ws3",
+                conn_config=cfg,
+                on_audio=AsyncMock(),
+                on_event=AsyncMock(),
+                conversation=MagicMock(),
+                session_id="s",
+                media_pipeline=None,
+                backend_pool=None,
+            )
+        assert cfg.llm.backend == "lmstudio"
+
+    @pytest.mark.asyncio
+    async def test_cloud_llm_with_no_local_backend_falls_back_to_ollama(self):
+        from dragon_voice.pipeline_init import build_and_initialize_pipeline
+        cfg = _make_conn_config(llm="tinkerclaw", local_backend="")
+        with patch("dragon_voice.pipeline_init.VoicePipeline") as VP:
+            VP.return_value.initialize = AsyncMock()
+            await build_and_initialize_pipeline(
+                _make_ws(),
+                ws_id="ws4",
+                conn_config=cfg,
+                on_audio=AsyncMock(),
+                on_event=AsyncMock(),
+                conversation=MagicMock(),
+                session_id="s",
+                media_pipeline=None,
+                backend_pool=None,
+            )
+        assert cfg.llm.backend == "ollama"
+
+    @pytest.mark.asyncio
+    async def test_local_llm_left_alone(self):
+        """Critical pin (#80 lesson): non-ollama local backends
+        like `dual` or `router` MUST NOT be silently reset to
+        ollama just because we're hitting the local-defaults code
+        path.  The cloud-backend gate is intentionally narrow."""
+        from dragon_voice.pipeline_init import build_and_initialize_pipeline
+        cfg = _make_conn_config(llm="dual")
+        with patch("dragon_voice.pipeline_init.VoicePipeline") as VP:
+            VP.return_value.initialize = AsyncMock()
+            await build_and_initialize_pipeline(
+                _make_ws(),
+                ws_id="ws5",
+                conn_config=cfg,
+                on_audio=AsyncMock(),
+                on_event=AsyncMock(),
+                conversation=MagicMock(),
+                session_id="s",
+                media_pipeline=None,
+                backend_pool=None,
+            )
+        # `dual` is local — must survive the reset.
+        assert cfg.llm.backend == "dual"
+
+    @pytest.mark.asyncio
+    async def test_router_local_backend_left_alone(self):
+        """`router` (multi-model fleet, #185) is a local-tier
+        backend — must NOT be reset."""
+        from dragon_voice.pipeline_init import build_and_initialize_pipeline
+        cfg = _make_conn_config(llm="router")
+        with patch("dragon_voice.pipeline_init.VoicePipeline") as VP:
+            VP.return_value.initialize = AsyncMock()
+            await build_and_initialize_pipeline(
+                _make_ws(),
+                ws_id="ws6",
+                conn_config=cfg,
+                on_audio=AsyncMock(),
+                on_event=AsyncMock(),
+                conversation=MagicMock(),
+                session_id="s",
+                media_pipeline=None,
+                backend_pool=None,
+            )
+        assert cfg.llm.backend == "router"
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_and_max_tokens_set_to_local_defaults(self):
+        from dragon_voice.config import (
+            SYSTEM_PROMPT_LOCAL,
+            MAX_TOKENS_LOCAL,
+        )
+        from dragon_voice.pipeline_init import build_and_initialize_pipeline
+        cfg = _make_conn_config()
+        with patch("dragon_voice.pipeline_init.VoicePipeline") as VP:
+            VP.return_value.initialize = AsyncMock()
+            await build_and_initialize_pipeline(
+                _make_ws(),
+                ws_id="ws7",
+                conn_config=cfg,
+                on_audio=AsyncMock(),
+                on_event=AsyncMock(),
+                conversation=MagicMock(),
+                session_id="s",
+                media_pipeline=None,
+                backend_pool=None,
+            )
+        assert cfg.llm.system_prompt == SYSTEM_PROMPT_LOCAL
+        assert cfg.llm.max_tokens == MAX_TOKENS_LOCAL
+
+
+# ─── Happy path ──────────────────────────────────────────────
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_initialised_pipeline(self):
+        from dragon_voice.pipeline_init import build_and_initialize_pipeline
+        with patch("dragon_voice.pipeline_init.VoicePipeline") as VP:
+            inst = MagicMock()
+            inst.initialize = AsyncMock()
+            VP.return_value = inst
+
+            result = await build_and_initialize_pipeline(
+                _make_ws(),
+                ws_id="ws8",
+                conn_config=_make_conn_config(),
+                on_audio=AsyncMock(),
+                on_event=AsyncMock(),
+                conversation=MagicMock(),
+                session_id="sess",
+                media_pipeline=None,
+                backend_pool=None,
+            )
+
+        assert result is inst
+        inst.initialize.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_voicepipeline_constructed_with_tool_callbacks(self):
+        """Audit A2 (#142): tool callbacks must reach the pipeline
+        constructor so voice turns surface tool indicators."""
+        from dragon_voice.pipeline_init import build_and_initialize_pipeline
+        on_call = MagicMock()
+        on_result = MagicMock()
+        on_error = MagicMock()
+
+        with patch("dragon_voice.pipeline_init.VoicePipeline") as VP:
+            VP.return_value.initialize = AsyncMock()
+            await build_and_initialize_pipeline(
+                _make_ws(),
+                ws_id="ws9",
+                conn_config=_make_conn_config(),
+                on_audio=AsyncMock(),
+                on_event=AsyncMock(),
+                conversation=MagicMock(),
+                session_id="sess",
+                media_pipeline=None,
+                backend_pool=None,
+                on_tool_call=on_call,
+                on_tool_result=on_result,
+                on_tool_error=on_error,
+            )
+
+        kwargs = VP.call_args.kwargs
+        assert kwargs["on_tool_call"] is on_call
+        assert kwargs["on_tool_result"] is on_result
+        assert kwargs["on_tool_error"] is on_error
+
+    @pytest.mark.asyncio
+    async def test_voicepipeline_constructed_with_surface_mgr(self):
+        """Audit B1 (#165): surface_mgr must reach the pipeline so
+        scheduler-fired widgets gate behind LLM-token interleave
+        protection."""
+        from dragon_voice.pipeline_init import build_and_initialize_pipeline
+        surface_mgr = MagicMock()
+
+        with patch("dragon_voice.pipeline_init.VoicePipeline") as VP:
+            VP.return_value.initialize = AsyncMock()
+            await build_and_initialize_pipeline(
+                _make_ws(),
+                ws_id="ws10",
+                conn_config=_make_conn_config(),
+                on_audio=AsyncMock(),
+                on_event=AsyncMock(),
+                conversation=MagicMock(),
+                session_id="sess",
+                media_pipeline=None,
+                backend_pool=None,
+                surface_mgr=surface_mgr,
+            )
+
+        assert VP.call_args.kwargs["surface_mgr"] is surface_mgr
+
+
+# ─── Init failure ───────────────────────────────────────────
+
+
+class TestInitFailure:
+    @pytest.mark.asyncio
+    async def test_init_failure_emits_pipeline_init_failed_and_returns_none(self):
+        from dragon_voice.pipeline_init import build_and_initialize_pipeline
+        ws = _make_ws()
+        send = _make_safe_send_json()
+
+        with patch("dragon_voice.pipeline_init.VoicePipeline") as VP:
+            VP.return_value.initialize = AsyncMock(
+                side_effect=RuntimeError("Moonshine OOM"),
+            )
+            result = await build_and_initialize_pipeline(
+                ws,
+                ws_id="ws11",
+                conn_config=_make_conn_config(),
+                on_audio=AsyncMock(),
+                on_event=AsyncMock(),
+                conversation=MagicMock(),
+                session_id="s",
+                media_pipeline=None,
+                backend_pool=None,
+                safe_send_json=send,
+            )
+
+        assert result is None
+        send.assert_awaited_once()
+        frame = send.await_args.args[1]
+        assert frame["code"] == "pipeline_init_failed"
+        assert frame["severity"] == Severity.FATAL.value
+        assert frame["scope"] == Scope.SESSION.value
+
+    @pytest.mark.asyncio
+    async def test_error_message_does_not_leak_python_exception_text(self):
+        """Pin: the user-facing message MUST NOT be `str(e)`.
+        Tab5's caption is 128 chars and we don't want Python
+        tracebacks reaching a non-developer user."""
+        from dragon_voice.pipeline_init import build_and_initialize_pipeline
+        ws = _make_ws()
+        send = _make_safe_send_json()
+
+        with patch("dragon_voice.pipeline_init.VoicePipeline") as VP:
+            VP.return_value.initialize = AsyncMock(
+                side_effect=IndexError("list index out of range"),
+            )
+            await build_and_initialize_pipeline(
+                ws,
+                ws_id="ws12",
+                conn_config=_make_conn_config(),
+                on_audio=AsyncMock(),
+                on_event=AsyncMock(),
+                conversation=MagicMock(),
+                session_id="s",
+                media_pipeline=None,
+                backend_pool=None,
+                safe_send_json=send,
+            )
+
+        frame = send.await_args.args[1]
+        assert "list index out of range" not in frame["message"]
+        assert "Voice pipeline failed to start" in frame["message"]
+
+    @pytest.mark.asyncio
+    async def test_init_failure_with_closed_ws_skips_emit(self):
+        from dragon_voice.pipeline_init import build_and_initialize_pipeline
+        ws = _make_ws(closed=True)
+        send = _make_safe_send_json()
+
+        with patch("dragon_voice.pipeline_init.VoicePipeline") as VP:
+            VP.return_value.initialize = AsyncMock(
+                side_effect=RuntimeError("boom"),
+            )
+            result = await build_and_initialize_pipeline(
+                ws,
+                ws_id="ws13",
+                conn_config=_make_conn_config(),
+                on_audio=AsyncMock(),
+                on_event=AsyncMock(),
+                conversation=MagicMock(),
+                session_id="s",
+                media_pipeline=None,
+                backend_pool=None,
+                safe_send_json=send,
+            )
+
+        assert result is None
+        send.assert_not_awaited()
+        ws.send_json.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_init_failure_with_no_safe_send_json_uses_raw_ws(self):
+        """Backward-compat: callers that haven't wired
+        safe_send_json yet still get the error frame via raw
+        ws.send_json (preserves pre-extract behaviour)."""
+        from dragon_voice.pipeline_init import build_and_initialize_pipeline
+        ws = _make_ws()
+
+        with patch("dragon_voice.pipeline_init.VoicePipeline") as VP:
+            VP.return_value.initialize = AsyncMock(
+                side_effect=RuntimeError("boom"),
+            )
+            result = await build_and_initialize_pipeline(
+                ws,
+                ws_id="ws14",
+                conn_config=_make_conn_config(),
+                on_audio=AsyncMock(),
+                on_event=AsyncMock(),
+                conversation=MagicMock(),
+                session_id="s",
+                media_pipeline=None,
+                backend_pool=None,
+                # no safe_send_json
+            )
+
+        assert result is None
+        ws.send_json.assert_awaited_once()
+        frame = ws.send_json.await_args.args[0]
+        assert frame["code"] == "pipeline_init_failed"


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **fourteenth sub-extract** from the WS-handler family in server.py (round 4 spillover, after the thirteen prior extracts #227-#239). First slice from \`_handle_register\` since round 3 closed out #222-#226.

The post-session_start chunk of \`_handle_register\` (50 LOC) handled the cloud-config-leakage protection + VoicePipeline construction + initialize + structured failure emit.

### Behaviour preserved verbatim

**Local-defaults reset** (cloud-config-leakage protection):
- STT/TTS reset to moonshine/piper unconditionally
- LLM backend reset to \`local_backend or \"ollama\"\` ONLY when current backend is openrouter or tinkerclaw (cloud)
- Local-but-non-ollama backends (lmstudio, npu_genie, dual, router) left as-is (#80 dual-pipeline + #185 router pin)
- system_prompt set to SYSTEM_PROMPT_LOCAL
- max_tokens set to MAX_TOKENS_LOCAL

**VoicePipeline construction** with all per-connection deps:
- on_audio + on_event callbacks
- conversation engine + session_id + media_pipeline + backend_pool
- Audit A2 (#142) tool callbacks pass-through
- Audit B1 (#165) surface_mgr pass-through

**Failure semantics:**
- \`initialize()\` failure → log at EXCEPTION (operator visible), emit FATAL \`pipeline_init_failed\` event (Phase 3 γ1 — message NEVER leaks Python exception text), return None
- ws-closed mid-failure: skip the emit but still return None

### API improvement

Returns \`Optional[VoicePipeline]\` (None on failure) so the caller can short-circuit cleanly. No more inline try/except + early-return scaffolding.

### Test coverage

14 tests spanning:
- Local-defaults reset (cloud STT/TTS/LLM all get reset; local backends preserved; system_prompt + max_tokens set)
- Happy path (returns pipeline, constructor receives tool callbacks + surface_mgr)
- Init failure (emits FATAL event, message doesn't leak exception text, ws-closed skip, raw-ws fallback when no safe_send_json)

### Diff stats

| Metric | Before | After | Δ |
|---|---|---|---|
| \`server.py\` LOC | 1633 | 1614 | **-19** |
| \`server.py\` LOC (cumulative across 30-PR series, since #211) | 2714 | 1614 | **-40.5%** |

## Test plan

- [x] \`python3 -m pytest tests/test_pipeline_init.py -v\` → 14 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → 1015 passed, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)