### PR TITLE
refactor(server): extract _spawn_handler_task (~80 LOC) to handler_task_spawn module

### DIFF
--- a/dragon_voice/handler_task_spawn.py
+++ b/dragon_voice/handler_task_spawn.py
@@ -1,0 +1,156 @@
+"""Per-connection command-handler task spawning.
+
+Wave 23 SOLID-audit follow-up — nineteenth sub-extract from
+the WS-handler family in server.py (round 4 spillover, after
+the eighteen prior extracts #227-#244).
+
+Phase 1 of the UX-gap remediation (issue #91, see
+docs/UX-GAPS.md): the text/media/config handlers used to be
+awaited inline in the WS read loop, blocking it from receiving
+cancel/ping/voice frames for the full duration of the handler.
+
+This module provides the helper that detaches each handler as
+a tracked asyncio.Task in
+`conn_state["handler_tasks"][slot]` so:
+  * The cancel handler can selectively kill any of them
+    (cancel_handler.py from PR #237).
+  * `_handle_disconnect` can clean them up on WS close
+    (disconnect_handler.py from PR #244).
+
+Pre-extract this 80-LOC helper lived inline as
+`VoiceServer._spawn_handler_task`.  Now lives in its own
+dedicated module.
+
+## API
+
+```python
+await spawn_handler_task(
+    conn_state,
+    slot,
+    coro_func, *args,
+    conn_lock=None,
+    coalesce=False,
+)
+```
+
+Spawns `coro_func(*args)` as a tracked task in
+`conn_state["handler_tasks"][slot]`.
+
+## Coalesce vs. queue semantics
+
+  * `coalesce=False` (default): wait for any in-flight task in
+    the same slot to finish before spawning the new one.
+    Matches Tab5's "+1 QUEUED" stash semantics for text input —
+    a second text frame while the first is mid-LLM-stream
+    queues behind it.
+  * `coalesce=True`: cancel the in-flight task and replace.
+    Matches user intent for `config_update` mode toggles —
+    rapid-fire mode swaps should land the LAST one, not stack
+    them all up.
+
+## Why we swallow exceptions in `_run`
+
+A handler that raises wouldn't be caught by the outer
+`async for msg in ws` loop — that catch is for transport-level
+errors, not handler-level ones.  Propagating would tear down
+the WS read loop.  The handler's own try/except already
+logged the failure; we re-log here at EXCEPTION for
+discoverability and let the task transition to FINISHED
+naturally.
+
+`CancelledError` is re-raised so the task transitions to
+CANCELLED (rather than FINISHED) — this matters for the
+cancel_handler's done() check, which uses cancelled() vs.
+done() distinctions.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+CoroFunc = Callable[..., Awaitable[Any]]
+
+
+async def spawn_handler_task(
+    conn_state: dict,
+    slot: str,
+    coro_func: CoroFunc,
+    *args: Any,
+    conn_lock: Optional[asyncio.Lock] = None,
+    coalesce: bool = False,
+) -> None:
+    """Spawn `coro_func(*args)` as a tracked per-connection task
+    in `conn_state["handler_tasks"][slot]`.
+
+    Coalesce semantics:
+      * `coalesce=False` (default) — wait for any in-flight
+        task in the same slot to finish before spawning the
+        new one.  Preserves text-turn ordering.
+      * `coalesce=True` — cancel the in-flight task and replace.
+        Used for config_update mode toggles where last-write
+        wins.
+
+    Conn lock:
+      * When `conn_lock` is provided, the spawned task acquires
+        it before invoking the handler — preserves US-P10
+        serialisation with the voice path so two text turns
+        can't interleave LLM-state mutations.
+
+    Failure isolation in the spawned task:
+      * `CancelledError` re-raised so the task transitions to
+        CANCELLED (cancel_handler distinguishes cancelled() from
+        done()).
+      * Other exceptions logged at EXCEPTION but NOT re-raised
+        — propagating would tear down the WS read loop.
+    """
+    handler_tasks = conn_state.setdefault("handler_tasks", {})
+    prev = handler_tasks.get(slot)
+    if prev and not prev.done():
+        if coalesce:
+            prev.cancel()
+            try:
+                await prev
+            except (asyncio.CancelledError, Exception):
+                # Cancellation may surface as the underlying
+                # handler's exception; suppressed because we're
+                # about to replace it anyway.
+                pass
+        else:
+            # Wait for the previous handler to finish before
+            # spawning the new one (preserves ordering for
+            # text turns).
+            try:
+                await prev
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    async def _run() -> None:
+        try:
+            if conn_lock is not None:
+                async with conn_lock:
+                    await coro_func(*args)
+            else:
+                await coro_func(*args)
+        except asyncio.CancelledError:
+            # Re-raise so the task transitions to CANCELLED state.
+            # Resource cleanup is the handler's own responsibility;
+            # the cancel cmd path already killed any pipeline TTS
+            # subproc.
+            raise
+        except Exception:
+            # Handler raised — already logged inside the
+            # handler's own try/except.  Don't propagate to the
+            # WS loop or the loop dies on us; the WS catch at
+            # the outer `async for msg in ws` is for transport-
+            # level errors, not handler-level ones.
+            logger.exception(
+                "handler_tasks[%s] raised — task will exit",
+                slot,
+            )
+
+    task = asyncio.create_task(_run(), name=f"ws_handler:{slot}")
+    handler_tasks[slot] = task

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -56,6 +56,7 @@ from dragon_voice.stop_handler import handle_stop_command
 from dragon_voice.pipeline_init import build_and_initialize_pipeline
 from dragon_voice.widget_capabilities_init import init_widget_capabilities
 from dragon_voice.disconnect_handler import handle_disconnect as _disconnect_chain
+from dragon_voice.handler_task_spawn import spawn_handler_task
 from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
@@ -1068,75 +1069,17 @@ class VoiceServer:
     ) -> None:
         """Spawn a per-connection command handler as an asyncio task.
 
