### PR TITLE
feat(billing): daily-cap trigger emits cap_downgrade to Tab5 (W5-B)

### DIFF
--- a/dragon_voice/config.py
+++ b/dragon_voice/config.py
@@ -150,6 +150,29 @@ class ToolsConfig:
 
 
 @dataclass
+class BillingConfig:
+    """W5-B (cross-stack audit 2026-05-11): server-side daily budget cap.
+
+    When `daily_cap_cents > 0` and the running total of all
+    `api_usage` events for today UTC exceeds the cap, Dragon emits a
+    `cap_downgrade` frame to Tab5 — same shape the existing
+    Tab5→Dragon `config_update` with `reason='cap_downgrade'` uses,
+    just in the reverse direction.
+
+    Tab5's `voice_billing.c` will (in a follow-up wave) handle the
+    incoming frame by flipping NVS `voice_mode` to LOCAL and
+    surfacing a toast.  For now Dragon-side emit is observable via
+    journalctl + Tab5 obs ring.
+
+    Set via env var `BUDGET_DAILY_CENTS` (overrides config file).
+    `0` = disabled (default).  Per-connection state tracks whether
+    the alert already fired this day so we don't spam every
+    subsequent turn.
+    """
+    daily_cap_cents: int = 0
+
+
+@dataclass
 class DatabaseConfig:
     message_retention_days: int = 30  # Purge messages older than this (0 = never purge)
     # δ2 / H6 (issue #116): auto-end sessions in `paused` state whose
@@ -191,6 +214,7 @@ class VoiceConfig:
     tools: ToolsConfig = field(default_factory=ToolsConfig)
     memory: MemoryConfig = field(default_factory=MemoryConfig)
     database: DatabaseConfig = field(default_factory=DatabaseConfig)
+    billing: BillingConfig = field(default_factory=BillingConfig)
 
     # β-arch (issue #123): protocol-level transition flag for the
     # progress event bus.  When True (default), migrated emitters
@@ -342,6 +366,20 @@ def load_config(path: Optional[str] = None) -> VoiceConfig:
     _dragon_api_token = os.environ.get("DRAGON_API_TOKEN", "").strip()
     if _dragon_api_token:
         config.server.api_token = _dragon_api_token
+
+    # W5-B (cross-stack audit 2026-05-11): BUDGET_DAILY_CENTS env
+    # overrides the on-disk billing.daily_cap_cents (0 = disabled).
+    # Treating the env path as authoritative so an oncall can flip
+    # the cap without redeploying config.yaml.
+    _budget_cents_raw = os.environ.get("BUDGET_DAILY_CENTS", "").strip()
+    if _budget_cents_raw:
+        try:
+            _budget_cents = int(_budget_cents_raw)
+            if _budget_cents >= 0:
+                config.billing.daily_cap_cents = _budget_cents
+        except ValueError:
+            # Malformed env — ignore, leave config-file value in place.
+            pass
 
     # Wave 13 H7: same pattern for the TinkerClaw gateway token. Used to live
     # in config.yaml in the committed tree, which is a leak vector — now the

--- a/dragon_voice/pipeline_callbacks.py
+++ b/dragon_voice/pipeline_callbacks.py
@@ -105,12 +105,20 @@ class PipelineCallbacks:
         safe_send_bytes: SafeSendBytes,
         safe_send_json: SafeSendJson,
         db: Optional[Any],
+        billing_config: Optional[Any] = None,
     ) -> None:
         self._ws = ws
         self._conn_state = conn_state
         self._safe_send_bytes = safe_send_bytes
         self._safe_send_json = safe_send_json
         self._db = db
