### PR TITLE
refactor(server): extract text-turn precondition + B1 turn-busy bracket (~30 LOC) to text_turn_gate module

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -58,6 +58,7 @@ from dragon_voice.widget_capabilities_init import init_widget_capabilities
 from dragon_voice.disconnect_handler import handle_disconnect as _disconnect_chain
 from dragon_voice.handler_task_spawn import spawn_handler_task
 from dragon_voice.widget_action_handler import handle_widget_action
+from dragon_voice.text_turn_gate import invoke_with_text_turn_gate
 from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
@@ -1080,42 +1081,22 @@ class VoiceServer:
     async def _handle_text(
         self, ws: web.WebSocketResponse, conn_state: dict, cmd: dict
     ) -> None:
-        """Handle text input message — goes directly to conversation engine."""
-        session_id = conn_state.get("session_id")
-        if not session_id or not self._conversation:
-            await ws.send_json(error_event(
-                code="session_invalid",
-                message="Not registered — send register first.",
-                severity=Severity.FATAL, scope=Scope.SESSION,
-            ))
-            return
+        """Handle text input message — goes directly to conversation engine.
 
-        content = cmd.get("content", "").strip()
-        if not content:
-            return
-
-        text = content
-        logger.info("Text input on session %s: %s", session_id, text[:80])
-
-        # #75 phase 1b: reset the per-turn tool-call tracker.  Each
-        # incoming text starts a new turn; the `_on_tool_result`
-        # callback accumulates here so the end-of-turn empty-reply guard
-        # can synthesise a template wrap from what actually fired.
-        conn_state["tool_calls_this_turn"] = []
-
-        # Audit B1 (#165): mark turn busy so scheduler-fired widgets
-        # defer until this text turn completes — prevents the
-        # `llm token / widget_card / llm token` interleave.
-        if self._surface_mgr is not None:
-            self._surface_mgr.mark_turn_start(session_id)
-        try:
-            await self._handle_text_body(ws, conn_state, cmd, text, session_id, content)
-        finally:
-            if self._surface_mgr is not None:
-                try:
-                    await self._surface_mgr.mark_turn_end(session_id)
-                except Exception:
-                    logger.exception("B1: turn-end drain failed for text turn")
+        SOLID-audit follow-up: precondition guard + per-turn
+        tool-tracker reset + B1 turn-busy bracket extracted to
+        text_turn_gate.invoke_with_text_turn_gate.  That module
+        owns the gating; `_handle_text_body` owns the actual
+        LLM/TTS work and is invoked as the body callable.
+        """
+        await invoke_with_text_turn_gate(
+            ws,
+            conn_state=conn_state,
+            cmd=cmd,
+            conversation=self._conversation,
+            surface_mgr=self._surface_mgr,
+            body_fn=self._handle_text_body,
+        )
 
     async def _handle_text_body(
         self, ws: web.WebSocketResponse, conn_state: dict, cmd: dict,

--- a/dragon_voice/text_turn_gate.py
+++ b/dragon_voice/text_turn_gate.py
@@ -1,0 +1,147 @@
+"""Text-turn entry guard + B1 turn-busy bracket.
+
+Wave 23 SOLID-audit follow-up — twenty-first sub-extract from
+the WS-handler family in server.py (round 4 spillover, after
+the twenty prior extracts #227-#246).
+
+Every text turn coming through `_handle_text` needs three
+gates around the actual body invocation:
+
+  1. **Precondition guard**: not-yet-registered or empty-content
+     frames must short-circuit before reaching the LLM.
+  2. **Per-turn tool tracker reset** (#75 phase 1b): each
+     incoming text starts a fresh turn; the empty-reply guard
+     downstream synthesises a template wrap from what actually
+     fired during this turn.
+  3. **B1 turn-busy bracket** (audit B1 / #165): mark the
+     surface manager's turn-busy flag so scheduler-fired
+     widgets defer until this turn completes — prevents the
+     `llm token / widget_card / llm token` interleave that
+     made chat unreadable.
+
+Pre-extract this 39-LOC wrapper lived inline as
+`VoiceServer._handle_text`.  Now lives in its own dedicated
+module with the body invocation passed in as a callable.
+
+## API
+
+```python
+await invoke_with_text_turn_gate(
+    ws,
+    *,
+    conn_state,
+    cmd,
+    conversation,
+    surface_mgr,
+    safe_send_json,
+    body_fn,
+)
+```
+
+`body_fn` is the actual text-turn body — invoked as
+`await body_fn(ws, conn_state, cmd, text, session_id, content)`.
+The wrapper owns the gating; `body_fn` owns the LLM/TTS work.
+
+## Precondition guard
+
+  * No `session_id` in conn_state (not yet registered) → emit
+    FATAL `session_invalid` error_event, return without invoking
+    body.
+  * No `conversation` engine wired (boot race / test path) →
+    same error event, return.
+  * Empty / whitespace-only content → silent return (no error;
+    Tab5 may have sent a blank frame as a heartbeat).
+
+## B1 bracket failure isolation
+
+`mark_turn_end` failure is logged at EXCEPTION but never
+re-raised — a bug in the surface manager must NOT prevent the
+next text turn.  The bracket runs in a `try/finally` so
+`mark_turn_end` fires even when `body_fn` raises.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from aiohttp import web
+
+from dragon_voice.errors import Scope, Severity, error_event
+
+logger = logging.getLogger(__name__)
+
+
+SafeSendJson = Callable[[web.WebSocketResponse, dict], Awaitable[bool]]
+TextBodyFn = Callable[
+    [web.WebSocketResponse, dict, dict, str, str, str],
+    Awaitable[None],
+]
+
+
+async def invoke_with_text_turn_gate(
+    ws: web.WebSocketResponse,
+    *,
+    conn_state: dict,
+    cmd: dict,
+    conversation: Optional[Any],         # ConversationEngine
+    surface_mgr: Optional[Any],          # SurfaceManager
+    body_fn: TextBodyFn,
+) -> None:
+    """Run the text-turn body inside the precondition guard +
+    B1 turn-busy bracket.
+
+    No-op when:
+      * Not registered (no `session_id`) — emits `session_invalid`
+        FATAL error_event then returns.
+      * No conversation engine (boot race) — same error.
+      * Empty content (Tab5 heartbeat) — silent return.
+
+    Side effects on success:
+      * `conn_state["tool_calls_this_turn"] = []` (per-turn
+        reset for the empty-reply wrap downstream).
+      * `surface_mgr.mark_turn_start(session_id)` before body.
+      * `surface_mgr.mark_turn_end(session_id)` after body
+        (guaranteed via try/finally).
+      * INFO log of the first 80 chars of the text input.
+
+    `mark_turn_end` failure is logged at EXCEPTION but never
+    re-raised — must not block the next text turn.
+    """
+    session_id = conn_state.get("session_id")
+    if not session_id or not conversation:
+        await ws.send_json(error_event(
+            code="session_invalid",
+            message="Not registered — send register first.",
+            severity=Severity.FATAL, scope=Scope.SESSION,
+        ))
+        return
+
+    content = cmd.get("content", "").strip()
+    if not content:
+        return
+
+    text = content
+    logger.info("Text input on session %s: %s", session_id, text[:80])
+
+    # #75 phase 1b: reset the per-turn tool-call tracker.  Each
+    # incoming text starts a new turn; the `_on_tool_result`
+    # callback accumulates here so the end-of-turn empty-reply
+    # guard can synthesise a template wrap from what actually
+    # fired.
+    conn_state["tool_calls_this_turn"] = []
+
+    # Audit B1 (#165): mark turn busy so scheduler-fired widgets
+    # defer until this text turn completes — prevents the
+    # `llm token / widget_card / llm token` interleave.
+    if surface_mgr is not None:
+        surface_mgr.mark_turn_start(session_id)
+    try:
+        await body_fn(ws, conn_state, cmd, text, session_id, content)
+    finally:
+        if surface_mgr is not None:
+            try:
+                await surface_mgr.mark_turn_end(session_id)
+            except Exception:
+                logger.exception(
+                    "B1: turn-end drain failed for text turn",
+                )

--- a/tests/test_text_turn_gate.py
+++ b/tests/test_text_turn_gate.py
@@ -1,0 +1,321 @@
+"""Tests for ``dragon_voice.text_turn_gate``.
+
+Pin every gate branch + the B1 turn-busy bracket invariants
+that prevent widget/token interleave from regressing.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.errors import Scope, Severity
+from dragon_voice.text_turn_gate import invoke_with_text_turn_gate
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    ws.send_json = AsyncMock()
+    return ws
+
+
+def _make_surface_mgr() -> MagicMock:
+    mgr = MagicMock()
+    mgr.mark_turn_start = MagicMock()
+    mgr.mark_turn_end = AsyncMock()
+    return mgr
+
+
+def _make_body() -> AsyncMock:
+    return AsyncMock()
+
+
+# ─── Precondition guards ─────────────────────────────────────
+
+
+class TestPreconditionGuards:
+    @pytest.mark.asyncio
+    async def test_no_session_id_emits_fatal_session_invalid(self):
+        ws = _make_ws()
+        body = _make_body()
+
+        await invoke_with_text_turn_gate(
+            ws,
+            conn_state={},  # no session_id
+            cmd={"content": "hi"},
+            conversation=MagicMock(),
+            surface_mgr=_make_surface_mgr(),
+            body_fn=body,
+        )
+
+        ws.send_json.assert_awaited_once()
+        frame = ws.send_json.await_args.args[0]
+        assert frame["type"] == "error"
+        assert frame["code"] == "session_invalid"
+        assert frame["severity"] == Severity.FATAL.value
+        assert frame["scope"] == Scope.SESSION.value
+        body.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_conversation_emits_fatal(self):
+        """Conversation engine missing (boot race) → same error."""
+        ws = _make_ws()
+        body = _make_body()
+
+        await invoke_with_text_turn_gate(
+            ws,
+            conn_state={"session_id": "s"},
+            cmd={"content": "hi"},
+            conversation=None,
+            surface_mgr=_make_surface_mgr(),
+            body_fn=body,
+        )
+
+        ws.send_json.assert_awaited_once()
+        body.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_empty_content_silent_return(self):
+        ws = _make_ws()
+        body = _make_body()
+
+        await invoke_with_text_turn_gate(
+            ws,
+            conn_state={"session_id": "s"},
+            cmd={"content": ""},
+            conversation=MagicMock(),
+            surface_mgr=_make_surface_mgr(),
+            body_fn=body,
+        )
+
+        # Silent — no error frame
+        ws.send_json.assert_not_awaited()
+        body.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_content_silent_return(self):
+        ws = _make_ws()
+        body = _make_body()
+
+        await invoke_with_text_turn_gate(
+            ws,
+            conn_state={"session_id": "s"},
+            cmd={"content": "   \n\t  "},
+            conversation=MagicMock(),
+            surface_mgr=_make_surface_mgr(),
+            body_fn=body,
+        )
+
+        ws.send_json.assert_not_awaited()
+        body.assert_not_awaited()
+
+
+# ─── Per-turn tool tracker reset (#75 phase 1b) ──────────────
+
+
+class TestPerTurnToolTrackerReset:
+    @pytest.mark.asyncio
+    async def test_tool_tracker_reset_before_body(self):
+        """conn_state['tool_calls_this_turn'] must be cleared
+        before body_fn runs so the body can append fresh entries."""
+        ws = _make_ws()
+        # Simulate a previous turn's leftover tool calls
+        conn_state = {
+            "session_id": "s",
+            "tool_calls_this_turn": [{"name": "old_tool"}],
+        }
+
+        captured_state = {}
+
+        async def _body(ws_arg, cs, cmd_arg, text, sid, content):
+            # Snapshot the tracker state at body entry
+            captured_state["at_entry"] = list(cs["tool_calls_this_turn"])
+
+        await invoke_with_text_turn_gate(
+            ws,
+            conn_state=conn_state,
+            cmd={"content": "fresh turn"},
+            conversation=MagicMock(),
+            surface_mgr=None,
+            body_fn=_body,
+        )
+
+        # Body saw an empty list (reset before body ran)
+        assert captured_state["at_entry"] == []
+
+
+# ─── B1 turn-busy bracket (audit B1 / #165) ──────────────────
+
+
+class TestB1TurnBusyBracket:
+    @pytest.mark.asyncio
+    async def test_mark_turn_start_called_before_body(self):
+        ws = _make_ws()
+        surface = _make_surface_mgr()
+        order: list[str] = []
+
+        surface.mark_turn_start.side_effect = (
+            lambda sid: order.append(f"start:{sid}")
+        )
+
+        async def _body(*args):
+            order.append("body")
+
+        await invoke_with_text_turn_gate(
+            ws,
+            conn_state={"session_id": "s-A"},
+            cmd={"content": "x"},
+            conversation=MagicMock(),
+            surface_mgr=surface,
+            body_fn=_body,
+        )
+
+        # mark_turn_start fires BEFORE body
+        assert order[:2] == ["start:s-A", "body"]
+
+    @pytest.mark.asyncio
+    async def test_mark_turn_end_called_after_body(self):
+        ws = _make_ws()
+        surface = _make_surface_mgr()
+        order: list[str] = []
+
+        async def _body(*args):
+            order.append("body")
+
+        async def _record_end(sid):
+            order.append(f"end:{sid}")
+
+        surface.mark_turn_end.side_effect = _record_end
+
+        await invoke_with_text_turn_gate(
+            ws,
+            conn_state={"session_id": "s-B"},
+            cmd={"content": "x"},
+            conversation=MagicMock(),
+            surface_mgr=surface,
+            body_fn=_body,
+        )
+
+        # mark_turn_end fires AFTER body
+        assert order == ["body", "end:s-B"]
+
+    @pytest.mark.asyncio
+    async def test_mark_turn_end_fires_even_when_body_raises(self):
+        """try/finally invariant: mark_turn_end MUST fire even if
+        body raises, otherwise the next turn would be perpetually
+        deferred (audit B1 / #165 regression)."""
+        ws = _make_ws()
+        surface = _make_surface_mgr()
+
+        async def _broken(*args):
+            raise RuntimeError("body bug")
+
+        # Body's RuntimeError should propagate out (the wrapper
+        # doesn't swallow body exceptions — that's the dispatcher
+        # task's responsibility to handle).
+        with pytest.raises(RuntimeError, match="body bug"):
+            await invoke_with_text_turn_gate(
+                ws,
+                conn_state={"session_id": "s-X"},
+                cmd={"content": "x"},
+                conversation=MagicMock(),
+                surface_mgr=surface,
+                body_fn=_broken,
+            )
+
+        # But mark_turn_end MUST have fired despite the body raising.
+        surface.mark_turn_end.assert_awaited_once_with("s-X")
+
+    @pytest.mark.asyncio
+    async def test_mark_turn_end_failure_does_not_propagate(self):
+        """surface_mgr.mark_turn_end raising must NOT propagate —
+        a bug in surface mgr must not block the next text turn."""
+        ws = _make_ws()
+        surface = MagicMock()
+        surface.mark_turn_start = MagicMock()
+        surface.mark_turn_end = AsyncMock(
+            side_effect=RuntimeError("surface bug"),
+        )
+
+        async def _body(*args):
+            pass
+
+        # Must NOT raise.
+        await invoke_with_text_turn_gate(
+            ws,
+            conn_state={"session_id": "s"},
+            cmd={"content": "x"},
+            conversation=MagicMock(),
+            surface_mgr=surface,
+            body_fn=_body,
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_surface_mgr_skips_bracket(self):
+        """Test path / boot race — silent skip when surface_mgr
+        unavailable.  Body still runs."""
+        ws = _make_ws()
+        body = _make_body()
+
+        await invoke_with_text_turn_gate(
+            ws,
+            conn_state={"session_id": "s"},
+            cmd={"content": "x"},
+            conversation=MagicMock(),
+            surface_mgr=None,
+            body_fn=body,
+        )
+
+        body.assert_awaited_once()
+
+
+# ─── Body invocation ─────────────────────────────────────────
+
+
+class TestBodyInvocation:
+    @pytest.mark.asyncio
+    async def test_body_receives_canonical_args(self):
+        ws = _make_ws()
+        body = _make_body()
+        cmd = {"content": "  hello world  "}
+
+        await invoke_with_text_turn_gate(
+            ws,
+            conn_state={"session_id": "sess-1"},
+            cmd=cmd,
+            conversation=MagicMock(),
+            surface_mgr=None,
+            body_fn=body,
+        )
+
+        body.assert_awaited_once()
+        args = body.await_args.args
+        # (ws, conn_state, cmd, text, session_id, content)
+        assert args[0] is ws
+        assert args[2] is cmd
+        assert args[3] == "hello world"     # text (stripped)
+        assert args[4] == "sess-1"          # session_id
+        assert args[5] == "hello world"     # content (stripped)
+
+    @pytest.mark.asyncio
+    async def test_text_and_content_are_both_the_stripped_value(self):
+        """Pin the pre-extract behaviour: text=content, both equal
+        to the stripped cmd['content'].  A future refactor that
+        starts mutating one of them in the wrapper would surprise
+        downstream callers (TC bypass uses `text`, local path
+        uses `content`)."""
+        ws = _make_ws()
+        body = _make_body()
+
+        await invoke_with_text_turn_gate(
+            ws,
+            conn_state={"session_id": "s"},
+            cmd={"content": "  hi  "},
+            conversation=MagicMock(),
+            surface_mgr=None,
+            body_fn=body,
+        )
+
+        args = body.await_args.args
+        assert args[3] == args[5] == "hi"


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **twenty-first sub-extract** from the WS-handler family in server.py.

\`_handle_text\` is the WS dispatcher entry point that wraps \`_handle_text_body\` with three gates:
1. Precondition guard (registered + non-empty content)
2. Per-turn tool tracker reset (#75 phase 1b)
3. B1 turn-busy bracket (audit B1 / #165) — defers scheduler-fired widgets so they don't interleave with LLM token frames

Now lives in its own dedicated module with the body invocation passed in as a callable.

### Behaviour preserved verbatim

- No session_id OR no conversation → emit FATAL \`session_invalid\` (Phase 3 γ1) error_event then return without invoking body
- Empty / whitespace-only content → silent return (Tab5 heartbeat tolerance)
- \`conn_state[\"tool_calls_this_turn\"] = []\` reset BEFORE body runs (so body's own callbacks accumulate fresh entries)
- \`surface_mgr.mark_turn_start(sid)\` BEFORE body
- \`surface_mgr.mark_turn_end(sid)\` AFTER body — wrapped in try/finally so it fires EVEN IF body raises (audit B1 / #165 regression: without finally, a body crash would leave the surface in turn-busy forever and block all future widgets)
- \`mark_turn_end\` failure swallowed at EXCEPTION (a bug in surface_mgr must NOT block the next turn)
- Body invocation signature: \`(ws, conn_state, cmd, text, session_id, content)\` — text and content both stripped (TC bypass uses \`text\`, local path uses \`content\`)

### Test coverage

12 tests across 4 classes spanning 4 precondition-guard branches, per-turn tool tracker reset (with snapshot pin), 5 B1 bracket invariants (start-before-body, end-after-body, end-fires-on-body-raise, end-failure-doesn't-propagate, no-surface-mgr-skip), and 2 body-invocation contract pins.

### Diff stats

| Metric | Before | After | Δ |
|---|---|---|---|
| \`server.py\` LOC | 1497 | 1478 | **-19** |
| \`server.py\` LOC (cumulative across 37-PR series, since #211) | 2714 | 1478 | **-45.5%** |

## Test plan

- [x] \`python3 -m pytest tests/test_text_turn_gate.py -v\` → 12 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → 1093 passed, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)