### PR TITLE
refactor(pipeline): extract speak_system bracket (~28 LOC) — closes audit SRP-4 in flight

### DIFF
--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -1282,25 +1282,15 @@ class VoicePipeline:
         the screen off.  Delivered through the live TTS path so it respects
         the currently-selected voice (Piper / OpenRouter) and inherits the
         existing pacing + resampling.
+
+        SOLID-audit follow-up: the bracket invariant (snapshot
+        `_tts_started`, run synth, conditionally emit `tts_end`)
+        extracted to speak_system.speak_system_message so it's
+        testable in isolation.  This wrapper kept for backward
+        compat with existing call sites.
         """
-        if not text or not self._tts:
-            return
-        prev_started = self._tts_started
-        try:
-            await self._synthesize_and_send(text)
-        except Exception:
-            logger.exception("speak_system failed: %s", text[:40])
-        finally:
-            # Close the utterance so the Tab5 flushes its ring buffer.
-            if self._tts_started and not prev_started:
-                try:
-                    await self._on_event({
-                        "type": "tts_end",
-                        "tts_ms": round(self._tts_total_ms),
-                    })
-                except Exception:
-                    pass
-                self._tts_started = False
+        from dragon_voice.speak_system import speak_system_message
+        await speak_system_message(self, text)
 
     async def _synthesize_and_send(self, text: str) -> None:
         """Synthesize a sentence, resample to 16kHz, and stream paced to client.

