### PR TITLE
feat(llm): bridge gateway tool_calls into /api/v1/agent_log feed (closes #294, refs W7-A)

### DIFF
--- a/dragon_voice/llm/tinkerclaw_llm.py
+++ b/dragon_voice/llm/tinkerclaw_llm.py
@@ -607,12 +607,22 @@ class TinkerClawBackend(LLMBackend):
         buffer: dict[int, dict[str, Any]],
         flushed: set[int],
     ) -> None:
-        """Emit accumulated tool calls via the registered callback.
+        """Emit accumulated tool calls via the registered callback +
+        record into the cross-session agent_log ring (Wave 12 surface).
 
         Each buffer entry is rendered as Dragon's standard tool_call
         shape (`{"tool": "<name>", "args": <parsed dict>}`) and passed
         to `self._on_tool_call`.  Failures are logged + swallowed so a
         buggy callback can never tear down the LLM stream.
+
+        After the WS-side emit, the same call is appended to the
+        agent_log ring buffer (`dragon_voice.api.agent_log.record_call`)
+        so the `/api/v1/agent_log` feed surfaces gateway-routed calls
+        alongside the local-ToolRegistry ones — without the gateway
+        having to expose a separate skill-discovery endpoint.  This
+        closes the Wave 12 visibility gap mode 3 had:  ToolRegistry's
+        own chokepoint is bypassed when the LLM is `tinkerclaw`, so
+        agent_log was previously dark for mode-3 sessions.
 
         Idempotent: indexes already in `flushed` are skipped, so we can
         be called at finish_reason and again at EOS without duplicate
@@ -620,11 +630,6 @@ class TinkerClawBackend(LLMBackend):
         lets future runs in the same stream (rare) accumulate further
         argument fragments correctly.
         """
-        if not self._on_tool_call:
-            # No handler registered → nothing to surface.  Still mark
-            # entries flushed so we don't churn re-checking them.
-            flushed.update(buffer.keys())
-            return
         for idx, call in buffer.items():
             if idx in flushed:
                 continue
@@ -642,13 +647,27 @@ class TinkerClawBackend(LLMBackend):
                 # *something* useful for debugging.
                 args_obj = {"_raw": args_str[:512]}
             payload = {"tool": name, "args": args_obj}
+            if self._on_tool_call is not None:
+                try:
+                    await self._on_tool_call(payload)
+                except Exception:
+                    logger.exception(
+                        "W7-A: on_tool_call callback raised — swallowed "
+                        "to keep LLM stream alive (tool=%s)",
+                        name,
+                    )
+            # W7-A.b: record into the agent_log ring so /api/v1/agent_log
+            # surfaces gateway-routed calls.  Lazy-import to keep this
+            # module standalone if the API layer is ever broken out.
+            # Failures are best-effort — the ring buffer should never
+            # tear down LLM streaming.
             try:
-                await self._on_tool_call(payload)
+                from dragon_voice.api.agent_log import record_call as _alog
+                _alog(name, args_obj if isinstance(args_obj, dict) else {})
             except Exception:
-                logger.exception(
-                    "W7-A: on_tool_call callback raised — swallowed "
-                    "to keep LLM stream alive (tool=%s)",
-                    name,
+                logger.debug(
+                    "agent_log record_call suppressed for gateway tool %s",
+                    name, exc_info=True,
                 )
             flushed.add(idx)
 

--- a/tests/test_tinkerclaw_tool_events.py
+++ b/tests/test_tinkerclaw_tool_events.py
@@ -202,5 +202,65 @@ class TestSetToolEventHandler(unittest.TestCase):
         self.assertIsNone(be._on_tool_call)
 
 
+class TestAgentLogBridge(unittest.IsolatedAsyncioTestCase):
+    """W7-A.b: gateway tool calls land in the cross-session agent_log
+    ring (the /api/v1/agent_log feed Tab5 reads in Wave 12).  Pre-W7-A.b
+    the ToolRegistry.execute chokepoint was the only writer, so mode 3
+    was dark for the agent_log surface."""
+
+    async def asyncSetUp(self):
+        # The ring is process-global; snapshot + restore so tests don't
+        # cross-contaminate one another.
+        from dragon_voice.api import agent_log as _alog
+        self._alog = _alog
+        # Save state
+        with _alog._lock:
+            self._saved_ring = list(_alog._ring)
+            self._saved_next = _alog._next_id
+            _alog._ring.clear()
+            _alog._next_id = 1
+
+    async def asyncTearDown(self):
+        with self._alog._lock:
+            self._alog._ring.clear()
+            for item in self._saved_ring:
+                self._alog._ring.append(item)
+            self._alog._next_id = self._saved_next
+
+    async def test_flush_records_to_agent_log(self):
+        be = _NoInitBackend()
+        buf = {0: {"id": "x", "name": "web_search", "arguments": '{"q":"hi"}'}}
+        await be._flush_tool_calls(buf, set())
+        with self._alog._lock:
+            entries = list(self._alog._ring)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "web_search")
+        self.assertEqual(entries[0]["args"], {"q": "hi"})
+        self.assertEqual(entries[0]["status"], "running")
+
+    async def test_records_even_without_handler(self):
+        # The W7-A.b agent_log write must NOT depend on a handler being
+        # registered — it should fire regardless so /api/v1/agent_log is
+        # useful even when no WS-emit callback is wired.
+        be = _NoInitBackend()
+        self.assertIsNone(be._on_tool_call)
+        buf = {0: {"id": "x", "name": "remember", "arguments": '{"fact":"y"}'}}
+        await be._flush_tool_calls(buf, set())
+        with self._alog._lock:
+            entries = list(self._alog._ring)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "remember")
+
+    async def test_double_flush_records_once(self):
+        be = _NoInitBackend()
+        buf = {0: {"id": "x", "name": "t", "arguments": "{}"}}
+        flushed: set = set()
+        await be._flush_tool_calls(buf, flushed)
+        await be._flush_tool_calls(buf, flushed)
+        with self._alog._lock:
+            entries = list(self._alog._ring)
+        self.assertEqual(len(entries), 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- After W7-A's WS-side tool_call emit, also call `agent_log.record_call(name, args)` so gateway-routed calls surface in the same ring local-ToolRegistry calls use
- Recording fires whether or not a WS handler is registered (the log surface should be useful regardless)
- Lazy-import + best-effort swallow keeps the api.agent_log dependency from tearing down the LLM stream

## Test plan
- [x] 3 new tests pin the bridge; 11 existing W7-A tests unchanged
- [x] `pytest tests/test_tinkerclaw_tool_events.py -v` → 14/14 PASS in 0.10 s
- [x] Ruff CI gate clean

Smallest possible W7-B precursor — closes the Wave 12 visibility gap mode 3 had, without a new Dragon endpoint or any Tab5 firmware change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)