### PR TITLE
refactor(pipeline): dedup pool-aware backend-swap pattern in swap_backends (audit SRP-4 part 4)

### DIFF
--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -1491,66 +1491,93 @@ class VoicePipeline:
             old_config = self._config
             self._config = config
 
-            # W15-C01: pool-aware swap — prefer reusing existing pooled
-            # backend for the NEW signature; only tear down the old one
-            # if it wasn't pooled.
-            pool = self._backend_pool
-            tasks = []
+            # W15-C01: pool-aware swap — prefer reusing existing
+            # pooled backend for the NEW signature; only tear
+            # down the old one if it wasn't pooled.
+            #
+            # SOLID-audit follow-up: the three near-identical
+            # STT/TTS/LLM swap blocks dedupped to
+            # pool_aware_swap.swap_one_backend (PR #258).
+            from dragon_voice.pool_aware_swap import swap_one_backend
 
-            # STT
-            if (
+            pool = self._backend_pool
+            init_tasks = []
+
+            stt_changed = (
                 config.stt.backend != old_config.stt.backend
                 or config.stt.model != old_config.stt.model
-            ):
-                logger.info("Swapping STT: %s -> %s", old_config.stt.backend, config.stt.backend)
-                if self._stt and not self._pooled_stt:
-                    await self._stt.shutdown()
-                new_key = _stt_sig(config.stt)
-                if pool is not None and new_key in pool:
-                    self._stt = pool[new_key]
-                    self._pooled_stt = True
-                else:
-                    self._stt = create_stt(config.stt)
-                    self._pooled_stt = False
-                    tasks.append((self._stt, new_key, "stt"))
+            )
+            if stt_changed:
+                logger.info(
+                    "Swapping STT: %s -> %s",
+                    old_config.stt.backend, config.stt.backend,
+                )
+            stt_result = await swap_one_backend(
+                kind="stt",
+                config_changed=stt_changed,
+                old_instance=self._stt,
+                old_is_pooled=self._pooled_stt,
+                new_signature=_stt_sig(config.stt),
+                new_factory=lambda: create_stt(config.stt),
+                pool=pool,
+            )
+            self._stt = stt_result.new_instance
+            self._pooled_stt = stt_result.is_pooled
+            if stt_result.init_task is not None:
+                init_tasks.append(stt_result.init_task)
 
-            # TTS
-            if config.tts.backend != old_config.tts.backend:
-                logger.info("Swapping TTS: %s -> %s", old_config.tts.backend, config.tts.backend)
-                if self._tts and not self._pooled_tts:
-                    await self._tts.shutdown()
-                new_key = _tts_sig(config.tts)
-                if pool is not None and new_key in pool:
-                    self._tts = pool[new_key]
-                    self._pooled_tts = True
-                else:
-                    self._tts = create_tts(config.tts)
-                    self._pooled_tts = False
-                    tasks.append((self._tts, new_key, "tts"))
+            tts_changed = config.tts.backend != old_config.tts.backend
+            if tts_changed:
+                logger.info(
+                    "Swapping TTS: %s -> %s",
+                    old_config.tts.backend, config.tts.backend,
+                )
+            tts_result = await swap_one_backend(
+                kind="tts",
+                config_changed=tts_changed,
+                old_instance=self._tts,
+                old_is_pooled=self._pooled_tts,
+                new_signature=_tts_sig(config.tts),
+                new_factory=lambda: create_tts(config.tts),
+                pool=pool,
+            )
+            self._tts = tts_result.new_instance
+            self._pooled_tts = tts_result.is_pooled
+            if tts_result.init_task is not None:
+                init_tasks.append(tts_result.init_task)
 