-        Phase 1 of the UX-gap remediation (issue #91, see docs/UX-GAPS.md).
-        The text/media/config handlers used to be awaited inline in the
-        WS read loop, blocking it from receiving cancel/ping/voice frames
-        for the full duration of the handler.  This helper detaches them
-        as tracked tasks in `conn_state["handler_tasks"][slot]` so the
-        cancel handler can selectively kill any of them, and so
-        `_handle_disconnect` can clean them up on WS close.
-
-        Args:
-            conn_state: per-connection state dict (lives across the WS handler).
-            slot: name of the task slot ("text", "media", "config").
-            coro_func: the handler coroutine function to invoke.
-            *args: positional args passed to the handler.
-            conn_lock: if provided, acquired inside the spawned task before
-                       calling the handler (preserves prior US-P10 serialization
-                       semantics with the voice path).
-            coalesce: if True, cancel any in-flight task in the same slot
-                      before spawning the new one (last-write-wins — matches
-                      user intent for config_update mode toggles).  If False
-                      (default) the new task simply waits for `prev` to
-                      finish before starting (matches Tab5's "+1 QUEUED"
-                      stash semantics for text input).
+        SOLID-audit follow-up: implementation extracted to
+        handler_task_spawn.spawn_handler_task.  That module owns:
+        the queue-vs-coalesce dispatch, conn_lock acquisition,
+        the cancel/exception isolation in the spawned task, and
+        the task naming.  Wrapper kept for backward compat with
+        existing call sites; could be inlined in a follow-up.
         """
-        handler_tasks = conn_state.setdefault("handler_tasks", {})
-        prev = handler_tasks.get(slot)
-        if prev and not prev.done():
-            if coalesce:
-                prev.cancel()
-                try:
-                    await prev
-                except (asyncio.CancelledError, Exception):
-                    # cancellation may surface as the underlying handler's
-                    # exception; suppressed because we're about to replace
-                    # it anyway.
-                    pass
-            else:
-                # Wait for the previous handler in this slot to finish before
-                # spawning the new one (preserves ordering for text turns).
-                try:
-                    await prev
-                except (asyncio.CancelledError, Exception):
-                    pass
-
-        async def _run() -> None:
-            try:
-                if conn_lock is not None:
-                    async with conn_lock:
-                        await coro_func(*args)
-                else:
-                    await coro_func(*args)
-            except asyncio.CancelledError:
-                # Cancelled mid-handler — let it propagate so the task
-                # transitions to CANCELLED state.  Resource cleanup is
-                # the handler's responsibility (we've already cancelled
-                # any pipeline TTS subprocess in the cancel cmd path).
-                raise
-            except Exception:
-                # Handler raised — already logged inside the handler's
-                # own try/except.  Don't propagate to the WS loop or
-                # the loop dies on us; the WS catch at the outer
-                # `async for msg in ws` is for transport-level errors,
-                # not handler-level ones.
-                logger.exception(
-                    "handler_tasks[%s] raised — task will exit",
-                    slot,
-                )
-
-        task = asyncio.create_task(_run(), name=f"ws_handler:{slot}")
-        handler_tasks[slot] = task
+        await spawn_handler_task(
+            conn_state, slot, coro_func, *args,
+            conn_lock=conn_lock, coalesce=coalesce,
+        )
 
     async def _handle_text(
         self, ws: web.WebSocketResponse, conn_state: dict, cmd: dict

--- a/tests/test_handler_task_spawn.py
+++ b/tests/test_handler_task_spawn.py
@@ -1,0 +1,272 @@
+"""Tests for ``dragon_voice.handler_task_spawn``.
+
+Pin every spawn / coalesce / queue / lock / failure branch.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from dragon_voice.handler_task_spawn import spawn_handler_task
+
+
+# ─── Basic spawn ─────────────────────────────────────────────
+
+
+class TestBasicSpawn:
+    @pytest.mark.asyncio
+    async def test_spawn_creates_tracked_task(self):
+        ran = asyncio.Event()
+
+        async def _handler():
+            ran.set()
+            await asyncio.sleep(0)
+
+        conn_state: dict = {}
+        await spawn_handler_task(conn_state, "text", _handler)
+
+        # Task exists in the slot
+        task = conn_state["handler_tasks"]["text"]
+        assert task is not None
+        # Wait for the spawned task to complete
+        await task
+        assert ran.is_set()
+
+    @pytest.mark.asyncio
+    async def test_handler_args_passed_through(self):
+        captured: list = []
+
+        async def _handler(a, b, c):
+            captured.append((a, b, c))
+
+        conn_state: dict = {}
+        await spawn_handler_task(
+            conn_state, "media", _handler, "x", "y", "z",
+        )
+        await conn_state["handler_tasks"]["media"]
+
+        assert captured == [("x", "y", "z")]
+
+    @pytest.mark.asyncio
+    async def test_task_named_for_slot(self):
+        async def _handler():
+            await asyncio.sleep(0)
+
+        conn_state: dict = {}
+        await spawn_handler_task(conn_state, "config", _handler)
+        task = conn_state["handler_tasks"]["config"]
+        assert task.get_name() == "ws_handler:config"
+        await task
+
+
+# ─── Queue (default coalesce=False) ──────────────────────────
+
+
+class TestQueueSemantic:
+    @pytest.mark.asyncio
+    async def test_second_call_waits_for_first(self):
+        """Default coalesce=False: second call must WAIT for the
+        first to finish.  Preserves text-turn ordering."""
+        log: list[str] = []
+
+        async def _slow():
+            log.append("first-start")
+            await asyncio.sleep(0.02)
+            log.append("first-done")
+
+        async def _fast():
+            log.append("second-start")
+            await asyncio.sleep(0.005)
+            log.append("second-done")
+
+        conn_state: dict = {}
+        await spawn_handler_task(conn_state, "text", _slow)
+        # Tiny pause so _slow gets started
+        await asyncio.sleep(0)
+        # This call must wait for _slow to finish before _fast starts
+        await spawn_handler_task(conn_state, "text", _fast)
+        await conn_state["handler_tasks"]["text"]
+
+        assert log == [
+            "first-start", "first-done", "second-start", "second-done",
+        ]
+
+
+# ─── Coalesce (coalesce=True) ────────────────────────────────
+
+
+class TestCoalesceSemantic:
+    @pytest.mark.asyncio
+    async def test_coalesce_cancels_inflight(self):
+        """coalesce=True: inflight task gets cancelled before
+        the new one runs.  Used for config_update where last-
+        write-wins."""
+        cancelled_log: list[str] = []
+        ran_log: list[str] = []
+
+        async def _slow():
+            try:
+                await asyncio.sleep(10)  # never finishes naturally
+                ran_log.append("slow-finished")
+            except asyncio.CancelledError:
+                cancelled_log.append("slow-cancelled")
+                raise
+
+        async def _new():
+            ran_log.append("new-ran")
+
+        conn_state: dict = {}
+        await spawn_handler_task(conn_state, "config", _slow)
+        await asyncio.sleep(0)
+        # coalesce=True → cancels _slow
+        await spawn_handler_task(
+            conn_state, "config", _new, coalesce=True,
+        )
+        await conn_state["handler_tasks"]["config"]
+
+        assert "slow-cancelled" in cancelled_log
+        assert "slow-finished" not in ran_log
+        assert "new-ran" in ran_log
+
+
+# ─── Conn lock acquisition ───────────────────────────────────
+
+
+class TestConnLockAcquired:
+    @pytest.mark.asyncio
+    async def test_handler_waits_for_conn_lock_when_provided(self):
+        """When conn_lock is provided, the spawned task acquires
+        it before calling the handler.  Pin the US-P10
+        serialisation invariant."""
+        lock = asyncio.Lock()
+        await lock.acquire()
+        ran = asyncio.Event()
+
+        async def _handler():
+            ran.set()
+
+        conn_state: dict = {}
+        await spawn_handler_task(
+            conn_state, "text", _handler, conn_lock=lock,
+        )
+        # _handler hasn't run because lock is held externally
+        await asyncio.sleep(0.005)
+        assert not ran.is_set()
+        # Release → handler proceeds
+        lock.release()
+        await conn_state["handler_tasks"]["text"]
+        assert ran.is_set()
+
+    @pytest.mark.asyncio
+    async def test_no_lock_runs_immediately(self):
+        ran = asyncio.Event()
+
+        async def _handler():
+            ran.set()
+
+        conn_state: dict = {}
+        await spawn_handler_task(conn_state, "text", _handler)
+        await conn_state["handler_tasks"]["text"]
+        assert ran.is_set()
+
+
+# ─── Failure isolation ───────────────────────────────────────
+
+
+class TestFailureIsolation:
+    @pytest.mark.asyncio
+    async def test_handler_exception_does_not_propagate_to_caller(self):
+        """If the handler raises, the WS read loop must NOT see
+        the exception (the spawned task swallows + logs).  Pin
+        so the WS loop stays alive across handler bugs."""
+        async def _broken():
+            raise RuntimeError("handler bug")
+
+        conn_state: dict = {}
+        # Spawning must not raise
+        await spawn_handler_task(conn_state, "text", _broken)
+        # Awaiting the spawned task must not raise either
+        # (the inner _run swallows non-CancelledError)
+        await conn_state["handler_tasks"]["text"]
+
+    @pytest.mark.asyncio
+    async def test_handler_cancellederror_propagates_to_task(self):
+        """CancelledError MUST re-propagate inside the task so
+        the task transitions to CANCELLED state (not FINISHED).
+        cancel_handler relies on cancelled() vs. done() distinction."""
+
+        ready = asyncio.Event()
+
+        async def _hang():
+            ready.set()
+            await asyncio.sleep(60)
+
+        conn_state: dict = {}
+        await spawn_handler_task(conn_state, "text", _hang)
+        # Wait for the handler to actually start
+        await ready.wait()
+
+        task = conn_state["handler_tasks"]["text"]
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        assert task.cancelled()
+
+
+# ─── handler_tasks dict initialised on first spawn ───────────
+
+
+class TestStateInit:
+    @pytest.mark.asyncio
+    async def test_handler_tasks_dict_created_when_missing(self):
+        async def _h():
+            pass
+
+        conn_state: dict = {}  # no handler_tasks yet
+        await spawn_handler_task(conn_state, "text", _h)
+        assert "handler_tasks" in conn_state
+        await conn_state["handler_tasks"]["text"]
+
+    @pytest.mark.asyncio
+    async def test_existing_handler_tasks_preserved(self):
+        """Existing slots in handler_tasks must NOT be wiped by
+        the setdefault."""
+        async def _h():
+            pass
+
+        existing_other_slot = object()  # sentinel value
+        conn_state: dict = {
+            "handler_tasks": {"media": existing_other_slot},
+        }
+        await spawn_handler_task(conn_state, "text", _h)
+        assert conn_state["handler_tasks"]["media"] is existing_other_slot
+        await conn_state["handler_tasks"]["text"]
+
+
+# ─── Done previous task is fine ──────────────────────────────
+
+
+class TestDonePreviousTask:
+    @pytest.mark.asyncio
+    async def test_done_previous_task_does_not_block(self):
+        """Previous task already finished — new spawn doesn't
+        wait/cancel.  Pin the `prev.done()` shortcut."""
+        log: list[str] = []
+
+        async def _quick():
+            log.append("quick-1")
+
+        async def _second():
+            log.append("second")
+
+        conn_state: dict = {}
+        await spawn_handler_task(conn_state, "text", _quick)
+        await conn_state["handler_tasks"]["text"]
+        # First task is done; second should run promptly
+        await spawn_handler_task(conn_state, "text", _second)
+        await conn_state["handler_tasks"]["text"]
+        assert log == ["quick-1", "second"]


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **nineteenth sub-extract** from the WS-handler family in server.py (round 4 spillover, after the eighteen prior extracts #227-#244).

\`_spawn_handler_task\` is the Phase 1 (issue #91) helper that detaches text/media/config command handlers as tracked asyncio.Tasks so the WS read loop can keep receiving cancel/ping/voice frames while a handler is mid-flight. Cancel-side relies on \`conn_state[\"handler_tasks\"][slot]\` (cancel_handler PR #237); disconnect-side cleans up the same slots (disconnect_handler PR #244).

### Behaviour preserved verbatim

- \`coalesce=False\` (default): wait for any in-flight task in the same slot before spawning the new one — preserves text-turn ordering (\"+1 QUEUED\" stash semantics)
- \`coalesce=True\`: cancel the in-flight + replace — used for \`config_update\` mode toggles (last-write wins)
- \`conn_lock\` (when provided) acquired INSIDE the spawned task before invoking the handler — preserves US-P10 serialisation with the voice path
- \`CancelledError\` re-raises so the task transitions to CANCELLED state (cancel_handler distinguishes \`cancelled()\` from \`done()\`)
- Other exceptions logged at EXCEPTION but NOT re-raised — propagating would tear down the WS read loop
- \`task.name = \"ws_handler:{slot}\"\` for journal triage

Wrapper kept on VoiceServer for backward compat with existing call sites; could be inlined in a follow-up since the wrapper adds zero behaviour.

### Test coverage

12 tests across 7 classes spanning basic spawn (task tracked + args passed + named for slot), queue semantic (default coalesce=False — second call waits for first), coalesce semantic (cancels in-flight + new runs), conn_lock acquisition (handler waits for external lock + no-lock runs immediately), failure isolation (handler exception doesn't propagate to caller / CancelledError does propagate to task), state init (handler_tasks dict created if missing + existing slots preserved), and the done-previous-task fast-path.

### Diff stats

| Metric | Before | After | Δ |
|---|---|---|---|
| \`server.py\` LOC | 1558 | 1501 | **-57** |
| \`server.py\` LOC (cumulative across 35-PR series, since #211) | 2714 | 1501 | **-44.7%** |

## Test plan

- [x] \`python3 -m pytest tests/test_handler_task_spawn.py -v\` → 12 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → 1072 passed, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)