### PR TITLE
refactor(server): extract _handle_disconnect cleanup chain (~65 LOC) to disconnect_handler module

### DIFF
--- a/dragon_voice/disconnect_handler.py
+++ b/dragon_voice/disconnect_handler.py
@@ -1,0 +1,160 @@
+"""Tab5 WS disconnect cleanup chain.
+
+Wave 23 SOLID-audit follow-up — eighteenth sub-extract from
+the WS-handler family in server.py (round 4 spillover, after
+the seventeen prior extracts #227-#243).
+
+When a Tab5 WebSocket disconnects (clean close, transport drop,
+or evicted by P13 stale-conn-eviction), the server has to walk
+a chain of cleanups so nothing leaks past the connection's
+lifetime:
+
+  1. **Cancel bg_tasks** (W14-C06): per-connection background
+     tasks like cap_downgrade speak_system that hold Piper
+     subprocess + TTS lock past WS close.
+  2. **Cancel handler_tasks** (Phase 1 / #91): in-flight per-
+     command tasks (text/media/config) spawned by
+     `_spawn_handler_task`.  Without this, a slow text turn
+     mid-LLM-stream would keep generating + writing to the
+     dead session's DB until naturally complete.
+  3. **Unregister surface** (Phase 4g): drop the session's
+     SurfaceManager registration so skills with stale refs see
+     dropped sends explicitly.
+  4. **Pause session** (NOT end — sessions can be resumed on
+     reconnect via `requested_session_id` in register).
+  5. **Mark device offline** ONLY if no other active connection
+     exists for the same device_id.  Multi-tab / multi-device
+     scenarios where one WS drops but another stays up MUST
+     keep the device marked online.
+  6. **Pipeline shutdown** — release Moonshine/Piper/etc.
+
+Pre-extract this 65-LOC chain lived inline as
+`VoiceServer._handle_disconnect`.  Now lives in its own
+dedicated module with extensive tests.
+
+## API
+
+```python
+await handle_disconnect(
+    conn_state,
+    *,
+    active_connections,
+    session_mgr,
+    db,
+    surface_mgr,
+)
+```
+
+All deps passed in via kwargs (DIP).  Failures along the chain
+are isolated: bg_task/handler_task cancellation never raises;
+DB ops are wrapped in try/except (DB may be closed during
+server shutdown); surface unregister is best-effort; pipeline
+shutdown is whatever the pipeline's own `shutdown()` does.
+
+## Why no return value
+
+Disconnect handlers can't usefully fail back to the caller —
+the WS is already closing.  All recovery has to happen inside
+this function or be logged for ops triage.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_disconnect(
+    conn_state: dict,
+    *,
+    active_connections: dict,
+    session_mgr: Optional[Any],      # SessionManager
+    db: Optional[Any],               # async SQLite layer
+    surface_mgr: Optional[Any],      # SurfaceManager
+) -> None:
+    """Walk the disconnect cleanup chain.
+
+    Steps in order (each is independently failure-isolated):
+      1. Cancel + await bg_tasks (W14-C06)
+      2. Cancel + await handler_tasks (Phase 1 / #91)
+      3. Unregister session surface (Phase 4g)
+      4. Pause session via session_mgr (resumable on reconnect)
+      5. Mark device offline IFF no other active conn for the
+         same device_id (multi-tab safety)
+      6. Pipeline.shutdown()
+
+    The session is paused (not ended) so a Tab5 reconnect
+    within the resume window can pick up where it left off.
+    """
+    session_id = conn_state.get("session_id")
+    device_id = conn_state.get("device_id")
+    ws_id = conn_state.get("ws_id")
+    pipeline = conn_state.get("pipeline")
+
+    # ── 1. bg_tasks (W14-C06) ────────────────────────────────
+    # Per-connection background tasks (e.g. cap_downgrade
+    # speak_system).  Without cancel they hold Piper subproc +
+    # TTS lock past WS close.
+    bg_tasks = conn_state.get("bg_tasks") or set()
+    if bg_tasks:
+        for t in list(bg_tasks):
+            t.cancel()
+        await asyncio.gather(*bg_tasks, return_exceptions=True)
+
+    # ── 2. handler_tasks (Phase 1 / #91) ─────────────────────
+    # In-flight per-command tasks (text/media/config) spawned
+    # by `_spawn_handler_task`.  Without this, a slow text turn
+    # streaming to the LLM when Tab5 disconnects would keep
+    # generating tokens + writing assistant messages to the
+    # now-dead session's DB until naturally complete.
+    handler_tasks = conn_state.get("handler_tasks") or {}
+    live = [t for t in handler_tasks.values() if t and not t.done()]
+    if live:
+        for t in live:
+            t.cancel()
+        await asyncio.gather(*live, return_exceptions=True)
+
+    # ── 3. Unregister surface (Phase 4g) ─────────────────────
+    # Drop the session's surface so skills that kept a reference
+    # to it start seeing dropped sends explicitly rather than
+    # silently writing to a closed WS.
+    if session_id and surface_mgr is not None:
+        try:
+            await surface_mgr.unregister_session(session_id)
+        except Exception:
+            logger.debug("surface unregister failed")
+
+    # ── 4 + 5. Session pause + device offline ────────────────
+    try:
+        if session_id and session_mgr:
+            # Pause not end — Tab5 reconnect with the same
+            # session_id can resume.
+            await session_mgr.pause_session(session_id)
+
+        if device_id and db:
+            # Multi-tab safety: only mark offline when no other
+            # active connection holds the same device_id.
+            other_active = any(
+                c.get("device_id") == device_id and c.get("registered")
+                for cid, c in active_connections.items()
+                if cid != ws_id
+            )
+            if not other_active:
+                await db.set_device_online(device_id, False)
+                await db.add_event(
+                    "device.disconnected", device_id=device_id,
+                    data={"session_id": session_id},
+                )
+    except (RuntimeError, Exception) as e:
+        # DB may be closed during server shutdown — safe to
+        # ignore (the disconnect cleanup runs as the server
+        # winds down too).
+        logger.debug(
+            "handle_disconnect db access failed (shutdown?): %s", e,
+        )
+
+    # ── 6. Pipeline shutdown ─────────────────────────────────
+    if pipeline:
+        await pipeline.shutdown()

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -55,6 +55,7 @@ from dragon_voice.clear_handler import handle_clear_command
 from dragon_voice.stop_handler import handle_stop_command
 from dragon_voice.pipeline_init import build_and_initialize_pipeline
 from dragon_voice.widget_capabilities_init import init_widget_capabilities
+from dragon_voice.disconnect_handler import handle_disconnect as _disconnect_chain
 from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
@@ -1520,70 +1521,22 @@ class VoiceServer:
         )
 
     async def _handle_disconnect(self, conn_state: dict) -> None:
-        """Handle WebSocket disconnect: pause session, mark device offline."""
-        session_id = conn_state.get("session_id")
-        device_id = conn_state.get("device_id")
-        ws_id = conn_state.get("ws_id")
-        pipeline = conn_state.get("pipeline")
+        """Handle WebSocket disconnect: pause session, mark device offline.
 
-        # Wave 14 W14-C06: cancel any per-connection background tasks
-        # (e.g. cap_downgrade speak_system) before we shut down the pipeline
-        # they depend on. Without this, the orphan task holds the Piper
-        # subprocess + TTS lock past WS close.
-        bg_tasks = conn_state.get("bg_tasks") or set()
-        if bg_tasks:
-            for t in list(bg_tasks):
-                t.cancel()
-            await asyncio.gather(*bg_tasks, return_exceptions=True)
-
-        # Phase 1 (issue #91): cancel any in-flight per-command handler
-        # tasks (text/media/config).  These are spawned by
-        # `_spawn_handler_task` and tracked in
-        # `conn_state["handler_tasks"]`.  Without this, a slow text
-        # turn that's still streaming to the LLM when Tab5 disconnects
-        # would keep generating tokens (and writing assistant
-        # messages to the DB on the now-dead session) until naturally
-        # complete.
-        handler_tasks = conn_state.get("handler_tasks") or {}
-        live = [t for t in handler_tasks.values() if t and not t.done()]
-        if live:
-            for t in live:
-                t.cancel()
-            await asyncio.gather(*live, return_exceptions=True)
-
-        # v4·D Phase 4g: unregister the session's surface so skills that
-        # kept a reference to it start seeing dropped sends explicitly.
-        if session_id and self._surface_mgr is not None:
-            try:
-                await self._surface_mgr.unregister_session(session_id)
-            except Exception:
-                logger.debug("surface unregister failed")
-
-        try:
-            # Pause session (not end — it can be resumed)
-            if session_id and self._session_mgr:
-                await self._session_mgr.pause_session(session_id)
-
-            # Mark device offline ONLY if no other active connection for same device.
-            if device_id and self._db:
-                other_active = any(
-                    c.get("device_id") == device_id and c.get("registered")
-                    for cid, c in self._active_connections.items()
-                    if cid != ws_id
-                )
-                if not other_active:
-                    await self._db.set_device_online(device_id, False)
-                    await self._db.add_event(
-                        "device.disconnected", device_id=device_id,
-                        data={"session_id": session_id},
-                    )
-        except (RuntimeError, Exception) as e:
-            # Database may be closed during server shutdown — safe to ignore
-            logger.debug("_handle_disconnect db access failed (shutdown?): %s", e)
-
-        # Shut down pipeline
-        if pipeline:
-            await pipeline.shutdown()
+        SOLID-audit follow-up: full cleanup chain extracted to
+        disconnect_handler.handle_disconnect.  That module owns:
+        bg_task cancel (W14-C06), handler_task cancel (Phase 1
+        / #91), surface unregister (Phase 4g), session pause
+        (NOT end — resumable on reconnect), multi-tab-safe
+        device offline marking, and pipeline shutdown.
+        """
+        await _disconnect_chain(
+            conn_state,
+            active_connections=self._active_connections,
+            session_mgr=self._session_mgr,
+            db=self._db,
+            surface_mgr=self._surface_mgr,
+        )
 
 
 def run_server(config: VoiceConfig) -> None:

--- a/tests/test_disconnect_handler.py
+++ b/tests/test_disconnect_handler.py
@@ -1,0 +1,385 @@
+"""Tests for ``dragon_voice.disconnect_handler``.
+
+Pin every step of the cleanup chain so a future refactor can't
+accidentally drop one of:
+  * bg_task cancel (W14-C06 — Piper subproc would leak)
+  * handler_task cancel (Phase 1 / #91 — slow turn would keep
+    streaming to dead session's DB)
+  * surface unregister (Phase 4g)
+  * session pause (NOT end — must be resumable)
+  * multi-tab safety on device.set_device_online(False)
+  * pipeline shutdown
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.disconnect_handler import handle_disconnect
+
+
+def _make_session_mgr() -> MagicMock:
+    mgr = MagicMock()
+    mgr.pause_session = AsyncMock()
+    return mgr
+
+
+def _make_db() -> MagicMock:
+    db = MagicMock()
+    db.set_device_online = AsyncMock()
+    db.add_event = AsyncMock()
+    return db
+
+
+def _make_surface_mgr() -> MagicMock:
+    mgr = MagicMock()
+    mgr.unregister_session = AsyncMock()
+    return mgr
+
+
+def _make_pipeline() -> MagicMock:
+    p = MagicMock()
+    p.shutdown = AsyncMock()
+    return p
+
+
+def _make_inflight_task() -> asyncio.Task:
+    async def _hang():
+        await asyncio.sleep(60)
+    return asyncio.create_task(_hang())
+
+
+# ─── bg_tasks ────────────────────────────────────────────────
+
+
+class TestBgTasksCancel:
+    @pytest.mark.asyncio
+    async def test_bg_tasks_cancelled_and_awaited(self):
+        t1 = _make_inflight_task()
+        t2 = _make_inflight_task()
+        bg_tasks = {t1, t2}
+        await handle_disconnect(
+            {"bg_tasks": bg_tasks, "session_id": "s"},
+            active_connections={},
+            session_mgr=_make_session_mgr(),
+            db=_make_db(),
+            surface_mgr=None,
+        )
+        assert t1.cancelled()
+        assert t2.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_no_bg_tasks_is_silent_noop(self):
+        await handle_disconnect(
+            {"session_id": "s"},
+            active_connections={},
+            session_mgr=_make_session_mgr(),
+            db=_make_db(),
+            surface_mgr=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_done_bg_tasks_handled_gracefully(self):
+        async def _quick():
+            return "done"
+        finished = asyncio.create_task(_quick())
+        await asyncio.sleep(0)
+        assert finished.done()
+
+        # Must not raise — gather with return_exceptions handles it.
+        await handle_disconnect(
+            {"bg_tasks": {finished}, "session_id": "s"},
+            active_connections={},
+            session_mgr=_make_session_mgr(),
+            db=_make_db(),
+            surface_mgr=None,
+        )
+
+
+# ─── handler_tasks (Phase 1 / #91) ───────────────────────────
+
+
+class TestHandlerTasksCancel:
+    @pytest.mark.asyncio
+    async def test_inflight_handler_tasks_cancelled(self):
+        text_t = _make_inflight_task()
+        media_t = _make_inflight_task()
+        await handle_disconnect(
+            {
+                "handler_tasks": {"text": text_t, "media": media_t},
+                "session_id": "s",
+            },
+            active_connections={},
+            session_mgr=_make_session_mgr(),
+            db=_make_db(),
+            surface_mgr=None,
+        )
+        assert text_t.cancelled()
+        assert media_t.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_done_handler_tasks_skipped(self):
+        async def _quick():
+            return None
+        finished = asyncio.create_task(_quick())
+        await asyncio.sleep(0)
+        await handle_disconnect(
+            {
+                "handler_tasks": {"text": finished, "media": None},
+                "session_id": "s",
+            },
+            active_connections={},
+            session_mgr=_make_session_mgr(),
+            db=_make_db(),
+            surface_mgr=None,
+        )
+        # No assertion — just must not crash on done/None tasks
+
+
+# ─── Surface unregister ──────────────────────────────────────
+
+
+class TestSurfaceUnregister:
+    @pytest.mark.asyncio
+    async def test_surface_unregister_invoked_with_session_id(self):
+        surface = _make_surface_mgr()
+        await handle_disconnect(
+            {"session_id": "sess-A"},
+            active_connections={},
+            session_mgr=_make_session_mgr(),
+            db=_make_db(),
+            surface_mgr=surface,
+        )
+        surface.unregister_session.assert_awaited_once_with("sess-A")
+
+    @pytest.mark.asyncio
+    async def test_no_surface_mgr_skips_unregister(self):
+        # Must not raise.
+        await handle_disconnect(
+            {"session_id": "s"},
+            active_connections={},
+            session_mgr=_make_session_mgr(),
+            db=_make_db(),
+            surface_mgr=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_session_id_skips_unregister(self):
+        surface = _make_surface_mgr()
+        await handle_disconnect(
+            {},  # no session_id
+            active_connections={},
+            session_mgr=_make_session_mgr(),
+            db=_make_db(),
+            surface_mgr=surface,
+        )
+        surface.unregister_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unregister_failure_does_not_propagate(self):
+        surface = MagicMock()
+        surface.unregister_session = AsyncMock(
+            side_effect=RuntimeError("surface dead"),
+        )
+        # Must not raise.
+        await handle_disconnect(
+            {"session_id": "s"},
+            active_connections={},
+            session_mgr=_make_session_mgr(),
+            db=_make_db(),
+            surface_mgr=surface,
+        )
+
+
+# ─── Session pause ───────────────────────────────────────────
+
+
+class TestSessionPause:
+    @pytest.mark.asyncio
+    async def test_session_paused_not_ended(self):
+        """Pin: pause_session is called, NOT end_session.  Tab5
+        must be able to reconnect with the same session_id and
+        resume."""
+        mgr = _make_session_mgr()
+        mgr.end_session = AsyncMock()  # pin: NOT called
+
+        await handle_disconnect(
+            {"session_id": "sess-1", "device_id": "d"},
+            active_connections={},
+            session_mgr=mgr,
+            db=_make_db(),
+            surface_mgr=None,
+        )
+        mgr.pause_session.assert_awaited_once_with("sess-1")
+        mgr.end_session.assert_not_awaited()
+
+
+# ─── Device offline (multi-tab safety) ───────────────────────
+
+
+class TestDeviceOffline:
+    @pytest.mark.asyncio
+    async def test_device_marked_offline_when_no_other_active_conn(self):
+        db = _make_db()
+        await handle_disconnect(
+            {"session_id": "s", "device_id": "tab5-A", "ws_id": "ws-1"},
+            active_connections={},  # no other conns
+            session_mgr=_make_session_mgr(),
+            db=db,
+            surface_mgr=None,
+        )
+        db.set_device_online.assert_awaited_once_with("tab5-A", False)
+        db.add_event.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_device_stays_online_when_another_active_conn_exists(self):
+        """Multi-tab safety: a second WS for the same device must
+        keep the device marked online when one disconnects."""
+        db = _make_db()
+        other_conn = {
+            "device_id": "tab5-A",
+            "registered": True,
+        }
+        await handle_disconnect(
+            {"session_id": "s", "device_id": "tab5-A", "ws_id": "ws-1"},
+            active_connections={"ws-2": other_conn},
+            session_mgr=_make_session_mgr(),
+            db=db,
+            surface_mgr=None,
+        )
+        db.set_device_online.assert_not_awaited()
+        db.add_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unregistered_other_conn_does_not_keep_online(self):
+        """Same device_id but unregistered (e.g. mid-handshake) —
+        does NOT count as an active connection for offline-gate
+        purposes."""
+        db = _make_db()
+        unreg_conn = {"device_id": "tab5-A", "registered": False}
+        await handle_disconnect(
+            {"session_id": "s", "device_id": "tab5-A", "ws_id": "ws-1"},
+            active_connections={"ws-2": unreg_conn},
+            session_mgr=_make_session_mgr(),
+            db=db,
+            surface_mgr=None,
+        )
+        db.set_device_online.assert_awaited_once_with("tab5-A", False)
+
+    @pytest.mark.asyncio
+    async def test_different_device_does_not_keep_online(self):
+        """Another device_id active → first device still goes offline."""
+        db = _make_db()
+        other_conn = {"device_id": "tab5-B", "registered": True}
+        await handle_disconnect(
+            {"session_id": "s", "device_id": "tab5-A", "ws_id": "ws-1"},
+            active_connections={"ws-2": other_conn},
+            session_mgr=_make_session_mgr(),
+            db=db,
+            surface_mgr=None,
+        )
+        db.set_device_online.assert_awaited_once_with("tab5-A", False)
+
+    @pytest.mark.asyncio
+    async def test_no_db_skips_offline(self):
+        # Must not raise.
+        await handle_disconnect(
+            {"session_id": "s", "device_id": "d"},
+            active_connections={},
+            session_mgr=_make_session_mgr(),
+            db=None,
+            surface_mgr=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_db_failure_does_not_propagate(self):
+        """DB may be closed during server shutdown — failures
+        must not propagate (otherwise the disconnect chain
+        breaks mid-walk and pipeline doesn't shut down)."""
+        db = MagicMock()
+        db.set_device_online = AsyncMock(side_effect=RuntimeError("db closed"))
+        db.add_event = AsyncMock()
+        pipeline = _make_pipeline()
+
+        await handle_disconnect(
+            {
+                "session_id": "s", "device_id": "d", "ws_id": "ws",
+                "pipeline": pipeline,
+            },
+            active_connections={},
+            session_mgr=_make_session_mgr(),
+            db=db,
+            surface_mgr=None,
+        )
+        # Pipeline shutdown still ran despite DB failure.
+        pipeline.shutdown.assert_awaited_once()
+
+
+# ─── Pipeline shutdown ───────────────────────────────────────
+
+
+class TestPipelineShutdown:
+    @pytest.mark.asyncio
+    async def test_pipeline_shutdown_invoked(self):
+        pipeline = _make_pipeline()
+        await handle_disconnect(
+            {"session_id": "s", "pipeline": pipeline},
+            active_connections={},
+            session_mgr=_make_session_mgr(),
+            db=_make_db(),
+            surface_mgr=None,
+        )
+        pipeline.shutdown.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_pipeline_silent_skip(self):
+        """Boot race: disconnect arrives before register attached
+        the pipeline.  Must not crash."""
+        await handle_disconnect(
+            {"session_id": "s"},
+            active_connections={},
+            session_mgr=_make_session_mgr(),
+            db=_make_db(),
+            surface_mgr=None,
+        )
+
+
+# ─── End-to-end ──────────────────────────────────────────────
+
+
+class TestEndToEnd:
+    @pytest.mark.asyncio
+    async def test_full_chain_runs_in_order(self):
+        """Pin: every step runs even when no failures along the
+        way — bg cancel → handler cancel → surface unreg →
+        session pause → device offline → pipeline shutdown."""
+        text_t = _make_inflight_task()
+        bg_t = _make_inflight_task()
+        mgr = _make_session_mgr()
+        db = _make_db()
+        surface = _make_surface_mgr()
+        pipeline = _make_pipeline()
+
+        await handle_disconnect(
+            {
+                "session_id": "sess",
+                "device_id": "dev",
+                "ws_id": "ws",
+                "pipeline": pipeline,
+                "bg_tasks": {bg_t},
+                "handler_tasks": {"text": text_t},
+            },
+            active_connections={},
+            session_mgr=mgr,
+            db=db,
+            surface_mgr=surface,
+        )
+
+        assert bg_t.cancelled()
+        assert text_t.cancelled()
+        surface.unregister_session.assert_awaited_once_with("sess")
+        mgr.pause_session.assert_awaited_once_with("sess")
+        db.set_device_online.assert_awaited_once_with("dev", False)
+        pipeline.shutdown.assert_awaited_once()


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **eighteenth sub-extract** from the WS-handler family in server.py.

The full WS-disconnect cleanup chain (65 LOC) lived inline as \`VoiceServer._handle_disconnect\`. Six sequential cleanup steps that all need to run even when one fails — dropping any one of them leaks resources past the connection's lifetime (Piper subproc, DB writes to dead sessions, stale surface refs).

### Behaviour preserved verbatim

1. **bg_task cancel** (W14-C06): per-connection background tasks like \`cap_downgrade speak_system\` that hold Piper subproc + TTS lock past WS close
2. **handler_task cancel** (Phase 1 / #91): in-flight per-command tasks (text/media/config) — without cancel, slow text turns keep streaming + writing to dead session's DB until done
3. **Surface unregister** (Phase 4g): drop session's SurfaceManager registration; failure-isolated at DEBUG
4. **Session pause** (NOT end — must be resumable on reconnect)
5. **Device offline** ONLY when no OTHER active conn exists for the same device_id (multi-tab safety; unregistered conns don't count)
6. **Pipeline shutdown**

Steps 4-6 wrapped in try/except so DB-closed-during-shutdown errors don't break the chain mid-walk. Pipeline shutdown runs even when the DB write failed.

### Test coverage

19 tests across 7 classes spanning:
- bg_task cancel (in-flight, no tasks, done tasks gracefully handled)
- handler_task cancel (in-flight, done skipped)
- Surface unregister (invoked with session_id, no surface_mgr skip, no session_id skip, failure isolation)
- The session.pause-not-end contract pin
- Multi-tab safety matrix (no other conn → offline; other registered conn → stays online; unregistered other conn doesn't count; different device doesn't count; no DB skip; DB failure doesn't break chain)
- Pipeline shutdown (attached, unattached)
- Full end-to-end ordering

### Diff stats

| Metric | Before | After | Δ |
|---|---|---|---|
| \`server.py\` LOC | 1605 | 1558 | **-47** |
| \`server.py\` LOC (cumulative across 34-PR series, since #211) | 2714 | 1558 | **-42.6%** |

## Test plan

- [x] \`python3 -m pytest tests/test_disconnect_handler.py -v\` → 19 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → 1060 passed, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)