### PR TITLE
refactor(lifecycle): extract notes + MCP + background-tasks init from startup.py — CLOSES audit SRP-6

### DIFF
--- a/dragon_voice/lifecycle/background_tasks_init.py
+++ b/dragon_voice/lifecycle/background_tasks_init.py
@@ -1,0 +1,119 @@
+"""Background-task init step for `run_startup` — purge,
+media cleanup, memory monitor.
+
+Wave 23 SOLID-audit follow-up — twenty-eighth sub-extract
+(part of the SRP-6 finalisation trio with notes_init and
+mcp_init).
+
+Owns the boot wiring for the three long-running periodic tasks
+that watch over Dragon's lifetime:
+
+  * **Message-retention purge** (US-DQ14): runs an immediate
+    purge at startup to clean up sessions older than the
+    configured retention window, then schedules a periodic
+    re-run.  Disabled when `retention_days <= 0`.
+  * **Media cleanup**: hourly removal of expired upload
+    artifacts.  Always runs.
+  * **Memory monitor** (audit A04): periodic RSS/temp/FD
+    sampling with pipeline-drain on critical thresholds.
+    Always runs.
+
+Pre-extract this 26-LOC chunk lived inline at the tail of
+`run_startup`.  Now lives in its own module.
+
+## API
+
+```python
+init_background_tasks(server)
+```
+
+Mutates `server._purge_task`, `server._media_cleanup_task`,
+`server._memory_monitor_task` — all `asyncio.Task` handles so
+`run_shutdown` can cancel + await each on server stop.
+
+## Note: synchronous entry point
+
+This function is `def`, not `async def` — it only spawns tasks
+via `asyncio.create_task`, never awaits them.  The startup
+purge IS async and gets its own task too.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from dragon_voice.lifecycle import monitors, purge
+
+logger = logging.getLogger(__name__)
+
+
+def init_background_tasks(server: Any) -> None:
+    """Schedule the three lifetime background tasks.
+
+    Run LAST in the boot sequence — after all other modules are
+    initialised so the tasks have everything they need.
+
+    Side effects:
+      * `server._purge_task` ← asyncio.Task running
+        `purge.periodic_purge_loop` (only when retention_days>0)
+      * `server._media_cleanup_task` ← asyncio.Task running
+        `purge.media_cleanup_loop`
+      * `server._memory_monitor_task` ← asyncio.Task running
+        `monitors.memory_monitor_loop`
+
+    The startup purge is fire-and-forget within
+    `run_startup_purge_then_loop` so the boot sequence doesn't
+    block on it (a slow purge on a big DB would push other
+    services back).
+    """
+    retention_days = server._config.database.message_retention_days
+    if retention_days > 0:
+        # Spawn an async sub-task that does the initial purge
+        # then enters the periodic loop.  This keeps the boot
+        # sequence non-blocking on the initial purge.
+        server._purge_task = asyncio.create_task(
+            _run_startup_purge_then_loop(server, retention_days)
+        )
+
+    # Media cleanup (hourly, removes expired uploads).  Always
+    # runs — there's no way to disable media uploads themselves
+    # (Tab5 may send them at any time).
+    server._media_cleanup_task = asyncio.create_task(
+        purge.media_cleanup_loop(server)
+    )
+
+    # Start periodic memory monitor (audit A04).
+    server._memory_monitor_task = asyncio.create_task(
+        monitors.memory_monitor_loop(server)
+    )
+    rss = monitors.get_rss_mb()
+    logger.info(
+        "Memory monitor started (RSS=%.0f MB, warn=%d MB, crit=%d MB)",
+        rss, server._mem_warn_mb, server._mem_crit_mb,
+    )
+
+
+async def _run_startup_purge_then_loop(
+    server: Any,
+    retention_days: int,
+) -> None:
+    """Run the initial message purge, then enter the periodic
+    purge loop.  Wraps both so a single asyncio.Task handle
+    covers both phases.
+
+    The startup purge is wrapped in try/except so a transient
+    DB issue doesn't tear down the whole task — the periodic
+    loop still gets to run.
+    """
+    try:
+        result = await server._db.purge_old_messages(days=retention_days)
+        logger.info(
+            "Startup purge complete: %d messages, %d events removed "
+            "(retention=%d days)",
+            result["messages"], result["events"], retention_days,
+        )
+    except Exception as e:
+        logger.warning("Startup purge failed: %s", e)
+
+    await purge.periodic_purge_loop(server, retention_days)

--- a/dragon_voice/lifecycle/mcp_init.py
+++ b/dragon_voice/lifecycle/mcp_init.py
@@ -1,0 +1,73 @@
+"""MCP server bridges init step for `run_startup`.
+
+Wave 23 SOLID-audit follow-up — twenty-eighth sub-extract
+(part of the SRP-6 finalisation trio with notes_init and
+background_tasks_init).
+
+Owns the boot wiring for Model Context Protocol (MCP) servers:
+walks `server._config.mcp_servers` and bridges each one's tools
+into the local `_tool_registry` so the LLM can call them
+agentically alongside the built-in tools.
+
+Pre-extract this 14-LOC chunk lived inline in `run_startup`
+between Notes init and the purge/monitor wiring.  Now lives in
+its own module.
+
+## API
+
+```python
+await init_mcp_bridges(server)
+```
+
+For each MCP server entry in `server._config.mcp_servers` (a
+list of dicts with `name`, `url`, optional `token` keys),
+calls `bridge_mcp_server` to fetch the remote tool catalog and
+register each as a local Tool.
+
+## Failure isolation
+
+The whole chain is wrapped in try/except — a malformed MCP
+config, network failure, or missing dep logs at WARNING but
+doesn't block boot.  Per-server failures (one MCP down out of
+several) are NOT individually isolated in the pre-extract
+behaviour; they tear down the whole MCP init.  Preserved
+verbatim; a follow-up could narrow the try/except per server.
+
+## getattr fallback
+
+`server._config.mcp_servers` may not exist on older configs;
+the `getattr(..., [])` fallback returns an empty list so the
+loop is a no-op rather than crashing.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def init_mcp_bridges(server: Any) -> None:
+    """Bridge configured MCP servers into the local tool registry.
+
+    Run AFTER `init_agentic_modules` (the registry must exist).
+    No-op when `_tool_registry` is None or `mcp_servers` is
+    empty / missing from config.
+
+    Failure isolation: any exception in the bridge chain logs
+    at WARNING and returns.  Boot continues with whatever tools
+    were already registered.
+    """
+    try:
+        from dragon_voice.mcp.bridge import bridge_mcp_server
+        mcp_servers = getattr(server._config, "mcp_servers", [])
+        for mcp in mcp_servers:
+            count = await bridge_mcp_server(
+                server._tool_registry,
+                name=mcp.get("name", "mcp"),
+                url=mcp.get("url"),
+                token=mcp.get("token"),
+            )
+            logger.info("MCP %s: %d tools bridged", mcp.get("name"), count)
+    except Exception as e:
+        logger.warning("MCP bridge not available: %s", e)