--- a/dragon_voice/speak_system.py
+++ b/dragon_voice/speak_system.py
@@ -1,0 +1,101 @@
+"""Out-of-band system-message speech for `VoicePipeline`.
+
+Wave 23 SOLID-audit follow-up — thirty-ninth sub-extract.
+Sixth slice from `dragon_voice/pipeline.py` (audit SRP-4).
+
+`speak_system` lets the server speak a short alert (e.g.
+budget auto-downgrade — Gauntlet G7-F) out-of-band of the
+normal STT → LLM → TTS turn loop.  The user hears the
+message via the live TTS path so it respects the currently-
+selected voice (Piper / OpenRouter) and inherits the
+existing pacing + resampling.
+
+Pre-extract this 30 LOC was a method on `VoicePipeline` that
+wrapped `_synthesize_and_send` with a `tts_start`-tracking
+bracket so the post-utterance `tts_end` event fires
+correctly.  Now lives as a free function taking the pipeline
+explicitly.
+
+## API
+
+```python
+await speak_system_message(pipeline, "Switching to Local mode.")
+```
+
+The function is a thin functional wrapper around pipeline
+state — it reads `pipeline._tts`, `pipeline._tts_started`,
+`pipeline._tts_total_ms`, `pipeline._on_event` and calls
+`pipeline._synthesize_and_send`.  Tests can mock the pipeline
+attribute surface.
+
+## Bracket invariant (preserved verbatim)
+
+  1. Snapshot `_tts_started` BEFORE the synth.
+  2. Run `_synthesize_and_send(text)` (which may flip
+     `_tts_started` from False → True via its own `tts_start`
+     emit on first sentence).
+  3. After synth (success or failure), if WE were the one
+     who flipped it (`_tts_started AND not prev_started`),
+     emit `tts_end` so Tab5 flushes its ring buffer + clear
+     the flag.
+
+The `not prev_started` check prevents double-`tts_end` when
+speak_system is called mid-utterance (the active utterance's
+caller owns the close).
+
+## Failure isolation
+
+* Synth failure logged at EXCEPTION but NEVER re-raised —
+  callers (e.g. cap_downgrade `speak_system_message`) are
+  fire-and-forget and shouldn't crash on TTS failure.
+* `tts_end` emit failure swallowed (best-effort — the
+  user's already heard the audio; the close-frame is just
+  for ring-buffer hygiene).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def speak_system_message(pipeline: Any, text: str) -> None:
+    """Speak `text` via the pipeline's live TTS path,
+    out-of-band of the conversation turn loop.
+
+    No-op when:
+      * `text` is empty / falsy
+      * `pipeline._tts` is None (TTS not initialised yet)
+
+    Side effects (via the pipeline instance):
+      * Calls `pipeline._synthesize_and_send(text)` which may
+        flip `pipeline._tts_started` from False to True and
+        accumulate `pipeline._tts_total_ms`.
+      * Emits `tts_end` via `pipeline._on_event` IFF this
+        invocation was the one that started the utterance.
+
+    Failures swallowed: this is a fire-and-forget path used
+    by ops alerts (cap downgrade, etc.); a TTS error must NOT
+    propagate up into the caller's coroutine.
+    """
+    if not text or not pipeline._tts:
+        return
+    prev_started = pipeline._tts_started
+    try:
+        await pipeline._synthesize_and_send(text)
+    except Exception:
+        logger.exception("speak_system failed: %s", text[:40])
+    finally:
+        # Close the utterance so Tab5 flushes its ring buffer.
+        # Only emit if WE were the one who started it — prevents
+        # double-tts_end when speak_system fires mid-utterance.
+        if pipeline._tts_started and not prev_started:
+            try:
+                await pipeline._on_event({
+                    "type": "tts_end",
+                    "tts_ms": round(pipeline._tts_total_ms),
+                })
+            except Exception:
+                pass
+            pipeline._tts_started = False

--- a/tests/test_speak_system.py
+++ b/tests/test_speak_system.py
@@ -1,0 +1,183 @@
+"""Tests for ``dragon_voice.speak_system.speak_system_message``.
+
+Pin the bracket invariant (snapshot _tts_started, run synth,
+conditionally emit tts_end), the failure-isolation guarantees,
+and the no-op preconditions.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.speak_system import speak_system_message
+
+
+def _make_pipeline(
+    *,
+    has_tts: bool = True,
+    initial_tts_started: bool = False,
+    initial_tts_total_ms: float = 0.0,
+    synth_starts_tts: bool = True,
+    synth_raises: Exception | None = None,
+) -> SimpleNamespace:
+    """Build a minimal pipeline-shaped stub.
+
+    `synth_starts_tts=True` simulates `_synthesize_and_send`
+    flipping `_tts_started` to True (the typical first-utterance
+    path).  When False, the synth runs without flipping the flag
+    (e.g. mid-utterance call).
+    """
+    pipeline = SimpleNamespace(
+        _tts=MagicMock() if has_tts else None,
+        _tts_started=initial_tts_started,
+        _tts_total_ms=initial_tts_total_ms,
+        _on_event=AsyncMock(),
+    )
+
+    async def _synth(text):
+        if synth_raises:
+            raise synth_raises
+        if synth_starts_tts:
+            pipeline._tts_started = True
+            pipeline._tts_total_ms += 250  # simulate accumulator
+
+    pipeline._synthesize_and_send = AsyncMock(side_effect=_synth)
+    return pipeline
+
+
+# ─── No-op preconditions ────────────────────────────────────
+
+
+class TestNoOps:
+    @pytest.mark.asyncio
+    async def test_empty_text_silent_noop(self):
+        p = _make_pipeline()
+        await speak_system_message(p, "")
+        p._synthesize_and_send.assert_not_awaited()
+        p._on_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_tts_silent_noop(self):
+        """When TTS isn't initialised yet (boot race), skip
+        without crashing."""
+        p = _make_pipeline(has_tts=False)
+        await speak_system_message(p, "alert!")
+        p._synthesize_and_send.assert_not_awaited()
+        p._on_event.assert_not_awaited()
+
+
+# ─── Happy path ─────────────────────────────────────────────
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_synth_called_with_text(self):
+        p = _make_pipeline()
+        await speak_system_message(p, "hello world")
+        p._synthesize_and_send.assert_awaited_once_with("hello world")
+
+    @pytest.mark.asyncio
+    async def test_emits_tts_end_when_we_started_the_utterance(self):
+        """Bracket invariant: synth flipped _tts_started from
+        False → True, so we own the close → emit tts_end + clear."""
+        p = _make_pipeline(synth_starts_tts=True)
+        await speak_system_message(p, "hi")
+        # Pin: tts_end emitted with the accumulated tts_ms
+        p._on_event.assert_awaited_once()
+        ev = p._on_event.await_args.args[0]
+        assert ev["type"] == "tts_end"
+        assert ev["tts_ms"] == 250  # round(250)
+        # Flag cleared so the next utterance starts fresh
+        assert p._tts_started is False
+
+
+# ─── Bracket invariant: prev_started = True (mid-utterance) ──
+
+
+class TestMidUtteranceCall:
+    @pytest.mark.asyncio
+    async def test_does_NOT_emit_tts_end_when_already_started(self):
+        """Pin: speak_system called mid-utterance must NOT emit
+        tts_end — the active utterance's caller owns the close.
+        Without this, double-tts_end would confuse Tab5's
+        ring-buffer state machine."""
+        p = _make_pipeline(initial_tts_started=True)  # mid-utt
+        await speak_system_message(p, "interrupt!")
+        # No tts_end emit (prev_started was True so we didn't
+        # own the open).
+        p._on_event.assert_not_awaited()
+        # _tts_started preserved (caller still owns it)
+        assert p._tts_started is True
+
+
+# ─── Failure isolation ──────────────────────────────────────
+
+
+class TestFailureIsolation:
+    @pytest.mark.asyncio
+    async def test_synth_exception_does_NOT_propagate(self):
+        """Fire-and-forget invariant: a TTS failure during a
+        speak_system call MUST NOT propagate up into the caller's
+        coroutine.  Pin so a future refactor can't drop the
+        try/except."""
+        p = _make_pipeline(synth_raises=RuntimeError("piper crashed"))
+        # Must NOT raise.
+        await speak_system_message(p, "alert")
+
+    @pytest.mark.asyncio
+    async def test_synth_exception_still_runs_finally_emit_when_we_started(self):
+        """Pin: even when synth raises, IF we started the
+        utterance (somehow, mid-failure), the tts_end fires so
+        Tab5's ring buffer flushes.  Pre-extract behaviour."""
+        # Simulate: synth flips _tts_started THEN raises.
+        async def _raises_after_starting(text):
+            p._tts_started = True
+            p._tts_total_ms = 100
+            raise RuntimeError("crashed mid-way")
+
+        p = _make_pipeline()
+        p._synthesize_and_send = AsyncMock(side_effect=_raises_after_starting)
+
+        await speak_system_message(p, "alert")
+
+        # tts_end still fired (finally block ran)
+        p._on_event.assert_awaited_once()
+        assert p._tts_started is False
+
+    @pytest.mark.asyncio
+    async def test_tts_end_emit_failure_swallowed(self):
+        """Best-effort emit: if `_on_event(tts_end)` raises
+        (transport closed mid-stream), swallow at the close
+        bracket — user's already heard the audio."""
+        p = _make_pipeline()
+        p._on_event = AsyncMock(side_effect=RuntimeError("ws closed"))
+
+        # Must NOT raise.
+        await speak_system_message(p, "alert")
+
+        # Flag still cleared even though emit raised
+        assert p._tts_started is False
+
+
+# ─── tts_total_ms rounding ──────────────────────────────────
+
+
+class TestTtsMsRounding:
+    @pytest.mark.asyncio
+    async def test_tts_ms_rounded_to_int(self):
+        """Pin: tts_ms in the WS frame is `round(_tts_total_ms)` —
+        Tab5 expects an int (the caption widget formats as
+        `XX ms`)."""
+        async def _synth(text):
+            p._tts_started = True
+            p._tts_total_ms = 247.6  # fractional ms
+
+        p = _make_pipeline()
+        p._synthesize_and_send = AsyncMock(side_effect=_synth)
+
+        await speak_system_message(p, "x")
+        ev = p._on_event.await_args.args[0]
+        assert ev["tts_ms"] == 248  # rounded
+        assert isinstance(ev["tts_ms"], int)


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **thirty-ninth sub-extract**.  Sixth slice from \`dragon_voice/pipeline.py\` (audit **SRP-4**).

\`speak_system\` lets the server speak a short alert (e.g. budget auto-downgrade — Gauntlet G7-F) out-of-band of the normal STT → LLM → TTS turn loop.  Pre-extract this 28 LOC was a method on \`VoicePipeline\` that wrapped \`_synthesize_and_send\` with a \`tts_start\`-tracking bracket.  Now lives as a free function taking the pipeline explicitly.

### Behaviour preserved verbatim

- No-op when text is empty / falsy
- No-op when \`_tts\` is None (TTS not initialised yet)
- **Bracket invariant**: snapshot \`_tts_started\` BEFORE synth, then emit \`tts_end\` ONLY IF synth flipped it from False → True (we own the close).  Without the prev_started check, speak_system fired mid-utterance would double-tts_end and confuse Tab5's ring-buffer state machine.
- Synth exception swallowed (logged at EXCEPTION) — fire-and-forget invariant
- \`tts_end\` emit failure swallowed (best-effort)
- \`tts_ms\` rounded to int (Tab5 caption widget format)
- When synth raises BUT had already flipped \`_tts_started\`, the finally branch still fires the tts_end (preserves pre-extract crash-mid-utterance behaviour)

### Test coverage

9 new tests across 5 classes spanning no-op preconditions (empty text, no tts), happy path (synth called with text, emits tts_end with rounded tts_ms when we started), mid-utterance call doesn't double-emit, failure isolation (synth exception doesn't propagate, finally still fires when synth raises after flipping flag, tts_end emit failure swallowed), and tts_ms rounding pin.

### Diff stats

| Metric | Before | After |
|---|---|---|
| \`pipeline.py\` LOC | 1616 | 1606 (-10) |
| \`speak_system.py\` | (didn't exist) | 96 (new) |
| **\`pipeline.py\` cumulative SRP-4 across #255-#258 + #264 + #265** | **1733** | **1606 (-7.3%)** |

**SRP-4 in-flight portion fully done** — all 5+ named responsibilities from the audit doc extracted: dictation_post (#255), fallback STT cache (#256), fallback TTS cache (#257), pool-aware swap (#258), token-flush helpers (#264), speak_system bracket (this PR).  What remains in pipeline.py is the irreducibly orchestration \`_process_utterance\` body and the lifecycle methods.

## Test plan

- [x] \`python3 -m pytest tests/test_speak_system.py -v\` → 9 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → **1351 passed**, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)