### PR TITLE
refactor(pipeline): extract voice-path receipt emit (3 sites, ~80 LOC) — closes audit SRP-10

### DIFF
--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -847,23 +847,17 @@ class VoicePipeline:
             logger.info("STT (%.0fms): %s", stt_ms, transcript)
             await self._on_event({"type": "stt", "text": transcript, "stt_ms": round(stt_ms)})
 
-            # Audit F4 (2026-04-20): emit STT receipt so Tab5's per-turn
-            # transparency + budget tracker can see which STT backend ran
-            # and how long it took.  Cost_mils=0 for local Moonshine;
-            # OpenRouter STT cost would need per-audio-second pricing
-            # which the STT class doesn't currently expose — stub at 0
-            # and let the cloud-STT path surface its own charge later.
-            try:
-                _stt_backend = self._config.stt.backend or "stt"
-                await self._on_event({
-                    "type": "receipt",
-                    "stage": "stt",
-                    "model": _stt_backend,
-                    "stt_ms": round(stt_ms),
-                    "cost_mils": 0,
-                })
-            except Exception as _e:
-                logger.debug("STT receipt emit failed: %s", _e)
+            # SOLID-audit follow-up (PR #266 / SRP-10): STT
+            # receipt emit extracted to
+            # voice_path_receipt.emit_voice_path_stt_receipt.
+            from dragon_voice.voice_path_receipt import (
+                emit_voice_path_stt_receipt,
+            )
+            await emit_voice_path_stt_receipt(
+                self._on_event,
+                stt_backend=self._config.stt.backend,
+                stt_ms=stt_ms,
+            )
 
             if self._cancelled:
                 return
@@ -1106,60 +1100,16 @@ class VoicePipeline:
             logger.info("LLM (%.0fms): %s", llm_ms, full_response[:80])
             await self._on_event({"type": "llm_done", "llm_ms": round(llm_ms)})
 
-            # Phase 3 per-turn receipt. Only emit when the LLM is the
-            # OpenRouter backend (it's the only backend where we can
-            # charge real money); local (ollama, npu_genie) turns are
-            # free and don't need a receipt.  If the LLM exposes
-            # get_last_usage() we compute cost from the pricing table.
-            try:
-                # Wave 21b (#204): isinstance(SupportsUsage) over hasattr.
-                if isinstance(self._llm, SupportsUsage):
-                    usage = self._llm.get_last_usage()
-                    if usage and usage.get("total_tokens"):
-                        from dragon_voice.llm.openrouter_llm import price_for_model
-                        cost_mils = price_for_model(
-                            usage["model"],
-                            usage.get("prompt_tokens", 0),
-                            usage.get("completion_tokens", 0),
-                        )
-                        await self._on_event({
-                            "type": "receipt",
-                            "stage": "llm",
-                            "model": usage["model"],
-                            "prompt_tokens":     usage.get("prompt_tokens", 0),
-                            "completion_tokens": usage.get("completion_tokens", 0),
-                            "total_tokens":      usage.get("total_tokens", 0),
-                            "cost_mils":         cost_mils,
-                            "llm_ms":            round(llm_ms),
-                            # v4·D Gauntlet G2: surface retries so the chat
-                            # bubble can stamp a "retried" chip instead of
-                            # silently presenting a possibly-degraded reply.
-                            "retried":           bool(usage.get("retried", False)),
-                            "retry_reason":      usage.get("retry_reason", ""),
-                        })
-            except Exception as e:
-                # Never let receipt emission break the turn.  v4·D audit
-                # P0 fix: emit a MINIMAL receipt even when the usage-
-                # based path failed so the Tab5 chat bubble still gets a
-                # stamp and the day-budget accumulator still increments
-                # by 0 (harmless but consistent).
-                logger.warning("Receipt emit failed: %s -- emitting fallback", e)
-                try:
-                    fallback_model = getattr(self._llm, "name", "") or "llm"
-                    await self._on_event({
-                        "type": "receipt",
-                        "stage": "llm",
-                        "model": fallback_model,
-                        "prompt_tokens": 0,
-                        "completion_tokens": 0,
-                        "total_tokens": 0,
-                        "cost_mils": 0,
-                        "llm_ms": round(llm_ms) if isinstance(llm_ms, (int, float)) else 0,
-                        "retried": False,
-                        "retry_reason": "receipt-fallback: " + type(e).__name__,
-                    })
-                except Exception:
-                    logger.debug("fallback receipt also failed", exc_info=True)
+            # SOLID-audit follow-up (PR #266 / SRP-10): LLM
+            # receipt emit (Phase 3 per-turn + v4·D audit P0
+            # fallback) extracted to
+            # voice_path_receipt.emit_voice_path_llm_receipt.
+            from dragon_voice.voice_path_receipt import (
+                emit_voice_path_llm_receipt,
+            )
+            await emit_voice_path_llm_receipt(
+                self._on_event, llm=self._llm, llm_ms=llm_ms,
+            )
 
             # Rich media detection on full response.
             # Audit D4 (#137): emit progress before render — voice path
