### PR TITLE
refactor(server): extract widget_action handler (~20 LOC) to widget_action_handler module

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -57,6 +57,7 @@ from dragon_voice.pipeline_init import build_and_initialize_pipeline
 from dragon_voice.widget_capabilities_init import init_widget_capabilities
 from dragon_voice.disconnect_handler import handle_disconnect as _disconnect_chain
 from dragon_voice.handler_task_spawn import spawn_handler_task
+from dragon_voice.widget_action_handler import handle_widget_action
 from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
@@ -799,24 +800,19 @@ class VoiceServer:
                         )
 
                     elif cmd_type == "widget_action":
-                        # v4·D Phase 4g (audit P0 fix): Tab5 fires this
-                        # when the user taps a prompt choice / live action
-                        # button / list row.  Before this branch existed,
-                        # every interactive widget tap was silently
-                        # dropped into the "Unknown command" logger.
-                        sid = conn_state.get("session_id")
-                        cid = cmd.get("card_id")
-                        ev  = cmd.get("event")
-                        payload = cmd.get("payload") or {}
-                        logger.info("widget_action: session=%s card=%s event=%s",
-                                    sid, cid, ev)
-                        if sid and cid and ev and self._surface_mgr is not None:
-                            try:
-                                await self._surface_mgr.handle_action(
-                                    sid, cid, ev, payload,
-                                )
-                            except Exception:
-                                logger.exception("widget_action dispatch failed")
+                        # SOLID-audit follow-up: widget_action chain
+                        # extracted to widget_action_handler.handle_widget_action.
+                        # That module owns: input field validation
+                        # (session_id / card_id / event present),
+                        # surface_mgr presence guard, dispatch via
+                        # handle_action, and the failure-isolation
+                        # try/except (a buggy skill must NOT tear
+                        # down the WS read loop).
+                        await handle_widget_action(
+                            cmd=cmd,
+                            conn_state=conn_state,
+                            surface_mgr=self._surface_mgr,
+                        )
 
                     elif cmd_type == "config_ack":
                         logger.debug("Connection %s: config_ack %s", ws_id, cmd.get("applied"))

