### PR TITLE
refactor(db): extract message CRUD (~155 LOC, 6 methods incl. batched purge) to db_messages (audit SRP-7 part 4)

### DIFF
--- a/dragon_voice/db.py
+++ b/dragon_voice/db.py
@@ -263,6 +263,9 @@ class Database:
         return await _impl(self.conn, retention_days=retention_days)
 
     # ── Messages ───────────────────────────────────────────────────────
+    # SOLID-audit follow-up (PR #262): message CRUD extracted
+    # to db_messages module.  Methods below are thin
+    # forwarders so existing call sites keep working unchanged.
 
     async def add_message(
         self,
@@ -277,26 +280,14 @@ class Database:
         model: Optional[str] = None,
         latency_ms: Optional[float] = None,
     ) -> dict:
-        """Insert an append-only message. Returns the message row as dict."""
-        now = time.time()
-        await self.conn.execute(
-            """
-            INSERT INTO messages (id, session_id, role, content, input_mode, interrupted,
-                                  audio_duration_s, token_count, model, latency_ms, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (message_id, session_id, role, content, input_mode,
-             1 if interrupted else 0, audio_duration_s, token_count,
-             model, latency_ms, now),
+        from dragon_voice.db_messages import add_message as _impl
+        return await _impl(
+            self.conn,
+            message_id=message_id, session_id=session_id, role=role,
+            content=content, input_mode=input_mode, interrupted=interrupted,
+            audio_duration_s=audio_duration_s, token_count=token_count,
+            model=model, latency_ms=latency_ms,
         )
-        await self.conn.commit()
-
-        # Update denormalized count
-        await self.increment_message_count(session_id)
-
-        cursor = await self.conn.execute("SELECT * FROM messages WHERE id = ?", (message_id,))
-        row = await cursor.fetchone()
-        return dict(row) if row else {}
 
     async def get_messages(
         self,
@@ -304,134 +295,26 @@ class Database:
         limit: int = 100,
         offset: int = 0,
     ) -> list[dict]:
-        """Get messages for a session, ordered by creation time (ascending)."""
-        cursor = await self.conn.execute(
-            """
-            SELECT * FROM messages WHERE session_id = ?
-            ORDER BY created_at ASC LIMIT ? OFFSET ?
-            """,
-            (session_id, limit, offset),
-        )
-        rows = await cursor.fetchall()
-        return [dict(r) for r in rows]
+        from dragon_voice.db_messages import get_messages as _impl
+        return await _impl(self.conn, session_id, limit=limit, offset=offset)
 
     async def count_messages(self, session_id: str) -> int:
-        """Count messages in a session."""
-        cursor = await self.conn.execute(
-            "SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,)
-        )
-        row = await cursor.fetchone()
-        return row[0] if row else 0
+        from dragon_voice.db_messages import count_messages as _impl
+        return await _impl(self.conn, session_id)
 
     async def get_message(self, message_id: str) -> Optional[dict]:
-        """Fetch a single message by ID."""
-        cursor = await self.conn.execute("SELECT * FROM messages WHERE id = ?", (message_id,))
-        row = await cursor.fetchone()
-        return dict(row) if row else None
+        from dragon_voice.db_messages import get_message as _impl
+        return await _impl(self.conn, message_id)
 
     async def purge_old_messages(
-        self, days: int = 30, batch_size: int = 500
+        self, days: int = 30, batch_size: int = 500,
     ) -> dict[str, int]:
-        """Purge messages and orphaned events older than `days`.
-
-        Skips messages belonging to active or paused sessions to avoid
-        deleting context from sessions still in use.
-
-        Wave 14 W14-H10: previously a single ``DELETE ... WHERE NOT IN
-        (SELECT ...)`` ran on the shared aiosqlite connection — on a
-        large tail it serialized every other coroutine behind 2-3 s of
-        purge. Now the delete runs in ``batch_size``-row chunks with
-        ``await asyncio.sleep(0)`` between batches, yielding the event
-        loop so WS keepalives and receipt emits can progress even on a
-        huge purge.
-
-        Returns dict with counts: {"messages": N, "events": M}.
-        """
-        if days <= 0:
-            logger.info("Message purge disabled (days=%d)", days)
-            return {"messages": 0, "events": 0}
-
-        cutoff = time.time() - (days * 86400)
-
-        # Delete old messages, but only from ended sessions (or sessions
-        # with no matching row, i.e. orphaned messages).
-        # Wave 14 W14-H10: batch via LIMIT + asyncio.sleep(0) yield so
-        # the purge does NOT hold the aiosqlite background thread
-        # exclusively for the full delete.
-        msg_count = 0
-        while True:
-            cursor = await self.conn.execute(
-                """
-                DELETE FROM messages
-                WHERE rowid IN (
-                    SELECT rowid FROM messages
-                    WHERE created_at < ?
-                      AND session_id NOT IN (
-                          SELECT id FROM sessions WHERE status IN ('active', 'paused')
-                      )
-                    LIMIT ?
-                )
-                """,
-                (cutoff, batch_size),
-            )
-            deleted = cursor.rowcount
-            await self.conn.commit()
-            msg_count += deleted
-            if deleted < batch_size:
-                break
-            await asyncio.sleep(0)  # yield the loop between batches
-
-        # Delete orphaned events older than the cutoff — same batching.
-        evt_count = 0
-        while True:
-            cursor = await self.conn.execute(
-                """
-                DELETE FROM events
-                WHERE rowid IN (
-                    SELECT rowid FROM events
-                    WHERE created_at < ?
-                      AND (session_id IS NULL
-                           OR session_id NOT IN (
-                               SELECT id FROM sessions WHERE status IN ('active', 'paused')
-                           ))
-                    LIMIT ?
-                )
-                """,
-                (cutoff, batch_size),
-            )
-            deleted = cursor.rowcount
-            await self.conn.commit()
-            evt_count += deleted
-            if deleted < batch_size:
-                break
-            await asyncio.sleep(0)
-
-        # PASSIVE checkpoint after bulk deletes — moves WAL pages back into
-        # the main DB file without blocking readers. Reduces WAL file growth
-        # and consolidates writes to reduce eMMC wear (DQ04).
-        if msg_count > 0 or evt_count > 0:
-            try:
-                await self.conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
-                logger.info("WAL passive checkpoint after purge")
-            except Exception as ckpt_err:
-                logger.warning("WAL checkpoint after purge failed: %s", ckpt_err)
-
-        logger.info(
-            "Purged %d messages and %d events older than %d days",
-            msg_count, evt_count, days,
-        )
-        return {"messages": msg_count, "events": evt_count}
+        from dragon_voice.db_messages import purge_old_messages as _impl
+        return await _impl(self.conn, days=days, batch_size=batch_size)
 
     async def delete_messages(self, session_id: str) -> int:
-        """Delete all messages for a session. Returns count deleted."""
-        count = await self.count_messages(session_id)
-        await self.conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
-        # Reset denormalized count
-        await self.conn.execute(
-            "UPDATE sessions SET message_count = 0 WHERE id = ?", (session_id,)
-        )
-        await self.conn.commit()
-        return count
+        from dragon_voice.db_messages import delete_messages as _impl
+        return await _impl(self.conn, session_id)
 
     # ── Notes ──────────────────────────────────────────────────────────
 

--- a/dragon_voice/db_messages.py
+++ b/dragon_voice/db_messages.py
@@ -1,0 +1,291 @@
+"""Message CRUD — free async functions taking an aiosqlite connection.
+
+Wave 23 SOLID-audit follow-up — thirty-sixth sub-extract.
+Fourth slice from `dragon_voice/db.py` (audit SRP-7).
+
+Pre-extract these were 6 methods on `Database` (~155 LOC of
+SQL).  Now lives as free functions taking the connection
+explicitly.
+
+## API
+
+```python
+msg = await add_message(conn, message_id="m1", session_id="s1",
+                        role="user", content="hello")
+msgs = await get_messages(conn, "s1", limit=100, offset=0)
+n = await count_messages(conn, "s1")
+m = await get_message(conn, "m1")
+counts = await purge_old_messages(conn, days=30, batch_size=500)
+n_deleted = await delete_messages(conn, "s1")
+```
+
+## Wave 14 W14-H10 batched purge invariant preserved
+
+The purge runs in `batch_size`-row chunks with
+`await asyncio.sleep(0)` between batches.  Pre-fix a single
+`DELETE ... WHERE NOT IN (SELECT ...)` ran on the shared
+aiosqlite connection — on a large tail it serialized every
+other coroutine behind 2-3 s of purge.  Now WS keepalives and
+receipt emits can progress even on a huge purge.
+
+## DQ04 PASSIVE checkpoint preserved
+
+After bulk deletes, a `PRAGMA wal_checkpoint(PASSIVE)` moves
+WAL pages back into the main DB file without blocking
+readers.  Reduces WAL file growth and consolidates writes to
+reduce eMMC wear.
+
+## add_message side-effect
+
+Calls into the sessions module's `increment_message_count`
+to maintain the denormalized counter on the session row.
+The order is: insert message → commit → increment counter
+(separate commit).  Pre-extract this depended on
+`self.increment_message_count`; now we import the
+`db_sessions` helper to maintain the same side effect.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Optional
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+# Default batch size for the purge loop.  500 rows × ~few-ms
+# per batch keeps each yield window short enough that WS
+# keepalives + receipt emits don't starve.
+_PURGE_BATCH_SIZE = 500
+
+
+async def add_message(
+    conn: aiosqlite.Connection,
+    *,
+    message_id: str,
+    session_id: str,
+    role: str,
+    content: str,
+    input_mode: str = "text",
+    interrupted: bool = False,
+    audio_duration_s: Optional[float] = None,
+    token_count: Optional[int] = None,
+    model: Optional[str] = None,
+    latency_ms: Optional[float] = None,
+) -> dict:
+    """Insert an append-only message.  Returns the message row
+    as dict.
+
+    Side effect: increments the denormalized
+    `sessions.message_count` for the parent session.
+    """
+    now = time.time()
+    await conn.execute(
+        """
+        INSERT INTO messages (id, session_id, role, content, input_mode, interrupted,
+                              audio_duration_s, token_count, model, latency_ms, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            message_id, session_id, role, content, input_mode,
+            1 if interrupted else 0, audio_duration_s, token_count,
+            model, latency_ms, now,
+        ),
+    )
+    await conn.commit()
+
+    # Update denormalized count on the session row.
+    from dragon_voice.db_sessions import increment_message_count
+    await increment_message_count(conn, session_id)
+
+    cursor = await conn.execute(
+        "SELECT * FROM messages WHERE id = ?", (message_id,),
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else {}
+
+
+async def get_messages(
+    conn: aiosqlite.Connection,
+    session_id: str,
+    *,
+    limit: int = 100,
+    offset: int = 0,
+) -> list[dict]:
+    """Get messages for a session, ordered by creation time
+    (ascending — chat-replay order)."""
+    cursor = await conn.execute(
+        """
+        SELECT * FROM messages WHERE session_id = ?
+        ORDER BY created_at ASC LIMIT ? OFFSET ?
+        """,
+        (session_id, limit, offset),
+    )
+    rows = await cursor.fetchall()
+    return [dict(r) for r in rows]
+
+
+async def count_messages(
+    conn: aiosqlite.Connection,
+    session_id: str,
+) -> int:
+    """Count messages in a session."""
+    cursor = await conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE session_id = ?",
+        (session_id,),
+    )
+    row = await cursor.fetchone()
+    return row[0] if row else 0
+
+
+async def get_message(
+    conn: aiosqlite.Connection,
+    message_id: str,
+) -> Optional[dict]:
+    """Fetch a single message by ID.  Returns None when not
+    found."""
+    cursor = await conn.execute(
+        "SELECT * FROM messages WHERE id = ?", (message_id,),
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def purge_old_messages(
+    conn: aiosqlite.Connection,
+    *,
+    days: int = 30,
+    batch_size: int = _PURGE_BATCH_SIZE,
+) -> dict[str, int]:
+    """Purge messages and orphaned events older than `days`.
+
+    Skips messages belonging to active or paused sessions to
+    avoid deleting context from sessions still in use.
+
+    Wave 14 W14-H10: the delete runs in `batch_size`-row chunks
+    with `await asyncio.sleep(0)` between batches.  Pre-fix a
+    single DELETE ... WHERE NOT IN (SELECT ...) ran on the
+    shared aiosqlite connection — on a large tail it
+    serialized every other coroutine behind 2-3 s of purge.
+
+    Returns dict with counts: {"messages": N, "events": M}.
+    days <= 0 disables purge (returns zeros).
+    """
+    if days <= 0:
+        logger.info("Message purge disabled (days=%d)", days)
+        return {"messages": 0, "events": 0}
+
+    cutoff = time.time() - (days * 86400)
+
+    msg_count = await _batched_delete_messages(conn, cutoff, batch_size)
+    evt_count = await _batched_delete_events(conn, cutoff, batch_size)
+
+    # DQ04 PASSIVE checkpoint after bulk deletes — moves WAL
+    # pages back into the main DB file without blocking readers.
+    # Reduces WAL file growth and consolidates writes to reduce
+    # eMMC wear.
+    if msg_count > 0 or evt_count > 0:
+        try:
+            await conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+            logger.info("WAL passive checkpoint after purge")
+        except Exception as ckpt_err:
+            logger.warning(
+                "WAL checkpoint after purge failed: %s", ckpt_err,
+            )
+
+    logger.info(
+        "Purged %d messages and %d events older than %d days",
+        msg_count, evt_count, days,
+    )
+    return {"messages": msg_count, "events": evt_count}
+
+
+async def _batched_delete_messages(
+    conn: aiosqlite.Connection,
+    cutoff: float,
+    batch_size: int,
+) -> int:
+    """Delete messages older than `cutoff` in batches; skip
+    messages whose session is still active/paused.  Yields the
+    event loop between batches so other coroutines can progress.
+    """
+    total = 0
+    while True:
+        cursor = await conn.execute(
+            """
+            DELETE FROM messages
+            WHERE rowid IN (
+                SELECT rowid FROM messages
+                WHERE created_at < ?
+                  AND session_id NOT IN (
+                      SELECT id FROM sessions WHERE status IN ('active', 'paused')
+                  )
+                LIMIT ?
+            )
+            """,
+            (cutoff, batch_size),
+        )
+        deleted = cursor.rowcount
+        await conn.commit()
+        total += deleted
+        if deleted < batch_size:
+            break
+        await asyncio.sleep(0)  # yield the loop between batches
+    return total
+
+
+async def _batched_delete_events(
+    conn: aiosqlite.Connection,
+    cutoff: float,
+    batch_size: int,
+) -> int:
+    """Delete events older than `cutoff` in batches; skip events
+    whose session is still active/paused (and orphan events with
+    NULL session_id are eligible)."""
+    total = 0
+    while True:
+        cursor = await conn.execute(
+            """
+            DELETE FROM events
+            WHERE rowid IN (
+                SELECT rowid FROM events
+                WHERE created_at < ?
+                  AND (session_id IS NULL
+                       OR session_id NOT IN (
+                           SELECT id FROM sessions WHERE status IN ('active', 'paused')
+                       ))
+                LIMIT ?
+            )
+            """,
+            (cutoff, batch_size),
+        )
+        deleted = cursor.rowcount
+        await conn.commit()
+        total += deleted
+        if deleted < batch_size:
+            break
+        await asyncio.sleep(0)
+    return total
+
+
+async def delete_messages(
+    conn: aiosqlite.Connection,
+    session_id: str,
+) -> int:
+    """Delete all messages for a session.  Returns count
+    deleted.  Resets the denormalized `sessions.message_count`
+    to 0."""
+    count = await count_messages(conn, session_id)
+    await conn.execute(
+        "DELETE FROM messages WHERE session_id = ?", (session_id,),
+    )
+    # Reset denormalized count
+    await conn.execute(
+        "UPDATE sessions SET message_count = 0 WHERE id = ?",
+        (session_id,),
+    )
+    await conn.commit()
+    return count

--- a/tests/test_db_messages.py
+++ b/tests/test_db_messages.py
@@ -1,0 +1,271 @@
+"""Tests for ``dragon_voice.db_messages``.
+
+End-to-end SQL tests against an in-memory aiosqlite connection
+with the prod schema.  Pin the W14-H10 batched-purge invariant
++ the side-effect contract that add_message increments the
+session counter.
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from dragon_voice import db_messages, db_sessions
+
+_SCHEMA_PATH = Path(__file__).parent.parent / "schema.sql"
+
+
+@pytest_asyncio.fixture
+async def conn():
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await db.executescript(_SCHEMA_PATH.read_text())
+    await db.commit()
+    yield db
+    await db.close()
+
+
+@pytest_asyncio.fixture
+async def session_conn(conn):
+    """Conn with a pre-created session 's1' for message tests."""
+    await db_sessions.create_session(conn, session_id="s1")
+    return conn
+
+
+# ─── add_message ─────────────────────────────────────────────
+
+
+class TestAddMessage:
+    @pytest.mark.asyncio
+    async def test_inserts_with_required_fields(self, session_conn):
+        msg = await db_messages.add_message(
+            session_conn,
+            message_id="m1",
+            session_id="s1",
+            role="user",
+            content="hello",
+        )
+        assert msg["id"] == "m1"
+        assert msg["role"] == "user"
+        assert msg["content"] == "hello"
+        assert msg["interrupted"] == 0
+
+    @pytest.mark.asyncio
+    async def test_optional_fields_persisted(self, session_conn):
+        msg = await db_messages.add_message(
+            session_conn,
+            message_id="m1",
+            session_id="s1",
+            role="assistant",
+            content="hi",
+            input_mode="voice",
+            interrupted=True,
+            audio_duration_s=2.5,
+            token_count=42,
+            model="anthropic/claude-haiku",
+            latency_ms=350.0,
+        )
+        assert msg["input_mode"] == "voice"
+        assert msg["interrupted"] == 1
+        assert msg["audio_duration_s"] == 2.5
+        assert msg["token_count"] == 42
+        assert msg["model"] == "anthropic/claude-haiku"
+        assert msg["latency_ms"] == 350.0
+
+    @pytest.mark.asyncio
+    async def test_increments_session_message_count(self, session_conn):
+        """Pin the side-effect contract: add_message MUST
+        increment the denormalized counter on the session row."""
+        for i in range(3):
+            await db_messages.add_message(
+                session_conn,
+                message_id=f"m{i}", session_id="s1",
+                role="user", content=f"msg {i}",
+            )
+        s = await db_sessions.get_session(session_conn, "s1")
+        assert s["message_count"] == 3
+
+
+# ─── get_messages ────────────────────────────────────────────
+
+
+class TestGetMessages:
+    @pytest.mark.asyncio
+    async def test_ordered_ascending_by_created_at(self, session_conn):
+        import asyncio
+        await db_messages.add_message(
+            session_conn, message_id="m1", session_id="s1",
+            role="user", content="first",
+        )
+        await asyncio.sleep(0.01)
+        await db_messages.add_message(
+            session_conn, message_id="m2", session_id="s1",
+            role="assistant", content="second",
+        )
+        msgs = await db_messages.get_messages(session_conn, "s1")
+        assert msgs[0]["content"] == "first"
+        assert msgs[1]["content"] == "second"
+
+    @pytest.mark.asyncio
+    async def test_pagination(self, session_conn):
+        for i in range(5):
+            await db_messages.add_message(
+                session_conn, message_id=f"m{i}", session_id="s1",
+                role="user", content=str(i),
+            )
+        page1 = await db_messages.get_messages(
+            session_conn, "s1", limit=2, offset=0,
+        )
+        page2 = await db_messages.get_messages(
+            session_conn, "s1", limit=2, offset=2,
+        )
+        assert [m["content"] for m in page1] == ["0", "1"]
+        assert [m["content"] for m in page2] == ["2", "3"]
+
+    @pytest.mark.asyncio
+    async def test_filter_by_session(self, conn):
+        await db_sessions.create_session(conn, session_id="a")
+        await db_sessions.create_session(conn, session_id="b")
+        await db_messages.add_message(
+            conn, message_id="ma1", session_id="a",
+            role="user", content="A msg",
+        )
+        await db_messages.add_message(
+            conn, message_id="mb1", session_id="b",
+            role="user", content="B msg",
+        )
+
+        a_msgs = await db_messages.get_messages(conn, "a")
+        b_msgs = await db_messages.get_messages(conn, "b")
+        assert len(a_msgs) == 1 and a_msgs[0]["content"] == "A msg"
+        assert len(b_msgs) == 1 and b_msgs[0]["content"] == "B msg"
+
+
+# ─── count_messages / get_message ──────────────────────────
+
+
+class TestCountAndGet:
+    @pytest.mark.asyncio
+    async def test_count(self, session_conn):
+        assert await db_messages.count_messages(session_conn, "s1") == 0
+        for i in range(7):
+            await db_messages.add_message(
+                session_conn, message_id=f"m{i}", session_id="s1",
+                role="user", content=str(i),
+            )
+        assert await db_messages.count_messages(session_conn, "s1") == 7
+
+    @pytest.mark.asyncio
+    async def test_get_returns_none_when_missing(self, session_conn):
+        assert await db_messages.get_message(session_conn, "nope") is None
+
+
+# ─── purge_old_messages ─────────────────────────────────────
+
+
+class TestPurge:
+    @pytest.mark.asyncio
+    async def test_disabled_returns_zero(self, session_conn):
+        result = await db_messages.purge_old_messages(session_conn, days=0)
+        assert result == {"messages": 0, "events": 0}
+
+    @pytest.mark.asyncio
+    async def test_purges_old_messages_from_ended_sessions(self, conn):
+        # Create an ended session with old messages
+        await db_sessions.create_session(conn, session_id="old")
+        await db_sessions.update_session_status(conn, "old", "ended")
+        await db_messages.add_message(
+            conn, message_id="m1", session_id="old",
+            role="user", content="old msg",
+        )
+        # Backdate to 60 days ago
+        await conn.execute(
+            "UPDATE messages SET created_at = ? WHERE id = ?",
+            (time.time() - (60 * 86400), "m1"),
+        )
+        await conn.commit()
+
+        result = await db_messages.purge_old_messages(conn, days=30)
+        assert result["messages"] == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_messages_in_active_session(self, conn):
+        """W14-H10 / safety pin: messages in active or paused
+        sessions MUST NOT be purged even if old (they're in-use
+        context)."""
+        await db_sessions.create_session(conn, session_id="active")
+        await db_messages.add_message(
+            conn, message_id="m1", session_id="active",
+            role="user", content="old but in active session",
+        )
+        # Backdate to 60 days ago
+        await conn.execute(
+            "UPDATE messages SET created_at = ? WHERE id = ?",
+            (time.time() - (60 * 86400), "m1"),
+        )
+        await conn.commit()
+
+        result = await db_messages.purge_old_messages(conn, days=30)
+        assert result["messages"] == 0
+        # Message still there
+        assert await db_messages.get_message(conn, "m1") is not None
+
+    @pytest.mark.asyncio
+    async def test_batched_purge_handles_large_set(self, conn):
+        """W14-H10 invariant: purge handles N > batch_size by
+        looping with yields between batches."""
+        await db_sessions.create_session(conn, session_id="ended")
+        await db_sessions.update_session_status(conn, "ended", "ended")
+
+        # Insert 12 old messages with batch_size=5 so we exercise
+        # the multi-batch loop.
+        cutoff = time.time() - (60 * 86400)
+        for i in range(12):
+            await db_messages.add_message(
+                conn, message_id=f"m{i}", session_id="ended",
+                role="user", content=str(i),
+            )
+        await conn.execute(
+            "UPDATE messages SET created_at = ?", (cutoff,),
+        )
+        await conn.commit()
+
+        result = await db_messages.purge_old_messages(
+            conn, days=30, batch_size=5,
+        )
+        assert result["messages"] == 12
+
+
+# ─── delete_messages ────────────────────────────────────────
+
+
+class TestDeleteMessages:
+    @pytest.mark.asyncio
+    async def test_deletes_and_returns_count(self, session_conn):
+        for i in range(4):
+            await db_messages.add_message(
+                session_conn, message_id=f"m{i}", session_id="s1",
+                role="user", content=str(i),
+            )
+        n = await db_messages.delete_messages(session_conn, "s1")
+        assert n == 4
+        assert await db_messages.count_messages(session_conn, "s1") == 0
+
+    @pytest.mark.asyncio
+    async def test_resets_session_message_count_to_zero(self, session_conn):
+        for i in range(3):
+            await db_messages.add_message(
+                session_conn, message_id=f"m{i}", session_id="s1",
+                role="user", content=str(i),
+            )
+        s_before = await db_sessions.get_session(session_conn, "s1")
+        assert s_before["message_count"] == 3
+
+        await db_messages.delete_messages(session_conn, "s1")
+
+        s_after = await db_sessions.get_session(session_conn, "s1")
+        assert s_after["message_count"] == 0


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **thirty-sixth sub-extract**.  Fourth slice from \`dragon_voice/db.py\` (audit **SRP-7**).

Pre-extract 6 methods on \`Database\` (add_message, get_messages, count_messages, get_message, purge_old_messages, delete_messages) — ~155 LOC including the chunky **W14-H10 batched purge**.

### Behaviour preserved verbatim

- \`add_message\` side-effect: increments \`sessions.message_count\` via the sessions module's helper
- \`get_messages\` returns chat-replay order (created_at ASC)
- \`purge_old_messages\` **Wave 14 W14-H10 batched-delete loop**:
  - \`batch_size\` rows per chunk
  - \`await asyncio.sleep(0)\` between batches so WS keepalives + receipt emits can progress
  - Skips messages in active or paused sessions (in-use context)
  - Skips events similarly (orphan events with NULL session_id are eligible)
  - DQ04 PASSIVE WAL checkpoint after bulk deletes
  - days <= 0 disables (returns zeros)
- \`delete_messages\` resets \`session.message_count\` to 0

### API improvement

- Batched-delete loops factored into \`_batched_delete_messages\` + \`_batched_delete_events\` private helpers
- \`_PURGE_BATCH_SIZE = 500\` module constant exposes the default

### Test coverage

14 new tests across 5 classes spanning add_message field persistence + the session-counter side-effect, get_messages ordering + pagination + per-session filter, count + missing-message-returns-None, purge disabled returns zeros, purge of ended-session messages, **purge skips active-session messages (W14-H10 safety pin)**, batched purge handles N > batch_size, delete returns count + resets the denormalized counter.

### Diff stats

| Metric | Before | After |
|---|---|---|
| \`db.py\` LOC | 613 | 496 (-117) |
| \`db_messages.py\` | (didn't exist) | 250 (new) |
| **\`db.py\` cumulative SRP-7 across #259-#262** | **844** | **496 (-41.2%)** |

3 more method-domain mixins still bundled (note/event/config CRUD).

## Test plan

- [x] \`python3 -m pytest tests/test_db_messages.py -v\` → 14 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → **1291 passed**, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)