-            # LLM
-            if (
+            llm_changed = (
                 config.llm.backend != old_config.llm.backend
                 or config.llm.ollama_model != old_config.llm.ollama_model
-            ):
-                logger.info("Swapping LLM: %s -> %s", old_config.llm.backend, config.llm.backend)
-                if self._llm and not self._pooled_llm:
-                    await self._llm.shutdown()
-                new_key = _llm_sig(config.llm)
-                if pool is not None and new_key in pool:
-                    self._llm = pool[new_key]
-                    self._pooled_llm = True
-                else:
-                    self._llm = create_llm(config.llm)
-                    self._pooled_llm = False
-                    tasks.append((self._llm, new_key, "llm"))
+            )
+            if llm_changed:
+                logger.info(
+                    "Swapping LLM: %s -> %s",
+                    old_config.llm.backend, config.llm.backend,
+                )
+            llm_result = await swap_one_backend(
+                kind="llm",
+                config_changed=llm_changed,
+                old_instance=self._llm,
+                old_is_pooled=self._pooled_llm,
+                new_signature=_llm_sig(config.llm),
+                new_factory=lambda: create_llm(config.llm),
+                pool=pool,
+            )
+            self._llm = llm_result.new_instance
+            self._pooled_llm = llm_result.is_pooled
+            if llm_result.init_task is not None:
+                init_tasks.append(llm_result.init_task)
 
-            if tasks:
-                await asyncio.gather(*(t[0].initialize() for t in tasks))
-                # Register freshly-created backends in the pool.
+            if init_tasks:
+                await asyncio.gather(*(t.instance.initialize() for t in init_tasks))
+                # Register freshly-created backends in the pool
+                # AFTER successful initialize so a failed init
+                # doesn't leave a half-constructed backend in
+                # the pool.
                 if pool is not None:
-                    for backend, key, _kind in tasks:
-                        pool[key] = backend
+                    for t in init_tasks:
+                        pool[t.key] = t.instance
                 logger.info("Backend swap complete")
 
             # Audit B6 (#154): when swapping INTO a cloud STT mode,

