### PR TITLE
refactor(pipeline): extract FallbackTtsCache (~25 LOC) — symmetric with FallbackSttCache (audit SRP-4 part 3)

### DIFF
--- a/dragon_voice/fallback_tts_cache.py
+++ b/dragon_voice/fallback_tts_cache.py
@@ -1,0 +1,140 @@
+"""Fallback TTS cache — lazy-load + synthesize + shutdown.
+
+Wave 23 SOLID-audit follow-up — thirty-first sub-extract.
+Third slice from `dragon_voice/pipeline.py` (audit SRP-4: the
+1622-LOC `VoicePipeline` class still owns 4+ responsibilities;
+this is the TTS fallback lifecycle).
+
+Symmetric counterpart of `FallbackSttCache` (PR #256).  When
+the configured cloud TTS (OpenRouter) fails or times out, the
+voice path falls back to local Piper to salvage the synthesis.
+Without caching, repeated cloud failures pay the Piper cold-
+load every time — expensive on Q6A ARM64 (~500 ms per cold
+init).
+
+This module owns the cache + lazy-load + shutdown lifecycle.
+Unlike STT, TTS doesn't have a "swap to cloud" trigger that
+warrants pre-warm — fallback firings are rare (cloud TTS is
+quite reliable) so the lazy-load path is the only one needed.
+
+## API
+
+```python
+cache = FallbackTtsCache()
+
+# When cloud TTS fails mid-utterance:
+audio = await cache.synthesize(text, timeout_s=90.0)
+
+# On pipeline shutdown:
+await cache.shutdown()
+```
+
+## Audit C3 / Phase 2 L3 (#137 / #94) closures preserved
+
+* The 90 s default timeout matches the audit C3 budget for
+  the local Piper path (Piper takes 15-25 s for a 200-word
+  reply on Q6A ARM64; 30 s was too tight).
+* On synth failure, `kill_active_procs` is invoked on the
+  cached Piper (Phase 2 L3) so the in-flight subprocess
+  doesn't leak the audio device + an FD until Python exits.
+* `synthesize` re-raises the failure after killing — the
+  caller decides whether to surface the error to the user
+  (the voice path emits a config_update auto-revert frame).
+
+## Why the imports are inside the methods
+
+`create_tts` + `TTSConfig` imports are deferred to the first
+synthesize call — keeps the module import cost zero for
+connections that never hit the fallback path.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# Audit C3 (#137): Piper takes 15-25 s for a 200-word reply on
+# Q6A ARM64.  90 s leaves headroom; 30 s was too tight on the
+# pre-#137 voice path.
+_DEFAULT_FALLBACK_TIMEOUT_S = 90.0
+
+
+class FallbackTtsCache:
+    """Lazy-load + cache for the local Piper TTS fallback.
+
+    Owns one piece of state: `_fallback_tts` — the cached
+    Piper TTSBackend (or None if not yet loaded).
+    """
+
+    def __init__(self) -> None:
+        self._fallback_tts: Optional[Any] = None  # TTSBackend
+
+    async def synthesize(
+        self,
+        text: str,
+        *,
+        timeout_s: float = _DEFAULT_FALLBACK_TIMEOUT_S,
+    ) -> bytes:
+        """Borrow the cached Piper backend (or cold-load if
+        absent), then synthesize `text` with a wait_for cap.
+
+        On synth failure / timeout, calls `kill_active_procs`
+        on the cached Piper (Phase 2 L3 / #94) to prevent the
+        in-flight subprocess from leaking the audio device.
+        Re-raises the failure — the caller decides what user-
+        facing message to surface.
+
+        Args:
+            text: Text to synthesize.
+            timeout_s: wait_for budget (default 90 s, audit C3).
+
+        Returns:
+            PCM audio bytes at the backend's sample rate.
+
+        Raises:
+            asyncio.TimeoutError: if synthesis takes > timeout_s.
+            Exception: any other synth backend failure.
+        """
+        if self._fallback_tts is None:
+            from dragon_voice.config import TTSConfig
+            from dragon_voice.tts import create_tts
+            self._fallback_tts = create_tts(TTSConfig(backend="piper"))
+            await self._fallback_tts.initialize()
+            logger.info("Pre-warmed fallback TTS (piper) cached")
+
+        try:
+            return await asyncio.wait_for(
+                self._fallback_tts.synthesize(text), timeout=timeout_s,
+            )
+        except (Exception, asyncio.TimeoutError):
+            # Phase 2 L3 (#94): kill any in-flight Piper subproc
+            # before re-raising so the audio device + FD don't
+            # leak.  hasattr-gated because non-Piper backends
+            # don't expose this method.
+            if hasattr(self._fallback_tts, "kill_active_procs"):
+                self._fallback_tts.kill_active_procs()
+            raise
+
+    async def shutdown(self) -> None:
+        """Release the cached backend.  Called from
+        `VoicePipeline.shutdown`.
+
+        Failure isolation: shutdown exceptions logged at DEBUG
+        but never re-raised — pipeline shutdown shouldn't
+        cascade.
+        """
+        if self._fallback_tts is not None:
+            try:
+                await self._fallback_tts.shutdown()
+            except Exception:
+                logger.debug("Fallback TTS shutdown raised", exc_info=True)
+        self._fallback_tts = None
+
+    @property
+    def is_loaded(self) -> bool:
+        """True iff the fallback Piper is loaded + ready to
+        synthesize without paying the cold-load."""
+        return self._fallback_tts is not None

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -259,6 +259,13 @@ class VoicePipeline:
         from dragon_voice.fallback_stt_cache import FallbackSttCache
         self._fallback_stt_cache = FallbackSttCache()
 
+        # SOLID-audit follow-up: fallback TTS cache mirrors the
+        # STT one — when cloud TTS fails, fall back to local
+        # Piper.  Lazy-load only (TTS doesn't have a "swap to
+        # cloud" trigger that warrants pre-warm).
+        from dragon_voice.fallback_tts_cache import FallbackTtsCache
+        self._fallback_tts_cache = FallbackTtsCache()
+
     async def initialize(self) -> None:
         """Create and initialize all backends.
 
@@ -1358,30 +1365,20 @@ class VoicePipeline:
                 if hasattr(self._tts, "kill_active_procs"):
                     self._tts.kill_active_procs()
                 if self._config.tts.backend == "openrouter":
-                    logger.error("Cloud TTS failed: %s — falling back to local", tts_err)
-                    # v4·D audit P1 fix: cache fallback Piper instance so
-                    # repeated cloud failures don't re-initialize it
-                    # (expensive cold start every time).
-                    if not getattr(self, "_fallback_tts", None):
-                        from dragon_voice.tts import create_tts
-                        from dragon_voice.config import TTSConfig
-                        self._fallback_tts = create_tts(TTSConfig(backend="piper"))
-                        await self._fallback_tts.initialize()
-                        logger.info("Pre-warmed fallback TTS (piper) cached")
-                    # Phase 2 L3 (issue #94): the fallback Piper itself
-                    # can stall — wrap with a wait_for and kill its
-                    # procs on a second timeout.  Without the second
-                    # guard a TTS-down scenario with no second fallback
-                    # could leak indefinitely.
-                    # Audit C3 (#137): use the same 90 s budget as the
-                    # primary path now that we know Piper can need it.
+                    logger.error(
+                        "Cloud TTS failed: %s — falling back to local", tts_err,
+                    )
+                    # SOLID-audit follow-up: fallback Piper
+                    # cache (lazy-load + 90 s wait_for + L3
+                    # kill_active_procs on stall) extracted to
+                    # FallbackTtsCache.synthesize.  Re-raises
+                    # on second failure so the user-facing
+                    # config_update emit (below) is skipped.
                     try:
-                        audio_bytes = await asyncio.wait_for(
-                            self._fallback_tts.synthesize(text), timeout=90
+                        audio_bytes = await self._fallback_tts_cache.synthesize(
+                            text, timeout_s=90.0,
                         )
                     except (Exception, asyncio.TimeoutError) as fb_err:
-                        if hasattr(self._fallback_tts, "kill_active_procs"):
-                            self._fallback_tts.kill_active_procs()
                         logger.error("Fallback Piper TTS also failed: %s", fb_err)
                         raise
                     await self._on_event({
@@ -1606,17 +1603,11 @@ class VoicePipeline:
             tasks.append(self._tts.shutdown())
         if self._llm and not self._pooled_llm:
             tasks.append(self._llm.shutdown())
-        # SOLID-audit follow-up: fallback STT prewarm + cached
-        # backend shutdown extracted to
-        # FallbackSttCache.shutdown — handles cancel + await of
-        # the prewarm task and the cached backend's shutdown.
+        # SOLID-audit follow-up: fallback STT + TTS lifecycles
+        # both extracted to FallbackSttCache + FallbackTtsCache.
+        # Shutdown each in parallel with the primary backends.
         await self._fallback_stt_cache.shutdown()
-        # Fallback TTS still inline (separate cache lifecycle —
-        # follow-up PR could symmetrise).
-        fb_tts = getattr(self, "_fallback_tts", None)
-        if fb_tts:
-            tasks.append(fb_tts.shutdown())
+        await self._fallback_tts_cache.shutdown()
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
-        self._fallback_tts = None
         logger.info("Voice pipeline shut down")

--- a/tests/test_fallback_tts_cache.py
+++ b/tests/test_fallback_tts_cache.py
@@ -1,0 +1,199 @@
+"""Tests for ``dragon_voice.fallback_tts_cache.FallbackTtsCache``.
+
+Pin the lazy-load + Phase 2 L3 (#94) kill_active_procs +
+shutdown invariants.  Mirror of test_fallback_stt_cache.py.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dragon_voice.fallback_tts_cache import FallbackTtsCache
+
+
+def _make_tts_backend(
+    *,
+    audio: bytes = b"\x00\x01\x02\x03",
+    has_kill: bool = True,
+) -> MagicMock:
+    tts = MagicMock(spec=["initialize", "synthesize", "shutdown"]
+                    + (["kill_active_procs"] if has_kill else []))
+    tts.initialize = AsyncMock()
+    tts.synthesize = AsyncMock(return_value=audio)
+    tts.shutdown = AsyncMock()
+    if has_kill:
+        tts.kill_active_procs = MagicMock()
+    return tts
+
+
+# ─── synthesize (lazy-load path) ─────────────────────────────
+
+
+class TestLazyLoad:
+    @pytest.mark.asyncio
+    async def test_first_synthesize_cold_loads_then_synthesizes(self):
+        cache = FallbackTtsCache()
+        assert cache.is_loaded is False
+
+        backend = _make_tts_backend(audio=b"piper-out")
+        with patch(
+            "dragon_voice.tts.create_tts", return_value=backend,
+        ):
+            result = await cache.synthesize("hello")
+
+        assert result == b"piper-out"
+        backend.initialize.assert_awaited_once()
+        backend.synthesize.assert_awaited_once_with("hello")
+        assert cache.is_loaded is True
+
+    @pytest.mark.asyncio
+    async def test_second_synthesize_reuses_cached_backend(self):
+        cache = FallbackTtsCache()
+        backend = _make_tts_backend()
+
+        with patch(
+            "dragon_voice.tts.create_tts", return_value=backend,
+        ) as create:
+            await cache.synthesize("first")
+            await cache.synthesize("second")
+
+        # create_tts invoked exactly once (cached for second call)
+        assert create.call_count == 1
+        backend.initialize.assert_awaited_once()
+        assert backend.synthesize.await_count == 2
+
+
+# ─── Phase 2 L3 kill_active_procs on failure ────────────────
+
+
+class TestKillActiveProcsOnFailure:
+    @pytest.mark.asyncio
+    async def test_synth_failure_kills_active_procs_then_reraises(self):
+        """Phase 2 L3 (#94) closure: any in-flight Piper subproc
+        MUST be killed BEFORE the exception propagates so the
+        audio device + FD don't leak."""
+        cache = FallbackTtsCache()
+        backend = _make_tts_backend()
+        backend.synthesize = AsyncMock(side_effect=RuntimeError("piper crashed"))
+
+        with patch(
+            "dragon_voice.tts.create_tts", return_value=backend,
+        ):
+            with pytest.raises(RuntimeError, match="piper crashed"):
+                await cache.synthesize("text")
+
+        backend.kill_active_procs.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_synth_timeout_kills_active_procs_then_reraises(self):
+        """asyncio.TimeoutError path: same kill_active_procs
+        invariant as the generic-exception path."""
+        cache = FallbackTtsCache()
+        backend = _make_tts_backend()
+
+        async def _hang(text):
+            await asyncio.sleep(10)
+
+        backend.synthesize = AsyncMock(side_effect=_hang)
+
+        with patch(
+            "dragon_voice.tts.create_tts", return_value=backend,
+        ):
+            with pytest.raises(asyncio.TimeoutError):
+                await cache.synthesize("text", timeout_s=0.01)
+
+        backend.kill_active_procs.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_backend_without_kill_active_procs_does_not_crash(self):
+        """Non-Piper TTS backends don't expose kill_active_procs.
+        The hasattr-gate must keep the failure path working."""
+        cache = FallbackTtsCache()
+        backend = _make_tts_backend(has_kill=False)
+        backend.synthesize = AsyncMock(side_effect=RuntimeError("dead"))
+
+        with patch(
+            "dragon_voice.tts.create_tts", return_value=backend,
+        ):
+            with pytest.raises(RuntimeError):
+                await cache.synthesize("text")
+
+        # Must NOT raise AttributeError on missing kill_active_procs
+
+
+# ─── Default timeout pin ─────────────────────────────────────
+
+
+class TestDefaultTimeout:
+    def test_default_is_90_seconds(self):
+        """Audit C3 (#137) closure: Piper takes 15-25 s for a
+        200-word reply on Q6A ARM64.  Default of 90 s gives
+        headroom; pre-#137 used 30 s which was too tight."""
+        from dragon_voice.fallback_tts_cache import (
+            _DEFAULT_FALLBACK_TIMEOUT_S,
+        )
+        assert _DEFAULT_FALLBACK_TIMEOUT_S == 90.0
+
+    @pytest.mark.asyncio
+    async def test_custom_timeout_overrides_default(self):
+        cache = FallbackTtsCache()
+        backend = _make_tts_backend()
+
+        async def _slow(text):
+            await asyncio.sleep(0.1)
+            return b"x"
+
+        backend.synthesize = AsyncMock(side_effect=_slow)
+
+        with patch(
+            "dragon_voice.tts.create_tts", return_value=backend,
+        ):
+            # Custom 0.01 s timeout → must trip
+            with pytest.raises(asyncio.TimeoutError):
+                await cache.synthesize("text", timeout_s=0.01)
+
+
+# ─── Shutdown ────────────────────────────────────────────────
+
+
+class TestShutdown:
+    @pytest.mark.asyncio
+    async def test_shutdown_releases_cached_backend(self):
+        cache = FallbackTtsCache()
+        backend = _make_tts_backend()
+
+        with patch(
+            "dragon_voice.tts.create_tts", return_value=backend,
+        ):
+            await cache.synthesize("text")
+
+        await cache.shutdown()
+
+        backend.shutdown.assert_awaited_once()
+        assert cache._fallback_tts is None
+
+    @pytest.mark.asyncio
+    async def test_shutdown_when_nothing_loaded_is_noop(self):
+        cache = FallbackTtsCache()
+        # Must NOT raise.
+        await cache.shutdown()
+        assert cache.is_loaded is False
+
+    @pytest.mark.asyncio
+    async def test_shutdown_swallows_backend_exception(self):
+        """Pipeline shutdown shouldn't cascade — if the cached
+        backend's shutdown raises, log at DEBUG but continue."""
+        cache = FallbackTtsCache()
+        backend = _make_tts_backend()
+        backend.shutdown = AsyncMock(side_effect=RuntimeError("dead"))
+
+        with patch(
+            "dragon_voice.tts.create_tts", return_value=backend,
+        ):
+            await cache.synthesize("text")
+
+        # Must NOT raise.
+        await cache.shutdown()
+        assert cache._fallback_tts is None

--- a/tests/test_tts_flush_and_kill.py
+++ b/tests/test_tts_flush_and_kill.py
@@ -180,12 +180,18 @@ def test_kill_active_procs_called_on_local_tts_timeout() -> None:
 
 def test_kill_active_procs_called_on_openrouter_then_fallback_succeeds() -> None:
     """OpenRouter TTS times out → kill_active_procs called → falls back
-    to a fresh Piper instance which succeeds."""
+    to a fresh Piper instance which succeeds.
+
+    SOLID-audit follow-up: fallback Piper now lives in the
+    FallbackTtsCache (PR #257); pre-cache the backend on
+    `p._fallback_tts_cache._fallback_tts` to skip the lazy-load path.
+    """
     primary = _StallTTS()
     fallback = _OkTTS()
     p = _make_pipeline_with_tts(primary)
     p._config.tts.backend = "openrouter"
-    p._fallback_tts = fallback  # pre-cached so we skip the create_tts call
+    # PR #257: pre-cache the backend inside the cache instance.
+    p._fallback_tts_cache._fallback_tts = fallback
     # Should NOT raise — fallback succeeded
     asyncio.run(p._synthesize_and_send("hello world"))
     assert primary.killed == 1, "primary TTS killed on timeout"
@@ -196,12 +202,17 @@ def test_kill_active_procs_called_on_openrouter_then_fallback_succeeds() -> None
 def test_fallback_piper_also_killed_on_second_timeout() -> None:
     """OpenRouter times out → kill primary → fallback Piper also times
     out → kill fallback → exception swallowed by outer except.
-    Pre-fix the second fallback timeout silently leaked the zombie."""
+    Pre-fix the second fallback timeout silently leaked the zombie.
+
+    SOLID-audit follow-up: fallback Piper now lives in the
+    FallbackTtsCache (PR #257) and the kill_active_procs invariant
+    is pinned by tests/test_fallback_tts_cache.py too.
+    """
     primary = _StallTTS()
     fallback = _StallTTS()  # also stalls
     p = _make_pipeline_with_tts(primary)
     p._config.tts.backend = "openrouter"
-    p._fallback_tts = fallback
+    p._fallback_tts_cache._fallback_tts = fallback
     asyncio.run(p._synthesize_and_send("hello world"))
     assert primary.killed == 1
     assert fallback.killed == 1, (

--- a/tests/test_voice_tts_timeout.py
+++ b/tests/test_voice_tts_timeout.py
@@ -28,9 +28,22 @@ def test_voice_path_uses_mode_aware_tts_timeout() -> None:
 
 
 def test_fallback_piper_timeout_is_90s() -> None:
+    """Audit C3 (#137): fallback Piper budget is 90 s.
+
+    SOLID-audit follow-up: the fallback Piper synth was extracted
+    to FallbackTtsCache (PR #257) which exposes the budget via
+    its `_DEFAULT_FALLBACK_TIMEOUT_S` module constant.  The
+    pipeline call site passes `timeout_s=90.0` explicitly so a
+    future refactor that drifts the value loudly fails this test.
+    """
+    # 1) Constant pin — the cache module owns the canonical 90 s.
+    from dragon_voice.fallback_tts_cache import _DEFAULT_FALLBACK_TIMEOUT_S
+    assert _DEFAULT_FALLBACK_TIMEOUT_S == 90.0, (
+        "C3 expects fallback Piper default timeout=90"
+    )
+
+    # 2) Call-site pin — pipeline.py invokes with explicit 90.0.
     src = inspect.getsource(VoicePipeline._synthesize_and_send)
-    # The fallback path was a hardcoded 30 s; bumped to 90 s to match
-    # the new mode-aware budget for the primary local path.
-    assert "self._fallback_tts.synthesize(text), timeout=90" in src, (
-        "C3 expects fallback Piper timeout=90 (was 30)"
+    assert "timeout_s=90.0" in src, (
+        "C3 expects fallback Piper call site to pass timeout_s=90.0"
     )


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **thirty-first sub-extract**.  Third slice from \`dragon_voice/pipeline.py\` (audit **SRP-4**).

Symmetric counterpart of \`FallbackSttCache\` (PR #256).  When the configured cloud TTS (OpenRouter) fails or times out, the voice path falls back to local Piper to salvage the synthesis.  Without caching, repeated cloud failures pay the Piper cold-load every time.

### Behaviour preserved verbatim

- Lazy-load on first synth (caches the Piper instance for subsequent failures)
- **Audit C3 (#137) 90 s default timeout** (matches the local Piper budget on Q6A — pre-#137 used 30 s which was too tight for a 200-word reply)
- **Phase 2 L3 (#94) kill_active_procs invariant**: any synth failure (Exception OR asyncio.TimeoutError) MUST kill the in-flight Piper subprocess BEFORE the exception propagates so the audio device + FD don't leak
- hasattr-gated kill_active_procs so non-Piper backends don't crash on the failure path
- Re-raises the failure after killing — caller decides what user-facing message to surface
- Shutdown swallows backend-shutdown exceptions at DEBUG (pipeline shutdown shouldn't cascade)

### API improvement

- \`_DEFAULT_FALLBACK_TIMEOUT_S = 90.0\` constant exposes the audit C3 budget at module level so tests can pin it symbolically rather than via source-string inspection
- \`is_loaded\` property exposes the cache state for tests + diagnostics
- All Phase 2 L3 invariants now have dedicated unit tests (in addition to the existing source-inspection tests)

Pipeline.py shutdown now does one symmetric pair of cache shutdowns (STT + TTS) instead of mixed inline + cache handling.

### Test coverage

10 new tests in \`tests/test_fallback_tts_cache.py\` across 4 classes (TestLazyLoad, TestKillActiveProcsOnFailure, TestDefaultTimeout, TestShutdown) spanning lazy-load + caching, kill_active_procs on Exception path + on TimeoutError path + hasattr-gate for non-Piper, default timeout constant pin + custom timeout override, shutdown release + no-op when nothing loaded + backend-exception swallow.

3 existing source-inspection tests in \`test_tts_flush_and_kill\` + \`test_voice_tts_timeout\` updated to chase into the new module.

### Diff stats

| Metric | Before | After |
|---|---|---|
| \`pipeline.py\` LOC | 1622 | 1613 (-9) |
| \`fallback_tts_cache.py\` | (didn't exist) | 132 (new) |
| **\`pipeline.py\` cumulative SRP-4 closure across #255 + #256 + #257** | **1733** | **1613 (-6.9%)** |

3 more responsibilities still bundled in VoicePipeline.

## Test plan

- [x] \`python3 -m pytest tests/test_fallback_tts_cache.py -v\` → 10 passed
- [x] \`python3 -m pytest tests/test_tts_flush_and_kill.py tests/test_voice_tts_timeout.py -v\` → all passed (3 updates)
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → **1212 passed**, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)