### PR TITLE
feat(server): Dragon reads turn_id from start/text frames (W4-B)

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -682,12 +682,22 @@ class VoiceServer:
                         if pipeline:
                             mode = cmd.get("mode", "ask")
                             conn_state["mode"] = mode
+                            # W4-B (cross-stack audit 2026-05-11): Tab5 stamps a
+                            # 12-hex turn_id on every start/text frame so a
+                            # turn's Tab5 obs events correlate with Dragon's
+                            # log lines.  Store on conn_state for downstream
+                            # emit echo + log alongside session_id.
+                            turn_id = cmd.get("turn_id") or "-"
+                            conn_state["turn_id"] = turn_id
                             pipeline._audio_buffer.clear()
                             pipeline._dictation_mode = (mode == "dictate")
                             if mode == "dictate":
                                 pipeline._segment_buffer.clear()
                                 pipeline._dictation_segments.clear()
-                            logger.info("Connection %s: start (mode=%s, audio buffer cleared)", ws_id, mode)
+                            logger.info(
+                                "Connection %s: start (mode=%s, turn_id=%s, audio buffer cleared)",
+                                ws_id, mode, turn_id,
+                            )
 
                     elif cmd_type == "segment":
                         pipeline = conn_state.get("pipeline")
@@ -1083,6 +1093,16 @@ class VoiceServer:
         owns the gating; `_handle_text_body` owns the actual
         LLM/TTS work and is invoked as the body callable.
         """
+        # W4-B (cross-stack audit 2026-05-11): Tab5 stamps a turn_id
+        # on every text frame.  Store on conn_state so downstream
+        # emits + log lines can echo it back, enabling cross-system
+        # trace correlation with Tab5 obs events.
+        turn_id = cmd.get("turn_id") or "-"
+        conn_state["turn_id"] = turn_id
+        logger.info(
+            "Text turn enqueued (turn_id=%s, session=%s)",
+            turn_id, conn_state.get("session_id", "-"),
+        )
         await invoke_with_text_turn_gate(
             ws,
             conn_state=conn_state,


### PR DESCRIPTION
## Summary

**Wave 4-B** Dragon-side mirror of W4-A (TinkerTab PR #396).  Every Tab5 \`start\` / \`text\` frame now carries a 12-hex \`turn_id\`; Dragon reads + stores + logs it.

Pre-W4 a failed Tab5 turn → matching Dragon log line was timestamp + grep guessing.  After W4-A + W4-B, both sides emit the same turn_id at turn boundaries.  W4-C will echo it through Dragon's emit chain (stt / llm / llm_done / tts).

## Changes

\`dragon_voice/server.py\`:
- \`_handle_ws_voice\` cmd_type \`\"start\"\`: read \`cmd.get(\"turn_id\")\`, store on \`conn_state[\"turn_id\"]\`, append to the existing start-log line
- \`_handle_text\`: read + store on \`conn_state\`, emit new log line \"Text turn enqueued (turn_id=..., session=...)\" before invoking the turn-gate
- Missing turn_id → defaults to \`\"-\"\` so logs stay greppable + structured

## Test results

\`\`\`
pytest -q tests/ --ignore=tests/audit -x
  1392 passed, 1 skipped, 121 subtests passed in 12.32 s
  Zero regressions.

ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006
  All checks passed.
\`\`\`

## Test plan
- [x] ruff clean
- [x] pytest full suite passes (1392 / 1 skip / 121 subtests)
- [x] Source-level review: \`conn_state[\"turn_id\"]\` populated from both \`start\` and \`text\` cmd dispatch paths
- [ ] CI green
- [ ] After merge + deploy to Dragon: live test Tab5 sends text turn → Dragon journalctl shows \"Text turn enqueued (turn_id=<hex>, session=...)\"

## Non-goals (W4-C follow-up)

- Echo turn_id back in stt / llm / llm_done / tts / tool emits so Tab5 obs events round-trip with Dragon log lines
- pipeline.py + conversation.py logger lines include turn_id

Closes #277 — refs #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)