--- a/dragon_voice/pool_aware_swap.py
+++ b/dragon_voice/pool_aware_swap.py
@@ -1,0 +1,173 @@
+"""Pool-aware backend swap helper for `VoicePipeline.swap_backends`.
+
+Wave 23 SOLID-audit follow-up — thirty-second sub-extract.
+Fourth slice from `dragon_voice/pipeline.py` (audit SRP-4: the
+1613-LOC `VoicePipeline` class still owns 4+ responsibilities;
+this dedups the three near-identical STT/TTS/LLM swap blocks
+inside `swap_backends`).
+
+Pre-extract `swap_backends` had three almost-line-for-line
+repetitions of the pool-aware swap pattern:
+
+```python
+if config_changed:
+    if old_instance and not is_pooled:
+        await old_instance.shutdown()
+    new_key = _sig(new_config)
+    if pool is not None and new_key in pool:
+        new_instance = pool[new_key]
+        is_pooled = True
+    else:
+        new_instance = factory(new_config)
+        is_pooled = False
+        tasks.append((new_instance, new_key, kind))
+```
+
+This module collapses that 11-line block into a single helper
+call: `swap_one_backend(...)`.
+
+## API
+
+```python
+new_instance, is_pooled, init_task = await swap_one_backend(
+    kind="stt",
+    config_changed=stt_config_changed,
+    old_instance=self._stt,
+    old_is_pooled=self._pooled_stt,
+    new_signature=_stt_sig(config.stt),
+    new_factory=lambda: create_stt(config.stt),
+    pool=self._backend_pool,
+)
+```
+
+Returns three values:
+  * `new_instance` — the live backend (may be the old instance
+    when `config_changed` is False; may be a pooled reuse;
+    may be freshly created).
+  * `is_pooled` — updated pooled flag for the caller to stash.
+  * `init_task` — None when no init needed (no change OR pooled
+    reuse); otherwise a `BackendInitTask` tuple
+    `(instance, key, kind)` for the caller to batch with
+    `asyncio.gather` + register in the pool post-init.
+
+## Why a function not a class
+
+The swap is a one-shot operation per backend.  No state needs
+to persist across calls.  Three free args + a returned
+namedtuple is the simplest shape.
+
+## W15-C01 closure preserved
+
+The pool-aware reuse avoids tearing down a backend that's
+still serving another connection.  `is_pooled` tracks whether
+the current instance came from the pool (in which case
+`shutdown` is the pool's job, not the pipeline's).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, NamedTuple, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class BackendInitTask(NamedTuple):
+    """A freshly-created backend that needs `initialize()` called
+    + registration in the pool post-init.  Returned from
+    `swap_one_backend` when a new instance was created
+    (vs. pooled reuse OR no-change).
+    """
+
+    instance: Any
+    key: Any
+    kind: str  # "stt" / "tts" / "llm" — for logging only
+
+
+class SwapResult(NamedTuple):
+    """The three values `swap_one_backend` returns to the caller."""
+
+    new_instance: Any
+    is_pooled: bool
+    init_task: Optional[BackendInitTask]
+
+
+async def swap_one_backend(
+    *,
+    kind: str,                       # "stt" / "tts" / "llm"
+    config_changed: bool,
+    old_instance: Any,
+    old_is_pooled: bool,
+    new_signature: Any,              # backend-pool key (typically a tuple)
+    new_factory: Callable[[], Any],  # zero-arg constructor
+    pool: Optional[dict],
+) -> SwapResult:
+    """Swap one backend (STT / TTS / LLM) according to the
+    pool-aware reuse policy.
+
+    Behaviour matrix:
+
+      * `config_changed=False` → returns the old instance
+        unchanged (no shutdown, no pool lookup, no init task).
+      * `config_changed=True` AND old instance not pooled →
+        old instance shut down first.
+      * `config_changed=True` AND `pool` has the new signature →
+        reuses the pooled instance, marks `is_pooled=True`,
+        no init task (the pool guarantees the instance is
+        already initialised).
+      * `config_changed=True` AND new signature not in pool →
+        creates via `new_factory`, marks `is_pooled=False`,
+        returns an init task for the caller to batch.
+
+    Args:
+        kind: "stt" / "tts" / "llm" — used for the swap-log
+            line only.
+        config_changed: True iff the new config differs from the
+            old one in a way that requires a swap.
+        old_instance: The currently-installed backend (or None).
+        old_is_pooled: True iff `old_instance` came from the
+            backend pool (skips shutdown on swap).
+        new_signature: Pool key for the new config (caller
+            computes via `_stt_sig` / `_tts_sig` / `_llm_sig`).
+        new_factory: Zero-arg callable returning a freshly-
+            constructed backend (caller wraps `create_stt(cfg)`).
+        pool: Backend pool (dict) or None (pool disabled).
+
+    Returns:
+        SwapResult(new_instance, is_pooled, init_task).
+    """
+    if not config_changed:
+        return SwapResult(
+            new_instance=old_instance,
+            is_pooled=old_is_pooled,
+            init_task=None,
+        )
+
+    # Shutdown the old instance ONLY if we own it (not pooled).
+    # Pooled instances are the pool's responsibility — tearing
+    # them down here would break other connections sharing the
+    # same backend.
+    if old_instance is not None and not old_is_pooled:
+        await old_instance.shutdown()
+
+    # Try the pool first.
+    if pool is not None and new_signature in pool:
+        return SwapResult(
+            new_instance=pool[new_signature],
+            is_pooled=True,
+            init_task=None,
+        )
+
+    # Cold path: construct + return an init task for the caller
+    # to batch.  The caller registers the new instance in the
+    # pool AFTER initialize() succeeds (so a failed init doesn't
+    # leave a half-constructed backend in the pool).
+    new_instance = new_factory()
+    return SwapResult(
+        new_instance=new_instance,
+        is_pooled=False,
+        init_task=BackendInitTask(
+            instance=new_instance,
+            key=new_signature,
+            kind=kind,
+        ),
+    )

--- a/tests/test_pool_aware_swap.py
+++ b/tests/test_pool_aware_swap.py
@@ -1,0 +1,296 @@
+"""Tests for ``dragon_voice.pool_aware_swap.swap_one_backend``.
+
+Pin every branch of the swap matrix:
+  * config_changed=False → no shutdown, no pool lookup, no init
+  * config_changed=True + pooled-old → no shutdown, pool lookup
+  * config_changed=True + not-pooled-old → shutdown, pool lookup
+  * config_changed=True + pool hit → reuse pooled, mark pooled
+  * config_changed=True + pool miss → factory, mark not-pooled, init task
+
+Plus the W15-C01 closure: shutting down a pooled instance MUST
+NOT happen (pool owns lifecycle).
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.pool_aware_swap import (
+    BackendInitTask,
+    SwapResult,
+    swap_one_backend,
+)
+
+
+def _make_backend(*, name: str = "backend") -> MagicMock:
+    backend = MagicMock(name=name)
+    backend.shutdown = AsyncMock()
+    backend.initialize = AsyncMock()
+    return backend
+
+
+# ─── No-change branch ────────────────────────────────────────
+
+
+class TestNoChange:
+    @pytest.mark.asyncio
+    async def test_returns_old_instance_unchanged(self):
+        old = _make_backend()
+        result = await swap_one_backend(
+            kind="stt",
+            config_changed=False,
+            old_instance=old,
+            old_is_pooled=False,
+            new_signature=("moonshine",),
+            new_factory=lambda: _make_backend(),  # MUST NOT be called
+            pool={},
+        )
+        assert result.new_instance is old
+        assert result.is_pooled is False
+        assert result.init_task is None
+
+    @pytest.mark.asyncio
+    async def test_no_change_does_not_shutdown_old(self):
+        old = _make_backend()
+        await swap_one_backend(
+            kind="stt",
+            config_changed=False,
+            old_instance=old,
+            old_is_pooled=False,
+            new_signature=("x",),
+            new_factory=lambda: _make_backend(),
+            pool=None,
+        )
+        old.shutdown.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_change_does_not_invoke_factory(self):
+        factory_calls = {"n": 0}
+
+        def _factory():
+            factory_calls["n"] += 1
+            return _make_backend()
+
+        await swap_one_backend(
+            kind="stt",
+            config_changed=False,
+            old_instance=_make_backend(),
+            old_is_pooled=False,
+            new_signature=("x",),
+            new_factory=_factory,
+            pool=None,
+        )
+        assert factory_calls["n"] == 0
+
+    @pytest.mark.asyncio
+    async def test_no_change_preserves_pooled_flag(self):
+        old = _make_backend()
+        result = await swap_one_backend(
+            kind="stt",
+            config_changed=False,
+            old_instance=old,
+            old_is_pooled=True,
+            new_signature=("x",),
+            new_factory=lambda: _make_backend(),
+            pool=None,
+        )
+        # Old pooled flag preserved
+        assert result.is_pooled is True
+
+
+# ─── Shutdown branch ─────────────────────────────────────────
+
+
+class TestShutdown:
+    @pytest.mark.asyncio
+    async def test_changed_non_pooled_shutdown_old(self):
+        old = _make_backend()
+        await swap_one_backend(
+            kind="stt",
+            config_changed=True,
+            old_instance=old,
+            old_is_pooled=False,
+            new_signature=("new",),
+            new_factory=lambda: _make_backend(),
+            pool=None,
+        )
+        old.shutdown.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_changed_pooled_does_NOT_shutdown_old(self):
+        """W15-C01 closure pin: a pooled instance is the pool's
+        responsibility to shut down — tearing it down here would
+        break other connections sharing it."""
+        old = _make_backend()
+        await swap_one_backend(
+            kind="stt",
+            config_changed=True,
+            old_instance=old,
+            old_is_pooled=True,
+            new_signature=("new",),
+            new_factory=lambda: _make_backend(),
+            pool=None,
+        )
+        old.shutdown.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_changed_with_no_old_instance_does_not_crash(self):
+        """Initial install (no old instance yet) must not crash
+        on the shutdown path."""
+        await swap_one_backend(
+            kind="stt",
+            config_changed=True,
+            old_instance=None,
+            old_is_pooled=False,
+            new_signature=("new",),
+            new_factory=lambda: _make_backend(),
+            pool=None,
+        )
+        # Just must not raise
+
+
+# ─── Pool-hit branch ────────────────────────────────────────
+
+
+class TestPoolHit:
+    @pytest.mark.asyncio
+    async def test_pool_hit_reuses_pooled_instance(self):
+        pooled = _make_backend(name="pooled-instance")
+        pool = {("openrouter",): pooled}
+
+        result = await swap_one_backend(
+            kind="stt",
+            config_changed=True,
+            old_instance=_make_backend(),
+            old_is_pooled=False,
+            new_signature=("openrouter",),
+            new_factory=lambda: _make_backend(name="should-not-create"),
+            pool=pool,
+        )
+
+        assert result.new_instance is pooled
+        assert result.is_pooled is True
+        assert result.init_task is None
+
+    @pytest.mark.asyncio
+    async def test_pool_hit_does_not_call_factory(self):
+        pool = {("k",): _make_backend()}
+        factory_calls = {"n": 0}
+
+        def _factory():
+            factory_calls["n"] += 1
+            return _make_backend()
+
+        await swap_one_backend(
+            kind="stt",
+            config_changed=True,
+            old_instance=_make_backend(),
+            old_is_pooled=False,
+            new_signature=("k",),
+            new_factory=_factory,
+            pool=pool,
+        )
+        assert factory_calls["n"] == 0
+
+
+# ─── Pool-miss branch ───────────────────────────────────────
+
+
+class TestPoolMiss:
+    @pytest.mark.asyncio
+    async def test_pool_miss_creates_via_factory(self):
+        new = _make_backend(name="new-via-factory")
+
+        result = await swap_one_backend(
+            kind="stt",
+            config_changed=True,
+            old_instance=_make_backend(),
+            old_is_pooled=False,
+            new_signature=("k",),
+            new_factory=lambda: new,
+            pool={},  # empty pool
+        )
+
+        assert result.new_instance is new
+        assert result.is_pooled is False
+        assert result.init_task is not None
+        assert result.init_task.instance is new
+        assert result.init_task.key == ("k",)
+        assert result.init_task.kind == "stt"
+
+    @pytest.mark.asyncio
+    async def test_no_pool_at_all_creates_via_factory(self):
+        new = _make_backend()
+
+        result = await swap_one_backend(
+            kind="tts",
+            config_changed=True,
+            old_instance=_make_backend(),
+            old_is_pooled=False,
+            new_signature=("k",),
+            new_factory=lambda: new,
+            pool=None,  # pool disabled
+        )
+
+        assert result.new_instance is new
+        assert result.is_pooled is False
+        assert result.init_task is not None
+
+    @pytest.mark.asyncio
+    async def test_pool_miss_does_NOT_initialize_in_helper(self):
+        """The init_task is a *deferred* call — the helper
+        returns it for the caller to batch with asyncio.gather.
+        Pin: initialize() is NOT called inside the helper."""
+        new = _make_backend()
+
+        await swap_one_backend(
+            kind="llm",
+            config_changed=True,
+            old_instance=None,
+            old_is_pooled=False,
+            new_signature=("k",),
+            new_factory=lambda: new,
+            pool={},
+        )
+
+        new.initialize.assert_not_awaited()
+
+
+# ─── Return-value contract ──────────────────────────────────
+
+
+class TestReturnContract:
+    @pytest.mark.asyncio
+    async def test_returns_swap_result_namedtuple(self):
+        result = await swap_one_backend(
+            kind="stt",
+            config_changed=False,
+            old_instance=_make_backend(),
+            old_is_pooled=False,
+            new_signature=("k",),
+            new_factory=lambda: _make_backend(),
+            pool=None,
+        )
+        assert isinstance(result, SwapResult)
+        # Three fields
+        assert hasattr(result, "new_instance")
+        assert hasattr(result, "is_pooled")
+        assert hasattr(result, "init_task")
+
+    @pytest.mark.asyncio
+    async def test_init_task_is_namedtuple_with_three_fields(self):
+        new = _make_backend()
+        result = await swap_one_backend(
+            kind="tts",
+            config_changed=True,
+            old_instance=None,
+            old_is_pooled=False,
+            new_signature=("k",),
+            new_factory=lambda: new,
+            pool={},
+        )
+        assert isinstance(result.init_task, BackendInitTask)
+        assert result.init_task.instance is new
+        assert result.init_task.key == ("k",)
+        assert result.init_task.kind == "tts"


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **thirty-second sub-extract**.  Fourth slice from \`dragon_voice/pipeline.py\` (audit **SRP-4**).

Pre-extract \`swap_backends\` had three almost-line-for-line repetitions of the W15-C01 pool-aware swap pattern, one each for STT/TTS/LLM.  Each was 11 LOC of:

\`\`\`python
if config_changed:
    if old and not is_pooled:
        await old.shutdown()
    new_key = _sig(new_cfg)
    if pool is not None and new_key in pool:
        new_inst = pool[new_key]
        is_pooled = True
    else:
        new_inst = factory()
        is_pooled = False
        tasks.append((new_inst, new_key, kind))
\`\`\`

Now collapsed into a single \`swap_one_backend(...)\` call per backend.  Returns a \`SwapResult\` NamedTuple \`(new_instance, is_pooled, init_task)\` — caller stashes the new instance, updates the pooled flag, and accumulates the init task for the batched \`asyncio.gather\` + post-init pool registration.

### Behaviour preserved verbatim

- \`config_changed=False\` → returns old instance unchanged, no shutdown, no pool lookup, no factory call, no init task
- \`config_changed=True\` + old not-pooled → shuts down old (W15-C01: pooled instances are NOT shut down — pool owns lifecycle)
- \`config_changed=True\` + pool hit → reuses pooled instance, marks \`is_pooled=True\`, no init task
- \`config_changed=True\` + pool miss → invokes factory, marks \`is_pooled=False\`, returns init task
- Initial install (\`old_instance=None\`) handled gracefully on the shutdown path
- \`initialize()\` is NOT called inside the helper — caller batches with \`asyncio.gather\` so a slow backend swap doesn't block on the others

### API improvement

- \`BackendInitTask\` NamedTuple replaces the bare 3-tuple \`(instance, key, kind)\` so the caller's pool-registration loop can use named field access
- The helper's \`kind\` arg flows into the \`init_task.kind\` for log triage

### Test coverage

14 new tests in \`tests/test_pool_aware_swap.py\` across 5 classes spanning the no-change branch (preserves old + flag, doesn't shutdown, doesn't invoke factory), shutdown-vs-no-shutdown matrix (W15-C01 closure pin), pool-hit branch (reuses + no factory call), pool-miss branch (factory invoked + init task returned + initialize NOT called in helper), and the return-contract pin.

### Diff stats

| Metric | Before | After |
|---|---|---|
| \`pipeline.py\` LOC | 1613 | 1640 (+27 — caller arg-passing) |
| \`pool_aware_swap.py\` | (didn't exist) | 173 (new) |

Net LOC went up because the call site is now more verbose (each of the 3 sub-swaps is ~10 LOC of arg-passing vs. the previous 11 LOC of inline logic).  **The win is in testability + single-point-of-change for the W15-C01 pool semantics** — adding a fourth backend (e.g. embedding) is now a 10-LOC \`swap_backends\` extension instead of a 14-LOC inline duplicate.

## Test plan

- [x] \`python3 -m pytest tests/test_pool_aware_swap.py -v\` → 14 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → **1226 passed**, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)