### PR TITLE
refactor(tools): extract tool formatter (~70 LOC) to tools/formatter module — closes audit SRP-5

### DIFF
--- a/dragon_voice/tools/formatter.py
+++ b/dragon_voice/tools/formatter.py
@@ -1,0 +1,172 @@
+"""Tool descriptor formatter — compact + full LLM-prompt formats.
+
+Wave 23 SOLID-audit follow-up — twenty-fourth sub-extract;
+second slice from `tools/registry.py` (audit SRP-5: registry +
+3-dialect parser + 2-format formatter all bundled in one
+class).  PR #249 already extracted the parser; this completes
+SRP-5 by extracting the formatter.
+
+The formatter renders a list of registered tools into a system-
+prompt block suitable for injection into LLM context.  Two
+flavours:
+
+  * **Compact** — minimal format for small local models
+    (qwen3:1.7b etc).  Fewer tokens, simpler structure, only
+    the priority tools — small models confuse easily on long
+    tool lists.
+  * **Full** — rich format for capable cloud models with
+    multiple worked examples.
+
+Pre-extract these were 70 LOC of `_format_compact` /
+`_format_full` methods on ToolRegistry, reaching back into
+`self._tools`.  Now lives as free functions taking the tool
+list explicitly; the registry keeps a thin `format_for_llm`
+forwarding method.
+
+## API
+
+```python
+text = format_for_llm(tools, compact=False)
+```
+
+`tools` is the iterable of registered Tool instances (typically
+`registry._tools.values()`).  `compact=True` switches to the
+small-model format.
+
+## Why a separate module
+
+Formatter concerns evolve independently of registry/parser:
+adding a new dialect to the prompt block, tuning the priority-
+tool list (issue #134 added schedule_reminder), or experimenting
+with template variations all happen here without touching the
+registry or parser modules.
+
+## Priority-tool list (issue #134 closure)
+
+`schedule_reminder` was missing from the compact priority list
+pre-#134 — local LLM hallucinated "no such tool available" when
+the user asked for a reminder.  The list is module-level here
+so the contract is greppable; future additions are a one-line
+edit visible to the audit doc.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+from dragon_voice.tools.base import Tool
+
+
+# Compact-format priority tool list.  Only these get included
+# in the small-model prompt — wider lists confuse qwen3:1.7b
+# etc into picking the wrong tool or refusing entirely.
+#
+# Issue #134: `schedule_reminder` was missing — local LLM
+# hallucinated "no such tool available" when the user asked
+# for a reminder.  Adding ~30 tokens to the system prompt is a
+# worthwhile trade for unlocking a high-value capability.
+COMPACT_PRIORITY_TOOLS: tuple[str, ...] = (
+    "web_search",
+    "datetime",
+    "remember",
+    "recall",
+    "calculator",
+    "schedule_reminder",
+)
+
+# Fallback when none of the priority tools are registered (e.g.
+# a test harness with a custom tool set).  Keeps the compact
+# block from being empty + structurally broken.
+_COMPACT_FALLBACK_LIMIT = 4
+
+
+def format_for_llm(
+    tools: Iterable[Tool],
+    *,
+    compact: bool = False,
+) -> str:
+    """Render the registered tools into a system-prompt block.
+
+    Args:
+        tools: Iterable of Tool instances to render (typically
+            `registry._tools.values()`).
+        compact: If True, use the small-model minimal format
+            (priority tools only, single example per tool).
+            If False, use the full format with multi-example
+            block.
+
+    Returns:
+        The formatted block ready to inject into the system
+        prompt.  Empty string when `tools` is empty (caller
+        should still inject — empty block is harmless).
+    """
+    tools_list = list(tools)
+    if not tools_list:
+        return ""
+
+    if compact:
+        return _format_compact(tools_list)
+    return _format_full(tools_list)
+
+
+def _format_compact(tools: list[Tool]) -> str:
+    """Minimal tool format for small models (qwen3:1.7b etc).
+
+    Uses fewer tokens and simpler structure to avoid confusing
+    small models.  Only shows the priority tools to reduce
+    context bloat.
+    """
+    selected = [t for t in tools if t.name in COMPACT_PRIORITY_TOOLS]
+    if not selected:
+        # No priority tools registered — fall back to the first
+        # few tools so the block isn't empty/broken.
+        selected = tools[:_COMPACT_FALLBACK_LIMIT]
+
+    lines = ["\n[TOOLS]"]
+    lines.append("Format: <tool>NAME</tool><args>{JSON}</args>")
+    for tool in selected:
+        params = tool.parameters_schema.get("properties", {})
+        required = tool.parameters_schema.get("required", [])
+        req_keys = [k for k in params if k in required]
+        lines.append(f"- {tool.name}: {tool.description}")
+        if req_keys:
+            lines.append(
+                f'  Example: <tool>{tool.name}</tool>'
+                f'<args>{{"{req_keys[0]}": "..."}}</args>'
+            )
+    lines.append("Only use tools when needed. Most questions don't need tools.")
+    lines.append("[/TOOLS]")
+    return "\n".join(lines)
+
+
+def _format_full(tools: list[Tool]) -> str:
+    """Full tool format for capable cloud models."""
+    lines = ["\n[TOOLS]"]
+    lines.append("You can use tools by outputting EXACTLY this format:")
+    lines.append('<tool>TOOLNAME</tool><args>{"key": "value"}</args>')
+    lines.append("")
+    lines.append("Available tools:")
+    for tool in tools:
+        params = tool.parameters_schema.get("properties", {})
+        lines.append(f"  {tool.name}: {tool.description}")
+        if params:
+            lines.append(
+                "    Args: {"
+                + ", ".join(
+                    f'"{k}": {v.get("type", "")}'
+                    for k, v in params.items()
+                )
+                + "}"
+            )
+
+    lines.append("")
+    lines.append("Examples:")
+    lines.append('  <tool>web_search</tool><args>{"query": "weather today"}</args>')
+    lines.append('  <tool>remember</tool><args>{"fact": "User likes pizza"}</args>')
+    lines.append('  <tool>recall</tool><args>{"query": "user preferences"}</args>')
+    lines.append('  <tool>calculator</tool><args>{"expression": "15% of 230"}</args>')
+    lines.append('  <tool>weather</tool><args>{"location": "Tokyo"}</args>')
+    lines.append("")
+    lines.append("IMPORTANT: Only use a tool when genuinely needed. Most questions don't need tools.")
+    lines.append("[/TOOLS]")
+
+    return "\n".join(lines)

--- a/dragon_voice/tools/registry.py
+++ b/dragon_voice/tools/registry.py
@@ -1,12 +1,14 @@
 """Tool registry: register + execute tools.
 
