### PR TITLE
fix(stt-fallback): skip prewarm when moonshine.ai download endpoint is dead

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,12 +74,13 @@ If you touched middleware, run `test_auth_middleware` + `test_security_headers` 
 A file is too big when it has more than one *reason to change*.  Before extracting, answer: "what stakeholder cares about the code I'm moving?"  If it's the same stakeholder as the rest of the file, don't extract yet.  Good candidates: middleware (ops/security), debug endpoints (dev/diagnostics), lifecycle (ops/reliability), business endpoints (product).
 
 ## Dragon Access
-- **Host:** 192.168.1.91 (static IP on LAN)
+- **Host (current 2026-05-04):** `192.168.70.242` (LAN flips between `192.168.1.x` and `192.168.70.x` — historic IP `192.168.1.91` was valid on the .1.x LAN; verify with `ping radxa-dragon-q6a` or `nmap -p 22,3502,18789 --open <subnet>/24`)
+- **Hostname:** `radxa-dragon-q6a` (nmap reverse DNS)
 - **User:** radxa
-- **Password:** `<DRAGON_SSH_PASSWORD>`
-- **SSH:** `ssh radxa@192.168.1.91  # password in ~/.ssh/config or use key auth`
+- **Password:** `<DRAGON_SSH_PASSWORD>` (passes via `sshpass -p '<pw>'`; sudo on Dragon is currently passwordless after SSH login)
+- **SSH:** `ssh radxa@192.168.70.242  # or whatever the current LAN IP is`
 - **OS:** Ubuntu (Dragon Q6A — Qualcomm QCS6490, ARM64)
-- **Connection:** Ethernet only (WiFi disabled). Static IP on enp1s0.
+- **Connection:** Ethernet, DHCP-managed via enp1s0 (was documented as static — empirically the IP rotates between LANs, so treat as DHCP).
 - **Services stripped:** gdm3, snapd, nanobot, rustdesk, fwupd masked.  Active services: tinkerclaw-voice, tinkerclaw-dashboard, tinkerclaw-ngrok, **ollama** (active for embeddings + Local-mode LLM inference; was previously masked but unmasked when the multi-model router landed in #185).
 
 ## Service Map
@@ -99,12 +100,12 @@ A file is too big when it has more than one *reason to change*.  Before extracti
 ## Deploy
 ```bash
 # Sync code to Dragon (includes new STT/TTS backends + notes module)
-scp -r dragon_voice/ radxa@192.168.1.91:/home/radxa/
-scp dashboard.py radxa@192.168.1.91:/home/radxa/
-scp schema.sql radxa@192.168.1.91:/home/radxa/
+scp -r dragon_voice/ radxa@192.168.70.242:/home/radxa/
+scp dashboard.py radxa@192.168.70.242:/home/radxa/
+scp schema.sql radxa@192.168.70.242:/home/radxa/
 
 # Restart services
-ssh radxa@192.168.1.91 "sudo systemctl restart tinkerclaw-voice"
+ssh radxa@192.168.70.242 "sudo systemctl restart tinkerclaw-voice"
 ```
 
 ### Post-Deploy Checklist
@@ -763,6 +764,6 @@ Aggregate pytest run (excluding `tests/audit/` which needs pytest-asyncio): **55
 
 Run tests against a live Dragon instance:
 ```bash
-# From workstation (Dragon must be running on 192.168.1.91:3502)
+# From workstation (Dragon must be running on 192.168.70.242:3502 — see Dragon Access for current IP)
 python3 tests/test_api_e2e.py
 ```

--- a/dragon_voice/fallback_stt_cache.py
+++ b/dragon_voice/fallback_stt_cache.py
@@ -96,6 +96,14 @@ class FallbackSttCache:
         if self._prewarm_task is not None and not self._prewarm_task.done():
             return
 
+        # download.moonshine.ai returns 404 for all models since 2026-05.
+        # Tiny was never cached locally; medium-only path works because the
+        # cache predates the URL outage. Skip prewarm to avoid log spam;
+        # the lazy path in transcribe() will surface a clear error if
+        # ever invoked.
+        logger.info('Fallback STT prewarm skipped (moonshine.ai download endpoint dead; medium-only operation)')
+        return
+
         async def _prewarm() -> None:
             try:
                 from dragon_voice.config import STTConfig


### PR DESCRIPTION
## Summary
- `download.moonshine.ai/model/<X>/quantized` returns 404 for all model sizes since ~2026-05
- B6 fallback-STT prewarm was logging the full 404 traceback on every voice startup + every cloud-mode swap (~10 noisy lines per cycle)
- Switch the prewarm to a single info line + early return; medium-only operation unchanged (already cached)
- Lazy path in `transcribe()` is left intact — if primary STT ever fails, the actual request surfaces the error instead of silent prewarm spam masking it

## Why this fix vs. fixing the URL
- HuggingFace mirror (`huggingface.co/UsefulSensors/moonshine`) only ships `.onnx` files; moonshine-voice runtime expects `.ort` (ONNX-Runtime serialized) — different format, can't symlink
- `download.moonshine.ai` itself returns 404 even for the `medium` model, so any URL pin against that origin is dead too
- Real long-term fix (convert `.onnx` → `.ort`, or pin a different mirror, or use `whisper_cpp` as fallback) is a separate session

## Test plan
- [x] Verified live on Dragon (Radxa Q6A): `sudo systemctl restart tinkerclaw-voice` 2026-05-07 13:12 — no Moonshine 404 spam in startup log; medium STT model still loads fine and live calls work
- [x] Audit confirmed: voice startup logs show only the new info line; pipeline status unchanged (mode 0 LOCAL still uses Moonshine medium + Ollama)

🤖 Generated with [Claude Code](https://claude.com/claude-code)