### PR TITLE
feat(api): POST /api/v1/sessions/{id}/messages — foundation for W3-C cross-mode message store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,4 +123,7 @@ jobs:
             tests/test_missing_key_gamma_arch.py \
             tests/test_d_tier_polish.py \
             tests/test_turn_gate.py \
-            tests/test_short_utterance_signal.py
+            tests/test_short_utterance_signal.py \
+            tests/test_voice_modes.py \
+            tests/test_config_swap.py \
+            tests/test_api_messages_post.py

--- a/dragon_voice/api/messages.py
+++ b/dragon_voice/api/messages.py
@@ -28,6 +28,10 @@ class MessageRoutes:
         # Sprint 1: new endpoints
         app.router.add_get("/api/v1/messages/{message_id}", self.get_message)
         app.router.add_delete("/api/v1/sessions/{session_id}/messages", self.delete_messages)
+        # Wave 3-C-a (cross-stack cohesion audit 2026-05-11): Tab5
+        # POSTs SOLO/K144 turn pairs here so Dragon becomes the
+        # canonical chat-message store across all 6 voice modes.
+        app.router.add_post("/api/v1/sessions/{session_id}/messages", self.add_message)
 
     async def list_messages(self, request: web.Request) -> web.Response:
         """GET /api/v1/sessions/{session_id}/messages"""
@@ -99,3 +103,80 @@ class MessageRoutes:
             return json_error("Session not found", 404)
         deleted = await self._db.delete_messages(session_id)
         return web.json_response({"status": "purged", "session_id": session_id, "deleted_count": deleted})
+
+    # ── Wave 3-C-a ──
+
+    _ALLOWED_ROLES = ("user", "assistant", "system", "tool")
+    _ALLOWED_INPUT_MODES = ("text", "voice", "system")
+
+    async def add_message(self, request: web.Request) -> web.Response:
+        """POST /api/v1/sessions/{session_id}/messages — append a turn.
+
+        Wave 3-C-a (cross-stack cohesion audit 2026-05-11).  Tab5 POSTs
+        SOLO and ONBOARD turn pairs here so the messages DB is the
+        canonical chat log across all 6 voice modes.
+
+        Body (JSON):
+            role      : "user" | "assistant" | "system" | "tool"  (required)
+            content   : str                                       (required)
+            input_mode: "text" | "voice" | "system"               (default "text")
+            model     : str | null                                (optional)
+            token_count    : int | null                           (optional)
+            latency_ms     : float | null                         (optional)
+            audio_duration_s : float | null                       (optional)
+            interrupted    : bool                                 (default false)
+            media_id  : str | null                                (optional, multimodal)
+
+        Returns 201 + the created message row.  404 if session not
+        found.  400 on validation failure.
+        """
+        session_id = request.match_info["session_id"]
+        session = await self._session_mgr.get_session(session_id)
+        if not session:
+            return json_error("Session not found", 404)
+
+        try:
+            body = await request.json()
+        except Exception:
+            return json_error("Invalid JSON body")
+        if not isinstance(body, dict):
+            return json_error("Body must be a JSON object")
+
+        role = body.get("role")
+        if role not in self._ALLOWED_ROLES:
+            return json_error(
+                f"'role' must be one of {self._ALLOWED_ROLES}; got {role!r}"
+            )
+
+        content = body.get("content")
+        if not isinstance(content, str) or content == "":
+            # Allow empty-content turns through MessageStore directly
+            # only via the WS path (assistant placeholder bubbles); REST
+            # callers always have real content because they're posting
+            # after the turn completes.
+            return json_error("'content' must be a non-empty string")
+
+        input_mode = body.get("input_mode", "text")
+        if input_mode not in self._ALLOWED_INPUT_MODES:
+            return json_error(
+                f"'input_mode' must be one of {self._ALLOWED_INPUT_MODES}; got {input_mode!r}"
+            )
+
+        try:
+            msg = await self._messages.add_message(
+                session_id=session_id,
+                role=role,
+                content=content,
+                input_mode=input_mode,
+                interrupted=bool(body.get("interrupted", False)),
+                audio_duration_s=body.get("audio_duration_s"),
+                token_count=body.get("token_count"),
+                model=body.get("model"),
+                latency_ms=body.get("latency_ms"),
+                media_id=body.get("media_id"),
+            )
+        except Exception as e:
+            logger.exception("add_message failed for session %s", session_id)
+            return json_error(f"Failed to add message: {e}", 500)
+
+        return web.json_response(msg, status=201)

