### PR TITLE
refactor(pipeline): extract fallback STT pre-warm + lazy-load cache to FallbackSttCache (audit SRP-4 part 2)

### DIFF
--- a/dragon_voice/fallback_stt_cache.py
+++ b/dragon_voice/fallback_stt_cache.py
@@ -1,0 +1,180 @@
+"""Fallback STT cache — pre-warm + lazy-load + shutdown.
+
+Wave 23 SOLID-audit follow-up — thirtieth sub-extract.
+Second slice from `dragon_voice/pipeline.py` (audit SRP-4: the
+1733-LOC `VoicePipeline` class owns 5+ responsibilities; the
+fallback-STT lifecycle is one of them).
+
+Cloud STT (OpenRouter) can fail mid-call (timeout, API error,
+network glitch) and Dragon falls back to local Moonshine to
+salvage the user's words.  Without pre-warm, the first cloud
+failure pays the 1-3 s Moonshine cold-load before any
+transcription — the user hears nothing for the bridge window
+and assumes Dragon broke.
+
+This module owns the pre-warm + lazy-load + shutdown lifecycle:
+
+  * `schedule_prewarm()` — fire-and-forget background load
+    when the active STT swaps to `openrouter` (audit B6 / #154).
+  * `transcribe(audio, sample_rate)` — borrow the pre-warmed
+    Moonshine OR cold-load if the prewarm hasn't finished yet.
+  * `shutdown()` — cancel any in-flight prewarm + shutdown the
+    cached backend.
+
+Pre-extract these were two methods + scattered state on
+VoicePipeline (`_fallback_stt`, `_fallback_prewarm_task`).  Now
+encapsulated in a single class.
+
+## API
+
+```python
+cache = FallbackSttCache()
+
+# When swap_backends sets STT to cloud:
+cache.schedule_prewarm()
+
+# When cloud STT fails mid-utterance:
+transcript = await cache.transcribe(audio, sample_rate=16000)
+
+# On pipeline shutdown:
+await cache.shutdown()
+```
+
+## Race guard preserved
+
+`schedule_prewarm` is idempotent — if a fallback already exists
+or a prewarm is already in flight, it no-ops.  When a real
+cloud-STT failure cold-loads in parallel with the prewarm,
+last-writer-wins; the loser is shut down to avoid leaking a
+Moonshine instance.
+
+## Why the imports are inside the methods
+
+`create_stt` + `STTConfig` imports are deferred to the first
+prewarm/transcribe call — keeps the module import cost zero
+for connections that never hit the fallback path.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class FallbackSttCache:
+    """Pre-warm + lazy-load + shutdown lifecycle for the
+    Moonshine fallback STT backend.
+
+    Owns two pieces of state:
+      * `_fallback_stt` — the cached Moonshine STTBackend (or
+        None if not yet loaded).
+      * `_prewarm_task` — the in-flight prewarm asyncio.Task
+        (or None when not running / completed).
+
+    Both are private; callers should use the three public
+    methods (schedule_prewarm, transcribe, shutdown).
+    """
+
+    def __init__(self) -> None:
+        self._fallback_stt: Optional[Any] = None  # STTBackend
+        self._prewarm_task: Optional[asyncio.Task] = None
+
+    def schedule_prewarm(self) -> None:
+        """Spawn a background task that loads Moonshine into the
+        cache so the first cloud-STT failure doesn't pay the
+        1-3 s cold-load.
+
+        Audit B6 (#154): called from `VoicePipeline.swap_backends`
+        whenever the new STT backend is `openrouter`.
+        Idempotent — if a fallback already exists or a prewarm
+        is already in flight, no-ops.
+        """
+        if self._fallback_stt is not None:
+            return
+        if self._prewarm_task is not None and not self._prewarm_task.done():
+            return
+
+        async def _prewarm() -> None:
+            try:
+                from dragon_voice.config import STTConfig
+                from dragon_voice.stt import create_stt
+                stt = create_stt(STTConfig(backend="moonshine"))
+                await stt.initialize()
+                # Race guard: a real cloud-STT failure could have
+                # cold-loaded one in parallel.  Last-writer-wins;
+                # the loser is shut down to avoid leaking a
+                # Moonshine instance.
+                if self._fallback_stt is None:
+                    self._fallback_stt = stt
+                    logger.info(
+                        "Pre-warmed fallback STT (moonshine) cached "
+                        "(background)",
+                    )
+                else:
+                    await stt.shutdown()
+            except Exception as e:
+                logger.warning("B6 fallback-STT prewarm failed: %s", e)
+
+        self._prewarm_task = asyncio.create_task(
+            _prewarm(), name="b6_fallback_stt_prewarm",
+        )
+
+    async def transcribe(
+        self,
+        audio_data: bytes,
+        *,
+        sample_rate: int,
+    ) -> str:
+        """Borrow the pre-warmed fallback STT (or cold-load if
+        absent), then transcribe `audio_data`.
+
+        Audit B6 (#154): keeps the fallback path single-line at
+        the callsite while preserving the v4·D P1 caching
+        behaviour and respecting the swap_backends pre-warm.
+        """
+        if self._fallback_stt is None:
+            from dragon_voice.config import STTConfig
+            from dragon_voice.stt import create_stt
+            self._fallback_stt = create_stt(STTConfig(backend="moonshine"))
+            await self._fallback_stt.initialize()
+            logger.info(
+                "Pre-warmed fallback STT (moonshine) cached (lazy path)",
+            )
+        return await self._fallback_stt.transcribe(audio_data, sample_rate)
+
+    async def shutdown(self) -> None:
+        """Cancel any in-flight prewarm + shutdown the cached
+        backend.  Called from `VoicePipeline.shutdown`.
+
+        Audit B6 (#154): cancel the prewarm so shutdown doesn't
+        have to wait for a 1-3 s model load just to immediately
+        throw it away.
+        """
+        # Cancel + await the prewarm task so it can't outlive
+        # us.  Both CancelledError and any exception from the
+        # task body are swallowed.
+        if self._prewarm_task is not None and not self._prewarm_task.done():
+            self._prewarm_task.cancel()
+            try:
+                await self._prewarm_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._prewarm_task = None
+
+        # Shutdown the cached backend if loaded.
+        if self._fallback_stt is not None:
+            try:
+                await self._fallback_stt.shutdown()
+            except Exception:
+                logger.debug("Fallback STT shutdown raised", exc_info=True)
+        self._fallback_stt = None
+
+    @property
+    def is_loaded(self) -> bool:
+        """True iff the fallback backend is loaded + ready to
+        transcribe without paying the cold-load.  Used by tests
+        + diagnostics; production code calls `transcribe`
+        directly which handles the lazy-load path itself."""
+        return self._fallback_stt is not None

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -251,6 +251,14 @@ class VoicePipeline:
         self._segment_buffer = bytearray()
         self._dictation_segments: list[str] = []
 
+        # SOLID-audit follow-up: fallback STT lifecycle (pre-warm
+        # + lazy-load + shutdown) extracted to FallbackSttCache.
+        # Audit B6 (#154): cloud STT failures fall back to
+        # Moonshine; without pre-warm, the first failure pays
+        # the 1-3 s cold-load.
+        from dragon_voice.fallback_stt_cache import FallbackSttCache
+        self._fallback_stt_cache = FallbackSttCache()
+
     async def initialize(self) -> None:
         """Create and initialize all backends.
 
@@ -1435,55 +1443,24 @@ class VoicePipeline:
         """Borrow the pre-warmed fallback STT (or cold-load if absent),
         then transcribe `audio_data`.
 
-        Audit B6 (#154): keeps the fallback path single-line at the
-        callsite while preserving the v4·D P1 caching behaviour and
-        respecting the new `swap_backends` pre-warm.
+        SOLID-audit follow-up: lazy-load + transcribe extracted to
+        FallbackSttCache.transcribe.  This wrapper keeps the
+        existing call site unchanged.
         """
-        if not getattr(self, "_fallback_stt", None):
-            from dragon_voice.stt import create_stt
-            from dragon_voice.config import STTConfig
-            self._fallback_stt = create_stt(STTConfig(backend="moonshine"))
-            await self._fallback_stt.initialize()
-            logger.info("Pre-warmed fallback STT (moonshine) cached (lazy path)")
-        return await self._fallback_stt.transcribe(
-            audio_data, self._config.audio.input_sample_rate
+        return await self._fallback_stt_cache.transcribe(
+            audio_data, sample_rate=self._config.audio.input_sample_rate,
         )
 
     def _schedule_fallback_stt_prewarm(self) -> None:
-        """Spawn a background task that loads Moonshine into
-        `self._fallback_stt` so the first cloud-STT failure doesn't
+        """Spawn a background task that loads Moonshine into the
+        fallback cache so the first cloud-STT failure doesn't
         pay the 1-3 s cold-load.
 
-        Audit B6 (#154): called from `swap_backends` whenever the new
-        STT backend is `openrouter`.  Idempotent — if a fallback already
-        exists or a prewarm is already in flight, no-ops.
+        SOLID-audit follow-up: extracted to
+        FallbackSttCache.schedule_prewarm.  This wrapper keeps
+        the existing call site unchanged.
         """
-        if getattr(self, "_fallback_stt", None):
-            return
-        prev = getattr(self, "_fallback_prewarm_task", None)
-        if prev is not None and not prev.done():
-            return
-
-        async def _prewarm() -> None:
-            try:
-                from dragon_voice.stt import create_stt
-                from dragon_voice.config import STTConfig
-                stt = create_stt(STTConfig(backend="moonshine"))
-                await stt.initialize()
-                # Race guard: a real cloud-STT failure could have
-                # cold-loaded one in parallel.  Last writer wins; the
-                # loser is discarded.
-                if not getattr(self, "_fallback_stt", None):
-                    self._fallback_stt = stt
-                    logger.info("Pre-warmed fallback STT (moonshine) cached (background)")
-                else:
-                    await stt.shutdown()
-            except Exception as e:
-                logger.warning("B6 fallback-STT prewarm failed: %s", e)
-
-        self._fallback_prewarm_task = asyncio.create_task(
-            _prewarm(), name="b6_fallback_stt_prewarm"
-        )
+        self._fallback_stt_cache.schedule_prewarm()
 
     async def swap_backends(self, config: VoiceConfig) -> None:
         """Hot-swap backends based on new configuration.
@@ -1629,24 +1606,17 @@ class VoicePipeline:
             tasks.append(self._tts.shutdown())
         if self._llm and not self._pooled_llm:
             tasks.append(self._llm.shutdown())
-        # Audit B6 (#154): cancel any in-flight Moonshine pre-warm so
-        # shutdown doesn't have to wait for a 1-3 s model load just to
-        # immediately throw it away.
-        prewarm = getattr(self, "_fallback_prewarm_task", None)
-        if prewarm is not None and not prewarm.done():
-            prewarm.cancel()
-            try:
-                await prewarm
-            except (asyncio.CancelledError, Exception):
-                pass
-            self._fallback_prewarm_task = None
-        # Pre-warmed fallback backends (from P1 STT/TTS cache fix).
-        fb_stt = getattr(self, "_fallback_stt", None)
+        # SOLID-audit follow-up: fallback STT prewarm + cached
+        # backend shutdown extracted to
+        # FallbackSttCache.shutdown — handles cancel + await of
+        # the prewarm task and the cached backend's shutdown.
+        await self._fallback_stt_cache.shutdown()
+        # Fallback TTS still inline (separate cache lifecycle —
+        # follow-up PR could symmetrise).
         fb_tts = getattr(self, "_fallback_tts", None)
-        if fb_stt: tasks.append(fb_stt.shutdown())
-        if fb_tts: tasks.append(fb_tts.shutdown())
+        if fb_tts:
+            tasks.append(fb_tts.shutdown())
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
-        self._fallback_stt = None
         self._fallback_tts = None
         logger.info("Voice pipeline shut down")

--- a/tests/test_b6_hybrid_first_utterance.py
+++ b/tests/test_b6_hybrid_first_utterance.py
@@ -40,7 +40,9 @@ def test_swap_into_cloud_stt_schedules_fallback_prewarm() -> None:
 
     p = VoicePipeline(cfg, on_audio=on_audio, on_event=on_event)
     # Sanity: no prewarm task before the swap.
-    assert getattr(p, "_fallback_prewarm_task", None) is None
+    # SOLID-audit follow-up: prewarm state extracted to
+    # FallbackSttCache (PR #256); inspect through the cache.
+    assert p._fallback_stt_cache._prewarm_task is None
 
     async def go():
         # Mock the create_stt + initialize so we don't actually load
@@ -69,7 +71,8 @@ def test_swap_into_cloud_stt_schedules_fallback_prewarm() -> None:
         # `from dragon_voice.stt import create_stt` resolves to.
         try:
             p._schedule_fallback_stt_prewarm()
-            task = getattr(p, "_fallback_prewarm_task", None)
+            # Inspection through the cache (PR #256 extract).
+            task = p._fallback_stt_cache._prewarm_task
             assert task is not None and not task.done(), "prewarm task should be spawned"
             await asyncio.wait_for(prewarm_invoked.wait(), timeout=1.0)
             # Task either done now or about to be — let it settle.
@@ -77,8 +80,8 @@ def test_swap_into_cloud_stt_schedules_fallback_prewarm() -> None:
                 await task
             except Exception:
                 pass
-            # _fallback_stt was populated by the task.
-            assert getattr(p, "_fallback_stt", None) is not None
+            # Fallback STT was populated by the task.
+            assert p._fallback_stt_cache._fallback_stt is not None
         finally:
             stt_mod.create_stt = original_create_stt  # type: ignore[assignment]
 
@@ -97,10 +100,11 @@ def test_prewarm_is_idempotent_when_fallback_already_present() -> None:
         return None
 
     p = VoicePipeline(cfg, on_audio=on_audio, on_event=on_event)
-    p._fallback_stt = object()  # already cached
+    # SOLID-audit follow-up: pre-populate via the cache (PR #256).
+    p._fallback_stt_cache._fallback_stt = object()  # already cached
 
     p._schedule_fallback_stt_prewarm()
-    assert getattr(p, "_fallback_prewarm_task", None) is None, (
+    assert p._fallback_stt_cache._prewarm_task is None, (
         "no task should spawn when fallback is already cached"
     )
 
@@ -135,10 +139,10 @@ def test_prewarm_skips_if_inflight_task_pending() -> None:
         stt_mod.create_stt = lambda cfg_: _SlowStt()  # type: ignore[assignment]
         try:
             p._schedule_fallback_stt_prewarm()
-            first = p._fallback_prewarm_task
+            first = p._fallback_stt_cache._prewarm_task
             await asyncio.sleep(0.05)
             p._schedule_fallback_stt_prewarm()
-            second = p._fallback_prewarm_task
+            second = p._fallback_stt_cache._prewarm_task
             assert first is second, "second call must reuse in-flight task"
             try:
                 await first

--- a/tests/test_fallback_stt_cache.py
+++ b/tests/test_fallback_stt_cache.py
@@ -1,0 +1,263 @@
+"""Tests for ``dragon_voice.fallback_stt_cache.FallbackSttCache``.
+
+Pin the prewarm idempotency, lazy-load fallback, race-guard
+last-writer-wins, and shutdown invariants.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dragon_voice.fallback_stt_cache import FallbackSttCache
+
+
+def _make_stt_backend(*, transcript: str = "hello") -> MagicMock:
+    stt = MagicMock()
+    stt.initialize = AsyncMock()
+    stt.transcribe = AsyncMock(return_value=transcript)
+    stt.shutdown = AsyncMock()
+    return stt
+
+
+# ─── transcribe (lazy-load path) ─────────────────────────────
+
+
+class TestTranscribeLazyLoad:
+    @pytest.mark.asyncio
+    async def test_first_transcribe_cold_loads_then_transcribes(self):
+        cache = FallbackSttCache()
+        assert cache.is_loaded is False
+
+        backend = _make_stt_backend(transcript="result")
+        with patch(
+            "dragon_voice.stt.create_stt", return_value=backend,
+        ):
+            result = await cache.transcribe(b"audio", sample_rate=16000)
+
+        assert result == "result"
+        backend.initialize.assert_awaited_once()
+        backend.transcribe.assert_awaited_once_with(b"audio", 16000)
+        assert cache.is_loaded is True
+
+    @pytest.mark.asyncio
+    async def test_second_transcribe_reuses_cached_backend(self):
+        cache = FallbackSttCache()
+        backend = _make_stt_backend()
+
+        with patch(
+            "dragon_voice.stt.create_stt", return_value=backend,
+        ) as create:
+            await cache.transcribe(b"a", sample_rate=16000)
+            await cache.transcribe(b"b", sample_rate=16000)
+
+        # create_stt invoked exactly once (cached for the second call)
+        assert create.call_count == 1
+        backend.initialize.assert_awaited_once()
+        assert backend.transcribe.await_count == 2
+
+
+# ─── schedule_prewarm (idempotent + race-guard) ──────────────
+
+
+class TestSchedulePrewarm:
+    @pytest.mark.asyncio
+    async def test_prewarm_loads_backend_in_background(self):
+        cache = FallbackSttCache()
+        backend = _make_stt_backend()
+
+        with patch(
+            "dragon_voice.stt.create_stt", return_value=backend,
+        ):
+            cache.schedule_prewarm()
+            # Wait for the background task to complete
+            assert cache._prewarm_task is not None
+            await cache._prewarm_task
+
+        assert cache.is_loaded is True
+        backend.initialize.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_prewarm_idempotent_when_already_loaded(self):
+        """schedule_prewarm called when fallback already exists
+        → no-op, no second backend created."""
+        cache = FallbackSttCache()
+        backend = _make_stt_backend()
+
+        # Pre-populate the cache via transcribe
+        with patch(
+            "dragon_voice.stt.create_stt", return_value=backend,
+        ):
+            await cache.transcribe(b"audio", sample_rate=16000)
+
+        # Now try to prewarm — must no-op
+        with patch(
+            "dragon_voice.stt.create_stt"
+        ) as create2:
+            cache.schedule_prewarm()
+            # No new task scheduled
+            assert (
+                cache._prewarm_task is None
+                or cache._prewarm_task.done()
+            )
+            create2.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_prewarm_idempotent_when_already_in_flight(self):
+        """schedule_prewarm called twice rapidly → second call
+        no-ops while the first task is still running."""
+        cache = FallbackSttCache()
+        backend = _make_stt_backend()
+
+        # Make initialize hang so the prewarm task stays in-flight
+        slow = asyncio.Event()
+
+        async def _hang():
+            await slow.wait()
+
+        backend.initialize = AsyncMock(side_effect=_hang)
+
+        with patch(
+            "dragon_voice.stt.create_stt", return_value=backend,
+        ) as create:
+            cache.schedule_prewarm()
+            await asyncio.sleep(0)  # let task start
+            cache.schedule_prewarm()  # second call, should no-op
+            slow.set()
+            await cache._prewarm_task
+
+        # create_stt invoked exactly once
+        assert create.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_race_guard_last_writer_wins(self):
+        """When prewarm finishes BUT a real cloud-STT failure
+        already cold-loaded a fallback in parallel, the prewarm
+        instance is shut down (not stored) — last-writer wins."""
+        cache = FallbackSttCache()
+
+        prewarm_started = asyncio.Event()
+        prewarm_can_finish = asyncio.Event()
+        prewarm_backend = _make_stt_backend()
+        lazy_backend = _make_stt_backend()
+
+        async def _slow_init():
+            prewarm_started.set()
+            await prewarm_can_finish.wait()
+
+        prewarm_backend.initialize = AsyncMock(side_effect=_slow_init)
+
+        # First call returns the prewarm backend; second call (the
+        # lazy-load) returns a different backend.
+        backends_iter = iter([prewarm_backend, lazy_backend])
+
+        with patch(
+            "dragon_voice.stt.create_stt",
+            side_effect=lambda cfg: next(backends_iter),
+        ):
+            cache.schedule_prewarm()
+            await prewarm_started.wait()
+            # Prewarm is in-flight; force the lazy-load path by
+            # calling transcribe directly.  This sets
+            # _fallback_stt to lazy_backend.
+            await cache.transcribe(b"audio", sample_rate=16000)
+            # Now release the prewarm task — it should detect
+            # the cache is already populated and shut DOWN its
+            # own backend (last-writer-wins).
+            prewarm_can_finish.set()
+            await cache._prewarm_task
+
+        # Cache holds the lazy-load backend (first writer)
+        assert cache._fallback_stt is lazy_backend
+        # Prewarm backend was shut down (race-guard discard)
+        prewarm_backend.shutdown.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_prewarm_failure_is_swallowed(self):
+        """A prewarm exception logs at WARNING but doesn't
+        propagate (it's a background task; nobody's awaiting it)."""
+        cache = FallbackSttCache()
+
+        with patch(
+            "dragon_voice.stt.create_stt",
+            side_effect=ImportError("moonshine-voice missing"),
+        ):
+            cache.schedule_prewarm()
+            # Awaiting the task should NOT raise
+            await cache._prewarm_task
+
+        assert cache.is_loaded is False
+
+
+# ─── shutdown ────────────────────────────────────────────────
+
+
+class TestShutdown:
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_in_flight_prewarm(self):
+        """Audit B6 closure: cancel any pending prewarm so
+        shutdown doesn't have to wait for a 1-3 s model load
+        just to immediately throw it away."""
+        cache = FallbackSttCache()
+
+        # Make initialize hang so the prewarm task is in-flight
+        slow = asyncio.Event()
+
+        async def _hang():
+            await slow.wait()
+
+        backend = _make_stt_backend()
+        backend.initialize = AsyncMock(side_effect=_hang)
+
+        with patch(
+            "dragon_voice.stt.create_stt", return_value=backend,
+        ):
+            cache.schedule_prewarm()
+            await asyncio.sleep(0)
+            await cache.shutdown()
+
+        # Prewarm task was cancelled (not awaited to completion)
+        assert cache._prewarm_task is None
+        assert cache._fallback_stt is None
+
+    @pytest.mark.asyncio
+    async def test_shutdown_releases_cached_backend(self):
+        cache = FallbackSttCache()
+        backend = _make_stt_backend()
+
+        with patch(
+            "dragon_voice.stt.create_stt", return_value=backend,
+        ):
+            await cache.transcribe(b"audio", sample_rate=16000)
+
+        await cache.shutdown()
+
+        backend.shutdown.assert_awaited_once()
+        assert cache._fallback_stt is None
+
+    @pytest.mark.asyncio
+    async def test_shutdown_when_nothing_loaded_is_noop(self):
+        """Pin: shutdown on a fresh cache must not raise."""
+        cache = FallbackSttCache()
+        # Must NOT raise.
+        await cache.shutdown()
+        assert cache.is_loaded is False
+
+    @pytest.mark.asyncio
+    async def test_shutdown_swallows_backend_exception(self):
+        """If the cached backend's shutdown raises, log at DEBUG
+        but don't propagate — pipeline shutdown shouldn't
+        cascade."""
+        cache = FallbackSttCache()
+        backend = _make_stt_backend()
+        backend.shutdown = AsyncMock(side_effect=RuntimeError("dead"))
+
+        with patch(
+            "dragon_voice.stt.create_stt", return_value=backend,
+        ):
+            await cache.transcribe(b"audio", sample_rate=16000)
+
+        # Must NOT raise.
+        await cache.shutdown()
+        assert cache._fallback_stt is None


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **thirtieth sub-extract**.  Second slice from \`dragon_voice/pipeline.py\` (audit **SRP-4**: the 1733-LOC \`VoicePipeline\` class owns 5+ responsibilities; the fallback-STT lifecycle is one of them).

Cloud STT (OpenRouter) can fail mid-call and Dragon falls back to local Moonshine.  Without pre-warm, the first cloud failure pays the 1-3 s Moonshine cold-load — the user hears nothing for the bridge window and assumes Dragon broke.

Pre-extract this ~70 LOC was scattered across two methods + init + shutdown blocks on VoicePipeline.  Now encapsulated in a single \`FallbackSttCache\` class.

### Behaviour preserved verbatim (audit B6 / #154)

- Pre-warm spawned in background when \`swap_backends\` sets STT to \`openrouter\`
- Idempotent: \`schedule_prewarm\` called when fallback already exists OR a prewarm is in-flight → no-op
- Lazy-load fallback path: cloud STT failure cold-loads Moonshine if prewarm hasn't completed yet
- **Race-guard**: prewarm task that completes AFTER a parallel lazy-load (real cloud failure) shuts down its own backend rather than overwriting the cache (last-writer wins)
- Pre-warm exception swallowed at WARNING (background task, nobody's awaiting it)
- Shutdown cancels any in-flight prewarm + shuts down the cached backend (audit B6 invariant — don't wait for a 1-3 s model load just to throw it away)
- Shutdown swallows backend-shutdown exceptions at DEBUG (pipeline shutdown shouldn't cascade)

### API improvement

All state encapsulated in one class — \`_fallback_stt\` and \`_fallback_prewarm_task\` no longer scattered across VoicePipeline.  \`is_loaded\` property exposes the cache state for tests + diagnostics.

Pipeline.py forwards via two thin wrapper methods so all 16+ existing call sites in pipeline.py + the 3 existing \`test_b6_hybrid_first_utterance\` tests keep working — those tests inspect through the cache attribute now (3-line update).

### Test coverage

11 new tests in \`tests/test_fallback_stt_cache.py\` across 3 classes:
- **Lazy-load** (cold-load on first call, reuse on second)
- **Prewarm** (loads in background, idempotent when already loaded, idempotent when in-flight, race-guard last-writer-wins, exception swallowed)
- **Shutdown** (cancels in-flight prewarm, releases cached backend, no-op when nothing loaded, swallows backend exception)

### Diff stats

| Metric | Before | After |
|---|---|---|
| \`pipeline.py\` LOC | 1652 | 1622 (-30) |
| \`fallback_stt_cache.py\` | (didn't exist) | 173 (new) |
| **\`pipeline.py\` cumulative SRP-4 closure across #255 + #256** | **1733** | **1622 (-6.4%)** |

3 more responsibilities still bundled in VoicePipeline.

## Test plan

- [x] \`python3 -m pytest tests/test_fallback_stt_cache.py -v\` → 11 passed
- [x] \`python3 -m pytest tests/test_b6_hybrid_first_utterance.py -v\` → 4 passed (3 updated to inspect through cache)
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → **1202 passed**, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)