### PR TITLE
refactor(lifecycle): extract agentic init (memory + 10 tools, ~55 LOC) to lifecycle/agentic_init (audit SRP-6 part 1)

### DIFF
--- a/dragon_voice/lifecycle/agentic_init.py
+++ b/dragon_voice/lifecycle/agentic_init.py
@@ -1,0 +1,138 @@
+"""Agentic-modules init step for `run_startup`.
+
+Wave 23 SOLID-audit follow-up — twenty-sixth sub-extract.
+First slice from `dragon_voice/lifecycle/startup.py` (audit
+SRP-6: `run_startup` mutates 21 attributes in a single 281-LOC
+sequence).
+
+This module owns the "agentic" init sub-step:
+  * `MemoryService` (facts + documents + RAG with Ollama
+    embeddings)
+  * `ToolRegistry` + 8 core tools (web_search, datetime, the 3
+    memory tools, calculator, unit_converter, weather,
+    system_info, stock_ticker)
+
+Pre-extract this 55-LOC chunk lived inline in `run_startup`,
+mutating `server._memory_service` and `server._tool_registry`
+in one big try/except.  Now lives in its own dedicated module.
+
+## API
+
+```python
+await init_agentic_modules(server)
+```
+
+Mutates ``server._memory_service`` and ``server._tool_registry``
+in place.  Both are set to ``None`` first so a partial-init
+failure leaves the server in a known state (and the downstream
+``init_surfaces_and_scheduler`` step's null-check works).
+
+## Failure isolation preserved
+
+The outer try/except wraps the whole agentic init — a missing
+optional dep (e.g. no Ollama running for memory embeddings)
+logs a WARNING but doesn't block boot.  The server starts in
+"no agentic" mode: voice/text still work, just no tool-calling
+or memory.
+
+## Tier-1 tool list
+
+The eight tools registered here are the "always available"
+tier — the agentic tools that ship with Dragon and don't need
+an external service.  Skill SDK or MCP-bridged tools register
+later (see `init_skills_and_scheduler` and the MCP bridge in
+`run_startup`).
+
+Audit D8/K7 dedup (2026-04-20): TimerTool deliberately NOT
+registered here — TimesenseTool (registered later, after
+SurfaceManager) covers "set a timer" AND emits widget_live
+progress.  Keeping both caused the LLM to pick TimerTool on
+short phrases, making the widget reference flow unreachable.
+TimerTool class file is retained for REST-only callers; it's
+just not wired into the agentic loop.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def init_agentic_modules(server: Any) -> None:
+    """Initialise MemoryService + ToolRegistry + 8 core tools.
+
+    Mutates `server._memory_service` and `server._tool_registry`
+    in place.  Both fields are set to None up front so a partial-
+    init failure leaves the server in a known state (downstream
+    init steps null-check both before using).
+
+    The whole chain is wrapped in try/except — a missing optional
+    dep (no Ollama for embeddings, etc.) logs at WARNING but
+    doesn't block boot.  Voice/text paths still work in "no
+    agentic" mode.
+    """
+    server._memory_service = None
+    server._tool_registry = None
+    try:
+        # Memory service first — embeddings backend for facts +
+        # documents + RAG.  Configured via VoiceConfig.memory.
+        from dragon_voice.memory import MemoryService
+        from dragon_voice.tools import ToolRegistry
+        from dragon_voice.tools.datetime_tool import DateTimeTool
+        from dragon_voice.tools.web_search import WebSearchTool
+
+        server._memory_service = MemoryService(
+            server._db,
+            ollama_url=server._config.llm.ollama_url,
+            # δ3 / D-docs (issue #118): wire the configured ingest
+            # cap so a runaway document upload can't OOM the embed.
+            max_document_bytes=server._config.memory.max_document_bytes,
+        )
+        await server._memory_service.initialize()
+
+        # Tool registry + tier-1 tools that don't depend on
+        # memory_service.
+        server._tool_registry = ToolRegistry()
+        server._tool_registry.register(WebSearchTool(
+            searxng_url=getattr(server._config.tools, "searxng_url", "")
+        ))
+        server._tool_registry.register(DateTimeTool())
+
+        # Memory-dependent tools.
+        from dragon_voice.tools.memory_tools import (
+            ForgetFactTool,
+            RecallFactsTool,
+            StoreFactTool,
+        )
+        server._tool_registry.register(StoreFactTool(server._memory_service))
+        server._tool_registry.register(RecallFactsTool(server._memory_service))
+        # v4·D Gauntlet G9: two-step confirm-gated forget_fact tool.
+        server._tool_registry.register(ForgetFactTool(server._memory_service))
+
+        # Tier-1 utility tools.  Audit D8/K7 dedup (2026-04-20):
+        # TimerTool deliberately NOT here — TimesenseTool
+        # (registered later in `init_surfaces_and_scheduler`) covers
+        # "set a timer" AND emits widget_live progress.  Keeping
+        # both caused the LLM to pick TimerTool on short phrases,
+        # making the widget reference flow unreachable.  TimerTool
+        # class file is retained for REST-only callers but not
+        # wired into the agentic loop.
+        from dragon_voice.tools.calculator_tool import CalculatorTool
+        from dragon_voice.tools.stock_ticker_tool import StockTickerTool
+        from dragon_voice.tools.system_tool import SystemInfoTool
+        from dragon_voice.tools.unit_converter_tool import UnitConverterTool
+        from dragon_voice.tools.weather_tool import WeatherTool
+
+        server._tool_registry.register(WeatherTool())
+        server._tool_registry.register(CalculatorTool())
+        server._tool_registry.register(UnitConverterTool())
+        server._tool_registry.register(SystemInfoTool())
+        server._tool_registry.register(StockTickerTool())
+
+        logger.info(
+            "Agentic modules initialized (tools: %d, memory: ok)",
+            len(server._tool_registry.list_tools()),
+        )
+    except Exception as e:
+        logger.warning("Agentic modules not available: %s", e)

--- a/dragon_voice/lifecycle/startup.py
+++ b/dragon_voice/lifecycle/startup.py
@@ -69,63 +69,14 @@ async def run_startup(server: Any, app: web.Application) -> None:
     # Message store
     server._message_store = MessageStore(server._db)
 
-    # Memory service (agentic: facts + documents + RAG) + core tools
-    server._memory_service = None
-    server._tool_registry = None
-    try:
-        from dragon_voice.memory import MemoryService
-        from dragon_voice.tools import ToolRegistry
-        from dragon_voice.tools.web_search import WebSearchTool
-        from dragon_voice.tools.datetime_tool import DateTimeTool
-
-        server._memory_service = MemoryService(
-            server._db,
-            ollama_url=server._config.llm.ollama_url,
-            # δ3 / D-docs (issue #118): wire the configured ingest cap.
-            max_document_bytes=server._config.memory.max_document_bytes,
-        )
-        await server._memory_service.initialize()
-
-        server._tool_registry = ToolRegistry()
-        server._tool_registry.register(WebSearchTool(
-            searxng_url=getattr(server._config.tools, "searxng_url", "")
-        ))
-        server._tool_registry.register(DateTimeTool())
-
-        # Memory tools need memory_service
-        from dragon_voice.tools.memory_tools import (
-            ForgetFactTool, RecallFactsTool, StoreFactTool,
-        )
-        server._tool_registry.register(StoreFactTool(server._memory_service))
-        server._tool_registry.register(RecallFactsTool(server._memory_service))
-        # v4·D Gauntlet G9: two-step confirm-gated forget_fact tool.
-        server._tool_registry.register(ForgetFactTool(server._memory_service))
-
-        # Tier 1 tools.  Audit D8/K7 dedup (2026-04-20): TimerTool is
-        # no longer registered here — TimesenseTool (registered below
-        # after SurfaceManager init) covers "set a timer" AND emits
-        # widget_live progress.  Keeping both caused the LLM to pick
-        # TimerTool on short phrases, making the widget reference flow
-        # unreachable.  TimerTool class file is retained for REST-only
-        # callers; it's just not wired into the agentic loop.
-        from dragon_voice.tools.calculator_tool import CalculatorTool
-        from dragon_voice.tools.stock_ticker_tool import StockTickerTool
-        from dragon_voice.tools.system_tool import SystemInfoTool
-        from dragon_voice.tools.unit_converter_tool import UnitConverterTool
-        from dragon_voice.tools.weather_tool import WeatherTool
-
-        server._tool_registry.register(WeatherTool())
-        server._tool_registry.register(CalculatorTool())
-        server._tool_registry.register(UnitConverterTool())
-        server._tool_registry.register(SystemInfoTool())
-        server._tool_registry.register(StockTickerTool())
-
-        logger.info(
-            "Agentic modules initialized (tools: %d, memory: ok)",
-            len(server._tool_registry.list_tools()),
-        )
-    except Exception as e:
-        logger.warning("Agentic modules not available: %s", e)
+    # SOLID-audit follow-up: agentic init (MemoryService +
+    # ToolRegistry + 8 tier-1 tools) extracted to
+    # lifecycle/agentic_init.py.  Mutates _memory_service and
+    # _tool_registry in place; whole chain wrapped in try/except
+    # so a missing optional dep (no Ollama for embeddings) logs
+    # at WARNING but doesn't block boot.
+    from dragon_voice.lifecycle.agentic_init import init_agentic_modules
+    await init_agentic_modules(server)
 
     # v4·D Phase 4g stability fix (audit P0 #1): SurfaceManager so Tab5
     # widget_action events have somewhere to land.

--- a/tests/test_agentic_init.py
+++ b/tests/test_agentic_init.py
@@ -1,0 +1,191 @@
+"""Tests for ``dragon_voice.lifecycle.agentic_init``.
+
+Pin the success path (8 tools registered) + the failure path
+(missing optional dep doesn't block boot).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dragon_voice.lifecycle.agentic_init import init_agentic_modules
+
+
+def _make_server() -> SimpleNamespace:
+    """A minimal server stub with the fields agentic_init reads."""
+    return SimpleNamespace(
+        _db=MagicMock(),
+        _config=SimpleNamespace(
+            llm=SimpleNamespace(ollama_url="http://127.0.0.1:11434"),
+            memory=SimpleNamespace(max_document_bytes=1_000_000),
+            tools=SimpleNamespace(searxng_url="http://127.0.0.1:8888"),
+        ),
+        _memory_service=None,
+        _tool_registry=None,
+    )
+
+
+# ─── Success path ────────────────────────────────────────────
+
+
+class TestSuccessPath:
+    @pytest.mark.asyncio
+    async def test_initializes_memory_service_and_registers_8_core_tools(self):
+        """Pin: post-init, server._tool_registry has all 8 tier-1
+        tools and server._memory_service is the live MemoryService."""
+        server = _make_server()
+
+        # Patch MemoryService.initialize so we don't need a live
+        # Ollama server in the test.
+        with patch(
+            "dragon_voice.memory.MemoryService"
+        ) as MemSvc:
+            mem_inst = MagicMock()
+            mem_inst.initialize = AsyncMock()
+            MemSvc.return_value = mem_inst
+
+            await init_agentic_modules(server)
+
+        assert server._memory_service is mem_inst
+        assert server._tool_registry is not None
+        # Pin the 8 tier-1 tools
+        names = {t["name"] for t in server._tool_registry.list_tools()}
+        # 10 tier-1 tools (UnitConverterTool registers as "convert")
+        expected = {
+            "web_search", "datetime",
+            "remember", "recall", "forget_fact",
+            "weather", "calculator", "convert",
+            "system_info", "stock_ticker",
+        }
+        assert expected <= names
+
+    @pytest.mark.asyncio
+    async def test_timer_tool_NOT_registered_in_agentic_init(self):
+        """Audit D8/K7 dedup pin: TimerTool deliberately not
+        registered here — TimesenseTool (registered later in
+        init_surfaces_and_scheduler) covers it.  Keeping both
+        caused the LLM to pick TimerTool on short phrases,
+        making the widget reference flow unreachable."""
+        server = _make_server()
+
+        with patch(
+            "dragon_voice.memory.MemoryService"
+        ) as MemSvc:
+            MemSvc.return_value.initialize = AsyncMock()
+
+            await init_agentic_modules(server)
+
+        names = {t["name"] for t in server._tool_registry.list_tools()}
+        assert "timer" not in names
+
+    @pytest.mark.asyncio
+    async def test_searxng_url_passed_to_websearch_tool(self):
+        """Pin: WebSearchTool gets the configured searxng_url so
+        the local SearXNG instance is honoured (vs falling back
+        to DDG)."""
+        server = _make_server()
+        server._config.tools.searxng_url = "http://my-searxng:8888"
+
+        with patch(
+            "dragon_voice.memory.MemoryService"
+        ) as MemSvc, patch(
+            "dragon_voice.tools.web_search.WebSearchTool"
+        ) as WebSearch:
+            MemSvc.return_value.initialize = AsyncMock()
+            WebSearch.return_value = MagicMock(name="ws")
+            WebSearch.return_value.name = "web_search"
+
+            await init_agentic_modules(server)
+
+        # WebSearchTool constructed with the configured URL
+        WebSearch.assert_called_once_with(searxng_url="http://my-searxng:8888")
+
+    @pytest.mark.asyncio
+    async def test_max_document_bytes_passed_to_memory(self):
+        server = _make_server()
+        server._config.memory.max_document_bytes = 5_000_000
+
+        with patch(
+            "dragon_voice.memory.MemoryService"
+        ) as MemSvc:
+            MemSvc.return_value.initialize = AsyncMock()
+
+            await init_agentic_modules(server)
+
+        # MemoryService constructed with the configured cap
+        MemSvc.assert_called_once_with(
+            server._db,
+            ollama_url="http://127.0.0.1:11434",
+            max_document_bytes=5_000_000,
+        )
+
+
+# ─── Failure isolation ──────────────────────────────────────
+
+
+class TestFailureIsolation:
+    @pytest.mark.asyncio
+    async def test_memory_init_failure_does_not_propagate(self):
+        """Pin the audit invariant: a missing optional dep (no
+        Ollama for embeddings, etc.) MUST log at WARNING but NOT
+        block boot.  The server starts in 'no agentic' mode."""
+        server = _make_server()
+
+        with patch(
+            "dragon_voice.memory.MemoryService"
+        ) as MemSvc:
+            MemSvc.side_effect = RuntimeError("Ollama not running")
+            # Must NOT raise.
+            await init_agentic_modules(server)
+
+        # Both fields left as None per the pre-extract null-check
+        # contract that downstream init steps rely on.
+        assert server._memory_service is None
+        assert server._tool_registry is None
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_after_some_tools_registered(self):
+        """If memory_init succeeds but a tool registration fails
+        partway through, the agentic chain still bails — there's
+        no point keeping a half-registered tool set."""
+        server = _make_server()
+
+        with patch(
+            "dragon_voice.memory.MemoryService"
+        ) as MemSvc, patch(
+            "dragon_voice.tools.calculator_tool.CalculatorTool"
+        ) as Calc:
+            MemSvc.return_value.initialize = AsyncMock()
+            Calc.side_effect = ImportError("calc dep missing")
+
+            # Must NOT raise.
+            await init_agentic_modules(server)
+
+        # tool_registry started but threw mid-build — left in
+        # whatever state the partial init produced.  The audit
+        # invariant cares about the boot not crashing, not about
+        # any specific intermediate state here.
+
+    @pytest.mark.asyncio
+    async def test_no_tools_config_field_uses_empty_searxng(self):
+        """Pin getattr fallback: server._config.tools missing the
+        searxng_url attr → empty string passed to WebSearchTool
+        (DDG fallback)."""
+        server = _make_server()
+        # Simulate config without the .tools.searxng_url attribute
+        server._config.tools = SimpleNamespace()  # no searxng_url
+
+        with patch(
+            "dragon_voice.memory.MemoryService"
+        ) as MemSvc, patch(
+            "dragon_voice.tools.web_search.WebSearchTool"
+        ) as WebSearch:
+            MemSvc.return_value.initialize = AsyncMock()
+            WebSearch.return_value = MagicMock(name="ws")
+            WebSearch.return_value.name = "web_search"
+
+            await init_agentic_modules(server)
+
+        WebSearch.assert_called_once_with(searxng_url="")


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **twenty-sixth sub-extract**.  First slice from \`dragon_voice/lifecycle/startup.py\` (audit **SRP-6** (P1): \`run_startup\` mutates 21 attributes in a single 281-LOC sequence — needs decomposition into discrete \`init_*\` sub-steps).

Pre-extract the agentic init was 55 LOC of inline try/except inside \`run_startup\`, mutating \`server._memory_service\` and \`server._tool_registry\` and registering 10 tier-1 tools (web_search, datetime, the 3 memory tools, calculator, unit_converter, weather, system_info, stock_ticker).

### Behaviour preserved verbatim

- \`_memory_service\` and \`_tool_registry\` set to None first so partial-init failures leave the server in a known state (downstream init steps null-check both before using)
- MemoryService gets \`ollama_url\` + \`max_document_bytes\` from config (δ3 / D-docs #118 caps)
- WebSearchTool gets the configured \`searxng_url\` via getattr fallback (empty string → DDG fallback)
- Memory-dependent tools (StoreFact, RecallFacts, ForgetFact — v4·D Gauntlet G9 confirm-gated) constructed with memory_service
- **TimerTool deliberately NOT registered** (audit D8/K7 dedup 2026-04-20 — TimesenseTool covers it AND emits widget_live progress; keeping both made widget reference flow unreachable)
- Whole chain wrapped in try/except — missing optional dep (no Ollama) logs WARNING, doesn't block boot.  Server starts in \"no agentic\" mode: voice/text still work

### Test coverage

7 tests across 2 classes (TestSuccessPath + TestFailureIsolation) spanning happy path (all 10 tools registered, TimerTool absent, configured searxng_url passed through, configured max_document_bytes passed through) + failure isolation (memory init failure doesn't propagate + leaves None state, partial mid-init failure handled, missing tools-config-field uses empty searxng URL).

### Diff stats

| Metric | Before | After |
|---|---|---|
| \`lifecycle/startup.py\` LOC | 320 | 271 (-49) |
| \`lifecycle/agentic_init.py\` | (didn't exist) | 138 (new) |

Two more \`run_startup\` sub-steps still inline (surfaces+scheduler init, notes/MCP/purge wiring) — follow-up PRs to fully close SRP-6.

## Test plan

- [x] \`python3 -m pytest tests/test_agentic_init.py -v\` → 7 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → **1158 passed**, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)