### PR TITLE
refactor(lifecycle): extract surfaces+scheduler init (~70 LOC) from startup.py (audit SRP-6 part 2)

### DIFF
--- a/dragon_voice/lifecycle/startup.py
+++ b/dragon_voice/lifecycle/startup.py
@@ -78,81 +78,17 @@ async def run_startup(server: Any, app: web.Application) -> None:
     from dragon_voice.lifecycle.agentic_init import init_agentic_modules
     await init_agentic_modules(server)
 
-    # v4·D Phase 4g stability fix (audit P0 #1): SurfaceManager so Tab5
-    # widget_action events have somewhere to land.
-    from dragon_voice.surfaces import SurfaceManager
-    server._surface_mgr = SurfaceManager()
-    logger.info("SurfaceManager initialized")
-
-    # Phase 5 ε1a/ε2 (issues #128, #131): in-process scheduler.
-    # ε2 (this PR) switches the default store from InMemoryNotificationStore
-    # to SqliteNotificationStore so notifications survive Dragon
-    # restart.  The in-memory store remains available as a fallback
-    # if SQLite store init fails (no rows lost in that case — the
-    # tables are still in place; just no fresh insertions persist
-    # until the next restart).
-    server._scheduler_mgr = None
-    try:
-        from dragon_voice.scheduler import (
-            InMemoryNotificationStore,
-            SchedulerManager,
-            SqliteNotificationStore,
-        )
-        # ε2: SqliteNotificationStore is the default.  Boot replay
-        # (in manager.start) reads list_due(now) so any due-but-
-        # unfired notifications from the prior process get
-        # rescheduled within the 15-minute REPLAY_WINDOW_SECONDS
-        # cap (RFC R8).
-        try:
-            server._scheduler_store = SqliteNotificationStore(server._db)
-        except Exception as e:
-            logger.warning(
-                "SqliteNotificationStore init failed: %s — "
-                "falling back to InMemoryNotificationStore "
-                "(notifications won't survive restart this run)", e,
-            )
-            server._scheduler_store = InMemoryNotificationStore()
-        server._scheduler_mgr = SchedulerManager(
-            store=server._scheduler_store,
-            surface_mgr=server._surface_mgr,
-            session_mgr=server._session_mgr,
-        )
-        await server._scheduler_mgr.start()
-        logger.info(
-            "SchedulerManager initialized (store=%s)",
-            type(server._scheduler_store).__name__,
-        )
-    except Exception as e:
-        logger.warning("SchedulerManager init failed: %s", e)
-
-    # Register widget-emitting tools AFTER surface_mgr exists.
-    if server._tool_registry is not None:
-        try:
-            from dragon_voice.tools.timesense_tool import TimesenseTool
-            server._tool_registry.register(TimesenseTool(server._surface_mgr))
-            logger.info("TimesenseTool registered (widget emitter)")
-            # Wave 12 skill SDK reference — declarative
-            # ``surface.prompt(on_action=handler)`` style.
-            from dragon_voice.tools.quick_poll_tool import QuickPollTool
-            server._tool_registry.register(QuickPollTool(server._surface_mgr))
-            logger.info("QuickPollTool registered (declarative widget skill)")
-        except Exception as e:
-            logger.warning("TimesenseTool registration failed: %s", e)
-
-        # Phase 5 ε1a: scheduler tool registration.  Separate try
-        # block so a tool-init error doesn't take down the rest of
-        # the registry.
-        if server._scheduler_mgr is not None:
-            try:
-                from dragon_voice.tools.schedule_reminder_tool import (
-                    ScheduleReminderTool,
-                )
-                server._tool_registry.register(
-                    ScheduleReminderTool(server._scheduler_mgr, server._db)
-                )
-                logger.info("ScheduleReminderTool registered (scheduler skill)")
-            except Exception as e:
-                logger.warning("ScheduleReminderTool registration failed: %s", e)
+    # SOLID-audit follow-up: SurfaceManager + SchedulerManager
+    # + widget/scheduler-tool registration extracted to
+    # lifecycle/surfaces_scheduler_init.py.  Mutates _surface_mgr,
+    # _scheduler_mgr, _scheduler_store; registers TimesenseTool +
+    # QuickPollTool + ScheduleReminderTool on the existing
+    # _tool_registry.  Layered try/except — failure of any
+    # sub-step doesn't take down the others.
+    from dragon_voice.lifecycle.surfaces_scheduler_init import (
+        init_surfaces_and_scheduler,
+    )
+    await init_surfaces_and_scheduler(server)
 
     # Conversation engine (shared LLM backend for text/API input).
     # #183 PR 3: pass media_store so multimodal user messages persist

