### PR TITLE
fix(conn_state): add turn_id field for W4-B (hot-fix)

### DIFF
--- a/dragon_voice/conn_state.py
+++ b/dragon_voice/conn_state.py
@@ -90,6 +90,12 @@ class ConnState:
 
     # ── Per-turn ephemeral state ──────────────────────────────────
     tool_calls_this_turn: list = field(default_factory=list)
+    # W4-B (cross-stack audit 2026-05-11): Tab5 stamps a 12-hex
+    # turn_id on each `start` / `text` frame.  Stored here so
+    # downstream emits + log lines can echo back, enabling cross-
+    # system trace correlation with Tab5 obs events.  Default "-"
+    # before the first turn (and for pre-W4-A firmwares).
+    turn_id: str = "-"
 
     # ── Background work tracking ──────────────────────────────────
     bg_tasks: set = field(default_factory=set)


### PR DESCRIPTION
## Summary

**Hot-fix for W4-B (#278)** which assigned \`conn_state[\"turn_id\"] = turn_id\` without declaring it on the \`ConnState\` dataclass.

\`ConnState.__setitem__\` raises \`KeyError\` on unknown fields by design (\"catches typos that the dict-era code would have silently accepted\") — so post-deploy, every text frame from a W4-A Tab5 blew up with:

\`\`\`
KeyError: \"ConnState has no field 'turn_id' — add it to the dataclass before assigning.\"
\`\`\`

## Fix
Add \`turn_id: str = \"-\"\` to ConnState's per-turn ephemeral section.  Default \`\"-\"\` matches W4-B handlers' fallback for missing/pre-W4-A frames.

## Tests
- \`pytest -q tests/ --ignore=tests/audit -x\` — 1392 passed, 1 skipped, 121 subtests passed
- \`ruff check\` — clean

## Deploy + verify
Once merged, scp conn_state.py to Dragon + restart tinkerclaw-voice + re-run the W4 round-trip E2E.

refs #277 #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)