### PR TITLE
refactor(db): extract _recover_corrupt_db (~70 LOC) to db_corruption_recovery module (audit SRP-7 first slice)

### DIFF
--- a/dragon_voice/db.py
+++ b/dragon_voice/db.py
@@ -90,74 +90,17 @@ class Database:
     async def _recover_corrupt_db(self) -> None:
         """Attempt to recover from a corrupt database file.
 
-        Strategy:
-        1. Close the connection if open.
-        2. Rename corrupt -wal and -shm files (preserve for diagnosis).
-        3. Retry opening the main DB (it should be consistent up to the
-           last successful WAL checkpoint).
-        4. If the main DB is also corrupt, rename it and create a fresh
-           database from schema.sql.
+        SOLID-audit follow-up: implementation extracted to
+        db_corruption_recovery.recover_corrupt_db.  This
+        wrapper resets `self._db` to None (the caller's
+        re-open path expects it) and forwards to the free
+        function.
         """
-        # Step 1: Close existing connection
-        if self._db is not None:
-            try:
-                await self._db.close()
-            except Exception:
-                pass
-            self._db = None
+        from dragon_voice.db_corruption_recovery import recover_corrupt_db
 
-        db_path = Path(self._db_path)
-        ts = int(time.time())
-
-        # Step 2: Rename WAL and SHM files
-        wal_path = db_path.with_name(db_path.name + "-wal")
-        shm_path = db_path.with_name(db_path.name + "-shm")
-
-        for sidecar in (wal_path, shm_path):
-            if sidecar.exists():
-                backup = sidecar.with_name(f"{sidecar.name}.corrupt.{ts}")
-                sidecar.rename(backup)
-                logger.error(
-                    "Renamed corrupt sidecar: %s -> %s", sidecar, backup.name
-                )
-
-        # Step 3: Try opening the main DB without the WAL
-        try:
-            test_db = await aiosqlite.connect(self._db_path)
-            await test_db.execute("PRAGMA integrity_check")
-            await test_db.close()
-            logger.info(
-                "Main database file is intact after removing corrupt WAL/SHM — "
-                "data up to last checkpoint is preserved"
-            )
-            return  # Main DB is OK, caller will open it normally
-        except Exception as retry_exc:
-            logger.error(
-                "Main database also corrupt after WAL removal: %s — "
-                "creating fresh database",
-                retry_exc,
-            )
-            try:
-                await test_db.close()
-            except Exception:
-                pass
-
-        # Step 4: Rename the entire DB and create fresh
-        if db_path.exists():
-            backup = db_path.with_name(f"{db_path.name}.corrupt.{ts}")
-            db_path.rename(backup)
-            logger.error(
-                "Renamed corrupt database: %s -> %s  "
-                "(recover data manually from this backup)",
-                db_path, backup.name,
-            )
-
-        # Fresh DB will be created by aiosqlite.connect + _apply_schema
-        logger.error(
-            "Recovery complete — a fresh empty database will be created. "
-            "Corrupt files preserved with .corrupt.%d suffix for diagnosis.",
-            ts,
-        )
+        prev_conn = self._db
+        self._db = None  # caller re-opens via aiosqlite.connect
+        await recover_corrupt_db(self._db_path, prev_conn)
 
     async def _apply_schema(self) -> None:
         """Read schema.sql and execute it (CREATE IF NOT EXISTS is idempotent)."""