--- a/dragon_voice/lifecycle/surfaces_scheduler_init.py
+++ b/dragon_voice/lifecycle/surfaces_scheduler_init.py
@@ -1,0 +1,176 @@
+"""Surfaces + Scheduler init step for `run_startup`.
+
+Wave 23 SOLID-audit follow-up — twenty-seventh sub-extract.
+Second slice from `dragon_voice/lifecycle/startup.py` (audit
+SRP-6: `run_startup` decomposition; PR #252 extracted the
+agentic init).
+
+Owns the boot wiring for:
+  * `SurfaceManager` (Tab5 widget surface registry — where
+    widget_action events from `widget_action_handler` land).
+  * `SchedulerManager` (Phase 5 in-process notification
+    scheduler) + its persistence store (SqliteNotificationStore
+    by default, InMemoryNotificationStore fallback).
+  * The widget-emitting tools that depend on SurfaceManager
+    (TimesenseTool — pomodoro/timer with widget_live progress;
+    QuickPollTool — Wave 12 declarative-widget skill SDK
+    reference).
+  * The scheduler-emitting tool (ScheduleReminderTool — issue
+    #134 closure for "set me a reminder" intents).
+
+Pre-extract this 70-LOC chunk lived inline in `run_startup`
+between the agentic init and the conversation engine.  Now
+lives in its own dedicated module with its own tests.
+
+## API
+
+```python
+await init_surfaces_and_scheduler(server)
+```
+
+Mutates ``server._surface_mgr``, ``server._scheduler_mgr``,
+``server._scheduler_store``, and registers TimesenseTool +
+QuickPollTool + ScheduleReminderTool on
+``server._tool_registry`` (when the registry exists — the
+agentic init may have failed; we silently skip the widget tools
+in that case).
+
+## Failure-isolation matrix
+
+The audit-D8 invariant is layered try/except — a failure in
+one sub-step doesn't take down the others:
+
+  * Scheduler init failure → `_scheduler_mgr` left as None;
+    skill registration silently skips.
+  * SqliteNotificationStore init failure → falls back to
+    InMemoryNotificationStore (notifications won't survive
+    restart this run, but new notifications still fire).
+  * TimesenseTool / QuickPollTool registration failure → both
+    skipped, scheduler tool registration still attempts.
+  * ScheduleReminderTool registration failure → just that tool
+    skipped; rest of the boot chain continues.
+
+## ε2 SqliteNotificationStore default (#131 closure)
+
+Pre-ε2 the default store was InMemoryNotificationStore, which
+meant a Dragon restart silently lost all pending reminders
+(user set "remind me at 6am tomorrow", Dragon restarted at 4am,
+6am came and went with no notification).  ε2 made the SQLite
+store the default; boot replay (in `manager.start`) reads
+`list_due(now)` so any due-but-unfired notifications from the
+prior process get rescheduled within the 15-minute
+REPLAY_WINDOW_SECONDS cap (RFC R8).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def init_surfaces_and_scheduler(server: Any) -> None:
+    """Initialize SurfaceManager + SchedulerManager + the
+    widget/scheduler-emitting tools.
+
+    Run AFTER `init_agentic_modules` (depends on
+    `_tool_registry` for the skill registration step) but
+    BEFORE `init_conversation_engine` (which doesn't depend on
+    these but expects the registry to be fully populated for
+    the system-prompt generation).
+
+    Side effects on ``server``:
+      * `_surface_mgr` — new SurfaceManager instance
+      * `_scheduler_mgr` — SchedulerManager (or None on init failure)
+      * `_scheduler_store` — Sqlite or in-memory notification store
+      * `_tool_registry` — TimesenseTool, QuickPollTool, and
+        ScheduleReminderTool registered (when applicable)
+
+    Failure isolation: see module docstring for the layered
+    try/except invariant.  No failure here blocks boot.
+    """
+    # v4·D Phase 4g stability fix (audit P0 #1): SurfaceManager so
+    # Tab5 widget_action events have somewhere to land.
+    from dragon_voice.surfaces import SurfaceManager
+    server._surface_mgr = SurfaceManager()
+    logger.info("SurfaceManager initialized")
+
+    # Phase 5 ε1a/ε2 (issues #128, #131): in-process scheduler.
+    # ε2: SqliteNotificationStore default; in-memory fallback if
+    # SQLite store init fails.
+    server._scheduler_mgr = None
+    try:
+        from dragon_voice.scheduler import (
+            InMemoryNotificationStore,
+            SchedulerManager,
+            SqliteNotificationStore,
+        )
+        try:
+            server._scheduler_store = SqliteNotificationStore(server._db)
+        except Exception as e:
+            logger.warning(
+                "SqliteNotificationStore init failed: %s — "
+                "falling back to InMemoryNotificationStore "
+                "(notifications won't survive restart this run)", e,
+            )
+            server._scheduler_store = InMemoryNotificationStore()
+        server._scheduler_mgr = SchedulerManager(
+            store=server._scheduler_store,
+            surface_mgr=server._surface_mgr,
+            session_mgr=server._session_mgr,
+        )
+        await server._scheduler_mgr.start()
+        logger.info(
+            "SchedulerManager initialized (store=%s)",
+            type(server._scheduler_store).__name__,
+        )
+    except Exception as e:
+        logger.warning("SchedulerManager init failed: %s", e)
+
+    # Register widget-emitting tools AFTER surface_mgr exists.
+    # When the agentic init failed, _tool_registry is None — skip
+    # the skill registration entirely.
+    if server._tool_registry is not None:
+        _register_surface_tools(server)
+        # Scheduler tool needs both _tool_registry AND _scheduler_mgr.
+        if server._scheduler_mgr is not None:
+            _register_scheduler_tool(server)
+
+
+def _register_surface_tools(server: Any) -> None:
+    """Register TimesenseTool + QuickPollTool on the registry.
+
+    Layered try/except: failure of either tool import / register
+    logs at WARNING but doesn't block the rest of the boot chain.
+    """
+    try:
+        from dragon_voice.tools.timesense_tool import TimesenseTool
+        server._tool_registry.register(TimesenseTool(server._surface_mgr))
+        logger.info("TimesenseTool registered (widget emitter)")
+        # Wave 12 skill SDK reference — declarative
+        # `surface.prompt(on_action=handler)` style.
+        from dragon_voice.tools.quick_poll_tool import QuickPollTool
+        server._tool_registry.register(QuickPollTool(server._surface_mgr))
+        logger.info("QuickPollTool registered (declarative widget skill)")
+    except Exception as e:
+        logger.warning("TimesenseTool registration failed: %s", e)
+
+
+def _register_scheduler_tool(server: Any) -> None:
+    """Register ScheduleReminderTool on the registry.
+
+    Separate try block from `_register_surface_tools` so a tool-
+    init error doesn't take down the rest of the registry.
+    Issue #134 closure: this tool is what makes "set me a
+    reminder" intents work.
+    """
+    try:
+        from dragon_voice.tools.schedule_reminder_tool import (
+            ScheduleReminderTool,
+        )
+        server._tool_registry.register(
+            ScheduleReminderTool(server._scheduler_mgr, server._db)
+        )
+        logger.info("ScheduleReminderTool registered (scheduler skill)")
+    except Exception as e:
+        logger.warning("ScheduleReminderTool registration failed: %s", e)

--- a/tests/test_surfaces_scheduler_init.py
+++ b/tests/test_surfaces_scheduler_init.py
@@ -1,0 +1,268 @@
+"""Tests for ``dragon_voice.lifecycle.surfaces_scheduler_init``.
+
+Pin every layer of the failure-isolation matrix + the
+SqliteNotificationStore-default contract (#131 ε2 closure).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dragon_voice.lifecycle.surfaces_scheduler_init import (
+    init_surfaces_and_scheduler,
+)
+
+
+def _make_server(*, with_registry: bool = True) -> SimpleNamespace:
+    server = SimpleNamespace(
+        _db=MagicMock(),
+        _session_mgr=MagicMock(),
+        _surface_mgr=None,
+        _scheduler_mgr=None,
+        _scheduler_store=None,
+        _tool_registry=MagicMock() if with_registry else None,
+    )
+    if with_registry:
+        server._tool_registry.register = MagicMock()
+    return server
+
+
+# ─── SurfaceManager init (always succeeds) ───────────────────
+
+
+class TestSurfaceManagerInit:
+    @pytest.mark.asyncio
+    async def test_surface_mgr_always_initialized(self):
+        """SurfaceManager has no required deps — always
+        constructs.  Pin so a future refactor that adds deps
+        can't silently break the always-init invariant."""
+        # Patch scheduler bits so the test doesn't need a live
+        # SQLite-vec install; SurfaceManager construction is the
+        # thing under test.
+        server = _make_server()
+
+        with patch(
+            "dragon_voice.scheduler.SqliteNotificationStore"
+        ), patch(
+            "dragon_voice.scheduler.SchedulerManager"
+        ) as SchedMgr:
+            sched = MagicMock()
+            sched.start = AsyncMock()
+            SchedMgr.return_value = sched
+
+            await init_surfaces_and_scheduler(server)
+
+        assert server._surface_mgr is not None
+        # Class check via the same import path the production
+        # code uses (avoids identity drift from sys.modules
+        # patching tricks).
+        assert type(server._surface_mgr).__name__ == "SurfaceManager"
+
+
+# ─── SchedulerManager + store fallback ───────────────────────
+
+
+class TestSchedulerInit:
+    @pytest.mark.asyncio
+    async def test_sqlite_store_default_when_init_succeeds(self):
+        """ε2 / #131 closure: SqliteNotificationStore is the default
+        store so notifications survive Dragon restart."""
+        server = _make_server()
+
+        with patch(
+            "dragon_voice.scheduler.SqliteNotificationStore"
+        ) as Sqlite, patch(
+            "dragon_voice.scheduler.SchedulerManager"
+        ) as SchedMgr:
+            sqlite_inst = MagicMock(name="sqlite_store")
+            Sqlite.return_value = sqlite_inst
+            sched_inst = MagicMock(name="sched")
+            sched_inst.start = AsyncMock()
+            SchedMgr.return_value = sched_inst
+
+            await init_surfaces_and_scheduler(server)
+
+        assert server._scheduler_store is sqlite_inst
+        assert server._scheduler_mgr is sched_inst
+        sched_inst.start.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_sqlite_init_failure_falls_back_to_in_memory(self):
+        """ε2 closure: SqliteNotificationStore failure → fall
+        back to in-memory store rather than disabling scheduler
+        entirely.  Notifications won't survive restart this run
+        but new ones still fire."""
+        server = _make_server()
+
+        with patch(
+            "dragon_voice.scheduler.SqliteNotificationStore"
+        ) as Sqlite, patch(
+            "dragon_voice.scheduler.InMemoryNotificationStore"
+        ) as InMem, patch(
+            "dragon_voice.scheduler.SchedulerManager"
+        ) as SchedMgr:
+            Sqlite.side_effect = RuntimeError("sqlite-vec missing")
+            inmem_inst = MagicMock(name="inmem")
+            InMem.return_value = inmem_inst
+            sched_inst = MagicMock()
+            sched_inst.start = AsyncMock()
+            SchedMgr.return_value = sched_inst
+
+            await init_surfaces_and_scheduler(server)
+
+        assert server._scheduler_store is inmem_inst
+        # Scheduler still wired with the fallback store
+        assert server._scheduler_mgr is sched_inst
+
+    @pytest.mark.asyncio
+    async def test_scheduler_module_import_failure_disables_scheduler(self):
+        """When the whole scheduler subsystem is unavailable
+        (import error), `_scheduler_mgr` stays None so downstream
+        skill registration silently skips."""
+        server = _make_server()
+
+        # Force the scheduler import to fail by patching the module
+        # to raise on any attribute access.
+        with patch.dict(
+            "sys.modules", {"dragon_voice.scheduler": None},
+        ):
+            await init_surfaces_and_scheduler(server)
+
+        assert server._scheduler_mgr is None
+
+
+# ─── Skill registration (TimesenseTool, QuickPollTool, ScheduleReminderTool) ──
+
+
+class TestSkillRegistration:
+    @pytest.mark.asyncio
+    async def test_widget_tools_registered_when_registry_present(self):
+        server = _make_server(with_registry=True)
+
+        with patch(
+            "dragon_voice.tools.timesense_tool.TimesenseTool"
+        ) as Timesense, patch(
+            "dragon_voice.tools.quick_poll_tool.QuickPollTool"
+        ) as QuickPoll, patch(
+            "dragon_voice.tools.schedule_reminder_tool.ScheduleReminderTool"
+        ) as Sched, patch(
+            "dragon_voice.scheduler.SqliteNotificationStore"
+        ), patch(
+            "dragon_voice.scheduler.SchedulerManager"
+        ) as SchedMgr:
+            ts_inst = MagicMock(name="ts")
+            qp_inst = MagicMock(name="qp")
+            sr_inst = MagicMock(name="sr")
+            Timesense.return_value = ts_inst
+            QuickPoll.return_value = qp_inst
+            Sched.return_value = sr_inst
+            sched_mgr = MagicMock()
+            sched_mgr.start = AsyncMock()
+            SchedMgr.return_value = sched_mgr
+
+            await init_surfaces_and_scheduler(server)
+
+        # All three tools registered
+        registered = [
+            c.args[0] for c in server._tool_registry.register.call_args_list
+        ]
+        assert ts_inst in registered
+        assert qp_inst in registered
+        assert sr_inst in registered
+
+    @pytest.mark.asyncio
+    async def test_no_registry_skips_skill_registration(self):
+        """When agentic init failed, _tool_registry is None — skip
+        the skill registration entirely.  Scheduler still init'd
+        for the REST API surface."""
+        server = _make_server(with_registry=False)
+
+        with patch(
+            "dragon_voice.scheduler.SqliteNotificationStore"
+        ), patch(
+            "dragon_voice.scheduler.SchedulerManager"
+        ) as SchedMgr:
+            sched = MagicMock()
+            sched.start = AsyncMock()
+            SchedMgr.return_value = sched
+
+            # Must NOT raise (no registry to register against).
+            await init_surfaces_and_scheduler(server)
+
+        # SurfaceManager + SchedulerManager still init'd
+        assert server._surface_mgr is not None
+        assert server._scheduler_mgr is sched
+
+    @pytest.mark.asyncio
+    async def test_scheduler_tool_skipped_when_scheduler_init_failed(self):
+        """If scheduler init failed (_scheduler_mgr is None),
+        ScheduleReminderTool MUST NOT register — the tool
+        constructor expects a live scheduler manager."""
+        server = _make_server(with_registry=True)
+
+        # Force scheduler init failure
+        with patch.dict("sys.modules", {"dragon_voice.scheduler": None}):
+            await init_surfaces_and_scheduler(server)
+
+        # ScheduleReminderTool was NOT registered
+        for c in server._tool_registry.register.call_args_list:
+            assert "ScheduleReminderTool" not in type(c.args[0]).__name__
+
+    @pytest.mark.asyncio
+    async def test_timesense_failure_does_not_block_scheduler_tool(self):
+        """Layered try/except: TimesenseTool registration failing
+        MUST NOT prevent ScheduleReminderTool from registering
+        (separate try blocks)."""
+        server = _make_server(with_registry=True)
+
+        with patch(
+            "dragon_voice.tools.timesense_tool.TimesenseTool"
+        ) as Timesense, patch(
+            "dragon_voice.tools.schedule_reminder_tool.ScheduleReminderTool"
+        ) as Sched, patch(
+            "dragon_voice.scheduler.SqliteNotificationStore"
+        ), patch(
+            "dragon_voice.scheduler.SchedulerManager"
+        ) as SchedMgr:
+            Timesense.side_effect = ImportError("timesense missing")
+            sr_inst = MagicMock(name="sr")
+            Sched.return_value = sr_inst
+            sched_mgr = MagicMock()
+            sched_mgr.start = AsyncMock()
+            SchedMgr.return_value = sched_mgr
+
+            await init_surfaces_and_scheduler(server)
+
+        # ScheduleReminderTool still registered despite Timesense
+        # failure — separate try block invariant.
+        registered = [
+            c.args[0] for c in server._tool_registry.register.call_args_list
+        ]
+        assert sr_inst in registered
+
+    @pytest.mark.asyncio
+    async def test_scheduler_tool_failure_does_not_propagate(self):
+        """ScheduleReminderTool registration failure logs at
+        WARNING but doesn't take down boot."""
+        server = _make_server(with_registry=True)
+
+        with patch(
+            "dragon_voice.tools.timesense_tool.TimesenseTool"
+        ), patch(
+            "dragon_voice.tools.quick_poll_tool.QuickPollTool"
+        ), patch(
+            "dragon_voice.tools.schedule_reminder_tool.ScheduleReminderTool"
+        ) as Sched, patch(
+            "dragon_voice.scheduler.SqliteNotificationStore"
+        ), patch(
+            "dragon_voice.scheduler.SchedulerManager"
+        ) as SchedMgr:
+            Sched.side_effect = ImportError("scheduler tool missing")
+            sched_mgr = MagicMock()
+            sched_mgr.start = AsyncMock()
+            SchedMgr.return_value = sched_mgr
+
+            # Must NOT raise.
+            await init_surfaces_and_scheduler(server)


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **twenty-seventh sub-extract**.  Second slice from \`dragon_voice/lifecycle/startup.py\` (audit **SRP-6**: \`run_startup\` decomposition; PR #252 extracted the agentic init).

Owns the boot wiring for SurfaceManager + SchedulerManager + the widget/scheduler-emitting tools (TimesenseTool, QuickPollTool, ScheduleReminderTool).

### Behaviour preserved verbatim

- SurfaceManager always init'd (no required deps)
- SchedulerManager wrapped in try/except — module import failure leaves \`_scheduler_mgr=None\` so downstream skill registration silently skips
- **SqliteNotificationStore is the default** (#131 ε2 closure — notifications survive Dragon restart via boot replay)
- SqliteNotificationStore init failure → InMemoryNotificationStore fallback (notifications fire this run but won't survive restart)
- TimesenseTool + QuickPollTool registered AFTER SurfaceManager exists
- ScheduleReminderTool registered in a SEPARATE try block from TimesenseTool/QuickPollTool so a Timesense import failure doesn't take down the scheduler tool too
- No tool registry (agentic init failed) → skip all skill registration entirely; scheduler still init'd for the REST API surface

### Test coverage

9 tests across 3 classes:
- SurfaceManager always-init invariant
- Scheduler init (sqlite default, sqlite failure → inmem fallback, module import failure → scheduler disabled)
- Skill registration (widget tools registered when registry present, no-registry skip, scheduler tool skipped when scheduler init failed, layered try/except keeping ScheduleReminderTool alive when TimesenseTool fails, scheduler tool failure swallowed)

### Diff stats

| Metric | Before | After |
|---|---|---|
| \`lifecycle/startup.py\` LOC | 271 | 207 (-64) |
| \`lifecycle/surfaces_scheduler_init.py\` | (didn't exist) | 178 (new) |
| \`lifecycle/startup.py\` cumulative across #252 + this | 320 | 207 (-35%) |

One sub-step still inline (notes/MCP/purge wiring, ~85 LOC) — final SRP-6 PR to follow.

## Test plan

- [x] \`python3 -m pytest tests/test_surfaces_scheduler_init.py -v\` → 9 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → **1167 passed**, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)