@@ -1189,22 +1139,17 @@ class VoicePipeline:
                 })
                 self._tts_started = False
 
-            # Audit F5 (2026-04-20): emit TTS receipt so per-turn chat
-            # bubbles can stamp the speech backend + time.  cost_mils=0
-            # for local Piper; OpenRouter TTS cost left at 0 (same
-            # rationale as the STT receipt).
-            if self._tts_total_ms > 0:
-                try:
-                    _tts_backend = self._config.tts.backend or "tts"
-                    await self._on_event({
-                        "type": "receipt",
-                        "stage": "tts",
-                        "model": _tts_backend,
-                        "tts_ms": round(self._tts_total_ms),
-                        "cost_mils": 0,
-                    })
-                except Exception as _e:
-                    logger.debug("TTS receipt emit failed: %s", _e)
+            # SOLID-audit follow-up (PR #266 / SRP-10): TTS
+            # receipt emit extracted to
+            # voice_path_receipt.emit_voice_path_tts_receipt.
+            from dragon_voice.voice_path_receipt import (
+                emit_voice_path_tts_receipt,
+            )
+            await emit_voice_path_tts_receipt(
+                self._on_event,
+                tts_backend=self._config.tts.backend,
+                tts_total_ms=self._tts_total_ms,
+            )
 
             # Trim in-memory history on legacy path only.
             # Wave 21b (#204): isinstance(SupportsHistoryTrim) over hasattr.

