### PR TITLE
refactor(tools): extract three-dialect tool-call parser (~230 LOC) to tools/parser module (audit SRP-5)

### DIFF
--- a/dragon_voice/tools/parser.py
+++ b/dragon_voice/tools/parser.py
@@ -1,0 +1,347 @@
+"""Tool-call parser — three-dialect XML/bracket marker recognition.
+
+Wave 23 SOLID-audit follow-up — twenty-third sub-extract; first
+slice from `tools/registry.py` (audit SRP-5: registry +
+3-dialect parser + 2-format formatter all bundled in one
+class).  The parser is a pure function (text in → call list
+out) that doesn't need the registry's instance state EXCEPT to
+validate dialect-3 names against the set of registered tools.
+
+This module exposes the parser as free functions taking a
+`registered_names` argument; `ToolRegistry` keeps thin
+forwarding methods for backward compat with the 16+ existing
+call sites.
+
+## Three accepted dialects
+
+  1. **LEGACY** (TinkerBox system-prompt format):
+     ``<tool>NAME</tool><args>{"k": "v"}</args>``
+     Dragon's own system prompt instructs models to emit this.
+
+  2. **STANDARD** (industry-typical FC fine-tunes):
+     ``<tool_call>{"name": "NAME", "arguments": {"k": "v"}}</tool_call>``
+     Models trained for function-calling almost universally
+     emit this regardless of system-prompt instruction — that's
+     what they were fine-tuned on.
+
+  3. **BRACKETED-NAME** (xLAM quirk, issue #82):
+     ``[NAME]{"k": "v"}</NAME>`` — JSON args + matching close
+     ``[NAME]UPPERCASE_IDENT()`` — empty args, function-call noise
+     The skill name IS the tag.  REQUIRES the name to be in the
+     registered tool set; without that gate the parser would
+     fire on innocent prose like ``[note]`` quoted in a chat
+     reply.
+
+All three dialects are extracted into the same
+``{"tool": name, "args": dict}`` record.
+
+## Tolerance knobs (preserved verbatim from pre-extract)
+
+  * Stray ``>`` after JSON, missing ``</args>``, extra
+    whitespace all handled.
+  * xLAM open-tag quirk on dialect 1: emits ``[tool>`` /
+    ``<tool]`` / ``[tool]`` — the anchor regex accepts all
+    four bracket combos because the closing ``</tool>`` is
+    always intact.
+  * Nested JSON values (e.g. ``{"filter": {"k": "v"}}``) —
+    the brace-walker honours string quoting + backslash
+    escapes so it won't truncate at the first inner ``}``.
+
+## API
+
+```python
+calls, errors = parse_tool_calls_with_errors(
+    text,
+    registered_names=registry.names,
+)
+
+has = has_tool_call(text, registered_names=registry.names)
+```
+
+Both functions are pure — no side effects, no I/O.
+
+## γ2-M1 (#104) closure preserved
+
+`parse_tool_calls_with_errors` returns errors so the caller can
+emit a `tool_parse_failed` event for user-visible agentic
+failure (LLM emits a tool call, parser fails to load args, tool
+never fires, user sees empty reply with no signal).  The
+backward-compatible `parse_tool_calls` swallows errors for the
+16 existing call sites that don't want them.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import AbstractSet, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# XML-style markers for tool calls in LLM output (legacy dialect).
+#
+# Tolerant regex: handles stray > after JSON, missing </args>, extra
+# whitespace.  The `[<\[]tool[>\]]` open-tag class accepts `<tool>`,
+# `[tool>`, `<tool]`, AND `[tool]` — quantized small models (notably
+# xLAM) emit broken open brackets semi-randomly; the closing `</tool>`
+# is always intact so there's no ambiguity.
+TOOL_PATTERN = re.compile(
+    r'[<\[]tool[>\]](\w+)</tool>\s*<args>\s*({.*?})\s*>?\s*</args>',
+    re.DOTALL,
+)
+# Fallback: if </args> is missing entirely, grab JSON after <args>.
+TOOL_PATTERN_LOOSE = re.compile(
+    r'[<\[]tool[>\]](\w+)</tool>\s*<args>\s*({[^<]*})',
+    re.DOTALL,
+)
+
+# Dialect-3 cheap pre-check.  Matches `[name]` where `name` looks like
+# an identifier.  False positives at this stage are fine; the parser
+# validates against the registered-tool set before accepting.
+_BRACKET_NAME_PRECHECK = re.compile(r"\[([a-z_][a-z0-9_]*)\]")
+# Dialect-3 noise-args sanity check — the GETCURRENTDATEANDTIME() form
+# from xLAM should look like a function name (uppercase identifier),
+# not prose.  3-50 chars keeps real-world cases without exploding the
+# match window.
+_BRACKET_NOISE_IDENT = re.compile(r"^[A-Z][A-Z0-9_]{2,49}$")
+
+
+# Anchor regexes used by parse_tool_calls_with_errors.  Module-level
+# so they compile once instead of per-call.
+_ANCHOR_LEGACY = re.compile(
+    r'[<\[]tool[>\]](\w+)</tool>\s*<args>\s*', re.DOTALL,
+)
+_ANCHOR_STD = re.compile(r'<tool_call>\s*', re.DOTALL)
+
+
+def _walk_json(text: str, start: int) -> int:
+    """Return index one past the matching `}` for the JSON object
+    that starts at `text[start] == '{'`.  Honors string quoting +
+    backslash escapes.  Returns -1 on unbalanced input.
+
+    Used by the parser to handle nested JSON without truncating at
+    the first inner `}` (audit P2 fix in pre-extract).
+    """
+    if start >= len(text) or text[start] != '{':
+        return -1
+    depth = 0
+    in_str = False
+    esc = False
+    for j in range(start, len(text)):
+        ch = text[j]
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == '\\':
+                esc = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch == '{':
+            depth += 1
+        elif ch == '}':
+            depth -= 1
+            if depth == 0:
+                return j + 1
+    return -1
+
+
+def parse_tool_calls_with_errors(
+    text: str,
+    *,
+    registered_names: AbstractSet[str],
+) -> Tuple[list[dict], list[dict]]:
+    """Parse tool-call markers from LLM output across all three
+    dialects.  Returns (calls, errors) so the caller can decide
+    whether to emit a `tool_parse_failed` event for γ2-M1 (#104)
+    user-visible agentic failure.
+
+    Args:
+        text: LLM output text to scan.
+        registered_names: Set of tool names known to the registry.
+            Used to gate dialect 3 (bracketed-name) so the parser
+            doesn't false-fire on prose like ``[note]`` quoted in
+            a chat reply.
+
+    Returns:
+        ``(calls, errors)`` where:
+        * ``calls`` is a list of ``{"tool": name, "args": dict}``.
+        * ``errors`` is a list of ``{"dialect": int, "name": str
+          | None, "reason": "json_decode"}`` records — one per
+          marker that anchored cleanly but whose JSON body failed
+          to parse.
+    """
+    calls: list[dict] = []
+    errors: list[dict] = []
+
+    # ── Dialect 1 — legacy <tool>NAME</tool><args>{json}</args> ──
+    for m in _ANCHOR_LEGACY.finditer(text):
+        name = m.group(1)
+        i = m.end()
+        end = _walk_json(text, i)
+        if end < 0:
+            continue
+        args_str = text[i:end].strip()
+        try:
+            args = json.loads(args_str)
+            calls.append({"tool": name, "args": args})
+        except json.JSONDecodeError:
+            logger.warning(
+                "Failed to parse tool args for %s: %s",
+                name, args_str[:100],
+            )
+            errors.append({
+                "dialect": 1, "name": name, "reason": "json_decode",
+            })
+
+    # ── Dialect 2 — industry-standard <tool_call>{...}</tool_call> ──
+    for m in _ANCHOR_STD.finditer(text):
+        i = m.end()
+        end = _walk_json(text, i)
+        if end < 0:
+            continue
+        body = text[i:end].strip()
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError:
+            logger.warning(
+                "Failed to parse <tool_call> body: %s", body[:120],
+            )
+            errors.append({
+                "dialect": 2, "name": None, "reason": "json_decode",
+            })
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        name = parsed.get("name")
+        args = parsed.get("arguments", parsed.get("args", {}))
+        if not isinstance(name, str) or not name:
+            continue
+        if not isinstance(args, dict):
+            args = {}
+        calls.append({"tool": name, "args": args})
+
+    # ── Dialect 3 — bracketed-name (xLAM quirk, #82) ─────────────
+    # Skip the pass entirely if no tools registered (the validation
+    # gate would reject everything anyway).
+    if registered_names:
+        for m in _BRACKET_NAME_PRECHECK.finditer(text):
+            name = m.group(1)
+            if name not in registered_names:
+                continue
+            i = m.end()
+            # Skip whitespace immediately after the opening bracket.
+            while i < len(text) and text[i] in " \t\n\r":
+                i += 1
+            if i >= len(text):
+                continue
+
+            args: Optional[dict] = None
+
+            if text[i] == "{":
+                # Sub-form A: [NAME]{json}</NAME>
+                end = _walk_json(text, i)
+                if end < 0:
+                    continue
+                try:
+                    parsed_args = json.loads(text[i:end])
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "Failed to parse bracket-name args for %s: %s",
+                        name, text[i:end][:100],
+                    )
+                    errors.append({
+                        "dialect": 3, "name": name,
+                        "reason": "json_decode",
+                    })
+                    continue
+                if not isinstance(parsed_args, dict):
+                    continue
+                args = parsed_args
+                # Matching </NAME> close is encouraged but not required —
+                # xLAM emits it cleanly on most prompts but truncates
+                # on others.  We accept either way.
+            else:
+                # Sub-form B: [NAME]IDENT() — empty args, fn-name noise.
+                paren = text.find("()", i, i + 80)
+                if paren < 0:
+                    continue
+                noise = text[i:paren].strip()
+                if not _BRACKET_NOISE_IDENT.match(noise):
+                    continue
+                args = {}
+
+            if args is not None:
+                calls.append({"tool": name, "args": args})
+
+    return calls, errors
+
+
+def parse_tool_calls(
+    text: str,
+    *,
+    registered_names: AbstractSet[str],
+) -> list[dict]:
+    """Backward-compatible wrapper around
+    `parse_tool_calls_with_errors` that returns just the call list
+    (no errors).  Preserves the original signature for the 16+
+    existing call sites that don't surface parse errors.
+    """
+    calls, _errors = parse_tool_calls_with_errors(
+        text, registered_names=registered_names,
+    )
+    return calls
+
+
+def has_tool_call(
+    text: str,
+    *,
+    registered_names: AbstractSet[str],
+) -> bool:
+    """Quick check if `text` contains a tool-call marker in any of
+    the three accepted dialects.
+
+    Same name-validation gate as the parser for dialect 3 — without
+    it, prose like ``[note]`` in a chat reply would over-fire.
+
+    Args:
+        text: LLM output text to scan.
+        registered_names: Set of tool names known to the registry.
+
+    Returns:
+        True iff at least one valid marker is present.
+    """
+    has_legacy = (
+        ("<tool>" in text or "[tool>" in text
+         or "[tool]" in text or "<tool]" in text)
+        and "</tool>" in text
+    )
+    has_std = "<tool_call>" in text and "</tool_call>" in text
+    if has_legacy or has_std:
+        return True
+
+    if not registered_names:
+        return False
+    for m in _BRACKET_NAME_PRECHECK.finditer(text):
+        if m.group(1) not in registered_names:
+            continue
+        # Peek past whitespace for the `{` (sub-form A) or
+        # `<word>(` (sub-form B) that distinguishes a real call
+        # from prose that mentions `[recall]`.  Without this
+        # guard, has_tool_call over-fires on chat replies whenever
+        # a tool name appears in brackets.
+        j = m.end()
+        while j < len(text) and text[j] in " \t\n\r":
+            j += 1
+        if j >= len(text):
+            continue
+        if text[j] == "{":
+            return True
+        # Sub-form B: identifier+`()` should appear within the
+        # same window parse_tool_calls scans.
+        if "()" in text[j:j + 80]:
+            return True
+    return False

--- a/dragon_voice/tools/registry.py
+++ b/dragon_voice/tools/registry.py
@@ -1,67 +1,32 @@
-"""Tool registry: register, parse, execute tools."""
+"""Tool registry: register + execute tools.
 
-import json
+Wave 23 SOLID-audit follow-up — parser extracted to
+`dragon_voice.tools.parser` (PR #249, audit SRP-5 first slice).
+This module now owns just the registry + execution + formatter
+responsibilities; the three-dialect XML/bracket parser lives
+next door and is invoked via thin forwarding methods on
+`ToolRegistry` for backward compat with the 16+ existing call
+sites.
+"""
+
 import logging
-import re
 import time
 from typing import Optional
 
 from dragon_voice.tools.base import Tool
 
+# Re-export parser symbols for backward compat with callers that
+# imported them from registry directly (e.g.
+# `from dragon_voice.tools.registry import TOOL_PATTERN`).
+from dragon_voice.tools.parser import (  # noqa: F401  (re-exports)
+    TOOL_PATTERN,
+    TOOL_PATTERN_LOOSE,
+    has_tool_call as _has_tool_call,
+    parse_tool_calls as _parse_tool_calls,
+    parse_tool_calls_with_errors as _parse_tool_calls_with_errors,
+)
+
 logger = logging.getLogger(__name__)
-
-# XML-style markers for tool calls in LLM output.
-#
-# Three dialects are accepted:
-#
-#   1. LEGACY (TinkerBox system-prompt format):
-#        <tool>NAME</tool><args>{"k": "v"}</args>
-#      This is what Dragon's own system prompt instructs the model to emit.
-#
-#   2. STANDARD (industry-typical, Qwen-FC / Gemma-FC / distil-* / many
-#      community function-calling fine-tunes):
-#        <tool_call>{"name": "NAME", "arguments": {"k": "v"}}</tool_call>
-#      Models trained for function-calling almost universally emit this
-#      shape regardless of what our system prompt asks — that's what they
-#      were fine-tuned on.  Accepting it here means we don't have to fight
-#      the training prior of every FC model we want to run.
-#
-#   3. BRACKETED-NAME (xLAM quirk, surfaced during the dual-pipeline bench
-#      in #80 / #81 — issue #82):
-#        [NAME]{"k": "v"}</NAME>     — JSON args + matching close
-#        [NAME]UPPERCASE_IDENT()     — empty args, function-call-style noise
-#      The skill name IS the tag, with the open form using square brackets.
-#      To avoid false positives on user prose like `[note]` quoted in a
-#      chat reply, this dialect REQUIRES the name to be in the registered
-#      tool set.  Without that gate, parser would fire on innocent text.
-#
-# All three shapes are extracted into the same `{"tool": name, "args": dict}`
-# record, so downstream execute() + server eventing is format-agnostic.
-#
-# Tolerance knobs inherited from the prior implementation:
-#   - Stray `>` after JSON, missing `</args>`, extra whitespace all handled.
-#   - xLAM quirk on dialect 1: emits `[tool>` (left-bracket instead of
-#     left-angle) on the opening tag — the anchor regex accepts either,
-#     since the closing `</tool>` still disambiguates unambiguously.
-#
-# Tolerant regex: handles stray > after JSON, missing </args>, extra whitespace.
-# The `[<\[]tool[>\]]` open-tag class accepts `<tool>`, `[tool>`, `<tool]`, AND
-# `[tool]` — quantized small models (notably xLAM) emit broken open brackets
-# semi-randomly; the closing `</tool>` is always intact so there's no ambiguity.
-TOOL_PATTERN = re.compile(r'[<\[]tool[>\]](\w+)</tool>\s*<args>\s*({.*?})\s*>?\s*</args>', re.DOTALL)
-# Fallback: if </args> is missing entirely, grab JSON after <args>
-TOOL_PATTERN_LOOSE = re.compile(r'[<\[]tool[>\]](\w+)</tool>\s*<args>\s*({[^<]*})', re.DOTALL)
-
-# Dialect 3 cheap pre-check — used by has_tool_call.  Matches `[name]`
-# where `name` looks like a registered-tool identifier.  False positives
-# at this stage are fine; parse_tool_calls validates against the tool
-# registry before accepting.
-_BRACKET_NAME_PRECHECK = re.compile(r"\[([a-z_][a-z0-9_]*)\]")
-# Dialect 3 noise-args sanity check — the GETCURRENTDATEANDTIME() form
-# from xLAM should look like a function name (uppercase identifier),
-# not prose.  3-50 chars keeps real-world cases without exploding the
-# match window.
-_BRACKET_NOISE_IDENT = re.compile(r"^[A-Z][A-Z0-9_]{2,49}$")
 
 
 class ToolRegistry:
@@ -134,237 +99,39 @@ class ToolRegistry:
     def parse_tool_calls(self, text: str) -> list[dict]:
         """Parse tool calls from LLM output text.
 
-        Looks for <tool>name</tool><args>{"key": "value"}</args> patterns.
-        Tolerant of small model quirks (stray >, missing </args>, etc).
-        Returns list of {"tool": name, "args": dict}.
-
-        v4·D audit P2 fix: the regex `{.*?}` is non-greedy and will
-        truncate at the first `}` it encounters -- a nested JSON value
-        like {"filter": {"k": "v"}} lost its outer closer.  We now
-        balance braces manually after the regex anchors the position.
-
-        γ2-M1 (issue #104): pre-fix this method swallowed JSON-decode
-        errors silently — `parse_tool_calls_with_errors` is the
-        error-surfacing sibling.  This method preserves the original
-        list-only signature for backward compatibility (16 existing
-        unit tests + 2 conversation.py call sites).
+        Backward-compatible wrapper around the
+        ``parser.parse_tool_calls_with_errors`` free function.  The
+        16+ existing call sites that don't surface parse errors
+        consume this signature; new code should prefer the
+        ``with_errors`` sibling so γ2-M1 (#104) parse failures
+        reach the user via tool_parse_failed events.
         """
-        calls, _errors = self.parse_tool_calls_with_errors(text)
-        return calls
+        return _parse_tool_calls(text, registered_names=self._tools.keys())
 
     def parse_tool_calls_with_errors(
         self, text: str
     ) -> tuple[list[dict], list[dict]]:
         """Like :meth:`parse_tool_calls`, but also returns parse errors.
 
-        γ2-M1 (issue #104, refs #89, refs #101).  The Phase-2 audit
-        identified the silent JSON-decode swallow as user-invisible
-        agentic failure: the LLM emits a tool call, the parser fails
-        to load the args, the tool never fires, and the user sees a
-        generic / empty reply with no signal that anything was tried.
-
-        Returns
-        -------
-        (calls, errors)
-            ``calls`` is identical to what :meth:`parse_tool_calls`
-            returns (list of ``{"tool": name, "args": dict}``).
-            ``errors`` is a list of error records:
-
-                {"dialect": 1|2|3,
-                 "name": str | None,
-                 "reason": "json_decode"}
-
-            ``name`` is ``None`` for dialect-2 errors, where the JSON
-            parse fails before the FC envelope's ``name`` field can be
-            read.  ``reason`` is currently always ``"json_decode"`` —
-            the only failure mode worth surfacing today; structurally-
-            wrong FC envelopes (e.g. missing ``name``) stay silent
-            because they look indistinguishable from prose-shaped JSON.
+        γ2-M1 (issue #104, refs #89, refs #101) — see
+        ``dragon_voice.tools.parser`` for the full implementation.
+        Pre-fix the silent JSON-decode swallow surfaced as
+        user-invisible agentic failure (LLM emits tool call,
+        parser fails, tool never fires, user sees empty reply).
         """
-        import re as _re
-        calls: list[dict] = []
-        errors: list[dict] = []
-
-        def _walk_json(text: str, start: int) -> int:
-            """Return index one past the matching `}` for the JSON object
-            that starts at `text[start] == '{'`.  Honors string quoting +
-            backslash escapes.  Returns -1 on unbalanced input."""
-            if start >= len(text) or text[start] != '{':
-                return -1
-            depth = 0
-            in_str = False
-            esc = False
-            for j in range(start, len(text)):
-                ch = text[j]
-                if in_str:
-                    if esc:
-                        esc = False
-                    elif ch == '\\':
-                        esc = True
-                    elif ch == '"':
-                        in_str = False
-                    continue
-                if ch == '"':
-                    in_str = True
-                elif ch == '{':
-                    depth += 1
-                elif ch == '}':
-                    depth -= 1
-                    if depth == 0:
-                        return j + 1
-            return -1
-
-        # Dialect 1 — legacy `<tool>NAME</tool><args>{json}</args>` (and the
-        # xLAM `[tool>...` / `[tool]...` bracket quirks on the open tag).
-        # Anchor on the `<args>` prefix so the JSON walker picks up the full
-        # object even with nested braces.
-        anchor_legacy = _re.compile(r'[<\[]tool[>\]](\w+)</tool>\s*<args>\s*', _re.DOTALL)
-        for m in anchor_legacy.finditer(text):
-            name = m.group(1)
-            i = m.end()
-            end = _walk_json(text, i)
-            if end < 0:
-                continue
-            args_str = text[i:end].strip()
-            try:
-                args = json.loads(args_str)
-                calls.append({"tool": name, "args": args})
-            except json.JSONDecodeError:
-                logger.warning("Failed to parse tool args for %s: %s",
-                               name, args_str[:100])
-                errors.append({
-                    "dialect": 1, "name": name, "reason": "json_decode",
-                })
-
-        # Dialect 2 — industry-standard `<tool_call>{"name": "X",
-        # "arguments": {...}}</tool_call>`.  Walk the JSON directly from
-        # right after the opening tag.  Whitespace / newlines between the
-        # tag and the `{` are tolerated.
-        anchor_std = _re.compile(r'<tool_call>\s*', _re.DOTALL)
-        for m in anchor_std.finditer(text):
-            i = m.end()
-            end = _walk_json(text, i)
-            if end < 0:
-                continue
-            body = text[i:end].strip()
-            try:
-                parsed = json.loads(body)
-            except json.JSONDecodeError:
-                logger.warning("Failed to parse <tool_call> body: %s",
-                               body[:120])
-                errors.append({
-                    "dialect": 2, "name": None, "reason": "json_decode",
-                })
-                continue
-            if not isinstance(parsed, dict):
-                continue
-            name = parsed.get("name")
-            args = parsed.get("arguments", parsed.get("args", {}))
-            if not isinstance(name, str) or not name:
-                continue
-            if not isinstance(args, dict):
-                args = {}
-            calls.append({"tool": name, "args": args})
-
-        # Dialect 3 — bracketed-name (xLAM quirk, issue #82).
-        # `[recall]{"query":"…"}</recall>` or `[datetime]GETCURRENTTIME()`.
-        # The skill name IS the tag, so without a registry validation step
-        # we'd false-positive on prose like `[note]` quoted in a chat
-        # reply.  Skip the pass entirely if no tools are registered (the
-        # validation gate would reject everything anyway).
-        if self._tools:
-            for m in _BRACKET_NAME_PRECHECK.finditer(text):
-                name = m.group(1)
-                if name not in self._tools:
-                    continue
-                i = m.end()
-                # Skip whitespace immediately after the opening bracket.
-                while i < len(text) and text[i] in " \t\n\r":
-                    i += 1
-                if i >= len(text):
-                    continue
-
-                args: Optional[dict] = None
-
-                if text[i] == "{":
-                    # Sub-form A: `[NAME]{json}</NAME>` — JSON args + close.
-                    end = _walk_json(text, i)
-                    if end < 0:
-                        continue
-                    try:
-                        parsed_args = json.loads(text[i:end])
-                    except json.JSONDecodeError:
-                        logger.warning(
-                            "Failed to parse bracket-name args for %s: %s",
-                            name, text[i:end][:100],
-                        )
-                        errors.append({
-                            "dialect": 3, "name": name, "reason": "json_decode",
-                        })
-                        continue
-                    if not isinstance(parsed_args, dict):
-                        continue
-                    args = parsed_args
-                    # The matching `</NAME>` close tag is *encouraged* but not
-                    # required — xLAM emits it cleanly on most prompts but
-                    # truncates on others.  We accept either way.
-                else:
-                    # Sub-form B: `[NAME]IDENT()` — empty args, function-name
-                    # noise.  Bail if the noise spans more than ~50 chars
-                    # (real-world cases like GETCURRENTDATEANDTIME stay
-                    # well under that) or doesn't look like an identifier.
-                    paren = text.find("()", i, i + 80)
-                    if paren < 0:
-                        continue
-                    noise = text[i:paren].strip()
-                    if not _BRACKET_NOISE_IDENT.match(noise):
-                        continue
-                    args = {}
-
-                if args is not None:
-                    calls.append({"tool": name, "args": args})
-
-        return calls, errors
+        return _parse_tool_calls_with_errors(
+            text, registered_names=self._tools.keys(),
+        )
 
     def has_tool_call(self, text: str) -> bool:
         """Quick check if text contains a tool call marker.
-        Accepts the three dialects the parser understands: the legacy
-        `<tool>NAME</tool>` shape, the industry-standard
-        `<tool_call>{...}</tool_call>` shape, and the bracketed-name
-        xLAM quirk `[NAME]{json}</NAME>` / `[NAME]IDENT()` (gated on the
-        name actually matching a registered tool, so prose like
-        `[note]` in a chat reply doesn't fire).
-        """
-        has_legacy = (
-            ("<tool>" in text or "[tool>" in text or "[tool]" in text or "<tool]" in text)
-            and "</tool>" in text
-        )
-        has_std = "<tool_call>" in text and "</tool_call>" in text
-        if has_legacy or has_std:
-            return True
+        Accepts all three dialects the parser understands.
 
-        if not self._tools:
-            return False
-        for m in _BRACKET_NAME_PRECHECK.finditer(text):
-            if m.group(1) not in self._tools:
-                continue
-            # Peek past whitespace for the `{` (sub-form A) or
-            # `<word>(` (sub-form B) that distinguishes a real call
-            # from prose that happens to mention `[recall]`.  Without
-            # this guard, `has_tool_call` over-fires on chat replies
-            # whenever a tool name appears in brackets.
-            j = m.end()
-            while j < len(text) and text[j] in " \t\n\r":
-                j += 1
-            if j >= len(text):
-                continue
-            if text[j] == "{":
-                return True
-            # Sub-form B: identifier+`()` should appear within the same
-            # window parse_tool_calls scans.
-            if "()" in text[j:j + 80]:
-                return True
-        return False
+        Forwards to ``parser.has_tool_call`` with the registered
+        tool-name set so dialect 3 doesn't false-fire on prose
+        like ``[note]`` quoted in a chat reply.
+        """
+        return _has_tool_call(text, registered_names=self._tools.keys())
 
     def format_for_llm(self, compact: bool = False) -> str:
         """Format tool descriptions for injection into LLM system prompt.

--- a/tests/test_tool_parser_module.py
+++ b/tests/test_tool_parser_module.py
@@ -1,0 +1,220 @@
+"""Tests for ``dragon_voice.tools.parser`` (the module-level API).
+
+The 27 existing tests in tests/test_tool_parser.py exercise the
+parser via ToolRegistry (the backward-compatible call site).
+This file exercises the parser as the module-level free
+functions directly — pinning the new API contract so callers
+that bypass the registry (future skill SDK introspection,
+external test harnesses) can rely on the same shape.
+"""
+from __future__ import annotations
+
+import pytest
+
+from dragon_voice.tools.parser import (
+    has_tool_call,
+    parse_tool_calls,
+    parse_tool_calls_with_errors,
+)
+
+
+# ─── parse_tool_calls (backward-compat list-only) ────────────
+
+
+class TestParseToolCalls:
+    def test_empty_string_returns_empty(self):
+        assert parse_tool_calls("", registered_names=set()) == []
+
+    def test_dialect1_basic(self):
+        text = '<tool>web_search</tool><args>{"q": "weather"}</args>'
+        calls = parse_tool_calls(text, registered_names={"web_search"})
+        assert calls == [{"tool": "web_search", "args": {"q": "weather"}}]
+
+    def test_dialect2_basic(self):
+        text = '<tool_call>{"name": "datetime", "arguments": {}}</tool_call>'
+        calls = parse_tool_calls(text, registered_names={"datetime"})
+        assert calls == [{"tool": "datetime", "args": {}}]
+
+    def test_dialect3_basic(self):
+        text = '[recall]{"query": "user prefs"}</recall>'
+        calls = parse_tool_calls(text, registered_names={"recall"})
+        assert calls == [{"tool": "recall", "args": {"query": "user prefs"}}]
+
+
+# ─── parse_tool_calls_with_errors (γ2-M1 surfacing) ──────────
+
+
+class TestParseToolCallsWithErrors:
+    def test_returns_tuple_of_calls_and_errors(self):
+        result = parse_tool_calls_with_errors(
+            "", registered_names=set(),
+        )
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        calls, errors = result
+        assert calls == []
+        assert errors == []
+
+    def test_dialect1_json_decode_failure_surfaced(self):
+        text = '<tool>x</tool><args>{not json}</args>'
+        calls, errors = parse_tool_calls_with_errors(
+            text, registered_names={"x"},
+        )
+        assert calls == []
+        assert errors == [
+            {"dialect": 1, "name": "x", "reason": "json_decode"},
+        ]
+
+    def test_dialect2_json_decode_failure_surfaced(self):
+        text = '<tool_call>{not json}</tool_call>'
+        calls, errors = parse_tool_calls_with_errors(
+            text, registered_names=set(),
+        )
+        assert calls == []
+        assert errors == [
+            {"dialect": 2, "name": None, "reason": "json_decode"},
+        ]
+
+    def test_dialect3_json_decode_failure_surfaced(self):
+        text = '[recall]{not json}</recall>'
+        calls, errors = parse_tool_calls_with_errors(
+            text, registered_names={"recall"},
+        )
+        assert calls == []
+        assert errors == [
+            {"dialect": 3, "name": "recall", "reason": "json_decode"},
+        ]
+
+
+# ─── Dialect 3 registry-name validation gate ─────────────────
+
+
+class TestDialect3NameGate:
+    def test_unregistered_name_silently_dropped(self):
+        """Pin: bracket-name pre-check that doesn't match a
+        registered tool MUST NOT enter the parse path — otherwise
+        prose like `[note]` quoted in a chat reply would over-fire."""
+        text = '[note]{"text": "hi"}</note>'
+        calls = parse_tool_calls(
+            text, registered_names={"web_search"},  # `note` NOT registered
+        )
+        assert calls == []
+
+    def test_empty_registry_skips_dialect3_entirely(self):
+        text = '[anything]{"key": "value"}</anything>'
+        calls, errors = parse_tool_calls_with_errors(
+            text, registered_names=set(),
+        )
+        assert calls == []
+        # Even malformed dialect-3 args won't surface errors when
+        # the registry is empty (we skip the whole pass).
+        assert errors == []
+
+
+# ─── Nested-JSON brace walker (audit P2 fix) ────────────────
+
+
+class TestNestedJsonWalker:
+    def test_dialect1_with_nested_json_args_preserved(self):
+        """audit P2: pre-fix the regex `{.*?}` truncated at the
+        first inner `}` and lost the outer closer."""
+        text = '<tool>x</tool><args>{"filter": {"k": "v"}}</args>'
+        calls = parse_tool_calls(text, registered_names={"x"})
+        assert calls == [
+            {"tool": "x", "args": {"filter": {"k": "v"}}},
+        ]
+
+    def test_dialect2_with_nested_json_arguments_preserved(self):
+        text = (
+            '<tool_call>{"name": "x", '
+            '"arguments": {"filter": {"k": {"deep": "v"}}}}</tool_call>'
+        )
+        calls = parse_tool_calls(text, registered_names={"x"})
+        assert calls == [
+            {"tool": "x", "args": {"filter": {"k": {"deep": "v"}}}},
+        ]
+
+
+# ─── xLAM open-tag bracket quirks ────────────────────────────
+
+
+class TestXlamBracketQuirks:
+    @pytest.mark.parametrize("open_tag", [
+        "<tool>", "[tool>", "<tool]", "[tool]",
+    ])
+    def test_dialect1_accepts_all_four_open_tag_combos(self, open_tag):
+        text = f'{open_tag}x</tool><args>{{"k": "v"}}</args>'
+        calls = parse_tool_calls(text, registered_names={"x"})
+        assert calls == [{"tool": "x", "args": {"k": "v"}}]
+
+
+# ─── has_tool_call ───────────────────────────────────────────
+
+
+class TestHasToolCall:
+    def test_empty_string_false(self):
+        assert has_tool_call("", registered_names=set()) is False
+
+    def test_dialect1_marker_true(self):
+        assert has_tool_call(
+            "<tool>x</tool>", registered_names=set(),
+        ) is True
+
+    def test_dialect2_marker_true(self):
+        assert has_tool_call(
+            "<tool_call>{}</tool_call>", registered_names=set(),
+        ) is True
+
+    def test_dialect3_with_registered_name_true(self):
+        assert has_tool_call(
+            '[recall]{"q": "x"}', registered_names={"recall"},
+        ) is True
+
+    def test_dialect3_with_unregistered_name_false(self):
+        """Pin: prose like `[note]` quoted in a chat reply MUST
+        NOT register as a tool call when `note` isn't a registered
+        tool."""
+        assert has_tool_call(
+            '[note]{"x": 1}', registered_names={"web_search"},
+        ) is False
+
+    def test_dialect3_bracket_name_without_following_brace_or_paren_false(self):
+        """`[recall] text follows` is prose — the bracket-name
+        peek-ahead must distinguish from a real call."""
+        assert has_tool_call(
+            "[recall] is what I just did",
+            registered_names={"recall"},
+        ) is False
+
+    def test_dialect3_bracket_name_with_paren_form_true(self):
+        """xLAM sub-form B: `[NAME]IDENT()` — empty args."""
+        assert has_tool_call(
+            "[datetime] GETCURRENTTIME()",
+            registered_names={"datetime"},
+        ) is True
+
+
+# ─── Multi-call extraction ──────────────────────────────────
+
+
+class TestMultiCall:
+    def test_two_dialect1_calls_in_one_text(self):
+        text = (
+            '<tool>a</tool><args>{"k":1}</args>'
+            ' some text '
+            '<tool>b</tool><args>{"k":2}</args>'
+        )
+        calls = parse_tool_calls(text, registered_names={"a", "b"})
+        assert calls == [
+            {"tool": "a", "args": {"k": 1}},
+            {"tool": "b", "args": {"k": 2}},
+        ]
+
+    def test_mixed_dialects_in_one_text(self):
+        text = (
+            '<tool>a</tool><args>{"k":1}</args>'
+            '<tool_call>{"name":"b", "arguments":{"k":2}}</tool_call>'
+        )
+        calls = parse_tool_calls(text, registered_names={"a", "b"})
+        names = [c["tool"] for c in calls]
+        assert "a" in names and "b" in names


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **twenty-third sub-extract**.  First slice from \`dragon_voice/tools/registry.py\` (audit SRP-5: registry + 3-dialect parser + 2-format formatter all bundled in one ToolRegistry class).

Pre-extract \`tools/registry.py\` was 439 LOC mixing three concerns:
- Tool registration + execute (~70 LOC)
- **Tool-call parser across 3 dialects (~230 LOC) ← extracted**
- Formatter for LLM system prompts (~70 LOC)

The parser is a pure function (text in → call list out) that doesn't need ToolRegistry's instance state EXCEPT to validate dialect-3 names against the set of registered tools. Extracted as free functions taking a \`registered_names\` AbstractSet argument; ToolRegistry keeps thin forwarding methods for backward compat with the 16+ existing call sites.

### Behaviour preserved verbatim

- **Three accepted dialects:**
  1. Legacy: \`<tool>NAME</tool><args>{json}</args>\`
  2. Standard: \`<tool_call>{\"name\": \"X\", \"arguments\": {...}}</tool_call>\`
  3. Bracketed-name: \`[NAME]{json}</NAME>\` | \`[NAME]IDENT()\`
- xLAM open-tag bracket quirks accepted on dialect 1 (\`<tool>\`, \`[tool>\`, \`<tool]\`, \`[tool]\`)
- Nested-JSON brace walker (audit P2 fix) — handles \`{\"filter\": {\"k\": \"v\"}}\` without truncating at first inner \`}\`
- Dialect 3 registry-name validation gate — prevents prose like \`[note]\` quoted in chat replies from over-firing
- γ2-M1 (#104) parse-error surfacing via \`parse_tool_calls_with_errors\` return tuple
- \`TOOL_PATTERN\` / \`TOOL_PATTERN_LOOSE\` re-exported from registry for any external caller that imported them directly

### Test coverage

- **27 existing tests** in \`tests/test_tool_parser.py\` unchanged (exercise via ToolRegistry forwarding methods)
- **25 new tests** in \`tests/test_tool_parser_module.py\` exercising the free-function API directly

Total tool-parser coverage: **52 tests** across 6 dialect/edge categories (parse_tool_calls + parse_tool_calls_with_errors API, dialect-3 name gate, nested JSON walker, xLAM bracket quirks, has_tool_call cases, multi-call extraction).

### Diff stats

| Metric | Before | After |
|---|---|---|
| \`tools/registry.py\` LOC | 439 | 206 (-53%) |
| \`tools/parser.py\` | (didn't exist) | 347 (new) |

## Test plan

- [x] \`python3 -m pytest tests/test_tool_parser.py tests/test_tool_parser_module.py -v\` → 52 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → **1127 passed**, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)