--- a/dragon_voice/lifecycle/notes_init.py
+++ b/dragon_voice/lifecycle/notes_init.py
@@ -1,0 +1,89 @@
+"""Notes module + NoteTool init step for `run_startup`.
+
+Wave 23 SOLID-audit follow-up — twenty-eighth sub-extract.
+Third slice from `dragon_voice/lifecycle/startup.py` (audit
+SRP-6 finalisation, after PR #252 + #253).
+
+Owns the boot wiring for:
+  * `NotesDB` + `NotesService` (Notes module persistence layer
+    + service interface)
+  * Notes API routes (registered on the aiohttp `app`)
+  * `NoteTool` (registered on the existing `_tool_registry` so
+    the LLM can call it agentically)
+
+Pre-extract this 22-LOC chunk lived inline in `run_startup`
+between MCP bridges and the purge/monitor wiring.  Now lives
+in its own module with tests pinning the failure-isolation
+invariant (Notes-not-available doesn't block boot).
+
+## API
+
+```python
+await init_notes_module(server, app)
+```
+
+Mutates ``server._notes_svc`` in place; registers Notes API
+routes on `app`; registers `NoteTool` on `server._tool_registry`
+(when both registry + notes service are available).
+
+## Failure isolation
+
+Whole chain wrapped in try/except — Notes is an optional module
+(it depends on the notes_db schema being present, the
+NotesService being configured, etc.).  A missing optional dep
+logs at WARNING but doesn't block boot.  Voice/text paths still
+work; just no notes API surface or NoteTool calls.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+async def init_notes_module(
+    server: Any,
+    app: web.Application,
+) -> None:
+    """Initialise NotesDB + NotesService, register Notes API
+    routes on `app`, and register NoteTool on the tool registry.
+
+    Run AFTER `init_agentic_modules` (depends on the registry)
+    AND AFTER REST API setup (the Notes routes register on the
+    same `app`).
+
+    Side effects:
+      * `server._notes_svc` ← live NotesService (or unset on
+        init failure)
+      * Notes API routes added to `app.router`
+      * NoteTool registered on `server._tool_registry` (when
+        both registry + notes service are available)
+
+    Failure isolation: any exception in the chain logs at
+    WARNING and returns silently.  Boot continues.
+    """
+    try:
+        from dragon_voice.notes.api import setup_routes as setup_notes_routes
+        from dragon_voice.notes.db import NotesDB
+        from dragon_voice.notes.service import NotesService
+
+        notes_db = NotesDB()
+        # Wave 14 W14-C05: NotesDB.initialize is async now.
+        # NotesService awaits it internally so we don't call
+        # it here.
+        notes_svc = NotesService(server._config, notes_db)
+        await notes_svc.initialize()
+        server._notes_svc = notes_svc
+        setup_notes_routes(app, notes_svc)
+        logger.info("Notes API routes registered")
+
+        # Register NoteTool now that NotesService is available.
+        if server._tool_registry and server._notes_svc:
+            from dragon_voice.tools.note_tool import NoteTool
+            server._tool_registry.register(NoteTool(server._notes_svc))
+            logger.info("Note tool registered (notes service available)")
+    except Exception as e:
+        logger.warning("Notes API not available: %s", e)

--- a/dragon_voice/lifecycle/startup.py
+++ b/dragon_voice/lifecycle/startup.py
@@ -21,7 +21,6 @@ one callsite that always wants to wire the same graph.
 """
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Any
 