--- a/dragon_voice/voice_path_receipt.py
+++ b/dragon_voice/voice_path_receipt.py
@@ -1,0 +1,216 @@
+"""Per-turn `receipt` emission for the voice-path STT → LLM → TTS chain.
+
+Wave 23 SOLID-audit follow-up — fortieth sub-extract.  Closes
+audit SRP-10 (receipt emission was scattered across 3 inline
+sites in `pipeline.py` plus the text-path equivalent
+`text_path_receipt.py` from PR #229).
+
+Three receipt frames fire over a voice-path turn:
+
+  * **STT receipt** (audit F4, 2026-04-20) — after `stt`
+    transcript event lands.  Stamps which STT backend ran +
+    how long it took.  cost_mils=0 today (local Moonshine
+    + cloud STT-cost-per-second TBD).
+  * **LLM receipt** (Phase 3 per-turn) — after `llm_done`.
+    Pulls token counts + cost from `SupportsUsage` backends
+    (OpenRouter); falls back to a minimal receipt with
+    cost_mils=0 when the usage path fails.  Includes the
+    Gauntlet G2 retry surface fields.
+  * **TTS receipt** (audit F5, 2026-04-20) — after `tts_end`.
+    Stamps speech backend + accumulated tts_ms.
+
+This module owns all three so future receipt-shape changes
+(adding new fields, switching to cents-based pricing, etc.)
+happen in one place.
+
+## API
+
+```python
+await emit_voice_path_stt_receipt(
+    on_event,
+    stt_backend=conn_config.stt.backend,
+    stt_ms=stt_ms,
+)
+
+await emit_voice_path_llm_receipt(
+    on_event,
+    llm=self._llm,
+    llm_ms=llm_ms,
+)
+
+await emit_voice_path_tts_receipt(
+    on_event,
+    tts_backend=conn_config.tts.backend,
+    tts_total_ms=self._tts_total_ms,
+)
+```
+
+All three are failure-isolated: emit exceptions logged at
+DEBUG (the receipt is informational, not session-correctness)
+and never propagate.
+
+## v4·D audit P0 fallback (LLM receipt)
+
+The LLM receipt has a fallback path: if the usage-based emit
+fails (corrupt usage dict, pricing-table miss), emit a MINIMAL
+receipt with cost_mils=0 so the chat bubble still gets a
+stamp + the day-budget accumulator increments by 0
+(harmless but consistent).  Pre-extract this fallback was
+the difference between "missing receipt → no bubble stamp"
+and "stamped 0 → bubble shows".
+
+## SupportsUsage gate (Wave 21b #204)
+
+`isinstance(SupportsUsage)` over `hasattr` — backends like
+`dual` or `tinkerclaw` that don't implement the protocol but
+expose `get_last_usage` via `__getattr__` accidentally would
+have silently emitted `model='llm'` and skewed cost
+attribution.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+
+OnEvent = Callable[[dict], Awaitable[None]]
+
+
+async def emit_voice_path_stt_receipt(
+    on_event: OnEvent,
+    *,
+    stt_backend: str,
+    stt_ms: float,
+) -> None:
+    """Emit the per-turn STT receipt.  Audit F4 (2026-04-20):
+    Tab5's per-turn transparency + budget tracker can see which
+    STT backend ran and how long it took.
+
+    cost_mils=0 today.  Local Moonshine is free; OpenRouter STT
+    cost would need per-audio-second pricing which the STT
+    class doesn't currently expose — stub at 0 and let the
+    cloud-STT path surface its own charge later.
+
+    Failure isolation: emit exceptions logged at DEBUG.
+    """
+    try:
+        await on_event({
+            "type": "receipt",
+            "stage": "stt",
+            "model": stt_backend or "stt",
+            "stt_ms": round(stt_ms),
+            "cost_mils": 0,
+        })
+    except Exception as e:
+        logger.debug("STT receipt emit failed: %s", e)
+
+
+async def emit_voice_path_llm_receipt(
+    on_event: OnEvent,
+    *,
+    llm: Any,
+    llm_ms: float,
+) -> None:
+    """Emit the per-turn LLM receipt for the voice path.
+
+    Two-path emit:
+
+      1. **Usage-based** (Wave 21b #204 — only fires when the
+         backend implements ``SupportsUsage`` AND has a non-
+         zero ``total_tokens`` in last_usage).  Computes cost
+         via ``price_for_model`` and surfaces token counts +
+         retry-status fields (Gauntlet G2).
+
+      2. **Fallback** (v4·D audit P0) — fires when the usage-
+         based path fails.  Minimal receipt with cost_mils=0
+         + zero token counts so the chat bubble still gets a
+         stamp.  retry_reason field encodes the fallback
+         reason as ``"receipt-fallback: <ExcClass>"`` for ops
+         triage.
+
+    Both paths swallow exceptions at the outer level so a
+    receipt failure can't break the turn.
+    """
+    try:
+        # Wave 21b (#204): isinstance(SupportsUsage) over hasattr.
+        from dragon_voice.llm.base import SupportsUsage
+        if not isinstance(llm, SupportsUsage):
+            return
+
+        usage = llm.get_last_usage()
+        if not usage or not usage.get("total_tokens"):
+            return
+
+        from dragon_voice.llm.openrouter_llm import price_for_model
+        cost_mils = price_for_model(
+            usage["model"],
+            usage.get("prompt_tokens", 0),
+            usage.get("completion_tokens", 0),
+        )
+        await on_event({
+            "type": "receipt",
+            "stage": "llm",
+            "model": usage["model"],
+            "prompt_tokens":     usage.get("prompt_tokens", 0),
+            "completion_tokens": usage.get("completion_tokens", 0),
+            "total_tokens":      usage.get("total_tokens", 0),
+            "cost_mils":         cost_mils,
+            "llm_ms":            round(llm_ms),
+            # v4·D Gauntlet G2: surface retries so the chat
+            # bubble can stamp a "retried" chip instead of
+            # silently presenting a possibly-degraded reply.
+            "retried":           bool(usage.get("retried", False)),
+            "retry_reason":      usage.get("retry_reason", ""),
+        })
+    except Exception as e:
+        # v4·D audit P0 fallback: emit a minimal receipt so the
+        # chat bubble still gets a stamp + the day-budget
+        # accumulator stays consistent (increments by 0).
+        logger.warning("Receipt emit failed: %s -- emitting fallback", e)
+        try:
+            fallback_model = getattr(llm, "name", "") or "llm"
+            await on_event({
+                "type": "receipt",
+                "stage": "llm",
+                "model": fallback_model,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0,
+                "cost_mils": 0,
+                "llm_ms": round(llm_ms) if isinstance(llm_ms, (int, float)) else 0,
+                "retried": False,
+                "retry_reason": "receipt-fallback: " + type(e).__name__,
+            })
+        except Exception:
+            logger.debug("fallback receipt also failed", exc_info=True)
+
+
+async def emit_voice_path_tts_receipt(
+    on_event: OnEvent,
+    *,
+    tts_backend: str,
+    tts_total_ms: float,
+) -> None:
+    """Emit the per-turn TTS receipt.  Audit F5 (2026-04-20):
+    per-turn chat bubbles stamp the speech backend + time.
+
+    No-op when ``tts_total_ms <= 0`` (no audio actually
+    synthesised this turn — silence reply or cancelled).
+
+    cost_mils=0 today.  Local Piper is free; OpenRouter TTS
+    cost left at 0 (same rationale as the STT receipt).
+    """
+    if tts_total_ms <= 0:
+        return
+    try:
+        await on_event({
+            "type": "receipt",
+            "stage": "tts",
+            "model": tts_backend or "tts",
+            "tts_ms": round(tts_total_ms),
+            "cost_mils": 0,
+        })
+    except Exception as e:
+        logger.debug("TTS receipt emit failed: %s", e)

--- a/tests/test_voice_path_receipt.py
+++ b/tests/test_voice_path_receipt.py
@@ -1,0 +1,261 @@
+"""Tests for ``dragon_voice.voice_path_receipt``.
+
+Pin every receipt-emit branch + the v4·D audit P0 fallback +
+the SupportsUsage gate (Wave 21b #204) so a future refactor
+can't regress the receipt shape that Tab5 chat bubbles +
+day-budget accumulator depend on.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dragon_voice.voice_path_receipt import (
+    emit_voice_path_llm_receipt,
+    emit_voice_path_stt_receipt,
+    emit_voice_path_tts_receipt,
+)
+
+
+def _make_on_event() -> AsyncMock:
+    return AsyncMock()
+
+
+def _last_payload(on_event: AsyncMock) -> dict:
+    return on_event.await_args.args[0]
+
+
+# ─── STT receipt ────────────────────────────────────────────
+
+
+class TestSttReceipt:
+    @pytest.mark.asyncio
+    async def test_emits_stage_stt_with_backend_and_ms(self):
+        on_event = _make_on_event()
+        await emit_voice_path_stt_receipt(
+            on_event, stt_backend="moonshine", stt_ms=423.7,
+        )
+        p = _last_payload(on_event)
+        assert p["type"] == "receipt"
+        assert p["stage"] == "stt"
+        assert p["model"] == "moonshine"
+        assert p["stt_ms"] == 424  # rounded
+        assert p["cost_mils"] == 0  # no per-second cost yet
+
+    @pytest.mark.asyncio
+    async def test_empty_backend_falls_back_to_string_stt(self):
+        on_event = _make_on_event()
+        await emit_voice_path_stt_receipt(
+            on_event, stt_backend="", stt_ms=10,
+        )
+        assert _last_payload(on_event)["model"] == "stt"
+
+    @pytest.mark.asyncio
+    async def test_emit_failure_swallowed(self):
+        on_event = AsyncMock(side_effect=ConnectionResetError("dead"))
+        # Must NOT raise.
+        await emit_voice_path_stt_receipt(
+            on_event, stt_backend="moonshine", stt_ms=10,
+        )
+
+
+# ─── LLM receipt ────────────────────────────────────────────
+
+
+def _make_supports_usage_llm(usage: dict) -> MagicMock:
+    """Build an LLM that satisfies the SupportsUsage protocol
+    by exposing get_last_usage as a real method."""
+    from dragon_voice.llm.base import SupportsUsage
+
+    class _Backend:
+        name = "test_llm"
+
+        def get_last_usage(self) -> dict:
+            return usage
+
+    inst = _Backend()
+    assert isinstance(inst, SupportsUsage)
+    return inst
+
+
+class TestLlmReceipt:
+    @pytest.mark.asyncio
+    async def test_no_supports_usage_skips(self):
+        """Backends like `dual` or `tinkerclaw` that don't
+        implement SupportsUsage MUST be silently skipped (Wave
+        21b #204 closure pin)."""
+        on_event = _make_on_event()
+        plain = MagicMock(spec=[])  # no get_last_usage at all
+        await emit_voice_path_llm_receipt(
+            on_event, llm=plain, llm_ms=100,
+        )
+        on_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_zero_total_tokens_skips(self):
+        llm = _make_supports_usage_llm({
+            "model": "anthropic/claude-haiku-4.5",
+            "total_tokens": 0,
+        })
+        on_event = _make_on_event()
+        await emit_voice_path_llm_receipt(
+            on_event, llm=llm, llm_ms=100,
+        )
+        on_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_happy_path_full_receipt(self):
+        llm = _make_supports_usage_llm({
+            "model": "anthropic/claude-haiku-4.5",
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+        })
+        on_event = _make_on_event()
+        await emit_voice_path_llm_receipt(
+            on_event, llm=llm, llm_ms=2500,
+        )
+        p = _last_payload(on_event)
+        assert p["type"] == "receipt"
+        assert p["stage"] == "llm"
+        assert p["model"] == "anthropic/claude-haiku-4.5"
+        assert p["prompt_tokens"] == 100
+        assert p["completion_tokens"] == 50
+        assert p["total_tokens"] == 150
+        assert p["cost_mils"] > 0  # haiku has real pricing
+        assert p["llm_ms"] == 2500
+        assert p["retried"] is False
+        assert p["retry_reason"] == ""
+
+    @pytest.mark.asyncio
+    async def test_retried_field_surfaced(self):
+        """v4·D Gauntlet G2: when usage carries retried=True
+        the receipt MUST surface it so Tab5 can stamp a
+        'RETRIED' chip."""
+        llm = _make_supports_usage_llm({
+            "model": "anthropic/claude-sonnet-4.6",
+            "prompt_tokens": 200,
+            "completion_tokens": 100,
+            "total_tokens": 300,
+            "retried": True,
+            "retry_reason": "context_trim",
+        })
+        on_event = _make_on_event()
+        await emit_voice_path_llm_receipt(
+            on_event, llm=llm, llm_ms=4000,
+        )
+        p = _last_payload(on_event)
+        assert p["retried"] is True
+        assert p["retry_reason"] == "context_trim"
+
+    @pytest.mark.asyncio
+    async def test_v4d_audit_p0_fallback_on_pricing_failure(self):
+        """v4·D audit P0 closure: when the usage-based emit
+        fails (corrupt usage, pricing-table miss), MUST emit a
+        MINIMAL receipt with cost_mils=0 + zero token counts so
+        the chat bubble still gets a stamp + the day-budget
+        accumulator stays consistent."""
+        llm = _make_supports_usage_llm({
+            "model": "unknown/model-not-in-pricing",
+            "total_tokens": 10,
+        })
+        on_event = _make_on_event()
+
+        # Simulate price_for_model raising — exercises the
+        # except-branch fallback emit.
+        with patch(
+            "dragon_voice.llm.openrouter_llm.price_for_model",
+            side_effect=KeyError("unknown model"),
+        ):
+            await emit_voice_path_llm_receipt(
+                on_event, llm=llm, llm_ms=1000,
+            )
+
+        # Fallback receipt fired with zero tokens + cost
+        p = _last_payload(on_event)
+        assert p["type"] == "receipt"
+        assert p["stage"] == "llm"
+        assert p["model"] == "test_llm"  # llm.name fallback
+        assert p["prompt_tokens"] == 0
+        assert p["completion_tokens"] == 0
+        assert p["total_tokens"] == 0
+        assert p["cost_mils"] == 0
+        assert p["llm_ms"] == 1000
+        assert p["retried"] is False
+        # Encodes the failure cause for ops triage
+        assert p["retry_reason"].startswith("receipt-fallback: KeyError")
+
+    @pytest.mark.asyncio
+    async def test_double_failure_swallowed(self):
+        """If even the fallback emit raises, log at DEBUG and
+        return — never propagate."""
+        llm = _make_supports_usage_llm({
+            "model": "x", "total_tokens": 1,
+        })
+
+        # First emit (usage path) AND second emit (fallback)
+        # both raise.
+        on_event = AsyncMock(side_effect=RuntimeError("dead"))
+
+        with patch(
+            "dragon_voice.llm.openrouter_llm.price_for_model",
+            side_effect=KeyError("miss"),
+        ):
+            # Must NOT raise.
+            await emit_voice_path_llm_receipt(
+                on_event, llm=llm, llm_ms=10,
+            )
+
+
+# ─── TTS receipt ────────────────────────────────────────────
+
+
+class TestTtsReceipt:
+    @pytest.mark.asyncio
+    async def test_emits_stage_tts_with_backend_and_ms(self):
+        on_event = _make_on_event()
+        await emit_voice_path_tts_receipt(
+            on_event, tts_backend="piper", tts_total_ms=850.3,
+        )
+        p = _last_payload(on_event)
+        assert p["type"] == "receipt"
+        assert p["stage"] == "tts"
+        assert p["model"] == "piper"
+        assert p["tts_ms"] == 850
+        assert p["cost_mils"] == 0
+
+    @pytest.mark.asyncio
+    async def test_zero_tts_ms_is_noop(self):
+        """Pin: no audio synthesised this turn (silence reply
+        or cancelled mid-stream) → no receipt fires."""
+        on_event = _make_on_event()
+        await emit_voice_path_tts_receipt(
+            on_event, tts_backend="piper", tts_total_ms=0,
+        )
+        on_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_negative_tts_ms_is_noop(self):
+        """Defensive: pathological negative timing → silent skip."""
+        on_event = _make_on_event()
+        await emit_voice_path_tts_receipt(
+            on_event, tts_backend="piper", tts_total_ms=-5,
+        )
+        on_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_empty_backend_falls_back_to_string_tts(self):
+        on_event = _make_on_event()
+        await emit_voice_path_tts_receipt(
+            on_event, tts_backend="", tts_total_ms=100,
+        )
+        assert _last_payload(on_event)["model"] == "tts"
+
+    @pytest.mark.asyncio
+    async def test_emit_failure_swallowed(self):
+        on_event = AsyncMock(side_effect=ConnectionResetError("dead"))
+        # Must NOT raise.
+        await emit_voice_path_tts_receipt(
+            on_event, tts_backend="piper", tts_total_ms=100,
+        )


### PR DESCRIPTION
## Summary

Wave 23 SOLID-audit follow-up — **fortieth sub-extract**. **Closes audit SRP-10** (receipt emission was scattered across 3 inline sites in pipeline.py + the text-path equivalent text_path_receipt.py from PR #229).

Three receipt frames fire over a voice-path turn:
- **STT receipt** (audit F4) — after \`stt\` transcript event
- **LLM receipt** (Phase 3 per-turn) — after \`llm_done\`, with v4·D audit P0 fallback
- **TTS receipt** (audit F5) — after \`tts_end\`, only when audio synthesised

All three extracted to free functions in \`dragon_voice/voice_path_receipt.py\`.  Pipeline forwards via 3 thin call sites.

### Behaviour preserved verbatim

- STT receipt: stage='stt', backend-or-'stt' fallback, rounded ms, cost_mils=0
- LLM receipt: SupportsUsage gate (Wave 21b #204), pricing via price_for_model, Gauntlet G2 retried/retry_reason
- **LLM receipt v4·D audit P0 fallback**: when usage-based emit fails, MINIMAL receipt with cost_mils=0 + zero token counts so chat bubble still gets a stamp + day-budget stays consistent.  retry_reason encodes failure cause as \`receipt-fallback: <ExcClass>\` for ops triage
- TTS receipt: stage='tts', tts_total_ms<=0 silently skipped
- All three swallow emit exceptions (DEBUG log; never break the turn)

### E2E verification (live Dragon)

- Full sync deployed to Dragon (192.168.1.91); service restarted active; Tab5 (30eda0ea8e33) reconnected cleanly
- \`/api/v1/devices\`, \`/api/v1/sessions\`, \`/api/v1/events\`, \`/api/v1/agent_log\` all responding with expected shapes
- \`/api/v1/completions\` round-trip exercised the LLM stack
- SSE chat stream confirmed ConversationEngine + new pipeline modules work end-to-end
- Zero errors in \`journalctl -u tinkerclaw-voice\` since restart

### Test coverage

14 new tests across 3 classes:
- STT receipt: full payload, empty-backend fallback, emit-failure swallow
- LLM receipt: no-SupportsUsage skip, zero-tokens skip, happy path, Gauntlet G2 retried surface, audit-P0 fallback, double-failure swallow
- TTS receipt: full payload, zero-ms noop, negative-ms defensive, empty-backend fallback, emit-failure swallow

### Diff stats

| Metric | Before | After |
|---|---|---|
| \`pipeline.py\` LOC | 1606 | 1551 (-55) |
| \`voice_path_receipt.py\` | (didn't exist) | 196 (new) |
| **\`pipeline.py\` cumulative SRP-4 across #255-#258 + #264-#266** | **1733** | **1551 (-10.5%)** |

**SRP-10 fully closed** (text-path receipt #229 + voice-path receipt this PR).

## Test plan

- [x] \`python3 -m pytest tests/test_voice_path_receipt.py -v\` → 14 passed
- [x] \`python3 -m pytest tests/ --ignore=tests/audit -q\` → **1365 passed**, 1 skipped, 108 subtests passed
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/\` → All checks passed
- [x] **Live Dragon E2E**: full sync, service restart, Tab5 reconnect, REST round-trips, SSE chat, journalctl clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)