-Wave 23 SOLID-audit follow-up — parser extracted to
-`dragon_voice.tools.parser` (PR #249, audit SRP-5 first slice).
-This module now owns just the registry + execution + formatter
-responsibilities; the three-dialect XML/bracket parser lives
-next door and is invoked via thin forwarding methods on
-`ToolRegistry` for backward compat with the 16+ existing call
-sites.
+Wave 23 SOLID-audit follow-up (audit SRP-5):
+  * Parser extracted to `dragon_voice.tools.parser` (PR #249).
+  * Formatter extracted to `dragon_voice.tools.formatter`
+    (PR #250).
+
+This module now owns just the registry + execution
+responsibilities; the parser and formatter live next door and
+are invoked via thin forwarding methods on `ToolRegistry` for
+backward compat with the 16+ existing call sites.
 """
 
 import logging
@@ -25,6 +27,7 @@ from dragon_voice.tools.parser import (  # noqa: F401  (re-exports)
     parse_tool_calls as _parse_tool_calls,
     parse_tool_calls_with_errors as _parse_tool_calls_with_errors,
 )
+from dragon_voice.tools.formatter import format_for_llm as _format_for_llm
 
 logger = logging.getLogger(__name__)
 
@@ -136,71 +139,9 @@ class ToolRegistry:
     def format_for_llm(self, compact: bool = False) -> str:
         """Format tool descriptions for injection into LLM system prompt.
 
-        Args:
-            compact: If True, use minimal format for small local models
-                    (fewer tokens = faster generation, less confusion).
+        Forwards to ``formatter.format_for_llm`` with the
+        registered Tool instances.  Compact format is for small
+        local models (qwen3:1.7b etc — fewer tokens, priority
+        tools only); full format is for capable cloud models.
         """
-        if not self._tools:
-            return ""
-
-        if compact:
-            return self._format_compact()
-        return self._format_full()
-
-    def _format_compact(self) -> str:
-        """Minimal tool format for small models (qwen3:1.7b etc).
-
-        Uses fewer tokens and simpler structure to avoid confusing small models.
-        Only shows the most commonly used tools to reduce context bloat.
-        """
-        # Core tools that small models handle well.  Issue #134:
-        # `schedule_reminder` was missing — local LLM hallucinated
-        # "no such tool available" when the user asked for a reminder.
-        # Adding ~30 tokens to the system prompt is a worthwhile
-        # trade for unlocking a high-value capability.
-        priority_tools = [
-            "web_search", "datetime", "remember", "recall",
-            "calculator", "schedule_reminder",
-        ]
-        tools = [t for t in self._tools.values() if t.name in priority_tools]
-        if not tools:
-            tools = list(self._tools.values())[:4]
-
-        lines = ["\n[TOOLS]"]
-        lines.append("Format: <tool>NAME</tool><args>{JSON}</args>")
-        for tool in tools:
-            params = tool.parameters_schema.get("properties", {})
-            required = tool.parameters_schema.get("required", [])
-            req_keys = [k for k in params if k in required]
-            lines.append(f"- {tool.name}: {tool.description}")
-            if req_keys:
-                lines.append(f'  Example: <tool>{tool.name}</tool><args>{{"{req_keys[0]}": "..."}}</args>')
-        lines.append("Only use tools when needed. Most questions don't need tools.")
-        lines.append("[/TOOLS]")
-        return "\n".join(lines)
-
-    def _format_full(self) -> str:
-        """Full tool format for capable cloud models."""
-        lines = ["\n[TOOLS]"]
-        lines.append("You can use tools by outputting EXACTLY this format:")
-        lines.append('<tool>TOOLNAME</tool><args>{"key": "value"}</args>')
-        lines.append("")
-        lines.append("Available tools:")
-        for tool in self._tools.values():
-            params = tool.parameters_schema.get("properties", {})
-            lines.append(f"  {tool.name}: {tool.description}")
-            if params:
-                lines.append("    Args: {" + ", ".join(f'"{k}": {v.get("type","")}' for k,v in params.items()) + "}")
-
-        lines.append("")
-        lines.append("Examples:")
-        lines.append('  <tool>web_search</tool><args>{"query": "weather today"}</args>')
-        lines.append('  <tool>remember</tool><args>{"fact": "User likes pizza"}</args>')
-        lines.append('  <tool>recall</tool><args>{"query": "user preferences"}</args>')
-        lines.append('  <tool>calculator</tool><args>{"expression": "15% of 230"}</args>')
-        lines.append('  <tool>weather</tool><args>{"location": "Tokyo"}</args>')
-        lines.append("")
-        lines.append("IMPORTANT: Only use a tool when genuinely needed. Most questions don't need tools.")
-        lines.append("[/TOOLS]")
-
-        return "\n".join(lines)
+        return _format_for_llm(self._tools.values(), compact=compact)

--- a/tests/test_tool_formatter.py
+++ b/tests/test_tool_formatter.py
@@ -1,0 +1,205 @@
+"""Tests for ``dragon_voice.tools.formatter``.
+
+Pin every formatter branch + the priority-tool list (issue #134
+closure) so a future refactor can't silently regress to losing
+schedule_reminder from the compact format.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from dragon_voice.tools.formatter import (
+    COMPACT_PRIORITY_TOOLS,
+    format_for_llm,
+)
+
+
+def _make_tool(
+    name: str,
+    *,
+    description: str = "test desc",
+    properties: dict | None = None,
+    required: list[str] | None = None,
+) -> MagicMock:
+    tool = MagicMock()
+    tool.name = name
+    tool.description = description
+    tool.parameters_schema = {
+        "properties": properties or {},
+        "required": required or [],
+    }
+    return tool
+
+
+# ─── Empty input ─────────────────────────────────────────────
+
+
+class TestEmpty:
+    def test_empty_tools_returns_empty_string(self):
+        assert format_for_llm([]) == ""
+        assert format_for_llm([], compact=True) == ""
+
+
+# ─── Compact format ──────────────────────────────────────────
+
+
+class TestCompactFormat:
+    def test_compact_uses_priority_subset(self):
+        """Pin: only priority tools render in the compact format
+        even when the registry has more tools."""
+        tools = [
+            _make_tool("web_search"),
+            _make_tool("calculator"),
+            _make_tool("custom_tool"),       # NOT in priority list
+            _make_tool("another_custom"),    # NOT in priority list
+        ]
+        result = format_for_llm(tools, compact=True)
+        assert "web_search" in result
+        assert "calculator" in result
+        assert "custom_tool" not in result
+        assert "another_custom" not in result
+
+    def test_compact_falls_back_to_first_4_when_no_priority_tools(self):
+        """When NONE of the registered tools are in the priority
+        list, fall back to the first 4 so the block isn't empty/
+        broken."""
+        tools = [
+            _make_tool("custom_a"),
+            _make_tool("custom_b"),
+            _make_tool("custom_c"),
+            _make_tool("custom_d"),
+            _make_tool("custom_e"),  # 5th — should NOT appear
+        ]
+        result = format_for_llm(tools, compact=True)
+        assert "custom_a" in result
+        assert "custom_b" in result
+        assert "custom_c" in result
+        assert "custom_d" in result
+        assert "custom_e" not in result
+
+    def test_compact_includes_example_for_required_args(self):
+        tools = [
+            _make_tool(
+                "web_search",
+                properties={"query": {"type": "string"}},
+                required=["query"],
+            ),
+        ]
+        result = format_for_llm(tools, compact=True)
+        # Pin the exact example shape (catch any future drift)
+        assert '<tool>web_search</tool><args>{"query": "..."}</args>' in result
+
+    def test_compact_no_example_when_no_required_args(self):
+        tools = [_make_tool("datetime")]
+        result = format_for_llm(tools, compact=True)
+        assert "datetime" in result
+        assert "Example:" not in result
+
+    def test_compact_block_structure(self):
+        result = format_for_llm(
+            [_make_tool("web_search")], compact=True,
+        )
+        # [TOOLS] open + close
+        assert "[TOOLS]" in result
+        assert "[/TOOLS]" in result
+        # Format hint
+        assert "Format: <tool>NAME</tool><args>{JSON}</args>" in result
+        # Tail nudge
+        assert "Only use tools when needed" in result
+
+
+# ─── Full format ─────────────────────────────────────────────
+
+
+class TestFullFormat:
+    def test_full_includes_all_tools_no_filter(self):
+        """Full format injects EVERY registered tool — capable
+        cloud models can handle the longer list."""
+        tools = [
+            _make_tool("custom_a"),
+            _make_tool("custom_b"),
+            _make_tool("custom_c"),
+        ]
+        result = format_for_llm(tools, compact=False)
+        for name in ("custom_a", "custom_b", "custom_c"):
+            assert name in result
+
+    def test_full_includes_canonical_examples(self):
+        """Pin the canonical worked-example block — present in
+        the full format regardless of which tools are
+        registered.  Models (especially Claude) anchor on these."""
+        result = format_for_llm([_make_tool("x")], compact=False)
+        for canonical in (
+            "web_search", "remember", "recall", "calculator", "weather",
+        ):
+            assert canonical in result
+
+    def test_full_args_block_when_properties_present(self):
+        tools = [
+            _make_tool(
+                "search",
+                properties={
+                    "query": {"type": "string"},
+                    "limit": {"type": "integer"},
+                },
+            ),
+        ]
+        result = format_for_llm(tools, compact=False)
+        assert 'Args: {"query": string, "limit": integer}' in result
+
+    def test_full_no_args_block_when_no_properties(self):
+        tools = [_make_tool("datetime")]
+        result = format_for_llm(tools, compact=False)
+        assert "Args:" not in result.split("Examples:")[0]
+
+
+# ─── Compact / Full distinguishable ──────────────────────────
+
+
+class TestCompactVsFull:
+    def test_compact_default_is_false(self):
+        """format_for_llm(tools) → full format (compact=False)."""
+        result_default = format_for_llm([_make_tool("web_search")])
+        result_full = format_for_llm(
+            [_make_tool("web_search")], compact=False,
+        )
+        assert result_default == result_full
+
+    def test_compact_and_full_are_different(self):
+        tools = [_make_tool(
+            "web_search",
+            properties={"query": {"type": "string"}},
+            required=["query"],
+        )]
+        compact = format_for_llm(tools, compact=True)
+        full = format_for_llm(tools, compact=False)
+        assert compact != full
+        # Full has the multi-example block; compact doesn't
+        assert "weather" in full
+        assert "weather" not in compact
+
+
+# ─── Priority-tool list pin (issue #134) ─────────────────────
+
+
+class TestPriorityToolListPin:
+    def test_priority_tools_constant_includes_schedule_reminder(self):
+        """Pin issue #134 closure: schedule_reminder MUST be in the
+        compact priority list — pre-fix local LLM hallucinated
+        "no such tool available" when the user asked for a
+        reminder."""
+        assert "schedule_reminder" in COMPACT_PRIORITY_TOOLS
+
+    def test_priority_tools_canonical_set(self):
+        """Pin the priority-tool set so a future audit can
+        compare against this list and a user-facing change to
+        what local models can call has a single source of
+        truth."""
+        assert COMPACT_PRIORITY_TOOLS == (
+            "web_search",
+            "datetime",
+            "remember",
+            "recall",
+            "calculator",
+            "schedule_reminder",
+        )


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **twenty-fourth sub-extract**.  Second slice from \`dragon_voice/tools/registry.py\`, completing the audit SRP-5 split (registry + 3-dialect parser + 2-format formatter).  PR #249 already extracted the parser; this PR extracts the formatter — **closes SRP-5**.

Pre-extract \`_format_compact\` + \`_format_full\` were 70 LOC of methods on ToolRegistry reaching back into \`self._tools\`. Now lives as free functions taking the tool list explicitly; the registry keeps a thin \`format_for_llm\` forwarding method.

### Behaviour preserved verbatim

- **Compact format:** minimal, priority-tools-only block for small local models (qwen3:1.7b — fewer tokens, less confusion). Falls back to first 4 tools when none of the priority list are registered.
- **Full format:** rich block with all tools + canonical worked examples (web_search/remember/recall/calculator/weather) for capable cloud models.
- Empty input → empty string (callers can still inject unconditionally; harmless).
- Args-block in full format when properties present; Example-line in compact format when required args present.
- \`[TOOLS]\` / \`[/TOOLS]\` block delimiters preserved on both.

### API improvement

\`COMPACT_PRIORITY_TOOLS\` is now a module-level tuple — the contract is greppable, future audits can compare against this list, and a user-facing change to what local models can call has a single source of truth. **Issue #134 closure** (schedule_reminder inclusion) pinned by a dedicated test so a future refactor can't silently regress to losing it.

### Test coverage

14 new tests in \`tests/test_tool_formatter.py\` across 5 categories:
- Empty input
- Compact-format: priority filter / fallback / example block / structure
- Full-format: all-tools / canonical examples / args block / no-args case
- Compact-vs-full distinguishability
- Priority-tool-list pin including the issue #134 schedule_reminder closure

### Diff stats

| Metric | Before | After |
|---|---|---|
| \`tools/registry.py\` LOC | 206 | 147 (-29%) |
| \`tools/registry.py\` cumulative since #249 start | 439 | 147 (-67%) |
| \`tools/formatter.py\` | (didn't exist) | 172 (new) |

Total tools/* coverage after this and PR #249: **66 tests** across parser + formatter (52 + 14).

## Test plan

- [x] \`python3 -m pytest tests/test_tool_formatter.py -v\` → 14 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → **1141 passed**, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)