### PR TITLE
refactor(server): extract register-time codec negotiation (~24 LOC) into codec_negotiation module

### DIFF
--- a/dragon_voice/codec_negotiation.py
+++ b/dragon_voice/codec_negotiation.py
@@ -1,41 +1,43 @@
-"""Audio codec negotiation — handles `config_update` frames that
-include an `audio_uplink_codec` field for mid-session codec swap.
+"""Audio codec negotiation — register-time + mid-session paths.
 
-Wave 23 SOLID-audit follow-up — fifth sub-handler extract from
-`_handle_config_update` (after vision_capability #214,
-cap_downgrade #215, config_swap #216, config_swap_guards #217).
+Wave 23 SOLID-audit follow-up.  Two sibling functions:
 
-## What this does
+  * `negotiate_uplink_codec_at_register` — initial pick from the
+    capabilities list Tab5 advertises in its `register` frame.
+    Picks the best mutual codec (e.g. opus when both sides
+    support it) and tells Tab5 if the result is non-default.
+    Originally PR #173 / TinkerTab #262; extracted from
+    `_handle_register` in the round-4 spillover (PR #241).
 
-Tab5 may send a `config_update` with `audio_uplink_codec` to swap
-the uplink codec mid-session (e.g. from a Settings toggle).  This
-module:
+  * `maybe_swap_uplink_codec` — handles `config_update` frames
+    with an `audio_uplink_codec` field for mid-session codec
+    swap (e.g. from a Settings toggle).  Originally PR #218
+    sub-extract from `_handle_config_update`.
 
-  1. Parses the codec from the WS frame (with backward-compat
-     alias `audio_codec`).
-  2. Calls `pipeline.set_uplink_codec(...)` to apply it on the
-     active pipeline.
-  3. Sends a confirmation `config_update` echoing the codec that
-     was *actually* applied.
-
-The "actually applied" piece matters for fallback observability:
-if Tab5 requests `opus` but Dragon doesn't have libopus available,
-`set_uplink_codec` falls back to `pcm` and the client needs to
-know.
+Both share the "ACK with the codec that was actually applied"
+contract — if Tab5 requests `opus` but Dragon falls back to
+`pcm` (libopus missing), the client needs to know.
 
 ## Failure isolation
 
-If no pipeline is wired yet (boot race) the function is a no-op.
-The `safe_send_json` callable is passed in (DIP) — same shape as
-the other extracted modules.
+* `negotiate_uplink_codec_at_register`: any exception in the
+  whole chain (import, negotiate, set, send) is logged at
+  EXCEPTION but never re-raised — codec negotiation is a
+  voice-quality optimisation, not session-correctness.  The
+  pipeline starts on PCM if the negotiation fails.
+* `maybe_swap_uplink_codec`: silent no-op when no pipeline is
+  wired yet (boot race) or no codec is in the cmd.
+
+The `safe_send_json` callable is passed in (DIP) — same shape
+as the other extracted modules.
 
 ## Why a separate module
 
 Codec negotiation is a different axis of change than backend
-selection (PR 216), validation guards (PR 217), and per-mode UX
-notifications (vision/cap_downgrade).  It can grow independently
-to handle Opus capability ACKs, downlink codec negotiation, etc.
-without touching the WS dispatcher.
+selection (PR #216), validation guards (PR #217), and per-mode
+UX notifications (vision/cap_downgrade).  It can grow
+independently to handle Opus capability ACKs, downlink codec
+negotiation, etc. without touching the WS dispatcher.
 
 Refs: PR #173, TinkerTab #262 (initial codec-swap protocol).
 """
@@ -60,6 +62,68 @@ def _extract_codec_from_cmd(cmd: dict) -> Optional[str]:
     `audio_codec` alias for backward compat with older Tab5
     firmware.  Returns None when neither is present."""
     return cmd.get("audio_uplink_codec") or cmd.get("audio_codec")
+
+
+async def negotiate_uplink_codec_at_register(
+    ws: web.WebSocketResponse,
+    *,
+    pipeline: Any,                       # VoicePipeline
+    capabilities: Optional[dict],        # `register.capabilities` block
+    device_id: str,
+    safe_send_json: SafeSendJson,
+) -> None:
+    """Pick the best mutual uplink codec from Tab5's capability
+    advertisement and apply it to the pipeline.  Sends Tab5 a
+    `config_update` frame ONLY when the chosen codec is
+    non-default (i.e. not "pcm") so legacy clients without the
+    capability stay on PCM with no extra round-trip.
+
+    Tab5's `register` frame may include
+    `capabilities.audio_codec = ["pcm", "opus"]`.  We pick the
+    best mutual one via `audio_codec.negotiate_uplink`, apply
+    via `pipeline.set_uplink_codec`, and ACK with the codec that
+    was *actually* applied (which may differ from the request
+    if libopus is missing on Dragon).
+
+    No-op when:
+      * `capabilities` is None or not a dict.
+      * `capabilities["audio_codec"]` is missing or not a list.
+      * The chosen codec is "pcm" (default — no client switch
+        needed).
+      * The WS is closed (the ACK is best-effort).
+
+    Failure isolation: any exception in the whole chain is
+    logged at EXCEPTION but never re-raised — codec negotiation
+    is a voice-quality optimisation, not session-correctness.
+    The pipeline starts on PCM if anything blows up.
+    """
+    try:
+        client_codecs = (
+            capabilities.get("audio_codec")
+            if isinstance(capabilities, dict) else None
+        )
+        if not isinstance(client_codecs, list):
+            return
+
+        # Local import preserves the pre-extract pattern (lazy
+        # so the audio_codec module's import cost only fires when
+        # a client actually sends the capability).
+        from dragon_voice import audio_codec as _ac
+
+        chosen = _ac.negotiate_uplink(client_codecs)
+        applied = pipeline.set_uplink_codec(chosen)
+        logger.info(
+            "Audio codec negotiation %s: client=%s chosen=%s applied=%s",
+            device_id, client_codecs, chosen, applied,
+        )
+        if applied != "pcm" and not ws.closed:
+            await safe_send_json(ws, {
+                "type": "config_update",
+                "audio_uplink_codec": applied,
+                "reason": "codec_negotiation",
+            })
+    except Exception:
+        logger.exception("audio codec negotiation failed (non-fatal)")
 
 
 async def maybe_swap_uplink_codec(

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -22,7 +22,10 @@ from aiohttp import web, WSMsgType
 
 from dragon_voice.backend_swap import swap_pipeline_and_conversation_backends
 from dragon_voice.cap_downgrade import maybe_speak_cap_downgrade_alert
-from dragon_voice.codec_negotiation import maybe_swap_uplink_codec
+from dragon_voice.codec_negotiation import (
+    maybe_swap_uplink_codec,
+    negotiate_uplink_codec_at_register,
+)
 from dragon_voice.config_finalize import (
     apply_swap_config_to_conn,
     persist_session_config_to_db,
@@ -1032,30 +1035,23 @@ class VoiceServer:
 
         conn_state["pipeline"] = pipeline
 
-        # #173 / TinkerTab #262: codec negotiation.  Tab5 advertises
-        # capabilities.audio_codec = ["pcm", "opus"]; pick OPUS if both
-        # sides support it, send a config_update reply telling Tab5 to
-        # switch its encoder.  Backward-compat: legacy clients without
-        # the capability stay on PCM by default — no config_update
-        # needed for them.
-        try:
-            from . import audio_codec as _ac
-            client_codecs = (caps or {}).get("audio_codec") if isinstance(caps, dict) else None
-            if isinstance(client_codecs, list):
-                chosen = _ac.negotiate_uplink(client_codecs)
-                applied = pipeline.set_uplink_codec(chosen)
-                logger.info(
-                    "Audio codec negotiation %s: client=%s chosen=%s applied=%s",
-                    device_id, client_codecs, chosen, applied,
-                )
-                if applied != "pcm" and not ws.closed:
-                    await self._safe_send_json(ws, {
-                        "type": "config_update",
-                        "audio_uplink_codec": applied,
-                        "reason": "codec_negotiation",
-                    })
-        except Exception:
-            logger.exception("audio codec negotiation failed (non-fatal)")
+        # SOLID-audit follow-up: register-time codec negotiation
+        # (#173 / TinkerTab #262) extracted to
+        # codec_negotiation.negotiate_uplink_codec_at_register.
+        # That function picks the best mutual codec from
+        # capabilities.audio_codec, applies it on the pipeline,
+        # and sends config_update only when the result is non-PCM
+        # (so legacy clients without the capability stay on PCM
+        # with no extra round-trip).  Failure-isolated: codec
+        # negotiation is a voice-quality optimisation, never
+        # blocks register.
+        await negotiate_uplink_codec_at_register(
+            ws,
+            pipeline=pipeline,
+            capabilities=caps if isinstance(caps, dict) else None,
+            device_id=device_id,
+            safe_send_json=self._safe_send_json,
+        )
 
     async def _spawn_handler_task(
         self,

--- a/tests/test_codec_negotiation.py
+++ b/tests/test_codec_negotiation.py
@@ -178,3 +178,215 @@ async def test_ws_closed_skips_ack():
 
     pipeline.set_uplink_codec.assert_called_once_with("opus")
     send.assert_not_awaited()
+
+
+# ─── negotiate_uplink_codec_at_register (PR #241) ─────────────
+
+
+from dragon_voice.codec_negotiation import negotiate_uplink_codec_at_register
+
+
+class TestRegisterTimeCodecNego:
+    @pytest.mark.asyncio
+    async def test_opus_capable_client_gets_config_update(self):
+        """Tab5 advertises [pcm, opus] → Dragon picks opus, applies
+        on pipeline, sends config_update so Tab5 switches encoder."""
+        from unittest.mock import patch
+        ws = _make_ws()
+        pipeline = _make_pipeline_returning("opus")
+        send = _make_safe_send_json()
+
+        with patch(
+            "dragon_voice.audio_codec.negotiate_uplink",
+            return_value="opus",
+        ):
+            await negotiate_uplink_codec_at_register(
+                ws,
+                pipeline=pipeline,
+                capabilities={"audio_codec": ["pcm", "opus"]},
+                device_id="dev1",
+                safe_send_json=send,
+            )
+
+        pipeline.set_uplink_codec.assert_called_once_with("opus")
+        send.assert_awaited_once()
+        frame = send.await_args.args[1]
+        assert frame["type"] == "config_update"
+        assert frame["audio_uplink_codec"] == "opus"
+        assert frame["reason"] == "codec_negotiation"
+
+    @pytest.mark.asyncio
+    async def test_pcm_only_client_skips_config_update(self):
+        """Backward-compat: legacy clients without the capability
+        OR clients that only advertise PCM stay on PCM with no
+        config_update round-trip."""
+        from unittest.mock import patch
+        ws = _make_ws()
+        pipeline = _make_pipeline_returning("pcm")
+        send = _make_safe_send_json()
+
+        with patch(
+            "dragon_voice.audio_codec.negotiate_uplink",
+            return_value="pcm",
+        ):
+            await negotiate_uplink_codec_at_register(
+                ws,
+                pipeline=pipeline,
+                capabilities={"audio_codec": ["pcm"]},
+                device_id="dev2",
+                safe_send_json=send,
+            )
+
+        # set_uplink_codec still called (pipeline knows it's PCM)
+        pipeline.set_uplink_codec.assert_called_once_with("pcm")
+        # But no config_update — PCM is the default
+        send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_opus_request_falls_back_to_pcm_no_ack(self):
+        """Tab5 requests opus, Dragon's pipeline.set_uplink_codec
+        falls back to PCM (libopus missing on Dragon).  Result:
+        PCM applied + no config_update emit (since result == pcm)."""
+        from unittest.mock import patch
+        ws = _make_ws()
+        # Pipeline returns "pcm" even though "opus" requested
+        pipeline = _make_pipeline_returning("pcm")
+        send = _make_safe_send_json()
+
+        with patch(
+            "dragon_voice.audio_codec.negotiate_uplink",
+            return_value="opus",
+        ):
+            await negotiate_uplink_codec_at_register(
+                ws,
+                pipeline=pipeline,
+                capabilities={"audio_codec": ["pcm", "opus"]},
+                device_id="dev3",
+                safe_send_json=send,
+            )
+
+        pipeline.set_uplink_codec.assert_called_once_with("opus")
+        send.assert_not_awaited()  # applied=pcm → no client switch
+
+    @pytest.mark.asyncio
+    async def test_no_capabilities_skips(self):
+        ws = _make_ws()
+        pipeline = _make_pipeline_returning("pcm")
+        send = _make_safe_send_json()
+
+        await negotiate_uplink_codec_at_register(
+            ws,
+            pipeline=pipeline,
+            capabilities=None,
+            device_id="dev4",
+            safe_send_json=send,
+        )
+
+        pipeline.set_uplink_codec.assert_not_called()
+        send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_audio_codec_field_skips(self):
+        """Capabilities block exists but `audio_codec` is missing —
+        legacy field set without codec advertisement."""
+        ws = _make_ws()
+        pipeline = _make_pipeline_returning("pcm")
+        send = _make_safe_send_json()
+
+        await negotiate_uplink_codec_at_register(
+            ws,
+            pipeline=pipeline,
+            capabilities={"widgets": {"types": ["live"]}},
+            device_id="dev5",
+            safe_send_json=send,
+        )
+
+        pipeline.set_uplink_codec.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_audio_codec_not_a_list_skips(self):
+        """Defensive: if the field somehow isn't a list (string,
+        dict, etc.), silently skip rather than crashing."""
+        ws = _make_ws()
+        pipeline = _make_pipeline_returning("pcm")
+        send = _make_safe_send_json()
+
+        await negotiate_uplink_codec_at_register(
+            ws,
+            pipeline=pipeline,
+            capabilities={"audio_codec": "opus"},  # string, not list
+            device_id="dev6",
+            safe_send_json=send,
+        )
+
+        pipeline.set_uplink_codec.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_exception_in_negotiate_does_not_propagate(self):
+        """audio_codec.negotiate_uplink could raise; whole chain
+        wrapped in try/except so it never tears down register."""
+        from unittest.mock import patch
+        ws = _make_ws()
+        pipeline = _make_pipeline_returning("pcm")
+        send = _make_safe_send_json()
+
+        with patch(
+            "dragon_voice.audio_codec.negotiate_uplink",
+            side_effect=RuntimeError("malformed"),
+        ):
+            # Must NOT raise.
+            await negotiate_uplink_codec_at_register(
+                ws,
+                pipeline=pipeline,
+                capabilities={"audio_codec": ["pcm", "opus"]},
+                device_id="dev7",
+                safe_send_json=send,
+            )
+
+        send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_exception_in_set_uplink_codec_does_not_propagate(self):
+        from unittest.mock import patch
+        ws = _make_ws()
+        pipeline = MagicMock()
+        pipeline.set_uplink_codec = MagicMock(
+            side_effect=RuntimeError("backend dead"),
+        )
+        send = _make_safe_send_json()
+
+        with patch(
+            "dragon_voice.audio_codec.negotiate_uplink",
+            return_value="opus",
+        ):
+            # Must NOT raise.
+            await negotiate_uplink_codec_at_register(
+                ws,
+                pipeline=pipeline,
+                capabilities={"audio_codec": ["pcm", "opus"]},
+                device_id="dev8",
+                safe_send_json=send,
+            )
+
+    @pytest.mark.asyncio
+    async def test_ws_closed_skips_ack_but_still_sets_codec(self):
+        from unittest.mock import patch
+        ws = _make_ws(closed=True)
+        pipeline = _make_pipeline_returning("opus")
+        send = _make_safe_send_json()
+
+        with patch(
+            "dragon_voice.audio_codec.negotiate_uplink",
+            return_value="opus",
+        ):
+            await negotiate_uplink_codec_at_register(
+                ws,
+                pipeline=pipeline,
+                capabilities={"audio_codec": ["pcm", "opus"]},
+                device_id="dev9",
+                safe_send_json=send,
+            )
+
+        pipeline.set_uplink_codec.assert_called_once_with("opus")
+        # ACK skipped (ws closed)
+        send.assert_not_awaited()


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **fifteenth sub-extract** from the WS-handler family in server.py (round 4 spillover, after the fourteen prior extracts #227-#240).

The register-time codec-negotiation block (#173 / TinkerTab #262) was the last inline chunk at the tail of \`_handle_register\`. Now lives alongside its mid-session sibling \`maybe_swap_uplink_codec\` (PR #218) in the existing \`codec_negotiation\` module.

### Behaviour preserved verbatim

- Pulls \`capabilities.audio_codec\` (legacy clients without the field stay on PCM with no round-trip)
- Defensive: silently skips when capabilities is None / not a dict / audio_codec is not a list
- Calls \`audio_codec.negotiate_uplink\` to pick the best mutual codec
- Applies via \`pipeline.set_uplink_codec\` and emits the \`config_update\` with the *actually applied* codec — handles the libopus-missing fallback case where Tab5 requests opus but Dragon falls back to PCM
- Skip the \`config_update\` emit when applied == \"pcm\" (default — no client switch needed)
- Whole chain wrapped in try/except + EXCEPTION log: codec negotiation is a voice-quality optimisation, NEVER blocks register completion

### Test coverage

9 new tests in \`tests/test_codec_negotiation.py\`:
- Opus-capable client → config_update emitted
- PCM-only client → no config_update
- Opus-requested-but-PCM-fallback (no ack since applied=pcm)
- 3 defensive-skip branches (no caps, no audio_codec field, audio_codec not a list)
- 2 exception-isolation branches (negotiate raises, set_uplink_codec raises)
- ws-closed-skip-ack

### Diff stats

| Metric | Before | After | Δ |
|---|---|---|---|
| \`server.py\` LOC | 1614 | 1610 | **-4** |
| \`server.py\` LOC (cumulative across 31-PR series, since #211) | 2714 | 1610 | **-40.7%** |

## Test plan

- [x] \`python3 -m pytest tests/test_codec_negotiation.py -v\` → 16 passed (7 existing + 9 new)
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → 1024 passed, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)