--- a/tests/test_api_messages_post.py
+++ b/tests/test_api_messages_post.py
@@ -1,0 +1,245 @@
+"""REST API tests for the W3-C-a add-message POST endpoint.
+
+Wave 3-C-a (cross-stack cohesion audit 2026-05-11).  Tab5 POSTs SOLO
+and ONBOARD turn pairs to ``POST /api/v1/sessions/{session_id}/messages``
+so the Dragon DB becomes the canonical chat-message store across all
+six voice modes.
+
+Pattern matches ``tests/test_scheduler_api.py`` — real aiohttp
+TestServer/TestClient + stub managers so we can assert HTTP status,
+content-type, and body shape end-to-end.
+
+Coverage (one test per branch):
+
+  * happy path → 201 + full message dict
+  * unknown session → 404
+  * malformed JSON body → 400
+  * non-object body → 400
+  * missing role → 400
+  * unknown role → 400
+  * missing content → 400
+  * empty content → 400
+  * unknown input_mode → 400
+  * optional fields (model, latency_ms, token_count) → forwarded to store
+  * MessageStore raises → 500 with error body
+"""
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from dragon_voice.api.messages import MessageRoutes
+
+
+def _build_app(*, session_exists: bool = True, add_raises: bool = False) -> tuple[web.Application, MagicMock, AsyncMock]:
+    """Wire MessageRoutes against stub Database / SessionManager / MessageStore."""
+    db = MagicMock()
+    session_mgr = MagicMock()
+    if session_exists:
+        session_mgr.get_session = AsyncMock(return_value={"id": "sess_test"})
+    else:
+        session_mgr.get_session = AsyncMock(return_value=None)
+    message_store = MagicMock()
+    if add_raises:
+        message_store.add_message = AsyncMock(side_effect=RuntimeError("db is on fire"))
+    else:
+        message_store.add_message = AsyncMock(side_effect=lambda **kwargs: {
+            "id": "msg_abc123",
+            "session_id": kwargs["session_id"],
+            "role": kwargs["role"],
+            "content": kwargs["content"],
+            "input_mode": kwargs.get("input_mode", "text"),
+            "model": kwargs.get("model"),
+            "token_count": kwargs.get("token_count"),
+            "latency_ms": kwargs.get("latency_ms"),
+            "created_at": 1778519162.0,
+        })
+    app = web.Application()
+    MessageRoutes(db=db, session_mgr=session_mgr, message_store=message_store).register(app)
+    return app, session_mgr, message_store
+
+
+class AddMessagePostTests(unittest.TestCase):
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    # ── Happy path ────────────────────────────────────────────────
+
+    def test_post_creates_user_turn_201(self) -> None:
+        app, _, store = _build_app()
+
+        async def go():
+            async with TestServer(app) as srv, TestClient(srv) as client:
+                resp = await client.post(
+                    "/api/v1/sessions/sess_test/messages",
+                    json={"role": "user", "content": "Tell me a joke"},
+                )
+                self.assertEqual(resp.status, 201)
+                self.assertEqual(resp.content_type, "application/json")
+                body = await resp.json()
+                self.assertEqual(body["id"], "msg_abc123")
+                self.assertEqual(body["role"], "user")
+                self.assertEqual(body["content"], "Tell me a joke")
+                self.assertEqual(body["input_mode"], "text")
+            store.add_message.assert_awaited_once()
+
+        self._run(go())
+
+    def test_post_assistant_turn_with_optional_fields(self) -> None:
+        """All optional fields forward through to MessageStore.add_message."""
+        app, _, store = _build_app()
+
+        async def go():
+            async with TestServer(app) as srv, TestClient(srv) as client:
+                resp = await client.post(
+                    "/api/v1/sessions/sess_test/messages",
+                    json={
+                        "role": "assistant",
+                        "content": "Why did the ketchup blush?",
+                        "input_mode": "voice",
+                        "model": "openai/gpt-4o-audio-preview",
+                        "token_count": 18,
+                        "latency_ms": 5945.0,
+                        "audio_duration_s": 4.33,
+                    },
+                )
+                self.assertEqual(resp.status, 201)
+            kwargs = store.add_message.await_args.kwargs
+            self.assertEqual(kwargs["role"], "assistant")
+            self.assertEqual(kwargs["input_mode"], "voice")
+            self.assertEqual(kwargs["model"], "openai/gpt-4o-audio-preview")
+            self.assertEqual(kwargs["token_count"], 18)
+            self.assertEqual(kwargs["latency_ms"], 5945.0)
+            self.assertEqual(kwargs["audio_duration_s"], 4.33)
+
+        self._run(go())
+
+    # ── Negative paths ────────────────────────────────────────────
+
+    def test_post_unknown_session_404(self) -> None:
+        app, _, _ = _build_app(session_exists=False)
+
+        async def go():
+            async with TestServer(app) as srv, TestClient(srv) as client:
+                resp = await client.post(
+                    "/api/v1/sessions/sess_nope/messages",
+                    json={"role": "user", "content": "hi"},
+                )
+                self.assertEqual(resp.status, 404)
+
+        self._run(go())
+
+    def test_post_malformed_json_400(self) -> None:
+        app, _, _ = _build_app()
+
+        async def go():
+            async with TestServer(app) as srv, TestClient(srv) as client:
+                resp = await client.post(
+                    "/api/v1/sessions/sess_test/messages",
+                    data="not-json{[",
+                    headers={"Content-Type": "application/json"},
+                )
+                self.assertEqual(resp.status, 400)
+
+        self._run(go())
+
+    def test_post_non_object_body_400(self) -> None:
+        app, _, _ = _build_app()
+
+        async def go():
+            async with TestServer(app) as srv, TestClient(srv) as client:
+                resp = await client.post(
+                    "/api/v1/sessions/sess_test/messages",
+                    json=["not", "an", "object"],
+                )
+                self.assertEqual(resp.status, 400)
+
+        self._run(go())
+
+    def test_post_missing_role_400(self) -> None:
+        app, _, _ = _build_app()
+
+        async def go():
+            async with TestServer(app) as srv, TestClient(srv) as client:
+                resp = await client.post(
+                    "/api/v1/sessions/sess_test/messages",
+                    json={"content": "hi"},
+                )
+                self.assertEqual(resp.status, 400)
+
+        self._run(go())
+
+    def test_post_unknown_role_400(self) -> None:
+        app, _, _ = _build_app()
+
+        async def go():
+            async with TestServer(app) as srv, TestClient(srv) as client:
+                resp = await client.post(
+                    "/api/v1/sessions/sess_test/messages",
+                    json={"role": "narrator", "content": "hi"},
+                )
+                self.assertEqual(resp.status, 400)
+
+        self._run(go())
+
+    def test_post_missing_content_400(self) -> None:
+        app, _, _ = _build_app()
+
+        async def go():
+            async with TestServer(app) as srv, TestClient(srv) as client:
+                resp = await client.post(
+                    "/api/v1/sessions/sess_test/messages",
+                    json={"role": "user"},
+                )
+                self.assertEqual(resp.status, 400)
+
+        self._run(go())
+
+    def test_post_empty_content_400(self) -> None:
+        app, _, _ = _build_app()
+
+        async def go():
+            async with TestServer(app) as srv, TestClient(srv) as client:
+                resp = await client.post(
+                    "/api/v1/sessions/sess_test/messages",
+                    json={"role": "user", "content": ""},
+                )
+                self.assertEqual(resp.status, 400)
+
+        self._run(go())
+
+    def test_post_unknown_input_mode_400(self) -> None:
+        app, _, _ = _build_app()
+
+        async def go():
+            async with TestServer(app) as srv, TestClient(srv) as client:
+                resp = await client.post(
+                    "/api/v1/sessions/sess_test/messages",
+                    json={"role": "user", "content": "hi", "input_mode": "morse"},
+                )
+                self.assertEqual(resp.status, 400)
+
+        self._run(go())
+
+    def test_post_store_raises_returns_500(self) -> None:
+        app, _, _ = _build_app(add_raises=True)
+
+        async def go():
+            async with TestServer(app) as srv, TestClient(srv) as client:
+                resp = await client.post(
+                    "/api/v1/sessions/sess_test/messages",
+                    json={"role": "user", "content": "hi"},
+                )
+                self.assertEqual(resp.status, 500)
+                body = await resp.json()
+                self.assertIn("Failed to add message", body.get("error", ""))
+
+        self._run(go())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
**Wave 3-C-a** of the cross-stack cohesion audit (2026-05-11).  Dragon now exposes a REST endpoint to append a turn to the canonical messages DB.