@@ -30,7 +29,6 @@ from aiohttp import web
 
 from dragon_voice.conversation import ConversationEngine
 from dragon_voice.db import Database
-from dragon_voice.lifecycle import monitors, purge
 from dragon_voice.messages import MessageStore
 from dragon_voice.sessions import SessionManager
 
@@ -139,69 +137,24 @@ async def run_startup(server: Any, app: web.Application) -> None:
         scheduler_mgr=getattr(server, "_scheduler_mgr", None),
     )
 
-    # Notes API routes
-    try:
-        from dragon_voice.notes.api import setup_routes as setup_notes_routes
-        from dragon_voice.notes.db import NotesDB
-        from dragon_voice.notes.service import NotesService
+    # SOLID-audit follow-up: notes module + tool registration
+    # extracted to lifecycle/notes_init.py.
+    from dragon_voice.lifecycle.notes_init import init_notes_module
+    await init_notes_module(server, app)
 
-        notes_db = NotesDB()
-        # Wave 14 W14-C05: NotesDB.initialize is async now.  NotesService
-        # awaits it internally, so we don't call it here.
-        notes_svc = NotesService(server._config, notes_db)
-        await notes_svc.initialize()
-        server._notes_svc = notes_svc
-        setup_notes_routes(app, notes_svc)
-        logger.info("Notes API routes registered")
+    # SOLID-audit follow-up: MCP server bridges extracted to
+    # lifecycle/mcp_init.py.
+    from dragon_voice.lifecycle.mcp_init import init_mcp_bridges
+    await init_mcp_bridges(server)
 
