### PR TITLE
feat(llm): forward gateway tool_calls from TinkerClaw SSE (closes #292, refs W7-A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,4 +129,5 @@ jobs:
             tests/test_api_messages_post.py \
             tests/test_spend_tracker.py \
             tests/test_start_handler.py \
-            tests/test_protocol_contract.py
+            tests/test_protocol_contract.py \
+            tests/test_tinkerclaw_tool_events.py

--- a/dragon_voice/llm/tinkerclaw_llm.py
+++ b/dragon_voice/llm/tinkerclaw_llm.py
@@ -11,7 +11,7 @@ import json
 import logging
 import re
 import time
-from typing import AsyncIterator, Optional
+from typing import Any, AsyncIterator, Awaitable, Callable, Optional
 
 import aiohttp
 
@@ -143,6 +143,14 @@ class TinkerClawBackend(LLMBackend):
         # by is_healthy() and seeded by initialize().
         self._health_cache_ok: bool = False
         self._health_cache_until: float = 0.0
+        # W7-A (audit 2026-05-11): optional callback fired once per
+        # full tool call detected in the gateway's SSE stream.  When
+        # set, the SSE parser surfaces `delta.tool_calls` deltas from
+        # the OpenAI-compatible /v1/chat/completions response as
+        # complete tool_call events — Tab5 already renders these
+        # (Wave 12 agent_log feed).  Pre-W7-A the deltas were silently
+        # skipped because the parser only looked at `delta.content`.
+        self._on_tool_call: Optional[Callable[[dict], Awaitable[None]]] = None
 
     async def initialize(self) -> None:
         headers = {"Content-Type": "application/json"}
@@ -232,6 +240,33 @@ class TinkerClawBackend(LLMBackend):
         to maintain per-session conversation history internally.
         """
         self._session_key = session_key
+
+    def set_tool_event_handler(
+        self,
+        on_tool_call: Optional[Callable[[dict], Awaitable[None]]],
+    ) -> None:
+        """W7-A: register a callback fired once per gateway tool call.
+
+        The callback receives a dict shaped like Dragon's own ToolRegistry
+        emit payload — `{"tool": "<name>", "args": <parsed dict>}` — so
+        Tab5's existing Wave 12 agent_log feed renders it without changes.
+
+        Pass `None` to clear the handler (e.g. on backend swap).
+
+        The callback is awaited inside the SSE parse loop, so failure
+        modes:
+          * raises an exception → logged + swallowed (a buggy callback
+            must NOT tear down the LLM stream)
+          * blocks for more than the sock_read budget → can stall the
+            stream; keep callbacks fast (the existing ToolEventEmitter
+            already does fire-and-forget WS sends).
+
+        Tool result events from the gateway are NOT surfaced via this
+        callback yet — `/v1/chat/completions` doesn't emit them natively;
+        the OpenAI Responses-API path (event-typed SSE) is the next
+        slice (W7-A.2).
+        """
+        self._on_tool_call = on_tool_call
 
     async def generate_stream(
         self, prompt: str, system_prompt: str = ""
@@ -332,6 +367,15 @@ class TinkerClawBackend(LLMBackend):
                 _A5_PARAGRAPH_BREAK = "\n\n"
                 _A5_SENTENCE_END_CHARS = (".", "!", "?")
 
+                # W7-A: tool-call accumulator keyed by OpenAI's delta
+                # `tool_calls[*].index`.  OpenAI streams function name +
+                # arguments incrementally; we buffer per-index and flush
+                # when the index closes (next-chunk's tool_calls has a
+                # different index, or [DONE]/text-delta indicates calls
+                # are complete).  Flushed entries fire `_on_tool_call`.
+                tool_call_buffer: dict[int, dict[str, Any]] = {}
+                _flushed_tool_indices: set[int] = set()
+
                 # W14-M07: use readline with explicit byte cap so one
                 # pathologically long SSE frame can't blow memory.
                 while True:
@@ -382,6 +426,29 @@ class TinkerClawBackend(LLMBackend):
                         continue
 
                     delta = choices[0].get("delta", {})
+
+                    # W7-A: accumulate any incremental tool_calls deltas
+                    # by index before reading the text-content delta.
+                    # OpenAI's chat-completions streams tool_calls
+                    # incrementally — `function.name` arrives in one
+                    # chunk, `function.arguments` is split character by
+                    # character across many chunks.  We rebuild each
+                    # call here; the actual flush happens when we see
+                    # a finish_reason of "tool_calls" / "stop" or when
+                    # the stream ends.
+                    self._accumulate_tool_call_deltas(
+                        delta.get("tool_calls"), tool_call_buffer,
+                    )
+
+                    # If the upstream signals "tool_calls finished",
+                    # flush buffered calls immediately so Tab5 sees
+                    # them before the tool execution latency starts.
+                    finish_reason = choices[0].get("finish_reason")
+                    if finish_reason in ("tool_calls", "stop") and tool_call_buffer:
+                        await self._flush_tool_calls(
+                            tool_call_buffer, _flushed_tool_indices,
+                        )
+
                     token = delta.get("content", "")
                     if token:
                         token_count += 1
@@ -446,6 +513,15 @@ class TinkerClawBackend(LLMBackend):
                                 accumulated.clear()
                                 passthrough = True
 
+                # W7-A: end-of-stream flush — any tool calls that the
+                # upstream never gave a finish_reason for (some servers
+                # only emit finish_reason on the assistant-text path, not
+                # on tool-only chunks) still need to surface to Tab5.
+                if tool_call_buffer:
+                    await self._flush_tool_calls(
+                        tool_call_buffer, _flushed_tool_indices,
+                    )
+
                 # A07: Truncation detection — stream ended without [DONE]
                 if not saw_done:
                     if token_count > 0:
@@ -482,6 +558,99 @@ class TinkerClawBackend(LLMBackend):
             await self._session.close()
         self._session = None
         logger.info("TinkerClaw backend shut down")
+
+    # ── W7-A: gateway tool-event surfacing ─────────────────────────────
+
+    @staticmethod
+    def _accumulate_tool_call_deltas(
+        deltas: Optional[list[dict]],
+        buffer: dict[int, dict[str, Any]],
+    ) -> None:
+        """Merge incremental OpenAI tool_calls deltas into the buffer.
+
+        OpenAI streams tool calls in pieces — a chunk may carry just
+        `{"index": 0, "id": "call_abc"}`, the next `{"index": 0,
+        "function": {"name": "search"}}`, then a long tail of
+        `{"index": 0, "function": {"arguments": "{\"q\""}}` etc.  We
+        rebuild the full call in `buffer[index]`.
+
+        No callback is fired here — flush is the caller's job, since
+        the right moment depends on context (finish_reason / EOS).
+        """
+        if not deltas:
+            return
+        for d in deltas:
+            try:
+                idx = int(d.get("index", 0))
+            except (TypeError, ValueError):
+                idx = 0
+            slot = buffer.setdefault(
+                idx, {"id": "", "name": "", "arguments": ""},
+            )
+            call_id = d.get("id")
+            if call_id:
+                slot["id"] = str(call_id)
+            fn = d.get("function") or {}
+            name = fn.get("name")
+            if name:
+                # Some servers stream name in fragments too; concat
+                # rather than replace to be defensive.
+                slot["name"] += str(name) if not slot["name"] else ""
+                if not slot["name"]:
+                    slot["name"] = str(name)
+            arg_frag = fn.get("arguments")
+            if arg_frag:
+                slot["arguments"] += str(arg_frag)
+
+    async def _flush_tool_calls(
+        self,
+        buffer: dict[int, dict[str, Any]],
+        flushed: set[int],
+    ) -> None:
+        """Emit accumulated tool calls via the registered callback.
+
+        Each buffer entry is rendered as Dragon's standard tool_call
+        shape (`{"tool": "<name>", "args": <parsed dict>}`) and passed
+        to `self._on_tool_call`.  Failures are logged + swallowed so a
+        buggy callback can never tear down the LLM stream.
+
+        Idempotent: indexes already in `flushed` are skipped, so we can
+        be called at finish_reason and again at EOS without duplicate
+        emits.  The buffer itself is not cleared — keeping the records
+        lets future runs in the same stream (rare) accumulate further
+        argument fragments correctly.
+        """
+        if not self._on_tool_call:
+            # No handler registered → nothing to surface.  Still mark
+            # entries flushed so we don't churn re-checking them.
+            flushed.update(buffer.keys())
+            return
+        for idx, call in buffer.items():
+            if idx in flushed:
+                continue
+            name = call.get("name", "").strip()
+            if not name:
+                # Tool calls with no function name are gateway bugs;
+                # surface nothing rather than emit a malformed event.
+                continue
+            args_str = call.get("arguments") or "{}"
+            try:
+                args_obj: Any = json.loads(args_str) if args_str else {}
+            except json.JSONDecodeError:
+                # Streaming may have ended mid-JSON if the upstream
+                # crashed; surface the raw string so the obs ring shows
+                # *something* useful for debugging.
+                args_obj = {"_raw": args_str[:512]}
+            payload = {"tool": name, "args": args_obj}
+            try:
+                await self._on_tool_call(payload)
+            except Exception:
+                logger.exception(
+                    "W7-A: on_tool_call callback raised — swallowed "
+                    "to keep LLM stream alive (tool=%s)",
+                    name,
+                )
+            flushed.add(idx)
 
     @property
     def name(self) -> str:

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -315,6 +315,18 @@ class VoicePipeline:
             self._llm.name, " (pooled)" if self._pooled_llm else "",
         )
 
+        # W7-A (audit 2026-05-11): if the LLM is the TinkerClaw agent
+        # gateway backend, hand it the connection's on_tool_call hook so
+        # gateway-emitted tool_calls become visible Tab5 events (Wave 12
+        # agent_log feed already renders these).  Pre-W7-A the deltas
+        # were silently skipped because mode 3 bypassed Dragon's local
+        # ToolRegistry entirely.  Guarded by `hasattr` so other backends
+        # (which don't have the setter) keep working unchanged.
+        if self._on_tool_call is not None and hasattr(
+            self._llm, "set_tool_event_handler"
+        ):
+            self._llm.set_tool_event_handler(self._on_tool_call)
+
     def set_uplink_codec(self, codec: str) -> str:
         """Switch the uplink decoder.  Returns the codec actually applied.
 

--- a/tests/test_tinkerclaw_tool_events.py
+++ b/tests/test_tinkerclaw_tool_events.py
@@ -1,0 +1,206 @@
+"""W7-A: gateway tool-event surfacing from TinkerClawBackend SSE.
+
+Wave 7-A of the 2026-05-11 cross-stack audit.  Mode 3 routes LLM
+inference to the TinkerClaw agent gateway via OpenAI-compatible SSE
+on `/v1/chat/completions`.  Pre-W7-A the parser silently skipped
+`delta.tool_calls` entries (only `delta.content` was read), so users
+never saw the gateway's actual agentic activity in the Tab5
+agent_log feed.
+
+This module verifies:
+  * complete tool calls fire the registered on_tool_call callback
+    with Dragon's standard payload shape: {"tool": ..., "args": ...}
+  * incremental name + arguments deltas are reassembled correctly
+  * multiple parallel tool calls (different `index` values) all surface
+  * malformed JSON arguments fall back to {"_raw": "..."} rather than
+    raising
+  * callbacks that raise are swallowed (a buggy handler must NOT tear
+    down the LLM stream)
+  * if no handler is registered, the parser is a no-op (no regression
+    on existing behaviour)
+
+Run:
+    python3 -m pytest tests/test_tinkerclaw_tool_events.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import unittest
+
+# Construct the buffer + flush helpers in isolation — they're static/
+# instance methods on TinkerClawBackend but don't need a live HTTP
+# session.  Tests subclass-spy the callback instead of standing up
+# a real ConnState.
+from dragon_voice.llm.tinkerclaw_llm import TinkerClawBackend
+
+
+class _NoInitBackend(TinkerClawBackend):
+    """Skip the real __init__ — we only exercise the helpers."""
+
+    def __init__(self):  # type: ignore[override]
+        self._on_tool_call = None
+
+
+def _delta(index: int, *, id_: str = "", name: str = "", args: str = "") -> dict:
+    """Build one OpenAI tool_calls delta fragment."""
+    out: dict = {"index": index}
+    if id_:
+        out["id"] = id_
+    fn: dict = {}
+    if name:
+        fn["name"] = name
+    if args:
+        fn["arguments"] = args
+    if fn:
+        out["function"] = fn
+    return out
+
+
+class TestAccumulateToolCallDeltas(unittest.TestCase):
+    def test_empty_or_none_is_noop(self):
+        buf: dict = {}
+        TinkerClawBackend._accumulate_tool_call_deltas(None, buf)
+        TinkerClawBackend._accumulate_tool_call_deltas([], buf)
+        self.assertEqual(buf, {})
+
+    def test_single_call_assembled_across_fragments(self):
+        buf: dict = {}
+        # OpenAI streams: id arrives first, then name, then args char-by-char
+        TinkerClawBackend._accumulate_tool_call_deltas(
+            [_delta(0, id_="call_x")], buf,
+        )
+        TinkerClawBackend._accumulate_tool_call_deltas(
+            [_delta(0, name="web_search")], buf,
+        )
+        for piece in ['{"query":', ' "weather"', "}"]:
+            TinkerClawBackend._accumulate_tool_call_deltas(
+                [_delta(0, args=piece)], buf,
+            )
+        self.assertEqual(buf[0]["id"], "call_x")
+        self.assertEqual(buf[0]["name"], "web_search")
+        self.assertEqual(buf[0]["arguments"], '{"query": "weather"}')
+
+    def test_multiple_parallel_calls(self):
+        buf: dict = {}
+        TinkerClawBackend._accumulate_tool_call_deltas(
+            [_delta(0, name="search"), _delta(1, name="remember")], buf,
+        )
+        TinkerClawBackend._accumulate_tool_call_deltas(
+            [_delta(0, args='{"q":"x"}'), _delta(1, args='{"f":"y"}')], buf,
+        )
+        self.assertEqual(buf[0]["name"], "search")
+        self.assertEqual(buf[1]["name"], "remember")
+        self.assertEqual(buf[0]["arguments"], '{"q":"x"}')
+        self.assertEqual(buf[1]["arguments"], '{"f":"y"}')
+
+    def test_index_defaults_to_zero_when_missing(self):
+        buf: dict = {}
+        # Some streamers omit `index` on single-call streams — fall
+        # back to 0 instead of throwing.
+        TinkerClawBackend._accumulate_tool_call_deltas(
+            [{"function": {"name": "foo"}}], buf,
+        )
+        self.assertIn(0, buf)
+        self.assertEqual(buf[0]["name"], "foo")
+
+
+class TestFlushToolCalls(unittest.IsolatedAsyncioTestCase):
+    async def test_fires_callback_with_dragon_shape(self):
+        captured: list[dict] = []
+
+        async def cb(payload: dict) -> None:
+            captured.append(payload)
+
+        be = _NoInitBackend()
+        be._on_tool_call = cb
+        buf = {0: {"id": "call_a", "name": "web_search", "arguments": '{"q":"weather"}'}}
+        flushed: set = set()
+        await be._flush_tool_calls(buf, flushed)
+
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(captured[0]["tool"], "web_search")
+        self.assertEqual(captured[0]["args"], {"q": "weather"})
+        self.assertIn(0, flushed)
+
+    async def test_idempotent_on_double_flush(self):
+        captured: list[dict] = []
+
+        async def cb(payload: dict) -> None:
+            captured.append(payload)
+
+        be = _NoInitBackend()
+        be._on_tool_call = cb
+        buf = {0: {"id": "x", "name": "t", "arguments": "{}"}}
+        flushed: set = set()
+        await be._flush_tool_calls(buf, flushed)
+        await be._flush_tool_calls(buf, flushed)  # second call → no-op
+        self.assertEqual(len(captured), 1)
+
+    async def test_no_handler_marks_flushed_but_no_calls(self):
+        be = _NoInitBackend()
+        buf = {0: {"id": "x", "name": "t", "arguments": "{}"}}
+        flushed: set = set()
+        await be._flush_tool_calls(buf, flushed)
+        self.assertEqual(flushed, {0})  # marked
+
+    async def test_malformed_args_falls_back_to_raw(self):
+        captured: list[dict] = []
+
+        async def cb(payload: dict) -> None:
+            captured.append(payload)
+
+        be = _NoInitBackend()
+        be._on_tool_call = cb
+        # Truncated mid-JSON — common when the upstream crashes mid-call
+        buf = {0: {"id": "x", "name": "search", "arguments": '{"q":"hello'}}
+        flushed: set = set()
+        await be._flush_tool_calls(buf, flushed)
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(captured[0]["tool"], "search")
+        self.assertIn("_raw", captured[0]["args"])
+
+    async def test_callback_exception_is_swallowed(self):
+        async def boom(_payload: dict) -> None:
+            raise RuntimeError("buggy emitter")
+
+        be = _NoInitBackend()
+        be._on_tool_call = boom
+        buf = {0: {"id": "x", "name": "t", "arguments": "{}"}}
+        flushed: set = set()
+        # Must not raise — a buggy callback cannot tear down the LLM
+        # stream that's still surfacing tokens to the user.
+        await be._flush_tool_calls(buf, flushed)
+        self.assertIn(0, flushed)
+
+    async def test_empty_name_skipped(self):
+        captured: list[dict] = []
+
+        async def cb(payload: dict) -> None:
+            captured.append(payload)
+
+        be = _NoInitBackend()
+        be._on_tool_call = cb
+        buf = {0: {"id": "x", "name": "  ", "arguments": "{}"}}
+        flushed: set = set()
+        await be._flush_tool_calls(buf, flushed)
+        self.assertEqual(captured, [])  # never emit a nameless tool
+
+
+class TestSetToolEventHandler(unittest.TestCase):
+    def test_setter_stores_and_clears(self):
+        be = _NoInitBackend()
+        self.assertIsNone(be._on_tool_call)
+
+        async def h(_p: dict) -> None:
+            pass
+
+        be.set_tool_event_handler(h)
+        self.assertIs(be._on_tool_call, h)
+        be.set_tool_event_handler(None)
+        self.assertIsNone(be._on_tool_call)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- New `set_tool_event_handler(on_tool_call)` on `TinkerClawBackend` — fire-and-forget callback fired once per fully-assembled tool call from the gateway's SSE
- Payload shape matches Dragon's existing `ToolRegistry` wire format (`{"tool": "...", "args": {...}}`) — Tab5's Wave 12 `agent_log` feed renders it with zero firmware changes
- SSE parser accumulates `delta.tool_calls` fragments by `index` and flushes on `finish_reason in ("tool_calls", "stop")` or end-of-stream
- `pipeline.py` auto-wires `conn_state["on_tool_call"]` into the backend post-construction via `hasattr` guard — non-TinkerClaw backends untouched
- Defensive: malformed JSON → `{"_raw": ...}`, exceptions swallowed, double-flush idempotent, empty names skipped

`tool_result` events from the gateway are NOT yet surfaced — `/v1/chat/completions` doesn't emit them natively; the OpenAI Responses-API path (event-typed SSE) is the W7-A.2 follow-up.

## Test plan
- [x] `pytest tests/test_tinkerclaw_tool_events.py -v` → 11/11 PASS in 0.09 s
- [x] Adjacent suites unchanged: `pytest tests/test_protocol_contract.py tests/test_start_handler.py tests/test_voice_modes.py` → 50/50 total
- [x] Ruff CI gate: clean
- [x] Wired into `ci.yml` pytest list

Earns the right to W7-B (skill catalog browse) + W7-C (memory bridge) per the audit sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)