--- a/dragon_voice/widget_action_handler.py
+++ b/dragon_voice/widget_action_handler.py
@@ -1,0 +1,90 @@
+"""Tab5 `widget_action` WS command handler.
+
+Wave 23 SOLID-audit follow-up — twentieth sub-extract from
+the WS-handler family in server.py (round 4 spillover, after
+the nineteen prior extracts #227-#245).
+
+When Tab5 fires `widget_action` (user tapped a prompt choice,
+live action button, or list row), the server forwards the
+event to the SurfaceManager so the originating skill can react.
+
+Pre-extract this 20-LOC handler lived inline in
+`_handle_ws_voice`'s cmd_type dispatch.  Now lives in its own
+dedicated module.
+
+## Audit P0 closure (v4·D Phase 4g)
+
+Pre-fix this branch didn't exist — every interactive widget
+tap was silently dropped into the "Unknown command" logger.
+Skills with prompt widgets appeared broken: the user tapped
+a choice, nothing happened.  This handler closes that gap by
+calling `surface_mgr.handle_action(session_id, card_id, event,
+payload)` so the skill's registered handler fires.
+
+## API
+
+```python
+await handle_widget_action(
+    *,
+    cmd,
+    conn_state,
+    surface_mgr,
+)
+```
+
+The handler is fire-and-forget from the dispatcher's POV —
+SurfaceManager owns the actual delivery to the skill, the
+handler just bridges the WS frame to the manager.
+
+## Failure isolation
+
+`SurfaceManager.handle_action` failures (skill exception, dead
+session, malformed payload) are caught + logged at EXCEPTION
+but never re-raised.  A buggy skill must NOT tear down the WS
+read loop — every other widget on the same surface still works.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_widget_action(
+    *,
+    cmd: dict,
+    conn_state: dict,
+    surface_mgr: Optional[Any],   # SurfaceManager (Optional in tests)
+) -> None:
+    """Handle a Tab5 `widget_action` WS frame.
+
+    Required cmd fields:
+      * `card_id` — the surface card the action targets
+      * `event`   — the action name (skill-defined)
+      * `payload` — optional dict of action-specific data
+
+    No-op when:
+      * Session not yet registered (session_id missing)
+      * card_id or event missing (malformed frame)
+      * surface_mgr unavailable (boot race / test path)
+
+    Failures isolated: SurfaceManager.handle_action exceptions
+    logged at EXCEPTION but never re-raised — a buggy skill
+    must NOT tear down the WS read loop.
+    """
+    sid = conn_state.get("session_id")
+    cid = cmd.get("card_id")
+    ev = cmd.get("event")
+    payload = cmd.get("payload") or {}
+
+    logger.info(
+        "widget_action: session=%s card=%s event=%s",
+        sid, cid, ev,
+    )
+
+    if sid and cid and ev and surface_mgr is not None:
+        try:
+            await surface_mgr.handle_action(sid, cid, ev, payload)
+        except Exception:
+            logger.exception("widget_action dispatch failed")

--- a/tests/test_widget_action_handler.py
+++ b/tests/test_widget_action_handler.py
@@ -1,0 +1,178 @@
+"""Tests for ``dragon_voice.widget_action_handler``.
+
+Pin every guard branch + the audit-P0 (v4·D Phase 4g) closure
+that prompt taps don't get silently dropped into the "Unknown
+command" hole.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.widget_action_handler import handle_widget_action
+
+
+def _make_surface_mgr() -> MagicMock:
+    mgr = MagicMock()
+    mgr.handle_action = AsyncMock()
+    return mgr
+
+
+# ─── Happy path ──────────────────────────────────────────────
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_full_dispatch_to_surface_mgr(self):
+        mgr = _make_surface_mgr()
+        payload = {"choice_id": "yes", "extra": 42}
+
+        await handle_widget_action(
+            cmd={
+                "type": "widget_action",
+                "card_id": "card-123",
+                "event": "choice_picked",
+                "payload": payload,
+            },
+            conn_state={"session_id": "sess-A"},
+            surface_mgr=mgr,
+        )
+
+        mgr.handle_action.assert_awaited_once_with(
+            "sess-A", "card-123", "choice_picked", payload,
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_payload_defaults_to_empty_dict(self):
+        """Tab5 may omit payload for buttons with no data — pin
+        the default-to-{} semantic so SurfaceManager.handle_action
+        never receives None."""
+        mgr = _make_surface_mgr()
+
+        await handle_widget_action(
+            cmd={
+                "card_id": "btn-1",
+                "event": "tap",
+                # no payload
+            },
+            conn_state={"session_id": "s"},
+            surface_mgr=mgr,
+        )
+
+        mgr.handle_action.assert_awaited_once_with("s", "btn-1", "tap", {})
+
+
+# ─── Guard branches ─────────────────────────────────────────
+
+
+class TestGuards:
+    @pytest.mark.asyncio
+    async def test_no_session_id_skips_dispatch(self):
+        """Pre-register widget_action (boot race) — skip silently."""
+        mgr = _make_surface_mgr()
+
+        await handle_widget_action(
+            cmd={"card_id": "c", "event": "e"},
+            conn_state={},  # no session_id
+            surface_mgr=mgr,
+        )
+
+        mgr.handle_action.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_card_id_skips(self):
+        mgr = _make_surface_mgr()
+
+        await handle_widget_action(
+            cmd={"event": "e"},  # no card_id
+            conn_state={"session_id": "s"},
+            surface_mgr=mgr,
+        )
+
+        mgr.handle_action.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_event_skips(self):
+        mgr = _make_surface_mgr()
+
+        await handle_widget_action(
+            cmd={"card_id": "c"},  # no event
+            conn_state={"session_id": "s"},
+            surface_mgr=mgr,
+        )
+
+        mgr.handle_action.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_surface_mgr_skips(self):
+        """Test path / boot race — silent skip when surface_mgr
+        not available."""
+        await handle_widget_action(
+            cmd={"card_id": "c", "event": "e"},
+            conn_state={"session_id": "s"},
+            surface_mgr=None,
+        )
+        # No assertion — must not raise.
+
+
+# ─── Failure isolation ──────────────────────────────────────
+
+
+class TestFailureIsolation:
+    @pytest.mark.asyncio
+    async def test_skill_exception_does_not_propagate(self):
+        """Audit invariant: a buggy skill's handle_action exception
+        MUST NOT tear down the WS read loop.  Pin so a future
+        refactor can't drop the try/except."""
+        mgr = MagicMock()
+        mgr.handle_action = AsyncMock(
+            side_effect=RuntimeError("skill blew up"),
+        )
+
+        # Must NOT raise.
+        await handle_widget_action(
+            cmd={"card_id": "c", "event": "e"},
+            conn_state={"session_id": "s"},
+            surface_mgr=mgr,
+        )
+
+    @pytest.mark.asyncio
+    async def test_skill_exception_still_calls_handle_action(self):
+        """The dispatch attempt fires even if handle_action raises
+        — verify the call was actually made."""
+        mgr = MagicMock()
+        mgr.handle_action = AsyncMock(
+            side_effect=RuntimeError("skill blew up"),
+        )
+
+        await handle_widget_action(
+            cmd={"card_id": "c", "event": "tap"},
+            conn_state={"session_id": "s"},
+            surface_mgr=mgr,
+        )
+
+        mgr.handle_action.assert_awaited_once()
+
+
+# ─── Audit P0 closure pin ────────────────────────────────────
+
+
+class TestAuditP0Closure:
+    @pytest.mark.asyncio
+    async def test_widget_action_actually_dispatches(self):
+        """v4·D Phase 4g audit P0 closure: pre-fix every interactive
+        widget tap was silently dropped into the "Unknown command"
+        logger.  Pin that with valid inputs the handler ACTUALLY
+        forwards to SurfaceManager (not just no-ops at WARN)."""
+        mgr = _make_surface_mgr()
+
+        await handle_widget_action(
+            cmd={"card_id": "prompt-42", "event": "choice_a"},
+            conn_state={"session_id": "live"},
+            surface_mgr=mgr,
+        )
+
+        # The whole point of the branch existing — handle_action
+        # MUST be called (not silently skipped).
+        mgr.handle_action.assert_awaited_once()


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **twentieth sub-extract** from the WS-handler family in server.py.

When Tab5 fires \`widget_action\` (user tapped a prompt choice, live action button, or list row), the server forwards the event to the SurfaceManager so the originating skill can react.

### Behaviour preserved verbatim

- Input field validation: session_id (registered), card_id, event all required — silent skip on any missing
- surface_mgr presence guard (boot race / test path tolerance)
- \`surface_mgr.handle_action(session_id, card_id, event, payload)\` dispatch with payload defaulting to \`{}\` when omitted
- Failure isolation: \`handle_action\` exceptions logged at EXCEPTION but NEVER re-raised — a buggy skill must NOT tear down the WS read loop
- INFO log of session/card/event before dispatch — useful for triage when a skill misbehaves

### Audit P0 closure pinned (v4·D Phase 4g)

Pre-fix this branch didn't exist and every interactive widget tap was silently dropped into the \"Unknown command\" logger — skills with prompt widgets appeared broken (user tapped a choice, nothing happened). Test \`TestAuditP0Closure\` pins that the handler ACTUALLY forwards to SurfaceManager (not just no-ops at WARN) so a future refactor can't regress to the silent-drop state.

### Test coverage

9 tests across 4 classes spanning happy path (full dispatch + payload default to {}), 4 guard branches (no session_id, no card_id, no event, no surface_mgr), 2 failure isolation tests (skill exception doesn't propagate + handle_action still called), and the audit P0 closure pin.

### Diff stats

| Metric | Before | After | Δ |
|---|---|---|---|
| \`server.py\` LOC | 1501 | 1497 | **-4** |
| \`server.py\` LOC (cumulative across 36-PR series, since #211) | 2714 | 1497 | **-44.9%** |

## Test plan

- [x] \`python3 -m pytest tests/test_widget_action_handler.py -v\` → 9 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → 1081 passed, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)