-        # Register NoteTool now that NotesService is available.
-        if server._tool_registry and server._notes_svc:
-            from dragon_voice.tools.note_tool import NoteTool
-            server._tool_registry.register(NoteTool(server._notes_svc))
-            logger.info("Note tool registered (notes service available)")
-    except Exception as e:
-        logger.warning("Notes API not available: %s", e)
-
-    # MCP servers (from config)
-    try:
-        from dragon_voice.mcp.bridge import bridge_mcp_server
-        mcp_servers = getattr(server._config, "mcp_servers", [])
-        for mcp in mcp_servers:
-            count = await bridge_mcp_server(
-                server._tool_registry,
-                name=mcp.get("name", "mcp"),
-                url=mcp.get("url"),
-                token=mcp.get("token"),
-            )
-            logger.info("MCP %s: %d tools bridged", mcp.get("name"), count)
-    except Exception as e:
-        logger.warning("MCP bridge not available: %s", e)
-
-    # Run initial message purge + schedule periodic (US-DQ14)
-    retention_days = server._config.database.message_retention_days
-    if retention_days > 0:
-        try:
-            result = await server._db.purge_old_messages(days=retention_days)
-            logger.info(
-                "Startup purge complete: %d messages, %d events removed (retention=%d days)",
-                result["messages"], result["events"], retention_days,
-            )
-        except Exception as e:
-            logger.warning("Startup purge failed: %s", e)
-
-        server._purge_task = asyncio.create_task(
-            purge.periodic_purge_loop(server, retention_days)
-        )
-
-    # Media cleanup (hourly, removes expired uploads)
-    server._media_cleanup_task = asyncio.create_task(purge.media_cleanup_loop(server))
-
-    # Start periodic memory monitor (A04)
-    server._memory_monitor_task = asyncio.create_task(monitors.memory_monitor_loop(server))
-    rss = monitors.get_rss_mb()
-    logger.info(
-        "Memory monitor started (RSS=%.0f MB, warn=%d MB, crit=%d MB)",
-        rss, server._mem_warn_mb, server._mem_crit_mb,
+    # SOLID-audit follow-up: background-task scheduling
+    # (purge + media cleanup + memory monitor) extracted to
+    # lifecycle/background_tasks_init.py.  Synchronous (only
+    # spawns tasks) so the boot sequence never blocks on the
+    # initial purge.
+    from dragon_voice.lifecycle.background_tasks_init import (
+        init_background_tasks,
     )
+    init_background_tasks(server)
 
     logger.info("Foundation modules initialized")

--- a/tests/test_startup_final_wiring.py
+++ b/tests/test_startup_final_wiring.py
@@ -1,0 +1,329 @@
+"""Tests for the three SRP-6 finalisation modules:
+``dragon_voice.lifecycle.notes_init``,
+``dragon_voice.lifecycle.mcp_init``,
+``dragon_voice.lifecycle.background_tasks_init``.
+
+Pin the failure-isolation invariant for each (Notes/MCP/purge
+failure must NOT block boot) + the task-handle contract (the
+three task fields must all be populated for `run_shutdown` to
+cancel them).
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_server(*, retention_days: int = 30) -> SimpleNamespace:
+    server = SimpleNamespace(
+        _db=MagicMock(),
+        _config=SimpleNamespace(
+            database=SimpleNamespace(
+                message_retention_days=retention_days,
+            ),
+            mcp_servers=[],
+        ),
+        _tool_registry=MagicMock(),
+        _notes_svc=None,
+        _mem_warn_mb=400,
+        _mem_crit_mb=800,
+        _media_store=MagicMock(),
+        _purge_task=None,
+        _media_cleanup_task=None,
+        _memory_monitor_task=None,
+    )
+    server._tool_registry.register = MagicMock()
+    server._db.purge_old_messages = AsyncMock(
+        return_value={"messages": 0, "events": 0},
+    )
+    return server
+
+
+# ─── notes_init ──────────────────────────────────────────────
+
+
+class TestNotesInit:
+    @pytest.mark.asyncio
+    async def test_notes_svc_set_and_routes_registered(self):
+        from dragon_voice.lifecycle.notes_init import init_notes_module
+
+        server = _make_server()
+        app = MagicMock()
+
+        with patch(
+            "dragon_voice.notes.api.setup_routes"
+        ) as setup_routes, patch(
+            "dragon_voice.notes.db.NotesDB"
+        ), patch(
+            "dragon_voice.notes.service.NotesService"
+        ) as NotesSvc:
+            svc_inst = MagicMock()
+            svc_inst.initialize = AsyncMock()
+            NotesSvc.return_value = svc_inst
+
+            await init_notes_module(server, app)
+
+        assert server._notes_svc is svc_inst
+        setup_routes.assert_called_once_with(app, svc_inst)
+
+    @pytest.mark.asyncio
+    async def test_note_tool_registered_when_registry_and_svc_present(self):
+        from dragon_voice.lifecycle.notes_init import init_notes_module
+
+        server = _make_server()
+        app = MagicMock()
+
+        with patch(
+            "dragon_voice.notes.api.setup_routes"
+        ), patch(
+            "dragon_voice.notes.db.NotesDB"
+        ), patch(
+            "dragon_voice.notes.service.NotesService"
+        ) as NotesSvc, patch(
+            "dragon_voice.tools.note_tool.NoteTool"
+        ) as NoteTool:
+            svc = MagicMock()
+            svc.initialize = AsyncMock()
+            NotesSvc.return_value = svc
+            note_tool = MagicMock()
+            NoteTool.return_value = note_tool
+
+            await init_notes_module(server, app)
+
+        # NoteTool was constructed with the notes service AND
+        # registered on the registry.
+        NoteTool.assert_called_once_with(svc)
+        server._tool_registry.register.assert_called_with(note_tool)
+
+    @pytest.mark.asyncio
+    async def test_no_registry_skips_note_tool_but_still_registers_routes(self):
+        from dragon_voice.lifecycle.notes_init import init_notes_module
+
+        server = _make_server()
+        server._tool_registry = None  # agentic init failed
+        app = MagicMock()
+
+        with patch(
+            "dragon_voice.notes.api.setup_routes"
+        ) as setup_routes, patch(
+            "dragon_voice.notes.db.NotesDB"
+        ), patch(
+            "dragon_voice.notes.service.NotesService"
+        ) as NotesSvc:
+            svc = MagicMock()
+            svc.initialize = AsyncMock()
+            NotesSvc.return_value = svc
+
+            await init_notes_module(server, app)
+
+        # Routes still registered (REST API matters even
+        # without LLM tool integration)
+        setup_routes.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_init_failure_does_not_block_boot(self):
+        """Pin: a missing optional dep (no notes module
+        installed) logs at WARNING and returns silently."""
+        from dragon_voice.lifecycle.notes_init import init_notes_module
+
+        server = _make_server()
+        app = MagicMock()
+
+        with patch(
+            "dragon_voice.notes.service.NotesService"
+        ) as NotesSvc:
+            NotesSvc.side_effect = ImportError("notes module missing")
+            # Must NOT raise.
+            await init_notes_module(server, app)
+
+        # _notes_svc left as initialized state (None)
+        assert server._notes_svc is None
+
+
+# ─── mcp_init ────────────────────────────────────────────────
+
+
+class TestMcpInit:
+    @pytest.mark.asyncio
+    async def test_no_mcp_servers_is_silent_noop(self):
+        from dragon_voice.lifecycle.mcp_init import init_mcp_bridges
+
+        server = _make_server()
+        # mcp_servers = [] (default in _make_server)
+
+        with patch(
+            "dragon_voice.mcp.bridge.bridge_mcp_server"
+        ) as bridge:
+            await init_mcp_bridges(server)
+
+        bridge.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_each_mcp_server_bridged(self):
+        from dragon_voice.lifecycle.mcp_init import init_mcp_bridges
+
+        server = _make_server()
+        server._config.mcp_servers = [
+            {"name": "tool_box", "url": "http://x", "token": "t1"},
+            {"name": "skill_lib", "url": "http://y"},
+        ]
+
+        with patch(
+            "dragon_voice.mcp.bridge.bridge_mcp_server"
+        ) as bridge:
+            bridge.return_value = 5  # tools per server
+
+            await init_mcp_bridges(server)
+
+        assert bridge.await_count == 2
+        # First server has token; second doesn't (None)
+        first_kwargs = bridge.await_args_list[0].kwargs
+        assert first_kwargs["name"] == "tool_box"
+        assert first_kwargs["url"] == "http://x"
+        assert first_kwargs["token"] == "t1"
+        second_kwargs = bridge.await_args_list[1].kwargs
+        assert second_kwargs["name"] == "skill_lib"
+        assert second_kwargs["token"] is None
+
+    @pytest.mark.asyncio
+    async def test_missing_mcp_servers_attr_uses_empty_list(self):
+        """getattr fallback pin — older configs without the attr
+        must not crash."""
+        from dragon_voice.lifecycle.mcp_init import init_mcp_bridges
+
+        server = _make_server()
+        # Strip the attr entirely
+        del server._config.mcp_servers
+
+        with patch(
+            "dragon_voice.mcp.bridge.bridge_mcp_server"
+        ) as bridge:
+            await init_mcp_bridges(server)
+
+        bridge.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_bridge_failure_does_not_propagate(self):
+        from dragon_voice.lifecycle.mcp_init import init_mcp_bridges
+
+        server = _make_server()
+        server._config.mcp_servers = [{"name": "broken", "url": "http://x"}]
+
+        with patch(
+            "dragon_voice.mcp.bridge.bridge_mcp_server"
+        ) as bridge:
+            bridge.side_effect = ConnectionRefusedError("MCP down")
+            # Must NOT raise.
+            await init_mcp_bridges(server)
+
+
+# ─── background_tasks_init ───────────────────────────────────
+
+
+class TestBackgroundTasksInit:
+    @pytest.mark.asyncio
+    async def test_three_task_handles_assigned(self):
+        from dragon_voice.lifecycle.background_tasks_init import (
+            init_background_tasks,
+        )
+
+        server = _make_server(retention_days=30)
+
+        with patch(
+            "dragon_voice.lifecycle.purge.media_cleanup_loop",
+            new=AsyncMock(),
+        ), patch(
+            "dragon_voice.lifecycle.monitors.memory_monitor_loop",
+            new=AsyncMock(),
+        ), patch(
+            "dragon_voice.lifecycle.monitors.get_rss_mb",
+            return_value=512.0,
+        ):
+            init_background_tasks(server)
+            # Wait one tick to let create_task schedule
+            await asyncio.sleep(0)
+
+        assert server._purge_task is not None
+        assert server._media_cleanup_task is not None
+        assert server._memory_monitor_task is not None
+
+        # Cleanup so tests don't leak tasks
+        for t in (
+            server._purge_task,
+            server._media_cleanup_task,
+            server._memory_monitor_task,
+        ):
+            t.cancel()
+            try:
+                await t
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_retention_zero_skips_purge_task(self):
+        """Pin: retention_days=0 → no purge task spawned (admin
+        opted out of message retention)."""
+        from dragon_voice.lifecycle.background_tasks_init import (
+            init_background_tasks,
+        )
+
+        server = _make_server(retention_days=0)
+
+        with patch(
+            "dragon_voice.lifecycle.purge.media_cleanup_loop",
+            new=AsyncMock(),
+        ), patch(
+            "dragon_voice.lifecycle.monitors.memory_monitor_loop",
+            new=AsyncMock(),
+        ), patch(
+            "dragon_voice.lifecycle.monitors.get_rss_mb",
+            return_value=512.0,
+        ):
+            init_background_tasks(server)
+            await asyncio.sleep(0)
+
+        # _purge_task NOT assigned (still None)
+        assert server._purge_task is None
+        # Other two still assigned
+        assert server._media_cleanup_task is not None
+        assert server._memory_monitor_task is not None
+
+        for t in (
+            server._media_cleanup_task,
+            server._memory_monitor_task,
+        ):
+            t.cancel()
+            try:
+                await t
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_startup_purge_failure_does_not_block_periodic_loop(self):
+        """Pin invariant: a transient DB issue at startup-purge
+        time MUST NOT prevent the periodic loop from running.
+        The wrapped task swallows + falls through."""
+        from dragon_voice.lifecycle.background_tasks_init import (
+            _run_startup_purge_then_loop,
+        )
+
+        server = _make_server()
+        server._db.purge_old_messages = AsyncMock(
+            side_effect=RuntimeError("DB locked"),
+        )
+
+        loop_invoked = asyncio.Event()
+
+        async def _fake_loop(*args, **kwargs):
+            loop_invoked.set()
+
+        with patch(
+            "dragon_voice.lifecycle.purge.periodic_purge_loop",
+            new=_fake_loop,
+        ):
+            await _run_startup_purge_then_loop(server, 30)
+
+        assert loop_invoked.is_set()


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **twenty-eighth sub-extract**.  Final slice from \`dragon_voice/lifecycle/startup.py\`.  PRs #252 + #253 + this PR together **CLOSE audit SRP-6** (\`run_startup\` mutates 21 attrs in 281 LOC).

Three new modules under \`dragon_voice/lifecycle/\`:
- **\`notes_init.init_notes_module\`** — NotesDB + NotesService init, Notes API routes, NoteTool registration (~40 LOC)
- **\`mcp_init.init_mcp_bridges\`** — walks \`config.mcp_servers\` and bridges each MCP server's tool catalog (~30 LOC)
- **\`background_tasks_init.init_background_tasks\`** — schedules the three lifetime tasks (purge, media cleanup, memory monitor) (~70 LOC)

### Behaviour preserved verbatim

- Notes init failure (missing optional dep) logs WARNING, doesn't block boot
- MCP bridges wrapped in single try/except (preserved verbatim; per-server isolation is a follow-up)
- \`getattr(config, \"mcp_servers\", [])\` fallback for older configs without the field
- \`retention_days <= 0\` skips the purge task entirely (admin opt-out)
- Startup-purge wrapper isolates the initial purge from the periodic loop — a transient DB issue at startup time MUST NOT prevent the periodic loop from running
- All three task handles populated for \`run_shutdown\` to cancel + await

### API improvement

The startup-purge logic now lives in \`_run_startup_purge_then_loop\` which combines initial purge + periodic loop into a single asyncio.Task — matches the \"one task handle per concern\" pattern for cleaner shutdown.

### Test coverage

11 new tests across 3 classes (TestNotesInit, TestMcpInit, TestBackgroundTasksInit) spanning happy paths + all the failure-isolation invariants.

### Diff stats

| Metric | Before | After |
|---|---|---|
| \`lifecycle/startup.py\` LOC | 207 | 160 (-47) |
| Three new modules | (didn't exist) | 40 + 30 + 70 |
| **\`startup.py\` cumulative SRP-6 closure across #252+#253+#254** | **320** | **160 (-50%)** |

**SRP-6 fully closed.**

## Test plan

- [x] \`python3 -m pytest tests/test_startup_final_wiring.py -v\` → 11 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → **1178 passed**, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)