### PR TITLE
refactor(server): extract config_update rate-limit gate (~22 LOC) to config_update_rate_limit module

### DIFF
--- a/dragon_voice/config_update_rate_limit.py
+++ b/dragon_voice/config_update_rate_limit.py
@@ -1,0 +1,124 @@
+"""Per-connection rate-limit gate for `config_update` WS frames.
+
+Wave 23 SOLID-audit follow-up — seventeenth sub-extract from
+the WS-handler family in server.py (round 4 spillover, after
+the sixteen prior extracts #227-#242).
+
+Each `config_update` from Tab5 can trigger heavy backend init
+(swap STT/TTS/LLM, deep-copy config, persist to DB, etc.).  A
+buggy skill or trigger-happy test harness firing rapid mode
+swaps can stack these and starve the WS read loop.
+
+The rate-limit gate enforces a 0.5 s minimum between
+`config_update` frames per connection.  When a frame arrives
+under that threshold, we emit a structured γ-arch
+`config_update_rate_limited` (TRANSIENT/SESSION) so Tab5
+(γ2-H8) can render a toast like "Slow down — give the swap a
+moment."
+
+Pre-extract this 22-LOC chunk lived inline at the top of
+`_handle_config_update`.  Now lives in its own dedicated module.
+
+## Audit C1 (#137) closure pinned
+
+Pre-fix the gate was a silent `logger.debug` + `return` — Tab5's
+mode-toggle UI sat on its previous local state and the user
+assumed the swap landed.  Now we emit the γ-arch event so Tab5
+can actually surface the rejection.
+
+## API
+
+```python
+allowed = await check_config_update_rate_limit(
+    ws,
+    *,
+    conn_state,
+    ws_id,
+    safe_send_json,
+    min_interval_s=0.5,
+)
+```
+
+Returns `True` when the swap should proceed (caller continues),
+`False` when rate-limited (caller short-circuits — error
+already emitted).
+
+The interval is parameterised with a sensible default (0.5 s)
+so a future config knob can wire in different limits per
+deployment.
+
+## Why state lives on conn_state
+
+The last-update timestamp is stored on `conn_state["_last_config_update_ts"]`
+so it's per-connection (a busy device doesn't throttle a quiet
+one) and follows the connection's lifecycle (no cleanup needed
+on disconnect — conn_state goes away with it).
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Awaitable, Callable
+
+from aiohttp import web
+
+from dragon_voice.errors import Scope, Severity, error_event
+
+logger = logging.getLogger(__name__)
+
+
+SafeSendJson = Callable[[web.WebSocketResponse, dict], Awaitable[bool]]
+
+
+# Default minimum gap between config_update frames per
+# connection.  0.5 s is a balance between letting the user
+# rapid-toggle modes during testing and preventing a buggy
+# skill from storming the swap pipeline.
+_DEFAULT_MIN_INTERVAL_S = 0.5
+
+# conn_state key for the last-update timestamp.  Module-level
+# so a future audit can grep for "config_update_ts" and find
+# every read/write site.
+_LAST_TS_KEY = "_last_config_update_ts"
+
+
+async def check_config_update_rate_limit(
+    ws: web.WebSocketResponse,
+    *,
+    conn_state: Any,                 # ConnState (or compat dict)
+    ws_id: str,
+    safe_send_json: SafeSendJson,
+    min_interval_s: float = _DEFAULT_MIN_INTERVAL_S,
+) -> bool:
+    """Enforce the per-connection rate-limit on `config_update`
+    frames.
+
+    Returns True when the swap should proceed (also stamps
+    `conn_state["_last_config_update_ts"]` with the current
+    monotonic time so the next call can compare).
+
+    Returns False when the call arrived under `min_interval_s`
+    after the previous one.  Emits a γ-arch
+    `config_update_rate_limited` (TRANSIENT/SESSION) so Tab5
+    can render a toast — preserves the audit C1 (#137)
+    closure.
+
+    The error emit is best-effort: skipped when the WS is
+    closed (no point alerting a disconnected client) but
+    rate-limit gate still fires so the caller short-circuits.
+    """
+    now = time.monotonic()
+    last = conn_state.get(_LAST_TS_KEY, 0.0)
+    if now - last < min_interval_s:
+        logger.debug("config_update rate-limited on %s", ws_id)
+        if not ws.closed:
+            await safe_send_json(ws, error_event(
+                code="config_update_rate_limited",
+                message="Mode swap rate-limited — try again in a moment.",
+                severity=Severity.TRANSIENT,
+                scope=Scope.SESSION,
+            ))
+        return False
+
+    conn_state[_LAST_TS_KEY] = now
+    return True

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -33,6 +33,9 @@ from dragon_voice.config_finalize import (
 from dragon_voice.config_swap import select_backends_for_mode
 from dragon_voice.config_swap_guards import validate_config_swap_prereqs
 from dragon_voice.config_update_ack import emit_config_update_ack
+from dragon_voice.config_update_rate_limit import (
+    check_config_update_rate_limit,
+)
 from dragon_voice.conn_state import ConnState
 from dragon_voice.device_upsert import upsert_device_with_collision_guard
 from dragon_voice.session_handshake import (
@@ -1322,29 +1325,21 @@ class VoiceServer:
         """
         ws_id = conn_state.get("ws_id", "?")
 
-        # v4·D audit P1: rate-limit config_update to 2/sec/conn.  A buggy
-        # skill or trigger-happy test harness could storm mode swaps that
-        # each do heavy backend init.
-        #
-        # Audit C1 (#137): pre-fix this was a silent `logger.debug` +
-        # `return` — Tab5's mode-toggle UI sat on its previous local
-        # state and the user assumed the swap landed.  Now we emit a
-        # γ-arch TRANSIENT/SESSION error so Tab5 (γ2-H8) can render a
-        # toast like "Slow down — give the swap a moment."  Defensive:
-        # only emit if the WS is still open.
-        _now_cfg = time.monotonic()
-        _last_cfg = conn_state.get("_last_config_update_ts", 0.0)
-        if _now_cfg - _last_cfg < 0.5:
-            logger.debug("config_update rate-limited on %s", ws_id)
-            if not ws.closed:
-                await self._safe_send_json(ws, error_event(
-                    code="config_update_rate_limited",
-                    message="Mode swap rate-limited — try again in a moment.",
-                    severity=Severity.TRANSIENT,
-                    scope=Scope.SESSION,
-                ))
+        # SOLID-audit follow-up: per-connection rate-limit gate
+        # extracted to
+        # config_update_rate_limit.check_config_update_rate_limit.
+        # That module owns: 0.5 s minimum interval enforcement,
+        # γ-arch TRANSIENT/SESSION emit on block (audit C1 / #137
+        # closure — pre-fix was silent debug log + return), and
+        # the per-connection timestamp stash.  Returns False on
+        # rate-limit; caller short-circuits.
+        if not await check_config_update_rate_limit(
+            ws,
+            conn_state=conn_state,
+            ws_id=ws_id,
+            safe_send_json=self._safe_send_json,
+        ):
             return
-        conn_state["_last_config_update_ts"] = _now_cfg
 
         # Three-tier voice mode: 0=local, 1=hybrid, 2=cloud, 3=tinkerclaw
         voice_mode = cmd.get("voice_mode")

--- a/tests/test_config_update_rate_limit.py
+++ b/tests/test_config_update_rate_limit.py
@@ -1,0 +1,228 @@
+"""Tests for ``dragon_voice.config_update_rate_limit``.
+
+Pin every branch + the audit C1 (#137) closure that the
+rate-limit gate emits a γ-arch event (not silent debug).
+"""
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dragon_voice.config_update_rate_limit import (
+    _DEFAULT_MIN_INTERVAL_S,
+    _LAST_TS_KEY,
+    check_config_update_rate_limit,
+)
+from dragon_voice.errors import Scope, Severity
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    return ws
+
+
+def _make_safe_send_json() -> AsyncMock:
+    return AsyncMock(return_value=True)
+
+
+# ─── Allowed branch ──────────────────────────────────────────
+
+
+class TestAllowedBranch:
+    @pytest.mark.asyncio
+    async def test_first_ever_call_allowed_and_stamps_timestamp(self):
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        conn_state: dict = {}
+
+        result = await check_config_update_rate_limit(
+            ws, conn_state=conn_state, ws_id="ws1",
+            safe_send_json=send,
+        )
+
+        assert result is True
+        assert _LAST_TS_KEY in conn_state
+        assert conn_state[_LAST_TS_KEY] > 0
+        send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_call_after_interval_allowed_and_updates_timestamp(self):
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        # Pre-stamp with a timestamp from "long enough ago"
+        conn_state: dict = {_LAST_TS_KEY: time.monotonic() - 5.0}
+        old_ts = conn_state[_LAST_TS_KEY]
+
+        result = await check_config_update_rate_limit(
+            ws, conn_state=conn_state, ws_id="ws2",
+            safe_send_json=send,
+        )
+
+        assert result is True
+        assert conn_state[_LAST_TS_KEY] > old_ts
+        send.assert_not_awaited()
+
+
+# ─── Rate-limited branch ─────────────────────────────────────
+
+
+class TestRateLimitedBranch:
+    @pytest.mark.asyncio
+    async def test_too_soon_returns_false_emits_error(self):
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        # Pre-stamp with a timestamp from "just now"
+        conn_state: dict = {_LAST_TS_KEY: time.monotonic()}
+        old_ts = conn_state[_LAST_TS_KEY]
+
+        result = await check_config_update_rate_limit(
+            ws, conn_state=conn_state, ws_id="ws3",
+            safe_send_json=send,
+        )
+
+        assert result is False
+        # Timestamp NOT updated (so the original cooldown stays)
+        assert conn_state[_LAST_TS_KEY] == old_ts
+
+        # γ-arch event emitted — audit C1 (#137) closure
+        send.assert_awaited_once()
+        frame = send.await_args.args[1]
+        assert frame["code"] == "config_update_rate_limited"
+        assert frame["severity"] == Severity.TRANSIENT.value
+        assert frame["scope"] == Scope.SESSION.value
+        assert "rate-limited" in frame["message"]
+
+    @pytest.mark.asyncio
+    async def test_rate_limited_with_closed_ws_skips_emit_but_still_returns_false(self):
+        """Disconnected client: no point emitting, but the gate
+        still fires so the caller short-circuits."""
+        ws = _make_ws(closed=True)
+        send = _make_safe_send_json()
+        conn_state: dict = {_LAST_TS_KEY: time.monotonic()}
+
+        result = await check_config_update_rate_limit(
+            ws, conn_state=conn_state, ws_id="ws4",
+            safe_send_json=send,
+        )
+
+        assert result is False
+        send.assert_not_awaited()
+
+
+# ─── Custom interval parameter ───────────────────────────────
+
+
+class TestCustomInterval:
+    @pytest.mark.asyncio
+    async def test_custom_interval_overrides_default(self):
+        """A future config knob can pass a different
+        min_interval_s — pin the parameter wiring."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        # Stamp 0.3 s ago — under default 0.5, over a custom 0.1
+        conn_state: dict = {_LAST_TS_KEY: time.monotonic() - 0.3}
+
+        # Default: blocked
+        result_default = await check_config_update_rate_limit(
+            ws, conn_state=conn_state, ws_id="ws5",
+            safe_send_json=send,
+        )
+        assert result_default is False
+
+        # Custom 0.1 s: allowed
+        # (Reset timestamp because the previous call ran but
+        # didn't update on rate-limit)
+        conn_state[_LAST_TS_KEY] = time.monotonic() - 0.3
+        result_custom = await check_config_update_rate_limit(
+            ws, conn_state=conn_state, ws_id="ws5",
+            safe_send_json=_make_safe_send_json(),
+            min_interval_s=0.1,
+        )
+        assert result_custom is True
+
+
+# ─── Default constant pin ────────────────────────────────────
+
+
+class TestDefaultInterval:
+    def test_default_min_interval_is_500ms(self):
+        """Pin the 0.5 s default — matches pre-extract behaviour
+        and the 2-per-second tolerance v4·D audit P1 set."""
+        assert _DEFAULT_MIN_INTERVAL_S == 0.5
+
+    def test_last_ts_key_constant(self):
+        """conn_state key name is part of the call-site contract
+        — extracted modules and tests reference it directly."""
+        assert _LAST_TS_KEY == "_last_config_update_ts"
+
+
+# ─── Audit C1 (#137) closure pin ─────────────────────────────
+
+
+class TestAuditC1Closure:
+    @pytest.mark.asyncio
+    async def test_emits_gamma_arch_event_not_silent_debug(self):
+        """Pre-fix the rate-limit was a silent `logger.debug` +
+        `return` — Tab5's mode-toggle UI sat on its previous
+        local state and the user assumed the swap landed.  Pin
+        that we emit the γ-arch event so Tab5 can render a toast."""
+        ws = _make_ws()
+        send = _make_safe_send_json()
+        conn_state: dict = {_LAST_TS_KEY: time.monotonic()}
+
+        await check_config_update_rate_limit(
+            ws, conn_state=conn_state, ws_id="audit-c1",
+            safe_send_json=send,
+        )
+
+        # MUST emit something (not silently swallow).
+        send.assert_awaited_once()
+        # MUST be the structured γ-arch event (not a freeform "error"
+        # or "info" payload).
+        frame = send.await_args.args[1]
+        assert frame.get("type") == "error"
+        assert frame.get("code") == "config_update_rate_limited"
+
+
+# ─── Realistic timing test ───────────────────────────────────
+
+
+class TestRealisticTiming:
+    @pytest.mark.asyncio
+    async def test_two_quick_calls_then_wait_then_third_succeeds(self):
+        """Two rapid calls: first allowed, second blocked, then
+        wait 0.6 s and third succeeds."""
+        ws = _make_ws()
+        send_1 = _make_safe_send_json()
+        conn_state: dict = {}
+
+        # First — allowed
+        r1 = await check_config_update_rate_limit(
+            ws, conn_state=conn_state, ws_id="ws6",
+            safe_send_json=send_1,
+        )
+        assert r1 is True
+
+        # Second immediately — blocked
+        send_2 = _make_safe_send_json()
+        r2 = await check_config_update_rate_limit(
+            ws, conn_state=conn_state, ws_id="ws6",
+            safe_send_json=send_2,
+        )
+        assert r2 is False
+        send_2.assert_awaited_once()
+
+        # Simulate 0.6 s passing by rewinding the timestamp
+        conn_state[_LAST_TS_KEY] -= 1.0
+
+        # Third — allowed again
+        send_3 = _make_safe_send_json()
+        r3 = await check_config_update_rate_limit(
+            ws, conn_state=conn_state, ws_id="ws6",
+            safe_send_json=send_3,
+        )
+        assert r3 is True
+        send_3.assert_not_awaited()


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **seventeenth sub-extract** from the WS-handler family in server.py.

The per-connection rate-limit gate at the top of \`_handle_config_update\` (22 LOC) enforces a 0.5 s minimum between mode-swap frames so a buggy skill or trigger-happy test harness can't storm the swap pipeline. Now lives in its own dedicated module.

### Behaviour preserved verbatim

- 0.5 s minimum interval (v4·D audit P1: 2/sec/conn target)
- Per-connection timestamp on \`conn_state[\"_last_config_update_ts\"]\`
- **Audit C1 (#137) closure:** emits γ-arch TRANSIENT/SESSION \`config_update_rate_limited\` event on block (NOT a silent debug log) so Tab5 (γ2-H8) can render a toast
- Best-effort emit: skipped when ws is closed but gate still fires so caller short-circuits

### API improvement

- Returns \`bool\` (True = proceed, False = blocked) instead of the inline \`if .. return\` pattern. Caller is now a clean one-liner short-circuit.
- \`min_interval_s\` is parameterised (default 0.5 s) so a future config knob can wire in different limits per deployment.
- Module-level constants \`_DEFAULT_MIN_INTERVAL_S\` and \`_LAST_TS_KEY\` exposed so tests + other extracted modules can grep for them as the canonical contract.

### Test coverage

9 tests spanning the allowed branch (first ever call, after-interval call), rate-limited branch (too soon returns False + emits γ-arch event, ws-closed skips emit), custom-interval parameter, default-constant pin, the audit C1 closure pin (emits structured event not silent debug), and a realistic two-quick-then-wait timing test.

### Diff stats

| Metric | Before | After | Δ |
|---|---|---|---|
| \`server.py\` LOC | 1610 | 1605 | **-5** |
| \`server.py\` LOC (cumulative across 33-PR series, since #211) | 2714 | 1605 | **-40.9%** |

## Test plan

- [x] \`python3 -m pytest tests/test_config_update_rate_limit.py -v\` → 9 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → 1041 passed, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)