### PR TITLE
feat(server): echo turn_id in Dragon→Tab5 emits via PipelineCallbacks chokepoint (W4-C)

### DIFF
--- a/dragon_voice/pipeline_callbacks.py
+++ b/dragon_voice/pipeline_callbacks.py
@@ -132,7 +132,20 @@ class PipelineCallbacks:
         Failure isolation: DB write errors logged at DEBUG but
         never re-raised — events are observability, not
         session-correctness.
+
+        W4-C (cross-stack audit 2026-05-11): every pipeline-side
+        emit gets a `turn_id` field stamped from `conn_state.turn_id`
+        before forwarding.  This is THE single chokepoint for
+        Dragon→Tab5 frames originating in the voice pipeline
+        (stt / llm / llm_done / tts_start / tts_end / api_usage),
+        so a one-line injection wires the full round-trip with
+        Tab5's outbound turn_id (W4-A) and Dragon's stored
+        turn_id (W4-B).  Skip if a caller already set the field
+        explicitly — let downstream code override per-event.
         """
+        if "turn_id" not in event:
+            event["turn_id"] = self._conn_state.get("turn_id", "-")
+
         if not self._ws.closed:
             await self._safe_send_json(self._ws, event)
 

--- a/tests/test_pipeline_callbacks.py
+++ b/tests/test_pipeline_callbacks.py
@@ -107,6 +107,65 @@ class TestOnEvent:
         send_json.assert_awaited_once_with(ws, event)
 
     @pytest.mark.asyncio
+    async def test_turn_id_stamped_from_conn_state(self):
+        """W4-C: every Dragon→Tab5 emit picks up `turn_id` from
+        conn_state.  Single chokepoint for cross-system trace
+        correlation."""
+        ws = _make_ws()
+        send_json = _make_safe_send_json()
+        cb = PipelineCallbacks(
+            ws,
+            conn_state={"session_id": "s", "device_id": "d", "turn_id": "abc123def456"},
+            safe_send_bytes=_make_safe_send_bytes(),
+            safe_send_json=send_json,
+            db=None,
+        )
+        await cb.on_event({"type": "llm_done", "llm_ms": 123})
+
+        # Frame forwarded to ws includes turn_id from conn_state.
+        forwarded = send_json.await_args.args[1]
+        assert forwarded["turn_id"] == "abc123def456"
+        assert forwarded["type"] == "llm_done"
+        assert forwarded["llm_ms"] == 123
+
+    @pytest.mark.asyncio
+    async def test_turn_id_default_when_conn_state_missing_field(self):
+        """Pre-W4-A firmwares + warm-boot before first turn → conn_state
+        has no turn_id → fall back to "-" so logs/frames stay
+        greppable + structurally consistent."""
+        ws = _make_ws()
+        send_json = _make_safe_send_json()
+        cb = PipelineCallbacks(
+            ws,
+            conn_state={"session_id": "s", "device_id": "d"},
+            safe_send_bytes=_make_safe_send_bytes(),
+            safe_send_json=send_json,
+            db=None,
+        )
+        await cb.on_event({"type": "stt", "text": "hello"})
+        forwarded = send_json.await_args.args[1]
+        assert forwarded["turn_id"] == "-"
+
+    @pytest.mark.asyncio
+    async def test_explicit_turn_id_in_event_not_overwritten(self):
+        """W4-C respects an explicit turn_id set by the caller — lets
+        downstream emit sites override per-event (rare; useful for
+        background out-of-band emits like scheduler reminders that
+        don't belong to the current foreground turn)."""
+        ws = _make_ws()
+        send_json = _make_safe_send_json()
+        cb = PipelineCallbacks(
+            ws,
+            conn_state={"session_id": "s", "device_id": "d", "turn_id": "foreground"},
+            safe_send_bytes=_make_safe_send_bytes(),
+            safe_send_json=send_json,
+            db=None,
+        )
+        await cb.on_event({"type": "scheduler_fire", "turn_id": "background-scheduler-1"})
+        forwarded = send_json.await_args.args[1]
+        assert forwarded["turn_id"] == "background-scheduler-1"
+
+    @pytest.mark.asyncio
     async def test_closed_ws_skips_send_json_but_still_persists(self):
         """When ws is closed mid-flight, we skip the WS emit but
         STILL persist api_usage to the DB (cost tracking must
@@ -157,11 +216,16 @@ class TestApiUsagePersistence:
         assert db.add_event.await_args.args[0] == "api_usage"
         assert call_kwargs["session_id"] == "sess-A"
         assert call_kwargs["device_id"] == "tab5-7"
-        # Data dict has everything except `type` (already in pos arg)
+        # Data dict has everything except `type` (already in pos arg).
+        # W4-C (audit 2026-05-11) stamps `turn_id` from conn_state on every
+        # event, so it also lands in the persisted api_usage row — useful
+        # for per-turn cost analysis.  conn_state has no turn_id field in
+        # this test fixture, so falls back to the "-" default.
         assert call_kwargs["data"] == {
             "model": "anthropic/claude-haiku",
             "tokens": 150,
             "cost_mils": 5,
+            "turn_id": "-",
         }
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

**Wave 4-C** closes the emit-echo half of the trace-correlation story.  W4-A (Tab5 generates) + W4-B (Dragon reads) + this PR (Dragon echoes) = end-to-end round-trip: a single 12-hex id stamps the full Tab5→Dragon→Tab5 frame chain for one turn.

## One-line core change

\`dragon_voice/pipeline_callbacks.py:on_event\` is the **single chokepoint** for Dragon→Tab5 emit frames originating in the voice pipeline (stt / llm / llm_done / tts_start / tts_end / api_usage).  Stamping turn_id at the top hits every emit for free:

\`\`\`python
if \"turn_id\" not in event:
    event[\"turn_id\"] = self._conn_state.get(\"turn_id\", \"-\")
\`\`\`

## Behaviour

| conn_state | event input | output frame |
|---|---|---|
| \`turn_id=\"abc123\"\` | \`{\"type\":\"llm_done\",\"llm_ms\":123}\` | adds \`turn_id=\"abc123\"\` |
| no turn_id field | \`{\"type\":\"stt\",\"text\":\"hi\"}\` | adds \`turn_id=\"-\"\` (pre-W4-A FW fallback) |
| any | \`{\"type\":\"scheduler\",\"turn_id\":\"bg-1\"}\` | respects \`\"bg-1\"\` (out-of-band override) |

## Tests

\`\`\`
pytest -q tests/ --ignore=tests/audit -x
  1392 passed, 1 skipped, 121 subtests passed in 12.49 s — zero regressions

ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006
  All checks passed.
\`\`\`

3 new tests:
- \`test_turn_id_stamped_from_conn_state\` — happy path
- \`test_turn_id_default_when_conn_state_missing_field\` — pre-W4-A FW fallback
- \`test_explicit_turn_id_in_event_not_overwritten\` — out-of-band override

## Non-goals (deferred)

- \`vision_turn.py\` + \`local_text_stream.py\` + \`tinkerclaw_text_path.py\` emit via direct \`ws.send_json\` not through PipelineCallbacks — those bypass the chokepoint.  Major voice/text paths cover all production traffic; can fold in via a tiny helper later if needed.
- pipeline.py \`logger.info\` lines that include session_id should also include turn_id — separate logging-sweep PR if needed.

## Test plan
- [x] All existing tests pass
- [x] ruff clean
- [x] 3 new tests pin happy + fallback + override behaviour
- [ ] CI green
- [ ] After merge + deploy: Tab5 text turn → Dragon emit frames Tab5 receives carry the same \`turn_id\` as Tab5's outbound \`turn.start\` obs

Closes #280 — refs #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)