SOLO turns (vmode=5) and ONBOARD turns (vmode=4) currently bypass Dragon entirely.  SOLO writes its own session log to Tab5 SD; ONBOARD doesn't persist anywhere.  Three separate chat-message stores, zero sync, dashboard blind to mode 4/5.

Today Dragon's REST API had GET/DELETE for /messages but **no POST** — \`MessageStore.add_message\` was only callable via the WS path.  This PR exposes the missing shape so Tab5 (W3-C-b) can push turn pairs after every SOLO/K144 turn.

## Handler shape
\`\`\`
POST /api/v1/sessions/{session_id}/messages

Body (JSON):
  role         : user | assistant | system | tool       (required)
  content      : non-empty string                       (required)
  input_mode   : text | voice | system   (default text)
  model        : str | null   (optional)
  token_count  : int | null   (optional)
  latency_ms   : float | null (optional)
  audio_duration_s : float | null (optional)
  media_id     : str | null   (optional, multimodal)
  interrupted  : bool         (default false)

Returns:
  201 + full message row on success
  404 if session not found
  400 on validation failure
  500 on MessageStore exception
\`\`\`

## Tests

11 aiohttp \`TestClient\` cases in \`tests/test_api_messages_post.py\`:

\`\`\`
test_post_creates_user_turn_201                    PASS
test_post_assistant_turn_with_optional_fields      PASS
test_post_unknown_session_404                      PASS
test_post_malformed_json_400                       PASS
test_post_non_object_body_400                      PASS
test_post_missing_role_400                         PASS
test_post_unknown_role_400                         PASS
test_post_missing_content_400                      PASS
test_post_empty_content_400                        PASS
test_post_unknown_input_mode_400                   PASS
test_post_store_raises_returns_500                 PASS

54 passed, 48 subtests passed in 0.12s
ruff check — All checks passed
\`\`\`

## CI gate
Added \`test_api_messages_post.py\` to \`.github/workflows/ci.yml\` named test list.  Also added the previously-untracked \`test_voice_modes.py\` and \`test_config_swap.py\` — they were passing locally but weren't gated by CI (oversight from Wave-23).

## Anchor doc
\`TinkerTab/docs/AUDIT-state-of-stack-2026-05-11.md\` — Wave 3 section.

## Next: W3-C-b (TinkerTab side)
Tab5 firmware calls the new endpoint after every SOLO and ONBOARD turn completes.  WS-down → SD-card offline queue + drain on reconnect.

Closes #275 — refs #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)