--- a/dragon_voice/db_corruption_recovery.py
+++ b/dragon_voice/db_corruption_recovery.py
@@ -1,0 +1,168 @@
+"""SQLite corruption-recovery helper for `Database.initialize`.
+
+Wave 23 SOLID-audit follow-up — thirty-third sub-extract.
+First slice from `dragon_voice/db.py` (audit SRP-7 (P2): the
+844-LOC `Database` class is a monolith of 30+ method domains).
+
+When `Database.initialize` opens the SQLite file and detects
+corruption (PRAGMA integrity_check fails OR aiosqlite raises
+on connect), this module's `recover_corrupt_db` runs the
+4-step recovery chain:
+
+  1. Close any half-open connection.
+  2. Rename the corrupt -wal and -shm sidecar files (preserve
+     for diagnosis with `.corrupt.<timestamp>` suffix).
+  3. Try opening the main DB file alone — it should be
+     consistent up to the last successful WAL checkpoint, so
+     after removing the corrupt WAL the main file is often
+     fine and we can preserve user data.
+  4. If the main DB is also corrupt, rename the entire DB file
+     and let `Database.initialize` recreate from `schema.sql`.
+
+Pre-extract this 70-LOC chain lived as `Database._recover_corrupt_db`.
+Now lives in its own module, taking the db path + the
+already-opened (failed) connection as args.
+
+## API
+
+```python
+db_recreated = await recover_corrupt_db(db_path, current_connection)
+# `db_recreated` is True iff step 4 fired (main DB renamed →
+# fresh DB needed).  False means step 3 succeeded (main DB
+# intact, just WAL was bad).
+```
+
+The caller is responsible for re-opening the connection +
+re-running schema migrations after this returns.
+
+## Why a free function (not a class)
+
+Recovery is a one-shot operation; no state needs to persist
+across calls.  The `db_path` + the dead connection are passed
+explicitly so the recovery is testable in isolation (no
+Database instance needed).
+
+## Step 3 vs. Step 4 distinction
+
+Step 3 success is the common case (corrupt WAL is far more
+common than corrupt main file — power loss during a write
+typically only damages the WAL).  When it fires, the user
+loses at most the un-checkpointed transactions since the last
+WAL flush — usually < 1 minute of state.
+
+Step 4 is the catastrophic path: full DB rebuild.  The
+corrupt file is preserved for manual recovery, but the user
+sees an empty DB on next boot.  Logged at ERROR for ops
+visibility.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Optional
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+async def recover_corrupt_db(
+    db_path: str,
+    current_connection: Optional[aiosqlite.Connection],
+) -> bool:
+    """Attempt to recover from a corrupt SQLite database.
+
+    Args:
+        db_path: Filesystem path to the SQLite DB file.
+        current_connection: The already-opened (failed)
+            aiosqlite connection, or None if open didn't get
+            that far.  Will be closed (best-effort).
+
+    Returns:
+        True iff the main DB file was unsalvageable (step 4
+        fired — main file renamed, caller should let
+        `Database.initialize` recreate from schema).
+        False iff step 3 succeeded (corrupt WAL/SHM removed,
+        main DB intact, caller can re-open normally).
+    """
+    # Step 1: Close existing connection (best-effort).
+    if current_connection is not None:
+        try:
+            await current_connection.close()
+        except Exception:
+            pass
+
+    db_path_obj = Path(db_path)
+    ts = int(time.time())
+
+    # Step 2: Rename corrupt WAL + SHM sidecars.
+    _rename_corrupt_sidecars(db_path_obj, ts)
+
+    # Step 3: Try opening the main DB without the WAL.
+    # The main file is consistent up to the last successful
+    # WAL checkpoint — after removing the corrupt WAL, this
+    # often succeeds and preserves all but the un-checkpointed
+    # transactions.
+    test_db: Optional[aiosqlite.Connection] = None
+    try:
+        test_db = await aiosqlite.connect(db_path)
+        await test_db.execute("PRAGMA integrity_check")
+        await test_db.close()
+        logger.info(
+            "Main database file is intact after removing corrupt WAL/SHM — "
+            "data up to last checkpoint is preserved",
+        )
+        return False  # Main DB OK, caller re-opens normally
+    except Exception as retry_exc:
+        logger.error(
+            "Main database also corrupt after WAL removal: %s — "
+            "creating fresh database",
+            retry_exc,
+        )
+        if test_db is not None:
+            try:
+                await test_db.close()
+            except Exception:
+                pass
+
+    # Step 4: Rename the entire DB file.  Caller will recreate
+    # via aiosqlite.connect + schema.sql.
+    _rename_corrupt_main_db(db_path_obj, ts)
+
+    logger.error(
+        "Recovery complete — a fresh empty database will be created. "
+        "Corrupt files preserved with .corrupt.%d suffix for diagnosis.",
+        ts,
+    )
+    return True
+
+
+def _rename_corrupt_sidecars(db_path: Path, ts: int) -> None:
+    """Rename the -wal and -shm sidecars to `.corrupt.<ts>`.
+    Preserves both for ops to recover from manually if needed."""
+    wal_path = db_path.with_name(db_path.name + "-wal")
+    shm_path = db_path.with_name(db_path.name + "-shm")
+
+    for sidecar in (wal_path, shm_path):
+        if sidecar.exists():
+            backup = sidecar.with_name(f"{sidecar.name}.corrupt.{ts}")
+            sidecar.rename(backup)
+            logger.error(
+                "Renamed corrupt sidecar: %s -> %s",
+                sidecar, backup.name,
+            )
+
+
+def _rename_corrupt_main_db(db_path: Path, ts: int) -> None:
+    """Rename the main DB file to `.corrupt.<ts>` for ops
+    diagnosis.  No-op when the file doesn't exist (the very
+    first boot has no DB yet)."""
+    if db_path.exists():
+        backup = db_path.with_name(f"{db_path.name}.corrupt.{ts}")
+        db_path.rename(backup)
+        logger.error(
+            "Renamed corrupt database: %s -> %s  "
+            "(recover data manually from this backup)",
+            db_path, backup.name,
+        )

--- a/tests/test_db_corruption_recovery.py
+++ b/tests/test_db_corruption_recovery.py
@@ -1,0 +1,235 @@
+"""Tests for ``dragon_voice.db_corruption_recovery``.
+
+Pin the four-step recovery chain end-to-end:
+  1. Close existing connection (best-effort, swallow errors)
+  2. Rename corrupt -wal and -shm sidecars
+  3. Try opening the main DB alone — return False on success
+     (caller re-opens normally; user data preserved)
+  4. Main DB also corrupt → rename it, return True (caller
+     recreates from schema)
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dragon_voice.db_corruption_recovery import (
+    _rename_corrupt_main_db,
+    _rename_corrupt_sidecars,
+    recover_corrupt_db,
+)
+
+
+@pytest.fixture
+def tmp_db_path():
+    """Create a real on-disk SQLite file path for the test, with
+    sidecars to exercise the rename logic."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db = Path(tmp) / "test.db"
+        # Touch the file so step 4's `if db_path.exists()` fires.
+        db.touch()
+        yield str(db)
+
+
+# ─── Sidecar rename helper ──────────────────────────────────
+
+
+class TestSidecarRename:
+    def test_renames_existing_wal_and_shm(self, tmp_db_path):
+        db_path = Path(tmp_db_path)
+        wal = db_path.with_name(db_path.name + "-wal")
+        shm = db_path.with_name(db_path.name + "-shm")
+        wal.write_text("corrupt-wal")
+        shm.write_text("corrupt-shm")
+
+        _rename_corrupt_sidecars(db_path, ts=12345)
+
+        # Originals gone, backups present
+        assert not wal.exists()
+        assert not shm.exists()
+        assert db_path.with_name(f"{wal.name}.corrupt.12345").exists()
+        assert db_path.with_name(f"{shm.name}.corrupt.12345").exists()
+
+    def test_no_sidecars_is_silent_noop(self, tmp_db_path):
+        """When no sidecars exist (clean shutdown, fresh boot),
+        the rename helper must not crash."""
+        db_path = Path(tmp_db_path)
+        # No sidecars — must not raise.
+        _rename_corrupt_sidecars(db_path, ts=12345)
+
+
+# ─── Main DB rename helper ──────────────────────────────────
+
+
+class TestMainDbRename:
+    def test_renames_existing_db_with_timestamp_suffix(self, tmp_db_path):
+        db_path = Path(tmp_db_path)
+        db_path.write_text("corrupt-content")
+
+        _rename_corrupt_main_db(db_path, ts=12345)
+
+        # Original gone, backup present
+        assert not db_path.exists()
+        backup = db_path.with_name(f"{db_path.name}.corrupt.12345")
+        assert backup.exists()
+        assert backup.read_text() == "corrupt-content"
+
+    def test_missing_db_is_silent_noop(self):
+        """First-boot case: no DB file yet.  The helper must
+        not crash trying to rename a non-existent path."""
+        # Path that doesn't exist
+        # Must not raise.
+        _rename_corrupt_main_db(
+            Path("/nonexistent/path/db.sqlite"), ts=12345,
+        )
+
+
+# ─── Full recovery chain — step 3 success path ───────────────
+
+
+class TestRecoveryStep3Success:
+    @pytest.mark.asyncio
+    async def test_returns_false_when_main_db_intact(self, tmp_db_path):
+        """When the WAL was the only corrupt thing, removing it
+        + opening the main DB succeeds → return False (caller
+        re-opens normally; user data preserved)."""
+        # Create realistic sidecars
+        db_path_obj = Path(tmp_db_path)
+        wal = db_path_obj.with_name(db_path_obj.name + "-wal")
+        wal.write_text("corrupt")
+
+        # Mock aiosqlite.connect to return a successful test_db
+        test_db_mock = MagicMock()
+        test_db_mock.execute = AsyncMock()
+        test_db_mock.close = AsyncMock()
+
+        with patch(
+            "aiosqlite.connect",
+            new=AsyncMock(return_value=test_db_mock),
+        ):
+            result = await recover_corrupt_db(tmp_db_path, None)
+
+        assert result is False
+        # Sidecar was renamed
+        assert not wal.exists()
+        # Main DB file still present (step 4 didn't fire)
+        assert db_path_obj.exists()
+
+
+# ─── Full recovery chain — step 4 fires (main also corrupt) ─
+
+
+class TestRecoveryStep4Fires:
+    @pytest.mark.asyncio
+    async def test_returns_true_when_main_db_also_corrupt(self, tmp_db_path):
+        """When the main DB integrity_check ALSO fails, rename
+        the entire DB → return True (caller creates fresh)."""
+        db_path_obj = Path(tmp_db_path)
+
+        # First call (step 3): aiosqlite raises → main DB
+        # detected as corrupt
+        with patch(
+            "aiosqlite.connect",
+            new=AsyncMock(side_effect=RuntimeError("file is not a database")),
+        ):
+            result = await recover_corrupt_db(tmp_db_path, None)
+
+        assert result is True
+        # Main DB renamed
+        assert not db_path_obj.exists()
+        # Backup present (timestamp-suffixed)
+        backups = list(db_path_obj.parent.glob(f"{db_path_obj.name}.corrupt.*"))
+        assert len(backups) == 1
+
+
+# ─── Connection-close best-effort ────────────────────────────
+
+
+class TestConnectionCloseBestEffort:
+    @pytest.mark.asyncio
+    async def test_closes_provided_connection(self, tmp_db_path):
+        conn = MagicMock()
+        conn.close = AsyncMock()
+
+        # Mock recovery step 3 so we don't open a real DB
+        test_db = MagicMock()
+        test_db.execute = AsyncMock()
+        test_db.close = AsyncMock()
+
+        with patch(
+            "aiosqlite.connect", new=AsyncMock(return_value=test_db),
+        ):
+            await recover_corrupt_db(tmp_db_path, conn)
+
+        conn.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_close_failure_swallowed(self, tmp_db_path):
+        """If the dead connection's close() raises (already
+        broken), the recovery chain must still proceed."""
+        conn = MagicMock()
+        conn.close = AsyncMock(side_effect=RuntimeError("conn dead"))
+
+        test_db = MagicMock()
+        test_db.execute = AsyncMock()
+        test_db.close = AsyncMock()
+
+        with patch(
+            "aiosqlite.connect", new=AsyncMock(return_value=test_db),
+        ):
+            # Must NOT raise.
+            result = await recover_corrupt_db(tmp_db_path, conn)
+
+        assert result is False  # step 3 succeeded
+
+    @pytest.mark.asyncio
+    async def test_no_connection_provided_does_not_crash(self, tmp_db_path):
+        """When `current_connection=None` (open didn't get that
+        far), skip the close step silently."""
+        test_db = MagicMock()
+        test_db.execute = AsyncMock()
+        test_db.close = AsyncMock()
+
+        with patch(
+            "aiosqlite.connect", new=AsyncMock(return_value=test_db),
+        ):
+            await recover_corrupt_db(tmp_db_path, None)
+
+        # Just must not raise
+
+
+# ─── Timestamp suffix consistency ───────────────────────────
+
+
+class TestTimestampSuffix:
+    def test_sidecar_and_main_use_same_timestamp(self, tmp_db_path):
+        """When step 4 fires after step 2 already renamed
+        sidecars, both renames should use the SAME timestamp so
+        ops can correlate the backup files."""
+        db_path = Path(tmp_db_path)
+        wal = db_path.with_name(db_path.name + "-wal")
+        wal.write_text("x")
+
+        # Pre-existing main DB content
+        db_path.write_text("main")
+
+        # Pin the timestamp so both helpers use the same value
+        with patch(
+            "dragon_voice.db_corruption_recovery.time.time",
+            return_value=99999,
+        ), patch(
+            "aiosqlite.connect",
+            new=AsyncMock(side_effect=RuntimeError("corrupt")),
+        ):
+            import asyncio
+            asyncio.run(recover_corrupt_db(tmp_db_path, None))
+
+        # Both backups present with same timestamp
+        wal_backup = db_path.with_name(f"{wal.name}.corrupt.99999")
+        db_backup = db_path.with_name(f"{db_path.name}.corrupt.99999")
+        assert wal_backup.exists()
+        assert db_backup.exists()


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **thirty-third sub-extract**.  First slice from \`dragon_voice/db.py\` (audit **SRP-7** (P2): the 844-LOC \`Database\` class is a monolith of 30+ method domains).

The corruption-recovery chain runs when \`Database.initialize\` detects a SQLite corruption (PRAGMA integrity_check fails OR aiosqlite raises on connect).

### Behaviour preserved verbatim (4-step recovery chain)

1. Close existing connection (best-effort, swallow errors)
2. Rename corrupt -wal and -shm sidecars with \`.corrupt.<ts>\` suffix (preserve for ops diagnosis)
3. Try opening the main DB alone — succeeds when only the WAL was bad, returns False, caller re-opens normally; user data preserved up to the last WAL checkpoint
4. Main DB also corrupt → rename it, return True, caller recreates from schema.sql

### API improvement

- Returns \`bool\` (True iff step 4 fired) so the caller can log the catastrophic vs. minor distinction
- \`_rename_corrupt_sidecars\` and \`_rename_corrupt_main_db\` extracted as separate testable helpers
- \`current_connection\` parameter explicit so the helper is testable without a Database instance

### Test coverage

10 new tests in \`tests/test_db_corruption_recovery.py\` across 6 classes spanning:
- Sidecar rename (existing → renamed, none-exist → noop)
- Main-DB rename (existing → renamed with timestamp suffix, missing → noop)
- Step-3 success (returns False, sidecars renamed but main DB preserved)
- Step-4 fires (returns True, main DB renamed)
- Connection-close best-effort (close called, close failure swallowed, no-connection gracefully handled)
- Timestamp-suffix consistency (same ts used for sidecar + main backup so ops can correlate)

### Diff stats

| Metric | Before | After |
|---|---|---|
| \`db.py\` LOC | 844 | 787 (-57) |
| \`db_corruption_recovery.py\` | (didn't exist) | 159 (new) |

First slice from SRP-7 (P2).  6 method-domain mixins still bundled in Database (device/session/message/note/event/config CRUD).

## Test plan

- [x] \`python3 -m pytest tests/test_db_corruption_recovery.py -v\` → 10 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → **1236 passed**, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)