### PR TITLE
refactor(db): extract device CRUD (~80 LOC, 6 methods) to db_devices module (audit SRP-7 part 2)

### DIFF
--- a/dragon_voice/db.py
+++ b/dragon_voice/db.py
@@ -139,6 +139,9 @@ class Database:
         return self._db
 
     # ── Devices ────────────────────────────────────────────────────────
+    # SOLID-audit follow-up (PR #260): device CRUD extracted to
+    # db_devices module.  Methods below are thin forwarders so
+    # all existing call sites keep working unchanged.
 
     async def upsert_device(
         self,
@@ -149,82 +152,33 @@ class Database:
         platform: str = "",
         capabilities: Optional[dict] = None,
     ) -> dict:
-        """Register or update a device. Returns the device row as dict."""
-        now = time.time()
-        caps_json = json.dumps(capabilities or {})
-
-        await self.conn.execute(
-            """
-            INSERT INTO devices (id, hardware_id, name, firmware_ver, platform,
-                                 capabilities, is_online, last_seen_at, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?)
-            ON CONFLICT(id) DO UPDATE SET
-                hardware_id = excluded.hardware_id,
-                name = CASE WHEN excluded.name != '' THEN excluded.name ELSE devices.name END,
-                firmware_ver = CASE WHEN excluded.firmware_ver != '' THEN excluded.firmware_ver ELSE devices.firmware_ver END,
-                platform = CASE WHEN excluded.platform != '' THEN excluded.platform ELSE devices.platform END,
-                capabilities = CASE WHEN excluded.capabilities != '{}' THEN excluded.capabilities ELSE devices.capabilities END,
-                is_online = 1,
-                last_seen_at = excluded.last_seen_at,
-                updated_at = excluded.updated_at
-            """,
-            (device_id, hardware_id, name, firmware_ver, platform, caps_json, now, now, now),
+        from dragon_voice.db_devices import upsert_device as _impl
+        return await _impl(
+            self.conn,
+            device_id=device_id, hardware_id=hardware_id,
+            name=name, firmware_ver=firmware_ver, platform=platform,
+            capabilities=capabilities,
         )
-        await self.conn.commit()
-        return await self.get_device(device_id)
 
     async def get_device(self, device_id: str) -> Optional[dict]:
-        """Fetch a device by ID."""
-        cursor = await self.conn.execute("SELECT * FROM devices WHERE id = ?", (device_id,))
-        row = await cursor.fetchone()
-        return dict(row) if row else None
+        from dragon_voice.db_devices import get_device as _impl
+        return await _impl(self.conn, device_id)
 
     async def list_devices(self, online_only: bool = False) -> list[dict]:
-        """List all devices, optionally filtered to online-only."""
-        if online_only:
-            cursor = await self.conn.execute(
-                "SELECT * FROM devices WHERE is_online = 1 ORDER BY last_seen_at DESC"
-            )
-        else:
-            cursor = await self.conn.execute(
-                "SELECT * FROM devices ORDER BY last_seen_at DESC"
-            )
-        rows = await cursor.fetchall()
-        return [dict(r) for r in rows]
+        from dragon_voice.db_devices import list_devices as _impl
+        return await _impl(self.conn, online_only=online_only)
 
     async def set_device_online(self, device_id: str, online: bool) -> None:
-        """Mark a device as online or offline."""
-        now = time.time()
-        await self.conn.execute(
-            "UPDATE devices SET is_online = ?, last_seen_at = ?, updated_at = ? WHERE id = ?",
-            (1 if online else 0, now, now, device_id),
-        )
-        await self.conn.commit()
+        from dragon_voice.db_devices import set_device_online as _impl
+        await _impl(self.conn, device_id, online)
 
     async def update_device(self, device_id: str, **kwargs) -> None:
-        """Update device fields. Allowed: name, config."""
-        allowed = {"name", "config"}
-        updates = {k: v for k, v in kwargs.items() if k in allowed}
-        if not updates:
-            return
-        now = time.time()
-        sets = []
-        params = []
-        for k, v in updates.items():
-            sets.append(f"{k} = ?")
-            params.append(json.dumps(v) if k == "config" else v)
-        sets.append("updated_at = ?")
-        params.append(now)
-        params.append(device_id)
-        await self.conn.execute(
-            f"UPDATE devices SET {', '.join(sets)} WHERE id = ?", params
-        )
-        await self.conn.commit()
+        from dragon_voice.db_devices import update_device as _impl
+        await _impl(self.conn, device_id, **kwargs)
 
     async def delete_device(self, device_id: str) -> None:
-        """Delete a device. Sessions with this device get device_id=NULL (FK ON DELETE SET NULL)."""
-        await self.conn.execute("DELETE FROM devices WHERE id = ?", (device_id,))
-        await self.conn.commit()
+        from dragon_voice.db_devices import delete_device as _impl
+        await _impl(self.conn, device_id)
 
     # ── Sessions ───────────────────────────────────────────────────────
 

--- a/dragon_voice/db_devices.py
+++ b/dragon_voice/db_devices.py
@@ -1,0 +1,203 @@
+"""Device CRUD — free async functions taking an aiosqlite connection.
+
+Wave 23 SOLID-audit follow-up — thirty-fourth sub-extract.
+Second slice from `dragon_voice/db.py` (audit SRP-7: 844-LOC
+`Database` class is a monolith of 6+ method-domain mixins;
+this extracts the device CRUD).
+
+Pre-extract these were 6 methods on `Database` (~80 LOC of
+SQL).  Now lives as free functions taking the connection
+explicitly.  The `Database` methods become thin forwarders so
+all existing call sites keep working unchanged.
+
+## API
+
+```python
+device = await upsert_device(
+    conn, device_id="tab5-7", hardware_id="abc",
+    name="Living room", firmware_ver="1.2.3",
+    platform="esp32-p4",
+    capabilities={"widgets": {"types": ["live"]}},
+)
+device = await get_device(conn, "tab5-7")
+devices = await list_devices(conn, online_only=False)
+await set_device_online(conn, "tab5-7", True)
+await update_device(conn, "tab5-7", name="Bedroom")
+await delete_device(conn, "tab5-7")
+```
+
+## Why free functions instead of a mixin class
+
+Mixin classes share state with the parent and obscure the
+dependency surface.  Free functions taking the connection
+explicitly are testable in isolation (just hand them an
+aiosqlite connection — no Database instance needed) and the
+SQL surface is greppable to one file.
+
+## Behaviour preserved verbatim
+
+* `upsert_device` ON CONFLICT clause preserves existing values
+  for fields that arrive as empty strings (CASE WHEN excluded
+  pattern) — pre-extract intent: a re-register frame from
+  Tab5 firmware that omits `name` shouldn't blank the user-
+  set name in the dashboard.
+* `update_device` allowlist (`{name, config}`) — only those
+  two fields can be updated externally; other fields belong
+  to the registration / online lifecycle.
+* `delete_device` foreign-key behaviour: sessions get
+  device_id=NULL via the schema's ON DELETE SET NULL; we
+  don't cascade-delete sessions because they're history.
+"""
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Optional
+
+import aiosqlite
+
+
+async def upsert_device(
+    conn: aiosqlite.Connection,
+    *,
+    device_id: str,
+    hardware_id: str,
+    name: str = "",
+    firmware_ver: str = "",
+    platform: str = "",
+    capabilities: Optional[dict] = None,
+) -> dict:
+    """Register or update a device.  Returns the device row as
+    a dict.
+
+    The ON CONFLICT clause preserves existing values for fields
+    that arrive as empty strings — a re-register frame from
+    Tab5 firmware that omits `name` won't blank the user-set
+    name in the dashboard.
+
+    `capabilities` is JSON-encoded into the column; pass `None`
+    or an empty dict to leave the existing value alone (the
+    `excluded.capabilities != '{}'` guard preserves prior caps).
+    """
+    now = time.time()
+    caps_json = json.dumps(capabilities or {})
+
+    await conn.execute(
+        """
+        INSERT INTO devices (id, hardware_id, name, firmware_ver, platform,
+                             capabilities, is_online, last_seen_at, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+            hardware_id = excluded.hardware_id,
+            name = CASE WHEN excluded.name != '' THEN excluded.name ELSE devices.name END,
+            firmware_ver = CASE WHEN excluded.firmware_ver != '' THEN excluded.firmware_ver ELSE devices.firmware_ver END,
+            platform = CASE WHEN excluded.platform != '' THEN excluded.platform ELSE devices.platform END,
+            capabilities = CASE WHEN excluded.capabilities != '{}' THEN excluded.capabilities ELSE devices.capabilities END,
+            is_online = 1,
+            last_seen_at = excluded.last_seen_at,
+            updated_at = excluded.updated_at
+        """,
+        (device_id, hardware_id, name, firmware_ver, platform, caps_json, now, now, now),
+    )
+    await conn.commit()
+    return await get_device(conn, device_id)
+
+
+async def get_device(
+    conn: aiosqlite.Connection,
+    device_id: str,
+) -> Optional[dict]:
+    """Fetch a device by ID.  Returns None when not found."""
+    cursor = await conn.execute(
+        "SELECT * FROM devices WHERE id = ?", (device_id,),
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def list_devices(
+    conn: aiosqlite.Connection,
+    *,
+    online_only: bool = False,
+) -> list[dict]:
+    """List all devices, ordered by `last_seen_at` DESC.
+
+    `online_only=True` filters to `is_online = 1` (used by the
+    dashboard "active devices" panel).
+    """
+    if online_only:
+        cursor = await conn.execute(
+            "SELECT * FROM devices WHERE is_online = 1 ORDER BY last_seen_at DESC",
+        )
+    else:
+        cursor = await conn.execute(
+            "SELECT * FROM devices ORDER BY last_seen_at DESC",
+        )
+    rows = await cursor.fetchall()
+    return [dict(r) for r in rows]
+
+
+async def set_device_online(
+    conn: aiosqlite.Connection,
+    device_id: str,
+    online: bool,
+) -> None:
+    """Mark a device as online or offline.  Updates the
+    `last_seen_at` and `updated_at` timestamps too."""
+    now = time.time()
+    await conn.execute(
+        "UPDATE devices SET is_online = ?, last_seen_at = ?, updated_at = ? WHERE id = ?",
+        (1 if online else 0, now, now, device_id),
+    )
+    await conn.commit()
+
+
+# Allowlist of fields that can be updated via `update_device`.
+# Other fields (id, hardware_id, registration timestamps, etc.)
+# are owned by the registration / lifecycle flow and shouldn't
+# be touchable from external callers.
+_UPDATE_DEVICE_ALLOWED_FIELDS = frozenset({"name", "config"})
+
+
+async def update_device(
+    conn: aiosqlite.Connection,
+    device_id: str,
+    **kwargs: Any,
+) -> None:
+    """Update device fields from a kwargs dict.
+
+    Only fields in `_UPDATE_DEVICE_ALLOWED_FIELDS` are honoured;
+    others are silently dropped (they belong to the registration
+    or online-lifecycle flows and aren't user-editable).
+    """
+    updates = {
+        k: v for k, v in kwargs.items()
+        if k in _UPDATE_DEVICE_ALLOWED_FIELDS
+    }
+    if not updates:
+        return
+    now = time.time()
+    sets = []
+    params: list[Any] = []
+    for k, v in updates.items():
+        sets.append(f"{k} = ?")
+        params.append(json.dumps(v) if k == "config" else v)
+    sets.append("updated_at = ?")
+    params.append(now)
+    params.append(device_id)
+    await conn.execute(
+        f"UPDATE devices SET {', '.join(sets)} WHERE id = ?", params,
+    )
+    await conn.commit()
+
+
+async def delete_device(
+    conn: aiosqlite.Connection,
+    device_id: str,
+) -> None:
+    """Delete a device.  Sessions belonging to this device get
+    their `device_id` set to NULL via the schema's
+    `ON DELETE SET NULL` foreign-key constraint — we don't
+    cascade-delete sessions because they're history."""
+    await conn.execute("DELETE FROM devices WHERE id = ?", (device_id,))
+    await conn.commit()

--- a/tests/test_db_devices.py
+++ b/tests/test_db_devices.py
@@ -1,0 +1,250 @@
+"""Tests for ``dragon_voice.db_devices``.
+
+Uses a real in-memory aiosqlite connection (with the prod schema)
+so the SQL is exercised end-to-end.  Pin the upsert preserve-
+existing-on-empty behaviour, the online-filter, and the update
+allowlist.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from dragon_voice import db_devices
+
+# Project root → schema.sql lives here
+_SCHEMA_PATH = Path(__file__).parent.parent / "schema.sql"
+
+
+@pytest_asyncio.fixture
+async def conn():
+    """In-memory SQLite with the prod schema applied."""
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    schema = _SCHEMA_PATH.read_text()
+    await db.executescript(schema)
+    await db.commit()
+    yield db
+    await db.close()
+
+
+# ─── upsert_device ───────────────────────────────────────────
+
+
+class TestUpsert:
+    @pytest.mark.asyncio
+    async def test_first_register_creates_row(self, conn):
+        device = await db_devices.upsert_device(
+            conn,
+            device_id="tab5-7",
+            hardware_id="hw-abc",
+            name="Living room",
+            firmware_ver="1.2.3",
+            platform="esp32-p4",
+            capabilities={"widgets": {"types": ["live"]}},
+        )
+        assert device["id"] == "tab5-7"
+        assert device["name"] == "Living room"
+        assert device["firmware_ver"] == "1.2.3"
+        assert device["is_online"] == 1
+
+    @pytest.mark.asyncio
+    async def test_re_register_with_empty_name_preserves_existing(self, conn):
+        """Audit invariant: re-register frame from Tab5 firmware
+        that omits `name` MUST NOT blank the user-set name."""
+        await db_devices.upsert_device(
+            conn,
+            device_id="tab5-7", hardware_id="hw",
+            name="My Tab",
+        )
+        await db_devices.upsert_device(
+            conn,
+            device_id="tab5-7", hardware_id="hw",
+            name="",  # empty re-register
+        )
+        device = await db_devices.get_device(conn, "tab5-7")
+        assert device["name"] == "My Tab"  # preserved
+
+    @pytest.mark.asyncio
+    async def test_re_register_with_empty_capabilities_preserves(self, conn):
+        await db_devices.upsert_device(
+            conn,
+            device_id="tab5-7", hardware_id="hw",
+            capabilities={"widgets": {"types": ["live", "card"]}},
+        )
+        # Re-register with empty caps
+        await db_devices.upsert_device(
+            conn,
+            device_id="tab5-7", hardware_id="hw",
+            capabilities=None,
+        )
+        device = await db_devices.get_device(conn, "tab5-7")
+        caps = json.loads(device["capabilities"])
+        assert caps == {"widgets": {"types": ["live", "card"]}}
+
+    @pytest.mark.asyncio
+    async def test_re_register_with_new_name_overwrites(self, conn):
+        await db_devices.upsert_device(
+            conn, device_id="tab5-7", hardware_id="hw", name="Old name",
+        )
+        await db_devices.upsert_device(
+            conn, device_id="tab5-7", hardware_id="hw", name="New name",
+        )
+        device = await db_devices.get_device(conn, "tab5-7")
+        assert device["name"] == "New name"
+
+    @pytest.mark.asyncio
+    async def test_re_register_marks_online_again(self, conn):
+        await db_devices.upsert_device(
+            conn, device_id="x", hardware_id="hw",
+        )
+        await db_devices.set_device_online(conn, "x", False)
+        # Re-register should flip back to online
+        await db_devices.upsert_device(
+            conn, device_id="x", hardware_id="hw",
+        )
+        device = await db_devices.get_device(conn, "x")
+        assert device["is_online"] == 1
+
+
+# ─── get_device ──────────────────────────────────────────────
+
+
+class TestGet:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_not_found(self, conn):
+        assert await db_devices.get_device(conn, "nope") is None
+
+
+# ─── list_devices ────────────────────────────────────────────
+
+
+class TestList:
+    @pytest.mark.asyncio
+    async def test_lists_all_when_online_only_false(self, conn):
+        # Schema enforces UNIQUE(hardware_id) — distinct per device.
+        await db_devices.upsert_device(conn, device_id="a", hardware_id="hw-a")
+        await db_devices.upsert_device(conn, device_id="b", hardware_id="hw-b")
+        await db_devices.set_device_online(conn, "b", False)
+
+        devices = await db_devices.list_devices(conn, online_only=False)
+        ids = {d["id"] for d in devices}
+        assert ids == {"a", "b"}
+
+    @pytest.mark.asyncio
+    async def test_online_only_filters_offline(self, conn):
+        await db_devices.upsert_device(conn, device_id="a", hardware_id="hw-a")
+        await db_devices.upsert_device(conn, device_id="b", hardware_id="hw-b")
+        await db_devices.set_device_online(conn, "b", False)
+
+        devices = await db_devices.list_devices(conn, online_only=True)
+        ids = {d["id"] for d in devices}
+        assert ids == {"a"}
+
+    @pytest.mark.asyncio
+    async def test_ordered_by_last_seen_desc(self, conn):
+        import asyncio
+        await db_devices.upsert_device(
+            conn, device_id="first", hardware_id="hw-1",
+        )
+        await asyncio.sleep(0.01)
+        await db_devices.upsert_device(
+            conn, device_id="second", hardware_id="hw-2",
+        )
+
+        devices = await db_devices.list_devices(conn)
+        # Most-recently-seen first
+        assert devices[0]["id"] == "second"
+        assert devices[1]["id"] == "first"
+
+
+# ─── set_device_online ───────────────────────────────────────
+
+
+class TestSetOnline:
+    @pytest.mark.asyncio
+    async def test_toggle_online_off(self, conn):
+        await db_devices.upsert_device(conn, device_id="x", hardware_id="hw")
+        await db_devices.set_device_online(conn, "x", False)
+        device = await db_devices.get_device(conn, "x")
+        assert device["is_online"] == 0
+
+    @pytest.mark.asyncio
+    async def test_toggle_online_on(self, conn):
+        await db_devices.upsert_device(conn, device_id="x", hardware_id="hw")
+        await db_devices.set_device_online(conn, "x", False)
+        await db_devices.set_device_online(conn, "x", True)
+        device = await db_devices.get_device(conn, "x")
+        assert device["is_online"] == 1
+
+
+# ─── update_device ───────────────────────────────────────────
+
+
+class TestUpdate:
+    @pytest.mark.asyncio
+    async def test_update_name(self, conn):
+        await db_devices.upsert_device(
+            conn, device_id="x", hardware_id="hw", name="Old",
+        )
+        await db_devices.update_device(conn, "x", name="New")
+        device = await db_devices.get_device(conn, "x")
+        assert device["name"] == "New"
+
+    @pytest.mark.asyncio
+    async def test_update_config_json_encoded(self, conn):
+        await db_devices.upsert_device(conn, device_id="x", hardware_id="hw")
+        await db_devices.update_device(
+            conn, "x", config={"key": "value", "n": 42},
+        )
+        device = await db_devices.get_device(conn, "x")
+        cfg = json.loads(device["config"])
+        assert cfg == {"key": "value", "n": 42}
+
+    @pytest.mark.asyncio
+    async def test_disallowed_field_silently_dropped(self, conn):
+        """Pin: only the allowlisted fields go through.
+        Pre-extract this was a hardcoded `{"name", "config"}`
+        set; future allowlist edits happen in one place
+        (`_UPDATE_DEVICE_ALLOWED_FIELDS`)."""
+        await db_devices.upsert_device(
+            conn, device_id="x", hardware_id="hw", platform="orig",
+        )
+        await db_devices.update_device(
+            conn, "x", platform="hacked",  # not allowed
+        )
+        device = await db_devices.get_device(conn, "x")
+        assert device["platform"] == "orig"  # unchanged
+
+    @pytest.mark.asyncio
+    async def test_no_kwargs_is_silent_noop(self, conn):
+        await db_devices.upsert_device(conn, device_id="x", hardware_id="hw")
+        # Must NOT raise.
+        await db_devices.update_device(conn, "x")
+
+    @pytest.mark.asyncio
+    async def test_allowlist_constant_pin(self):
+        """Pin the allowlist so a future widening (e.g. firmware_ver
+        added externally) is a deliberate edit."""
+        from dragon_voice.db_devices import _UPDATE_DEVICE_ALLOWED_FIELDS
+        assert _UPDATE_DEVICE_ALLOWED_FIELDS == frozenset({"name", "config"})
+
+
+# ─── delete_device ───────────────────────────────────────────
+
+
+class TestDelete:
+    @pytest.mark.asyncio
+    async def test_delete_removes_row(self, conn):
+        await db_devices.upsert_device(conn, device_id="x", hardware_id="hw")
+        await db_devices.delete_device(conn, "x")
+        assert await db_devices.get_device(conn, "x") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_is_silent(self, conn):
+        # Must NOT raise.
+        await db_devices.delete_device(conn, "never-existed")


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **thirty-fourth sub-extract**.  Second slice from \`dragon_voice/db.py\` (audit **SRP-7**).

Pre-extract these were 6 methods on \`Database\` (\`upsert_device\`, \`get_device\`, \`list_devices\`, \`set_device_online\`, \`update_device\`, \`delete_device\`) — ~80 LOC of SQL + JSON shaping that all live on the same domain (the \`devices\` table).  Now lives as free async functions taking the aiosqlite connection explicitly.  \`Database\` methods become thin forwarders so all existing call sites keep working unchanged.

### Behaviour preserved verbatim

- **\`upsert_device\` ON CONFLICT clause:** empty \`name\` / \`firmware_ver\` / \`platform\` / \`capabilities='{}'\` from a re-register frame DOES NOT overwrite existing values.  Pre-extract intent: a Tab5 re-register that omits the user-set name shouldn't blank it.
- **\`update_device\` allowlist:** only \`name\` + \`config\` are user-editable.  Allowlist now exposed as \`_UPDATE_DEVICE_ALLOWED_FIELDS\` module constant + pinned by a dedicated test so a future widening is a deliberate edit.
- **\`delete_device\` FK behaviour:** sessions get \`device_id=NULL\` via the schema's ON DELETE SET NULL (no cascade — sessions are history).
- **Re-register marks online again** (audit invariant: a device that explicitly reconnects MUST flip back to is_online=1).

### API improvement

- Free functions instead of mixin class — testable in isolation (just hand them an aiosqlite connection; no Database instance needed)
- SQL surface for the device domain greppable to a single file
- \`_UPDATE_DEVICE_ALLOWED_FIELDS\` constant exposed for greppable/auditable allowlist

### Test coverage

18 new tests across 6 classes spanning upsert preserve-on-empty (name + capabilities), explicit overwrite on non-empty re-register, re-register marks online again, get returns None on missing, list filters by online_only + ordered by last_seen_at DESC, set_device_online toggles both ways, update only honours allowlist + JSON-encodes config + silent no-kwargs no-op + allowlist constant pin, delete removes + delete-nonexistent silent.

Tests use a **real in-memory aiosqlite connection with the prod schema applied** (no mocks) so the SQL is exercised end-to-end.

### Diff stats

| Metric | Before | After |
|---|---|---|
| \`db.py\` LOC | 787 | 741 (-46) |
| \`db_devices.py\` | (didn't exist) | 197 (new) |
| **\`db.py\` cumulative SRP-7 closure across #259 + #260** | **844** | **741 (-12.2%)** |

5 more method-domain mixins still bundled in Database (session/message/note/event/config CRUD).

## Test plan

- [x] \`python3 -m pytest tests/test_db_devices.py -v\` → 18 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → **1254 passed**, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)