### PR TITLE
refactor(db): extract notes + events + config CRUD — CLOSES audit SRP-7

### DIFF
--- a/dragon_voice/db.py
+++ b/dragon_voice/db.py
@@ -316,7 +316,11 @@ class Database:
         from dragon_voice.db_messages import delete_messages as _impl
         return await _impl(self.conn, session_id)
 
-    # ── Notes ──────────────────────────────────────────────────────────
+    # ── Notes / Events / Config ────────────────────────────────────────
+    # SOLID-audit follow-up (PR #263): notes, events, and
+    # config-store CRUD extracted to db_notes, db_events,
+    # db_config.  Closes audit SRP-7.  Methods below are thin
+    # forwarders so existing call sites keep working.
 
     async def add_note(
         self,
@@ -331,48 +335,26 @@ class Database:
         word_count: int = 0,
         embedding: Optional[bytes] = None,
     ) -> dict:
-        """Insert a note. Returns the note row as dict."""
-        now = time.time()
-        await self.conn.execute(
-            """
-            INSERT INTO notes (id, session_id, title, transcript, summary, tags,
-                               source, duration_s, word_count, embedding, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (note_id, session_id, title, transcript, summary,
-             json.dumps(tags or []), source, duration_s, word_count,
-             embedding, now, now),
+        from dragon_voice.db_notes import add_note as _impl
+        return await _impl(
+            self.conn, note_id=note_id, session_id=session_id,
+            title=title, transcript=transcript, summary=summary,
+            tags=tags, source=source, duration_s=duration_s,
+            word_count=word_count, embedding=embedding,
         )
-        await self.conn.commit()
-
-        cursor = await self.conn.execute("SELECT * FROM notes WHERE id = ?", (note_id,))
-        row = await cursor.fetchone()
-        return dict(row) if row else {}
 
     async def get_note(self, note_id: str) -> Optional[dict]:
-        """Fetch a note by ID."""
-        cursor = await self.conn.execute("SELECT * FROM notes WHERE id = ?", (note_id,))
-        row = await cursor.fetchone()
-        return dict(row) if row else None
+        from dragon_voice.db_notes import get_note as _impl
+        return await _impl(self.conn, note_id)
 
     async def list_notes(
-        self, session_id: Optional[str] = None, limit: int = 50, offset: int = 0
+        self, session_id: Optional[str] = None,
+        limit: int = 50, offset: int = 0,
     ) -> list[dict]:
-        """List notes, optionally filtered by session."""
-        if session_id:
-            cursor = await self.conn.execute(
-                "SELECT * FROM notes WHERE session_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?",
-                (session_id, limit, offset),
-            )
-        else:
-            cursor = await self.conn.execute(
-                "SELECT * FROM notes ORDER BY created_at DESC LIMIT ? OFFSET ?",
-                (limit, offset),
-            )
-        rows = await cursor.fetchall()
-        return [dict(r) for r in rows]
-
-    # ── Events ─────────────────────────────────────────────────────────
+        from dragon_voice.db_notes import list_notes as _impl
+        return await _impl(
+            self.conn, session_id=session_id, limit=limit, offset=offset,
+        )
 
     async def add_event(
         self,
@@ -381,17 +363,11 @@ class Database:
         device_id: Optional[str] = None,
         data: Optional[dict] = None,
     ) -> int:
-        """Insert a system event. Returns the auto-incremented event ID."""
-        now = time.time()
-        cursor = await self.conn.execute(
-            """
-            INSERT INTO events (type, session_id, device_id, data, created_at)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (event_type, session_id, device_id, json.dumps(data or {}), now),
+        from dragon_voice.db_events import add_event as _impl
+        return await _impl(
+            self.conn, event_type,
+            session_id=session_id, device_id=device_id, data=data,
         )
-        await self.conn.commit()
-        return cursor.lastrowid
 
     async def get_events(
         self,
@@ -401,96 +377,46 @@ class Database:
         since_id: int = 0,
         limit: int = 100,
     ) -> list[dict]:
-        """Get events with optional filters. Supports polling via since_id."""
-        conditions = ["id > ?"]
-        params: list[Any] = [since_id]
-
-        if event_type:
-            conditions.append("type = ?")
-            params.append(event_type)
-        if session_id:
-            conditions.append("session_id = ?")
-            params.append(session_id)
-        if device_id:
-            conditions.append("device_id = ?")
-            params.append(device_id)
-
-        where = f"WHERE {' AND '.join(conditions)}"
-        cursor = await self.conn.execute(
-            f"SELECT * FROM events {where} ORDER BY id ASC LIMIT ?",
-            (*params, limit),
+        from dragon_voice.db_events import get_events as _impl
+        return await _impl(
+            self.conn,
+            event_type=event_type, session_id=session_id,
+            device_id=device_id, since_id=since_id, limit=limit,
         )
-        rows = await cursor.fetchall()
-        return [dict(r) for r in rows]
-
-    # ── Config Store ───────────────────────────────────────────────────
 
     async def get_config(
-        self,
-        key: str,
-        scope: str = "global",
-        scope_id: Optional[str] = None,
+        self, key: str,
+        scope: str = "global", scope_id: Optional[str] = None,
     ) -> Optional[str]:
-        """Get a config value. Returns JSON-encoded string or None."""
-        cursor = await self.conn.execute(
-            "SELECT value FROM config WHERE key = ? AND scope = ? AND scope_id IS ?",
-            (key, scope, scope_id),
-        )
-        row = await cursor.fetchone()
-        return row["value"] if row else None
+        from dragon_voice.db_config import get_config as _impl
+        return await _impl(self.conn, key, scope=scope, scope_id=scope_id)
 
     async def set_config(
-        self,
-        key: str,
-        value: str,
-        scope: str = "global",
-        scope_id: Optional[str] = None,
+        self, key: str, value: str,
+        scope: str = "global", scope_id: Optional[str] = None,
     ) -> None:
-        """Set a config value (upsert). Value should be JSON-encoded."""
-        now = time.time()
-        await self.conn.execute(
-            """
-            INSERT INTO config (key, value, scope, scope_id, updated_at)
-            VALUES (?, ?, ?, ?, ?)
-            ON CONFLICT(key, scope, scope_id) DO UPDATE SET
-                value = excluded.value,
-                updated_at = excluded.updated_at
-            """,
-            (key, value, scope, scope_id, now),
-        )
-        await self.conn.commit()
+        from dragon_voice.db_config import set_config as _impl
+        await _impl(self.conn, key, value, scope=scope, scope_id=scope_id)
 
-    async def get_resolved_config(self, key: str, device_id: Optional[str] = None,
-                                   session_id: Optional[str] = None) -> Optional[str]:
-        """Get config with scope resolution: session > device > global."""
-        # Try session scope first
-        if session_id:
-            val = await self.get_config(key, "session", session_id)
-            if val is not None:
-                return val
-        # Then device scope
-        if device_id:
-            val = await self.get_config(key, "device", device_id)
-            if val is not None:
-                return val
-        # Fall back to global
-        return await self.get_config(key, "global")
-
-    async def list_config(self, scope: str = "global", scope_id: Optional[str] = None) -> dict[str, str]:
-        """List all config entries for a given scope."""
-        cursor = await self.conn.execute(
-            "SELECT key, value FROM config WHERE scope = ? AND scope_id IS ?",
-            (scope, scope_id),
+    async def get_resolved_config(
+        self, key: str,
+        device_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ) -> Optional[str]:
+        from dragon_voice.db_config import get_resolved_config as _impl
+        return await _impl(
+            self.conn, key, device_id=device_id, session_id=session_id,
         )
-        rows = await cursor.fetchall()
-        return {row["key"]: row["value"] for row in rows}
 
-    async def delete_config(self, key: str, scope: str = "global",
-                            scope_id: Optional[str] = None) -> bool:
-        """Delete a config key. Returns True if a row was deleted."""
-        cursor = await self.conn.execute(
-            "DELETE FROM config WHERE key = ? AND scope = ? AND scope_id IS ?",
-            (key, scope, scope_id),
-        )
-        await self.conn.commit()
-        return cursor.rowcount > 0
+    async def list_config(
+        self, scope: str = "global", scope_id: Optional[str] = None,
+    ) -> dict[str, str]:
+        from dragon_voice.db_config import list_config as _impl
+        return await _impl(self.conn, scope=scope, scope_id=scope_id)
+
+    async def delete_config(
+        self, key: str,
+        scope: str = "global", scope_id: Optional[str] = None,
+    ) -> bool:
+        from dragon_voice.db_config import delete_config as _impl
+        return await _impl(self.conn, key, scope=scope, scope_id=scope_id)

--- a/dragon_voice/db_config.py
+++ b/dragon_voice/db_config.py
@@ -1,0 +1,137 @@
+"""Config-store CRUD with scope-resolution — free async functions
+taking an aiosqlite connection.
+
+Wave 23 SOLID-audit follow-up — thirty-seventh sub-extract.
+Seventh slice from `dragon_voice/db.py` (audit SRP-7) — final
+domain mixin extract that closes SRP-7.
+
+The config table is a key/value store with three scopes:
+  * `global` — applies to all sessions/devices
+  * `device` — keyed by `scope_id = device_id`
+  * `session` — keyed by `scope_id = session_id`
+
+`get_resolved_config` walks the scope priority chain
+(session > device > global) so a session-specific override
+shadows the device default which shadows the global default.
+
+Pre-extract these were 5 methods on `Database` (~75 LOC).
+
+## API
+
+```python
+await set_config(conn, "voice_mode", "1", scope="device", scope_id="d1")
+val = await get_config(conn, "voice_mode", scope="device", scope_id="d1")
+val = await get_resolved_config(conn, "voice_mode",
+                                device_id="d1", session_id="s1")
+all_global = await list_config(conn, scope="global")
+existed = await delete_config(conn, "voice_mode",
+                              scope="device", scope_id="d1")
+```
+"""
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+import aiosqlite
+
+
+async def get_config(
+    conn: aiosqlite.Connection,
+    key: str,
+    *,
+    scope: str = "global",
+    scope_id: Optional[str] = None,
+) -> Optional[str]:
+    """Get a config value.  Returns the JSON-encoded string or
+    None if not present.
+
+    `scope_id` is None for global scope (the SQL uses `IS ?`
+    so NULL matches NULL on the unique index).
+    """
+    cursor = await conn.execute(
+        "SELECT value FROM config WHERE key = ? AND scope = ? AND scope_id IS ?",
+        (key, scope, scope_id),
+    )
+    row = await cursor.fetchone()
+    return row["value"] if row else None
+
+
+async def set_config(
+    conn: aiosqlite.Connection,
+    key: str,
+    value: str,
+    *,
+    scope: str = "global",
+    scope_id: Optional[str] = None,
+) -> None:
+    """Set a config value (upsert).  `value` should be a JSON-
+    encoded string — the caller owns the encoding so the same
+    column can hold strings, numbers, dicts, etc."""
+    now = time.time()
+    await conn.execute(
+        """
+        INSERT INTO config (key, value, scope, scope_id, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(key, scope, scope_id) DO UPDATE SET
+            value = excluded.value,
+            updated_at = excluded.updated_at
+        """,
+        (key, value, scope, scope_id, now),
+    )
+    await conn.commit()
+
+
+async def get_resolved_config(
+    conn: aiosqlite.Connection,
+    key: str,
+    *,
+    device_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> Optional[str]:
+    """Get config with scope resolution: session > device >
+    global.  Returns the most-specific scope's value, or None
+    when the key isn't set anywhere."""
+    if session_id:
+        val = await get_config(conn, key, scope="session", scope_id=session_id)
+        if val is not None:
+            return val
+    if device_id:
+        val = await get_config(conn, key, scope="device", scope_id=device_id)
+        if val is not None:
+            return val
+    return await get_config(conn, key, scope="global")
+
+
+async def list_config(
+    conn: aiosqlite.Connection,
+    *,
+    scope: str = "global",
+    scope_id: Optional[str] = None,
+) -> dict[str, str]:
+    """List all config entries for a given scope.  Returns
+    {key: value} dict (values are still JSON-encoded strings —
+    caller decodes)."""
+    cursor = await conn.execute(
+        "SELECT key, value FROM config WHERE scope = ? AND scope_id IS ?",
+        (scope, scope_id),
+    )
+    rows = await cursor.fetchall()
+    return {row["key"]: row["value"] for row in rows}
+
+
+async def delete_config(
+    conn: aiosqlite.Connection,
+    key: str,
+    *,
+    scope: str = "global",
+    scope_id: Optional[str] = None,
+) -> bool:
+    """Delete a config key.  Returns True iff a row was actually
+    deleted (False when the key didn't exist at that scope)."""
+    cursor = await conn.execute(
+        "DELETE FROM config WHERE key = ? AND scope = ? AND scope_id IS ?",
+        (key, scope, scope_id),
+    )
+    await conn.commit()
+    return cursor.rowcount > 0

--- a/dragon_voice/db_events.py
+++ b/dragon_voice/db_events.py
@@ -1,0 +1,93 @@
+"""Event CRUD — free async functions taking an aiosqlite connection.
+
+Wave 23 SOLID-audit follow-up — thirty-seventh sub-extract.
+Sixth slice from `dragon_voice/db.py` (audit SRP-7).
+
+The events table is a generic system-event log: device.connected,
+device.disconnected, api_usage, etc.  Each event has a type +
+optional session_id + optional device_id + JSON data + auto-
+incremented id (used by polling clients via `since_id`).
+
+Pre-extract these were 2 methods on `Database` (~50 LOC).
+
+## API
+
+```python
+event_id = await add_event(conn, "device.connected",
+                           device_id="d1",
+                           data={"firmware_ver": "1.2.3"})
+events = await get_events(conn, event_type="api_usage",
+                          since_id=last_seen_id, limit=100)
+```
+"""
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Optional
+
+import aiosqlite
+
+
+async def add_event(
+    conn: aiosqlite.Connection,
+    event_type: str,
+    *,
+    session_id: Optional[str] = None,
+    device_id: Optional[str] = None,
+    data: Optional[dict] = None,
+) -> int:
+    """Insert a system event.  Returns the auto-incremented
+    event ID.
+
+    `data` is JSON-encoded into the `data` column.  Both
+    `session_id` and `device_id` are optional — system-level
+    events (e.g. boot, shutdown) may have neither.
+    """
+    now = time.time()
+    cursor = await conn.execute(
+        """
+        INSERT INTO events (type, session_id, device_id, data, created_at)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (event_type, session_id, device_id, json.dumps(data or {}), now),
+    )
+    await conn.commit()
+    return cursor.lastrowid
+
+
+async def get_events(
+    conn: aiosqlite.Connection,
+    *,
+    event_type: Optional[str] = None,
+    session_id: Optional[str] = None,
+    device_id: Optional[str] = None,
+    since_id: int = 0,
+    limit: int = 100,
+) -> list[dict]:
+    """Get events with optional filters.  Supports polling via
+    `since_id` (returns events with `id > since_id`).
+
+    Ordered ASC by id so a polling client can use the last
+    returned id as the next since_id and never miss an event.
+    """
+    conditions = ["id > ?"]
+    params: list[Any] = [since_id]
+
+    if event_type:
+        conditions.append("type = ?")
+        params.append(event_type)
+    if session_id:
+        conditions.append("session_id = ?")
+        params.append(session_id)
+    if device_id:
+        conditions.append("device_id = ?")
+        params.append(device_id)
+
+    where = f"WHERE {' AND '.join(conditions)}"
+    cursor = await conn.execute(
+        f"SELECT * FROM events {where} ORDER BY id ASC LIMIT ?",
+        (*params, limit),
+    )
+    rows = await cursor.fetchall()
+    return [dict(r) for r in rows]

--- a/dragon_voice/db_notes.py
+++ b/dragon_voice/db_notes.py
@@ -1,0 +1,105 @@
+"""Note CRUD — free async functions taking an aiosqlite connection.
+
+Wave 23 SOLID-audit follow-up — thirty-seventh sub-extract.
+Fifth slice from `dragon_voice/db.py` (audit SRP-7).
+
+Notes are dictation-derived records (transcript + auto-summary
++ tags + audio metadata).  Pre-extract these were 3 methods on
+`Database` (~40 LOC).  Now lives as free functions taking the
+connection explicitly.
+
+## API
+
+```python
+note = await add_note(conn, note_id="n1", session_id="s1",
+                      title="My note", transcript="...")
+note = await get_note(conn, "n1")
+notes = await list_notes(conn, session_id="s1", limit=50)
+```
+"""
+from __future__ import annotations
+
+import json
+import time
+from typing import Optional
+
+import aiosqlite
+
+
+async def add_note(
+    conn: aiosqlite.Connection,
+    *,
+    note_id: str,
+    session_id: Optional[str] = None,
+    title: str = "",
+    transcript: str = "",
+    summary: str = "",
+    tags: Optional[list[str]] = None,
+    source: str = "text",
+    duration_s: float = 0.0,
+    word_count: int = 0,
+    embedding: Optional[bytes] = None,
+) -> dict:
+    """Insert a note.  Returns the note row as dict.
+
+    `tags` is JSON-encoded.  `embedding` is the raw vector
+    bytes (sqlite-vec compatible).  `source` is one of
+    "text" / "voice" — used by the dashboard's note-list UI to
+    show the right icon.
+    """
+    now = time.time()
+    await conn.execute(
+        """
+        INSERT INTO notes (id, session_id, title, transcript, summary, tags,
+                           source, duration_s, word_count, embedding, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            note_id, session_id, title, transcript, summary,
+            json.dumps(tags or []), source, duration_s, word_count,
+            embedding, now, now,
+        ),
+    )
+    await conn.commit()
+
+    cursor = await conn.execute(
+        "SELECT * FROM notes WHERE id = ?", (note_id,),
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else {}
+
+
+async def get_note(
+    conn: aiosqlite.Connection,
+    note_id: str,
+) -> Optional[dict]:
+    """Fetch a note by ID.  Returns None when not found."""
+    cursor = await conn.execute(
+        "SELECT * FROM notes WHERE id = ?", (note_id,),
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def list_notes(
+    conn: aiosqlite.Connection,
+    *,
+    session_id: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[dict]:
+    """List notes, optionally filtered by session, ordered by
+    creation time (newest first)."""
+    if session_id:
+        cursor = await conn.execute(
+            "SELECT * FROM notes WHERE session_id = ? "
+            "ORDER BY created_at DESC LIMIT ? OFFSET ?",
+            (session_id, limit, offset),
+        )
+    else:
+        cursor = await conn.execute(
+            "SELECT * FROM notes ORDER BY created_at DESC LIMIT ? OFFSET ?",
+            (limit, offset),
+        )
+    rows = await cursor.fetchall()
+    return [dict(r) for r in rows]

--- a/tests/test_db_notes_events_config.py
+++ b/tests/test_db_notes_events_config.py
@@ -1,0 +1,259 @@
+"""Tests for ``dragon_voice.db_notes``, ``db_events``, ``db_config``.
+
+End-to-end SQL tests against an in-memory aiosqlite connection
+with the prod schema.  Covers the three smaller SRP-7
+mixins in one file (40 + 50 + 75 LOC of source → ~30 tests).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from dragon_voice import db_config, db_events, db_notes, db_sessions
+
+_SCHEMA_PATH = Path(__file__).parent.parent / "schema.sql"
+
+
+@pytest_asyncio.fixture
+async def conn():
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await db.executescript(_SCHEMA_PATH.read_text())
+    await db.commit()
+    yield db
+    await db.close()
+
+
+# ─── db_notes ───────────────────────────────────────────────
+
+
+class TestNotes:
+    @pytest.mark.asyncio
+    async def test_add_minimal_required_fields(self, conn):
+        note = await db_notes.add_note(conn, note_id="n1")
+        assert note["id"] == "n1"
+        assert note["title"] == ""
+        assert note["transcript"] == ""
+
+    @pytest.mark.asyncio
+    async def test_add_full_payload(self, conn):
+        await db_sessions.create_session(conn, session_id="s1")
+        note = await db_notes.add_note(
+            conn, note_id="n1", session_id="s1",
+            title="Meeting recap",
+            transcript="long transcript...",
+            summary="short summary",
+            tags=["work", "ai"],
+            source="audio",  # schema CHECK: audio|text|import only
+            duration_s=125.5,
+            word_count=234,
+        )
+        assert note["title"] == "Meeting recap"
+        assert note["source"] == "audio"
+        assert note["duration_s"] == 125.5
+        assert note["word_count"] == 234
+        assert json.loads(note["tags"]) == ["work", "ai"]
+
+    @pytest.mark.asyncio
+    async def test_get_returns_none_when_missing(self, conn):
+        assert await db_notes.get_note(conn, "nope") is None
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_session(self, conn):
+        await db_sessions.create_session(conn, session_id="a")
+        await db_sessions.create_session(conn, session_id="b")
+        await db_notes.add_note(conn, note_id="n1", session_id="a")
+        await db_notes.add_note(conn, note_id="n2", session_id="b")
+
+        a_notes = await db_notes.list_notes(conn, session_id="a")
+        assert {n["id"] for n in a_notes} == {"n1"}
+
+    @pytest.mark.asyncio
+    async def test_list_ordered_newest_first(self, conn):
+        await db_notes.add_note(conn, note_id="n1")
+        await asyncio.sleep(0.01)
+        await db_notes.add_note(conn, note_id="n2")
+        notes = await db_notes.list_notes(conn)
+        # Newest first
+        assert notes[0]["id"] == "n2"
+
+
+# ─── db_events ──────────────────────────────────────────────
+
+
+class TestEvents:
+    @pytest.mark.asyncio
+    async def test_add_returns_auto_id(self, conn):
+        eid1 = await db_events.add_event(conn, "boot")
+        eid2 = await db_events.add_event(conn, "boot")
+        assert eid2 > eid1  # auto-incremented
+
+    @pytest.mark.asyncio
+    async def test_add_with_data_json_encoded(self, conn):
+        eid = await db_events.add_event(
+            conn, "api_usage",
+            data={"model": "claude-haiku", "tokens": 100},
+        )
+        events = await db_events.get_events(conn, since_id=eid - 1)
+        assert json.loads(events[0]["data"]) == {
+            "model": "claude-haiku", "tokens": 100,
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_filter_by_type(self, conn):
+        await db_events.add_event(conn, "boot")
+        await db_events.add_event(conn, "shutdown")
+        await db_events.add_event(conn, "boot")
+
+        boots = await db_events.get_events(conn, event_type="boot")
+        assert len(boots) == 2
+        assert all(e["type"] == "boot" for e in boots)
+
+    @pytest.mark.asyncio
+    async def test_get_filter_by_session(self, conn):
+        await db_sessions.create_session(conn, session_id="s1")
+        await db_events.add_event(conn, "x", session_id="s1")
+        await db_events.add_event(conn, "x")  # no session
+
+        s1_events = await db_events.get_events(conn, session_id="s1")
+        assert len(s1_events) == 1
+
+    @pytest.mark.asyncio
+    async def test_since_id_polling_pin(self, conn):
+        """Pin: get_events(since_id=N) returns events with id > N
+        — supports polling clients that track the last-seen id."""
+        eid1 = await db_events.add_event(conn, "a")
+        eid2 = await db_events.add_event(conn, "b")
+        eid3 = await db_events.add_event(conn, "c")
+
+        result = await db_events.get_events(conn, since_id=eid1)
+        ids = [e["id"] for e in result]
+        assert eid1 not in ids
+        assert eid2 in ids
+        assert eid3 in ids
+
+    @pytest.mark.asyncio
+    async def test_ordered_ascending_by_id(self, conn):
+        """Polling clients use the LAST returned id as the next
+        since_id — order MUST be ASC so they don't miss events."""
+        await db_events.add_event(conn, "first")
+        await db_events.add_event(conn, "second")
+        await db_events.add_event(conn, "third")
+
+        result = await db_events.get_events(conn)
+        types = [e["type"] for e in result]
+        assert types == ["first", "second", "third"]
+
+
+# ─── db_config ──────────────────────────────────────────────
+
+
+class TestConfig:
+    @pytest.mark.asyncio
+    async def test_set_and_get_global(self, conn):
+        await db_config.set_config(conn, "key", '"value"')
+        assert await db_config.get_config(conn, "key") == '"value"'
+
+    @pytest.mark.asyncio
+    async def test_get_returns_none_when_missing(self, conn):
+        assert await db_config.get_config(conn, "missing") is None
+
+    @pytest.mark.asyncio
+    async def test_set_upserts_at_scoped_key(self, conn):
+        """Pin upsert behaviour at a non-NULL scope_id (SQLite
+        treats NULL columns as distinct in PRIMARY KEY, so the
+        upsert at global/scope_id=NULL doesn't collapse two
+        inserts — that's a pre-existing schema quirk preserved
+        verbatim from the pre-extract code)."""
+        await db_sessions.create_session(conn, session_id="s1")
+        await db_config.set_config(
+            conn, "key", '"first"',
+            scope="session", scope_id="s1",
+        )
+        await db_config.set_config(
+            conn, "key", '"second"',
+            scope="session", scope_id="s1",
+        )
+        assert await db_config.get_config(
+            conn, "key", scope="session", scope_id="s1",
+        ) == '"second"'
+
+    @pytest.mark.asyncio
+    async def test_scoped_config_independent(self, conn):
+        await db_sessions.create_session(conn, session_id="s1")
+        await db_config.set_config(
+            conn, "voice_mode", "0", scope="global",
+        )
+        await db_config.set_config(
+            conn, "voice_mode", "2", scope="session", scope_id="s1",
+        )
+
+        glob = await db_config.get_config(conn, "voice_mode", scope="global")
+        sess = await db_config.get_config(
+            conn, "voice_mode", scope="session", scope_id="s1",
+        )
+        assert glob == "0"
+        assert sess == "2"
+
+    @pytest.mark.asyncio
+    async def test_resolve_session_overrides_global(self, conn):
+        """Pin: scope-resolution priority is session > device > global."""
+        await db_sessions.create_session(conn, session_id="s1")
+        await db_config.set_config(conn, "k", "global", scope="global")
+        await db_config.set_config(
+            conn, "k", "session", scope="session", scope_id="s1",
+        )
+
+        resolved = await db_config.get_resolved_config(
+            conn, "k", session_id="s1",
+        )
+        assert resolved == "session"
+
+    @pytest.mark.asyncio
+    async def test_resolve_device_overrides_global_when_no_session(self, conn):
+        from dragon_voice import db_devices
+        await db_devices.upsert_device(conn, device_id="d1", hardware_id="h1")
+        await db_config.set_config(conn, "k", "global", scope="global")
+        await db_config.set_config(
+            conn, "k", "device", scope="device", scope_id="d1",
+        )
+
+        resolved = await db_config.get_resolved_config(
+            conn, "k", device_id="d1",
+        )
+        assert resolved == "device"
+
+    @pytest.mark.asyncio
+    async def test_resolve_falls_back_to_global(self, conn):
+        from dragon_voice import db_devices
+        await db_sessions.create_session(conn, session_id="s1")
+        await db_devices.upsert_device(conn, device_id="d1", hardware_id="h1")
+        await db_config.set_config(conn, "k", "GLOBAL_VAL")
+
+        resolved = await db_config.get_resolved_config(
+            conn, "k", device_id="d1", session_id="s1",
+        )
+        assert resolved == "GLOBAL_VAL"
+
+    @pytest.mark.asyncio
+    async def test_list_returns_dict(self, conn):
+        await db_config.set_config(conn, "a", "1")
+        await db_config.set_config(conn, "b", "2")
+
+        result = await db_config.list_config(conn)
+        assert result == {"a": "1", "b": "2"}
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_true_when_existed(self, conn):
+        await db_config.set_config(conn, "k", "v")
+        assert await db_config.delete_config(conn, "k") is True
+        assert await db_config.get_config(conn, "k") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_false_when_missing(self, conn):
+        assert await db_config.delete_config(conn, "never-existed") is False


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **thirty-seventh sub-extract**.  Final slice from \`dragon_voice/db.py\`.  PRs #259 + #260 + #261 + #262 + this PR together **CLOSE SRP-7** (844-LOC \`Database\` monolith of 6+ method-domain mixins).

Three new modules, one per remaining domain:
- **\`db_notes.py\`** (~100 LOC) — \`add_note\`, \`get_note\`, \`list_notes\`
- **\`db_events.py\`** (~95 LOC) — \`add_event\`, \`get_events\` with \`since_id\` polling support
- **\`db_config.py\`** (~125 LOC) — \`get_config\`, \`set_config\`, \`get_resolved_config\` (session > device > global priority), \`list_config\`, \`delete_config\`

### Behaviour preserved verbatim

- **Notes:** add returns row dict; list DESC by created_at; session_id filter
- **Events:** add returns auto-incremented id; ordered ASC by id (polling-safe — clients track last-seen id and never miss events)
- **Config:** set is upsert via \`ON CONFLICT(key, scope, scope_id)\`; resolve priority pinned; delete returns True iff a row was actually deleted

### Pre-existing schema quirk preserved + documented

SQLite treats NULL columns as distinct in PRIMARY KEY constraints, so the upsert at \`scope=global/scope_id=NULL\` doesn't collapse two inserts.  Documented in the \`test_set_upserts_at_scoped_key\` test docstring; production code unchanged.

### Test coverage

21 new tests across 3 classes spanning notes (add minimal + full payload + missing returns None + session filter + newest-first ordering), events (auto-id + JSON data + type/session filters + since_id polling pin + ASC ordering pin), config (set+get global, missing returns None, scoped upsert, scope-independence, resolve session > device > global priority, list dict-shaped, delete returns true/false).

### Diff stats

| Metric | Before | After |
|---|---|---|
| \`db.py\` LOC | 496 | 422 (-74) |
| 3 new modules | (didn't exist) | 100 + 95 + 125 |
| **\`db.py\` cumulative SRP-7 closure across #259-#263** | **844** | **422 (-50%)** |

**SRP-7 fully closed.**  Database is now ~280 LOC of just lifecycle (init/recover/close + connection management) + ~140 LOC of thin forwarders to the 6 domain modules.

## Test plan

- [x] \`python3 -m pytest tests/test_db_notes_events_config.py -v\` → 21 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → **1312 passed**, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)