+        # W5-B: server-side daily-cap trigger.  When daily_cap_cents > 0
+        # and today's total spend exceeds it, emit a cap_downgrade
+        # frame once per UTC day per connection.  `_cap_alerted_day`
+        # tracks the ISO day we last fired so we don't spam every
+        # turn after the cap is hit.
+        self._billing_config = billing_config
+        self._cap_alerted_day: Optional[str] = None
 
     async def on_audio(self, audio_bytes: bytes) -> None:
         """TTS PCM frames flowing FROM pipeline TO Tab5.
@@ -163,3 +171,68 @@ class PipelineCallbacks:
                 )
             except Exception as e:
                 logger.debug("Callback error: %s", e)
+            # W5-B: check the daily cap *after* persistence so the
+            # SELECT inside spend_tracker sees the row we just
+            # wrote.  Best-effort — any failure here is logged + swallowed
+            # so observability never breaks a turn.
+            await self._maybe_emit_cap_downgrade()
+
+    async def _maybe_emit_cap_downgrade(self) -> None:
+        """W5-B: if BUDGET_DAILY_CENTS is set and today's spend
+        exceeds it, emit a one-shot `cap_downgrade` frame so Tab5
+        can flip back to LOCAL mode + surface a toast.
+
+        Idempotent across the same UTC day per connection — the
+        first hit fires the alert, subsequent turns same-day are
+        no-ops.  A WS reconnect resets the per-connection latch
+        which is OK: a reconnect after a cap hit means the user
+        probably noticed and we can re-alert if cost is still
+        accumulating.
+        """
+        if not self._billing_config:
+            return
+        cap_cents = getattr(self._billing_config, "daily_cap_cents", 0)
+        if cap_cents <= 0:
+            return
+        if self._db is None:
+            return
+
+        # Import inside the method so test fixtures that don't
+        # construct a Database aren't forced to satisfy the import
+        # graph.
+        from dragon_voice.billing.spend_tracker import (
+            summarize_spend_for_day,
+            today_iso,
+        )
+
+        try:
+            summary = await summarize_spend_for_day(self._db)
+        except Exception as e:
+            logger.debug("cap-check spend summary failed: %s", e)
+            return
+
+        if summary.total_cents < cap_cents:
+            return
+        # Once-per-day per connection.
+        day = today_iso()
+        if self._cap_alerted_day == day:
+            return
+        self._cap_alerted_day = day
+
+        frame: dict = {
+            "type": "cap_downgrade",
+            "reason": "daily_cap_hit",
+            "spent_cents": summary.total_cents,
+            "cap_cents": cap_cents,
+            "day": day,
+        }
+        # Stamp turn_id like every other emit (W4-C).  on_event
+        # already does this when frames flow through it; we're
+        # bypassing on_event here (would recurse), so stamp manually.
+        frame["turn_id"] = self._conn_state.get("turn_id", "-")
+        logger.warning(
+            "Daily cap hit (spent=%dc, cap=%dc, day=%s) — emitting cap_downgrade to client",
+            summary.total_cents, cap_cents, day,
+        )
+        if not self._ws.closed:
+            await self._safe_send_json(self._ws, frame)

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -639,6 +639,13 @@ class VoiceServer:
             safe_send_bytes=self._safe_send_bytes,
             safe_send_json=self._safe_send_json,
             db=self._db,
+            # W5-B: server-side daily-cap trigger.  Reads
+            # daily_cap_cents on every api_usage; emits
+            # cap_downgrade once per UTC day when exceeded.
+            # `conn_config` here is the per-WS deep copy; the
+            # billing dataclass is shared by reference (no
+            # per-connection overrides for it today).
+            billing_config=getattr(conn_config, "billing", None),
         )
         on_audio = _pipeline_callbacks.on_audio
         on_event = _pipeline_callbacks.on_event

--- a/tests/test_pipeline_callbacks.py
+++ b/tests/test_pipeline_callbacks.py
@@ -5,11 +5,19 @@ disconnects mid-stream don't raise into the pipeline loop.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from dragon_voice.pipeline_callbacks import PipelineCallbacks
+
+
+@dataclass
+class _StubBillingConfig:
+    """Minimal stand-in for BillingConfig that the W5-B cap-check
+    path reads.  Real config dataclass lives in dragon_voice.config."""
+    daily_cap_cents: int = 0
 
 
 def _make_ws(*, closed: bool = False) -> MagicMock:
@@ -317,3 +325,157 @@ class TestConnStateReadFreshPerCall:
         second_call = db.add_event.await_args_list[1]
         assert first_call.kwargs["session_id"] == "first"
         assert second_call.kwargs["session_id"] == "second"
+
+
+# ─── W5-B: daily cap trigger ─────────────────────────────────
+
+
+class TestDailyCapTrigger:
+    """Verify that PipelineCallbacks emits a one-shot `cap_downgrade`
+    frame when today's spend exceeds `billing_config.daily_cap_cents`.
+
+    Strategy: patch `summarize_spend_for_day` to return a known
+    SpendSummary so we can control whether the cap is breached
+    without setting up a real events table."""
+
+    @pytest.mark.asyncio
+    async def test_no_cap_when_cents_is_zero(self, monkeypatch):
+        """daily_cap_cents=0 → cap-check is a no-op even if spend is huge."""
+        send_json = _make_safe_send_json()
+        db = _make_db()
+        cb = PipelineCallbacks(
+            _make_ws(),
+            conn_state={"session_id": "s", "device_id": "d"},
+            safe_send_bytes=_make_safe_send_bytes(),
+            safe_send_json=send_json,
+            db=db,
+            billing_config=_StubBillingConfig(daily_cap_cents=0),
+        )
+
+        from dragon_voice.billing import spend_tracker as st
+
+        # If cap=0, summarize_spend_for_day should never even be called.
+        # Patch it to raise so we'd detect a regression.
+        async def _should_not_be_called(*a, **k):
+            raise AssertionError("summarize_spend_for_day called with cap=0")
+        monkeypatch.setattr(st, "summarize_spend_for_day", _should_not_be_called)
+
+        await cb.on_event({"type": "api_usage", "cost_mils": 9999})
+
+        # Only the api_usage emit was sent — no cap_downgrade.
+        types_sent = [c.args[1].get("type") for c in send_json.await_args_list]
+        assert types_sent == ["api_usage"]
+
+    @pytest.mark.asyncio
+    async def test_under_cap_no_emit(self, monkeypatch):
+        send_json = _make_safe_send_json()
+        cb = PipelineCallbacks(
+            _make_ws(),
+            conn_state={"session_id": "s", "device_id": "d"},
+            safe_send_bytes=_make_safe_send_bytes(),
+            safe_send_json=send_json,
+            db=_make_db(),
+            billing_config=_StubBillingConfig(daily_cap_cents=100),
+        )
+
+        # Mock the summary to report 50c spent — under the 100c cap.
+        from dragon_voice.billing import spend_tracker as st
+        from dragon_voice.billing.spend_tracker import SpendSummary
+
+        async def _fake(*a, **k):
+            return SpendSummary(day="2026-05-12", total_mils=50_000, event_count=5)
+        monkeypatch.setattr(st, "summarize_spend_for_day", _fake)
+
+        await cb.on_event({"type": "api_usage", "cost_mils": 10})
+
+        types_sent = [c.args[1].get("type") for c in send_json.await_args_list]
+        assert "cap_downgrade" not in types_sent
+
+    @pytest.mark.asyncio
+    async def test_over_cap_emits_once(self, monkeypatch):
+        send_json = _make_safe_send_json()
+        cb = PipelineCallbacks(
+            _make_ws(),
+            conn_state={"session_id": "s", "device_id": "d", "turn_id": "abc123"},
+            safe_send_bytes=_make_safe_send_bytes(),
+            safe_send_json=send_json,
+            db=_make_db(),
+            billing_config=_StubBillingConfig(daily_cap_cents=100),
+        )
+
+        from dragon_voice.billing import spend_tracker as st
+        from dragon_voice.billing.spend_tracker import SpendSummary
+
+        async def _fake(*a, **k):
+            return SpendSummary(day="2026-05-12", total_mils=150_000, event_count=10)
+        monkeypatch.setattr(st, "summarize_spend_for_day", _fake)
+        monkeypatch.setattr(st, "today_iso", lambda: "2026-05-12")
+
+        # First api_usage event — should trigger the alert.
+        await cb.on_event({"type": "api_usage", "cost_mils": 50})
+
+        # Second event — same day, cap already alerted, should NOT re-emit.
+        await cb.on_event({"type": "api_usage", "cost_mils": 20})
+
+        # Count cap_downgrade frames sent.
+        sent_types = [c.args[1].get("type") for c in send_json.await_args_list]
+        assert sent_types.count("cap_downgrade") == 1
+
+        # Verify the alert frame shape.
+        cap_frame = next(c.args[1] for c in send_json.await_args_list
+                         if c.args[1].get("type") == "cap_downgrade")
+        assert cap_frame["reason"] == "daily_cap_hit"
+        assert cap_frame["spent_cents"] == 150
+        assert cap_frame["cap_cents"] == 100
+        assert cap_frame["day"] == "2026-05-12"
+        assert cap_frame["turn_id"] == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_no_cap_check_when_billing_config_is_none(self, monkeypatch):
+        """Backward-compat: callers that don't pass billing_config get
+        the old behaviour (no cap trigger)."""
+        send_json = _make_safe_send_json()
+        cb = PipelineCallbacks(
+            _make_ws(),
+            conn_state={"session_id": "s", "device_id": "d"},
+            safe_send_bytes=_make_safe_send_bytes(),
+            safe_send_json=send_json,
+            db=_make_db(),
+            # No billing_config — defaults to None.
+        )
+
+        from dragon_voice.billing import spend_tracker as st
+
+        async def _should_not_be_called(*a, **k):
+            raise AssertionError("summarize_spend_for_day called with no billing_config")
+        monkeypatch.setattr(st, "summarize_spend_for_day", _should_not_be_called)
+
+        await cb.on_event({"type": "api_usage", "cost_mils": 9999})
+        sent_types = [c.args[1].get("type") for c in send_json.await_args_list]
+        assert "cap_downgrade" not in sent_types
+
+    @pytest.mark.asyncio
+    async def test_spend_tracker_failure_swallowed(self, monkeypatch):
+        """If summarize_spend_for_day raises, the turn must NOT
+        fail — cap-check is best-effort observability."""
+        send_json = _make_safe_send_json()
+        cb = PipelineCallbacks(
+            _make_ws(),
+            conn_state={"session_id": "s", "device_id": "d"},
+            safe_send_bytes=_make_safe_send_bytes(),
+            safe_send_json=send_json,
+            db=_make_db(),
+            billing_config=_StubBillingConfig(daily_cap_cents=100),
+        )
+
+        from dragon_voice.billing import spend_tracker as st
+
+        async def _boom(*a, **k):
+            raise RuntimeError("db connection dead")
+        monkeypatch.setattr(st, "summarize_spend_for_day", _boom)
+
+        # Should NOT raise even though the cap-check internally errors.
+        await cb.on_event({"type": "api_usage", "cost_mils": 50})
+        # api_usage still emitted.
+        sent_types = [c.args[1].get("type") for c in send_json.await_args_list]
+        assert sent_types == ["api_usage"]


### PR DESCRIPTION
## Summary

**Wave 5-B** closes the active-enforcement half of the cost-guard story.  W5-A (PR #283) shipped read-only \`/api/v1/spend\` visibility; this PR adds the trigger that emits Dragon→Tab5 \`cap_downgrade\` when today's total exceeds the configured cap.

Pre-W5-B the only \`cap_downgrade\` direction was Tab5→Dragon (Tab5 hits its own NVS budget, tells Dragon).  Dragon-side enforcement was missing entirely.

## Mechanism

\`\`\`python
# dragon_voice/config.py
@dataclass
class BillingConfig:
    daily_cap_cents: int = 0   # 0 = disabled
    # env BUDGET_DAILY_CENTS overrides
\`\`\`

\`PipelineCallbacks.on_event\` (the same chokepoint W4-C uses for turn_id stamping):
- After persisting an \`api_usage\` row, if \`daily_cap_cents > 0\`, run \`spend_tracker.summarize_spend_for_day\`
- If \`total_cents >= cap_cents\` AND not already alerted today → emit \`{type:cap_downgrade, reason:daily_cap_hit, spent_cents, cap_cents, day, turn_id}\`
- Per-connection \`_cap_alerted_day\` latch dedups within a UTC day
- Failures (DB lock, malformed event) logged at DEBUG and swallowed — cap-check is best-effort observability

## Frame shape

\`\`\`json
{
  \"type\":         \"cap_downgrade\",
  \"reason\":       \"daily_cap_hit\",
  \"spent_cents\":  150,
  \"cap_cents\":    100,
  \"day\":          \"2026-05-12\",
  \"turn_id\":      \"abc123def456\"
}
\`\`\`

## Deploy + use

\`\`\`bash
echo 'BUDGET_DAILY_CENTS=100' >> /home/radxa/.env  # $1.00/day
sudo systemctl restart tinkerclaw-voice
\`\`\`

## Tests

\`\`\`
pytest -q tests/ --ignore=tests/audit -x
  1416 passed (+5 vs pre-W5-B), 1 skipped, 121 subtests passed in 12.54 s

ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006
  All checks passed.
\`\`\`

5 new tests in \`tests/test_pipeline_callbacks.py\`:
- \`test_no_cap_when_cents_is_zero\` — disabled path
- \`test_under_cap_no_emit\` — happy below-cap
- \`test_over_cap_emits_once\` — fires + once-per-day dedup
- \`test_no_cap_check_when_billing_config_is_none\` — backward compat
- \`test_spend_tracker_failure_swallowed\` — graceful degrade

## Non-goals (W5-C)
- Tab5 firmware handler for incoming \`cap_downgrade\` frame (flips NVS vmode → LOCAL + toast).  Tab5 ignores the frame today per unknown-type convention.
- SOLO mode receipt POST (cross-stack, Tab5 firmware change).

Closes #284 — refs #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)