### PR TITLE
refactor(server): extract on_audio/on_event closures (~23 LOC) to PipelineCallbacks class

### DIFF
--- a/dragon_voice/pipeline_callbacks.py
+++ b/dragon_voice/pipeline_callbacks.py
@@ -1,0 +1,152 @@
+"""Per-connection pipeline audio + event callbacks.
+
+Wave 23 SOLID-audit follow-up — twenty-second sub-extract from
+the WS-handler family in server.py (round 4 spillover, after
+the twenty-one prior extracts #227-#247).
+
+Every WS-voice connection needs two callbacks wired into its
+VoicePipeline:
+
+  * `on_audio(bytes)` — TTS PCM frames flowing FROM the
+    pipeline TO Tab5.  Routes through the safe-send wrapper so
+    a transient disconnect mid-stream doesn't raise
+    ConnectionResetError up into the pipeline's tight loop.
+  * `on_event(dict)` — pipeline state events (api_usage,
+    cost-tracking, lifecycle).  Forwards via safe_send_json
+    AND (for `api_usage` events specifically) persists to the
+    DB events table so cost tracking survives restarts.
+
+Pre-extract these were 23 LOC of closures inline in
+`_handle_ws_voice` capturing `ws`, `self` (for safe-send +
+db), and `conn_state`.  Now lives as a small class with an
+explicit constructor — testable in isolation, and the
+captured state is visible at the type level.
+
+## API
+
+```python
+callbacks = PipelineCallbacks(
+    ws,
+    conn_state=conn_state,
+    safe_send_bytes=safe_send_bytes,
+    safe_send_json=safe_send_json,
+    db=db,
+)
+pipeline = VoicePipeline(
+    ...,
+    on_audio=callbacks.on_audio,
+    on_event=callbacks.on_event,
+)
+```
+
+The class is intentionally minimal — no caching, no batching,
+no internal state.  All state lives on the captured `ws` /
+`conn_state` so a config-update hot-swap can replace the
+pipeline without rebuilding the callbacks.
+
+## Why a class instead of two free functions
+
+Two reasons:
+
+  1. The caller stores both callbacks on conn_state for
+     pipeline re-init (audit A04 memory monitor); a single
+     instance with two methods is more ergonomic to pass
+     around than two separate function objects.
+  2. The audit follow-up "WsDispatcher" pattern (eventually)
+     will own one PipelineCallbacks per connection — having it
+     pre-shaped as a class makes the future migration a no-op.
+
+## v4·D audit P0 fix preserved
+
+`safe_send_bytes` / `safe_send_json` are passed in (DIP) so
+this module doesn't need to know about VoiceServer.  Pre-fix
+the audio callback used raw `ws.send_bytes` which would raise
+ConnectionResetError up into the pipeline's tight loop, where
+it was caught by a generic `except Exception` that ALSO
+swallowed real exceptions (silent voice-pipeline failures).
+
+## Why on_event persists ONLY api_usage events
+
+DB writes are slow (~ms each); persisting every pipeline
+event would balloon the events table and slow the WS path.
+`api_usage` is the only one with cost-tracking value (see the
+dashboard's API usage chart) so it's the only one worth the
+write.  All other events still emit to the WS for live
+observability but stop at the DB layer.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+SafeSendBytes = Callable[[web.WebSocketResponse, bytes], Awaitable[bool]]
+SafeSendJson = Callable[[web.WebSocketResponse, dict], Awaitable[bool]]
+
+
+class PipelineCallbacks:
+    """Bundles the on_audio + on_event callbacks for a single
+    WS-voice connection.
+
+    Constructed once per connection in `_handle_ws_voice`;
+    `pipeline` and any future re-init use `.on_audio` /
+    `.on_event` directly.
+    """
+
+    def __init__(
+        self,
+        ws: web.WebSocketResponse,
+        *,
+        conn_state: dict,
+        safe_send_bytes: SafeSendBytes,
+        safe_send_json: SafeSendJson,
+        db: Optional[Any],
+    ) -> None:
+        self._ws = ws
+        self._conn_state = conn_state
+        self._safe_send_bytes = safe_send_bytes
+        self._safe_send_json = safe_send_json
+        self._db = db
+
+    async def on_audio(self, audio_bytes: bytes) -> None:
+        """TTS PCM frames flowing FROM pipeline TO Tab5.
+
+        v4·D audit P0 fix: routes through safe_send_bytes so a
+        transient disconnect mid-stream doesn't raise
+        ConnectionResetError up into the pipeline's tight loop.
+        """
+        if self._ws.closed:
+            return
+        await self._safe_send_bytes(self._ws, audio_bytes)
+
+    async def on_event(self, event: dict) -> None:
+        """Pipeline state events (api_usage, cost-tracking,
+        lifecycle).  Forwards via safe_send_json AND (for
+        `api_usage` events specifically) persists to the DB
+        events table so cost tracking survives restarts.
+
+        Failure isolation: DB write errors logged at DEBUG but
+        never re-raised — events are observability, not
+        session-correctness.
+        """
+        if not self._ws.closed:
+            await self._safe_send_json(self._ws, event)
+
+        # Persist API usage events for cost tracking.  Other
+        # event types (state changes, debug, etc.) emit to WS
+        # but stop at the DB layer — keeps the events table
+        # focused on cost analysis.
+        if event.get("type") == "api_usage" and self._db:
+            try:
+                await self._db.add_event(
+                    "api_usage",
+                    session_id=self._conn_state.get("session_id"),
+                    device_id=self._conn_state.get("device_id"),
+                    data={k: v for k, v in event.items() if k != "type"},
+                )
+            except Exception as e:
+                logger.debug("Callback error: %s", e)

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -59,6 +59,7 @@ from dragon_voice.disconnect_handler import handle_disconnect as _disconnect_cha
 from dragon_voice.handler_task_spawn import spawn_handler_task
 from dragon_voice.widget_action_handler import handle_widget_action
 from dragon_voice.text_turn_gate import invoke_with_text_turn_gate
+from dragon_voice.pipeline_callbacks import PipelineCallbacks
 from dragon_voice.rich_media_emit import emit_rich_media_for_text_turn
 from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
 from dragon_voice.surface_register import register_surface_and_replay_scheduler
@@ -625,29 +626,22 @@ class VoiceServer:
         )
         self._active_connections[ws_id] = conn_state
 
-        # Callbacks for the pipeline.  v4·D audit P0 fix: route through
-        # the shared _safe_send_* helpers so transient disconnects mid-
-        # stream don't raise ConnectionResetError up into the pipeline's
-        # tight loop (which used to swallow real exceptions).
-        async def on_audio(audio_bytes: bytes) -> None:
-            if ws.closed:
-                return
-            await self._safe_send_bytes(ws, audio_bytes)
-
-        async def on_event(event: dict) -> None:
-            if not ws.closed:
-                await self._safe_send_json(ws, event)
-            # Persist API usage events for cost tracking
-            if event.get("type") == "api_usage" and self._db:
-                try:
-                    await self._db.add_event(
-                        "api_usage",
-                        session_id=conn_state.get("session_id"),
-                        device_id=conn_state.get("device_id"),
-                        data={k: v for k, v in event.items() if k != "type"},
-                    )
-                except Exception as e:
-                    logger.debug("Callback error: %s", e)
+        # SOLID-audit follow-up: pipeline callbacks bundled into
+        # PipelineCallbacks class.  on_audio routes through
+        # safe_send_bytes (v4·D audit P0 fix); on_event forwards
+        # via safe_send_json AND persists api_usage events to the
+        # DB events table for cost tracking.  Per-event conn_state
+        # lookup so a `clear` cmd that swaps session_id is
+        # reflected on the next persisted event.
+        _pipeline_callbacks = PipelineCallbacks(
+            ws,
+            conn_state=conn_state,
+            safe_send_bytes=self._safe_send_bytes,
+            safe_send_json=self._safe_send_json,
+            db=self._db,
+        )
+        on_audio = _pipeline_callbacks.on_audio
+        on_event = _pipeline_callbacks.on_event
 
         # Store callback refs for pipeline re-init (A04 memory monitor)
         conn_state["_on_audio"] = on_audio

--- a/tests/test_pipeline_callbacks.py
+++ b/tests/test_pipeline_callbacks.py
@@ -1,0 +1,255 @@
+"""Tests for ``dragon_voice.pipeline_callbacks``.
+
+Pin every callback branch + the v4·D audit P0 fix that
+disconnects mid-stream don't raise into the pipeline loop.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.pipeline_callbacks import PipelineCallbacks
+
+
+def _make_ws(*, closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    return ws
+
+
+def _make_safe_send_bytes() -> AsyncMock:
+    return AsyncMock(return_value=True)
+
+
+def _make_safe_send_json() -> AsyncMock:
+    return AsyncMock(return_value=True)
+
+
+def _make_db() -> MagicMock:
+    db = MagicMock()
+    db.add_event = AsyncMock()
+    return db
+
+
+def _make_callbacks(**overrides) -> PipelineCallbacks:
+    defaults = {
+        "ws": _make_ws(),
+        "conn_state": {"session_id": "s", "device_id": "d"},
+        "safe_send_bytes": _make_safe_send_bytes(),
+        "safe_send_json": _make_safe_send_json(),
+        "db": _make_db(),
+    }
+    defaults.update(overrides)
+    ws = defaults.pop("ws")
+    return PipelineCallbacks(ws=ws, **defaults)
+
+
+# ─── on_audio ────────────────────────────────────────────────
+
+
+class TestOnAudio:
+    @pytest.mark.asyncio
+    async def test_open_ws_routes_through_safe_send_bytes(self):
+        ws = _make_ws()
+        send_bytes = _make_safe_send_bytes()
+        cb = PipelineCallbacks(
+            ws,
+            conn_state={},
+            safe_send_bytes=send_bytes,
+            safe_send_json=_make_safe_send_json(),
+            db=None,
+        )
+
+        payload = b"\x01\x02\x03\x04"
+        await cb.on_audio(payload)
+
+        send_bytes.assert_awaited_once_with(ws, payload)
+
+    @pytest.mark.asyncio
+    async def test_closed_ws_skips_send(self):
+        """v4·D audit P0 fix: closed-ws check before routing
+        through safe_send_bytes prevents a redundant call."""
+        ws = _make_ws(closed=True)
+        send_bytes = _make_safe_send_bytes()
+        cb = PipelineCallbacks(
+            ws,
+            conn_state={},
+            safe_send_bytes=send_bytes,
+            safe_send_json=_make_safe_send_json(),
+            db=None,
+        )
+
+        await cb.on_audio(b"data")
+
+        send_bytes.assert_not_awaited()
+
+
+# ─── on_event ────────────────────────────────────────────────
+
+
+class TestOnEvent:
+    @pytest.mark.asyncio
+    async def test_event_forwarded_to_safe_send_json(self):
+        ws = _make_ws()
+        send_json = _make_safe_send_json()
+        cb = PipelineCallbacks(
+            ws,
+            conn_state={"session_id": "s", "device_id": "d"},
+            safe_send_bytes=_make_safe_send_bytes(),
+            safe_send_json=send_json,
+            db=None,
+        )
+
+        event = {"type": "state", "stage": "thinking"}
+        await cb.on_event(event)
+
+        send_json.assert_awaited_once_with(ws, event)
+
+    @pytest.mark.asyncio
+    async def test_closed_ws_skips_send_json_but_still_persists(self):
+        """When ws is closed mid-flight, we skip the WS emit but
+        STILL persist api_usage to the DB (cost tracking must
+        survive disconnect-mid-event)."""
+        ws = _make_ws(closed=True)
+        send_json = _make_safe_send_json()
+        db = _make_db()
+        cb = PipelineCallbacks(
+            ws,
+            conn_state={"session_id": "s", "device_id": "d"},
+            safe_send_bytes=_make_safe_send_bytes(),
+            safe_send_json=send_json,
+            db=db,
+        )
+
+        await cb.on_event({"type": "api_usage", "cost_mils": 12})
+
+        send_json.assert_not_awaited()
+        db.add_event.assert_awaited_once()
+
+
+# ─── api_usage DB persistence ────────────────────────────────
+
+
+class TestApiUsagePersistence:
+    @pytest.mark.asyncio
+    async def test_api_usage_persisted_with_session_and_device(self):
+        ws = _make_ws()
+        db = _make_db()
+        cb = PipelineCallbacks(
+            ws,
+            conn_state={"session_id": "sess-A", "device_id": "tab5-7"},
+            safe_send_bytes=_make_safe_send_bytes(),
+            safe_send_json=_make_safe_send_json(),
+            db=db,
+        )
+
+        event = {
+            "type": "api_usage",
+            "model": "anthropic/claude-haiku",
+            "tokens": 150,
+            "cost_mils": 5,
+        }
+        await cb.on_event(event)
+
+        db.add_event.assert_awaited_once()
+        call_kwargs = db.add_event.await_args.kwargs
+        assert db.add_event.await_args.args[0] == "api_usage"
+        assert call_kwargs["session_id"] == "sess-A"
+        assert call_kwargs["device_id"] == "tab5-7"
+        # Data dict has everything except `type` (already in pos arg)
+        assert call_kwargs["data"] == {
+            "model": "anthropic/claude-haiku",
+            "tokens": 150,
+            "cost_mils": 5,
+        }
+
+    @pytest.mark.asyncio
+    async def test_non_api_usage_event_does_not_persist(self):
+        """Pin the "only api_usage hits the DB" semantic — keeps
+        the events table focused on cost analysis."""
+        ws = _make_ws()
+        db = _make_db()
+        cb = PipelineCallbacks(
+            ws,
+            conn_state={"session_id": "s", "device_id": "d"},
+            safe_send_bytes=_make_safe_send_bytes(),
+            safe_send_json=_make_safe_send_json(),
+            db=db,
+        )
+
+        await cb.on_event({"type": "state", "stage": "idle"})
+        await cb.on_event({"type": "tool_call", "name": "x"})
+        await cb.on_event({"type": "llm_done"})
+
+        db.add_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_db_skips_persistence_silently(self):
+        """Test path / boot race — no DB available.  WS emit
+        still runs; persist silently skipped."""
+        ws = _make_ws()
+        send_json = _make_safe_send_json()
+        cb = PipelineCallbacks(
+            ws,
+            conn_state={"session_id": "s", "device_id": "d"},
+            safe_send_bytes=_make_safe_send_bytes(),
+            safe_send_json=send_json,
+            db=None,
+        )
+
+        await cb.on_event({"type": "api_usage", "cost_mils": 1})
+
+        send_json.assert_awaited_once()  # WS emit still ran
+        # No DB call possible (db is None); just must not crash.
+
+    @pytest.mark.asyncio
+    async def test_db_failure_does_not_propagate(self):
+        """add_event raising must NOT propagate up — that would
+        tear down the pipeline's tight event loop."""
+        ws = _make_ws()
+        db = MagicMock()
+        db.add_event = AsyncMock(side_effect=RuntimeError("db down"))
+        cb = PipelineCallbacks(
+            ws,
+            conn_state={"session_id": "s", "device_id": "d"},
+            safe_send_bytes=_make_safe_send_bytes(),
+            safe_send_json=_make_safe_send_json(),
+            db=db,
+        )
+
+        # Must NOT raise.
+        await cb.on_event({"type": "api_usage", "cost_mils": 1})
+
+
+# ─── Conn_state read-fresh per call ──────────────────────────
+
+
+class TestConnStateReadFreshPerCall:
+    @pytest.mark.asyncio
+    async def test_session_id_change_visible_on_next_event(self):
+        """Pin the per-event conn_state lookup so a `clear` cmd
+        that swapped the session_id is reflected on the next
+        api_usage persist."""
+        ws = _make_ws()
+        db = _make_db()
+        conn_state = {"session_id": "first", "device_id": "d"}
+        cb = PipelineCallbacks(
+            ws,
+            conn_state=conn_state,
+            safe_send_bytes=_make_safe_send_bytes(),
+            safe_send_json=_make_safe_send_json(),
+            db=db,
+        )
+
+        # First event — uses "first"
+        await cb.on_event({"type": "api_usage", "cost_mils": 1})
+        # Mid-stream, simulate a `clear` command swapping the session
+        conn_state["session_id"] = "second"
+        # Second event — must use "second"
+        await cb.on_event({"type": "api_usage", "cost_mils": 2})
+
+        first_call = db.add_event.await_args_list[0]
+        second_call = db.add_event.await_args_list[1]
+        assert first_call.kwargs["session_id"] == "first"
+        assert second_call.kwargs["session_id"] == "second"


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **twenty-second sub-extract** from the WS-handler family in server.py.

Every WS-voice connection wires two callbacks into its VoicePipeline: \`on_audio\` for TTS PCM frames flowing OUT and \`on_event\` for pipeline state events flowing OUT (with api_usage events also hitting the DB for cost tracking). Pre-extract these were 23 LOC of closures inline in \`_handle_ws_voice\` capturing \`ws\`, \`self\`, and \`conn_state\`. Now lives as a small class with explicit constructor — testable in isolation, captured state visible at the type level.

### Behaviour preserved verbatim

- **on_audio**: closed-ws guard then route through safe_send_bytes (v4·D audit P0 fix — pre-fix used raw \`ws.send_bytes\` which raised ConnectionResetError up into the pipeline's tight loop, where it was caught by a generic except that ALSO swallowed real exceptions)
- **on_event**: closed-ws guard for safe_send_json forward (BUT api_usage still persists to DB even when ws is closed — cost tracking must survive disconnect-mid-event)
- **api_usage DB persist**: only this event type hits the events table (other types emit to WS only)
- **Per-event conn_state lookup** so a \`clear\` cmd that swaps session_id is reflected on the next persisted event
- **DB write failure** swallowed at DEBUG (would tear down the pipeline tight loop otherwise)

### Why a class instead of two free functions

1. The caller stores both callbacks on conn_state for pipeline re-init (audit A04 memory monitor); a single instance with two methods is more ergonomic than two separate function objects.
2. The audit follow-up \"WsDispatcher\" pattern (eventually) will own one \`PipelineCallbacks\` per connection — having it pre-shaped as a class makes the future migration a no-op.

### Test coverage

9 tests across 4 classes spanning on_audio (open ws routes, closed ws skips), on_event (forwards via safe_send_json, closed-ws-still-persists), api_usage persistence (full session+device+data shape, only-api_usage-persists pin, no-db-skip, db-failure-swallow), and the per-event conn_state-read-fresh contract.

### Diff stats

| Metric | Before | After | Δ |
|---|---|---|---|
| \`server.py\` LOC | 1478 | 1472 | **-6** |
| \`server.py\` LOC (cumulative across 38-PR series, since #211) | 2714 | 1472 | **-45.8%** |

## Test plan

- [x] \`python3 -m pytest tests/test_pipeline_callbacks.py -v\` → 9 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → 1102 passed, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)