### PR TITLE
feat(api): GET /api/v1/agent_skills catalog endpoint (closes #296, refs W7-B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,4 +130,5 @@ jobs:
             tests/test_spend_tracker.py \
             tests/test_start_handler.py \
             tests/test_protocol_contract.py \
-            tests/test_tinkerclaw_tool_events.py
+            tests/test_tinkerclaw_tool_events.py \
+            tests/test_agent_skills_api.py

--- a/dragon_voice/api/__init__.py
+++ b/dragon_voice/api/__init__.py
@@ -14,6 +14,7 @@ from dragon_voice.api.devices import DeviceRoutes
 from dragon_voice.api.config_routes import ConfigRoutes
 from dragon_voice.api.events import EventRoutes
 from dragon_voice.api.agent_log import AgentLogRoutes
+from dragon_voice.api.agent_skills import AgentSkillsRoutes  # W7-B
 from dragon_voice.api.spend import SpendRoutes  # W5-A: daily spend
 from dragon_voice.api.media_routes import MediaRoutes
 from dragon_voice.api.synthesize import SynthesizeRoutes
@@ -58,6 +59,10 @@ def setup_all_routes(
     # (populated via dragon_voice.api.agent_log.record_call/result
     # from the WS voice handler's existing _on_tool_call hooks).
     AgentLogRoutes().register(app)
+    # W7-B (audit 2026-05-11): agent-skill catalog for mode-3 Tab5.
+    # Merges a known-static OpenClaw core-tool list with any tool names
+    # observed in the agent_log ring.
+    AgentSkillsRoutes().register(app)
     # W5-A: daily spend rollup from api_usage events
     SpendRoutes(db).register(app)
 

--- a/dragon_voice/api/agent_skills.py
+++ b/dragon_voice/api/agent_skills.py
@@ -1,0 +1,149 @@
+"""Agent skills catalog API — W7-B from the 2026-05-11 cross-stack audit.
+
+`GET /api/v1/agent_skills` returns a merged catalog of:
+
+  * **static** — the well-known OpenClaw gateway core tools every
+    mode-3 deployment ships with.  Hardcoded here because the gateway
+    speaks WS-RPC for `skills.status`, not REST; a long-lived WS client
+    from Dragon to the gateway is a bigger lift than this slice
+    deserves.  Real live-discovery is W7-B.2 follow-up.
+  * **observed** — distinct tool names captured in the cross-session
+    `agent_log` ring (Wave 12 + W7-A.b).  Anything the gateway has
+    actually called in this Dragon's lifetime, in addition to the
+    static set.  Surfaces grow with usage rather than needing manual
+    catalog upkeep.
+
+Response shape (intentionally close to the existing /api/v1/tools shape
+so Tab5's Agents overlay can render the two side-by-side with minimal
+new code):
+
+```json
+{
+  "items": [
+    {"name": "web_search", "source": "static",   "uses": 0,  "last_ts": null},
+    {"name": "bash",       "source": "static",   "uses": 2,  "last_ts": 1715561234},
+    {"name": "skill_xyz",  "source": "observed", "uses": 5,  "last_ts": 1715561300}
+  ],
+  "count": 3,
+  "static_count": 7,
+  "observed_count": 1
+}
+```
+
+`uses` and `last_ts` are best-effort, derived from the agent_log
+ring.  A tool that hasn't been called since the last process restart
+will show uses=0; the ring is bounded so very old usage rolls off.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from typing import Any
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+# OpenClaw gateway core tools as of the 2026-05-12 OpenClaw source
+# inspection.  Static list, not a runtime probe.  When the gateway
+# adds a tool, either (a) it surfaces via the `observed` path the first
+# time mode 3 calls it, or (b) we update this list — both work.
+# Source: ~/Desktop/openclaw/src/plugins/registry.ts + the bundled
+# default skill set.
+_STATIC_AGENT_SKILLS: tuple[str, ...] = (
+    "bash",          # shell command execution
+    "browser",       # CDP-driven browser automation
+    "edit_file",     # file write/patch
+    "memory",        # gateway-side fact store (sqlite-vec + FTS5)
+    "read_file",     # file read
+    "search_files",  # filesystem search
+    "task",          # subagent / multi-step task spawn
+    "web_search",    # web search via gateway provider
+)
+
+
+def _aggregate_observed(ring_items: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Walk the agent_log snapshot once and build {name → {uses, last_ts}}."""
+    stats: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {"uses": 0, "last_ts": None},
+    )
+    for rec in ring_items:
+        name = rec.get("tool")
+        if not isinstance(name, str) or not name:
+            continue
+        slot = stats[name]
+        slot["uses"] += 1
+        ts = rec.get("ts")
+        if isinstance(ts, int) and (slot["last_ts"] is None or ts > slot["last_ts"]):
+            slot["last_ts"] = ts
+    return stats
+
+
+def build_catalog() -> dict[str, Any]:
+    """Compose the static-merged-with-observed catalog.  Pure helper —
+    exposed so tests can drive it without a live aiohttp request."""
+    # Import inline so the agent_log ring is read fresh each call
+    # (don't cache; the ring mutates as new tools fire).
+    from dragon_voice.api import agent_log as _alog
+
+    with _alog._lock:
+        ring_snapshot = list(_alog._ring)
+
+    observed = _aggregate_observed(ring_snapshot)
+    items: list[dict[str, Any]] = []
+
+    for name in _STATIC_AGENT_SKILLS:
+        slot = observed.pop(name, {"uses": 0, "last_ts": None})
+        items.append({
+            "name": name,
+            "source": "static",
+            "uses": slot["uses"],
+            "last_ts": slot["last_ts"],
+        })
+
+    # Whatever remains in `observed` is a gateway skill we didn't know
+    # about at static-catalog time — surface it.  Sort by recency
+    # (most-recently-used first) so Tab5 can render "recently active"
+    # at the top of the agent-skills section.
+    extras = sorted(
+        observed.items(),
+        key=lambda kv: kv[1]["last_ts"] or 0,
+        reverse=True,
+    )
+    for name, slot in extras:
+        items.append({
+            "name": name,
+            "source": "observed",
+            "uses": slot["uses"],
+            "last_ts": slot["last_ts"],
+        })
+
+    static_count = sum(1 for it in items if it["source"] == "static")
+    observed_count = sum(1 for it in items if it["source"] == "observed")
+    return {
+        "items": items,
+        "count": len(items),
+        "static_count": static_count,
+        "observed_count": observed_count,
+    }
+
+
+class AgentSkillsRoutes:
+    """`GET /api/v1/agent_skills` — agent-skill catalog for mode-3 Tab5."""
+
+    def register(self, app: web.Application) -> None:
+        app.router.add_get("/api/v1/agent_skills", self.get_skills)
+
+    async def get_skills(self, request: web.Request) -> web.Response:
+        try:
+            catalog = build_catalog()
+        except Exception:
+            logger.exception("agent_skills catalog build failed")
+            return web.json_response(
+                {"items": [], "count": 0, "static_count": 0, "observed_count": 0,
+                 "error": "catalog_unavailable"},
+                status=500,
+            )
+        return web.json_response(catalog)

--- a/tests/test_agent_skills_api.py
+++ b/tests/test_agent_skills_api.py
@@ -1,0 +1,130 @@
+"""W7-B: agent-skill catalog API tests.
+
+Verifies that GET /api/v1/agent_skills:
+  * returns the full static OpenClaw core-tool list when the agent_log
+    ring is empty (initial Dragon boot)
+  * merges observed tool names from the ring on top of the static set
+    (so gateway tools surface as soon as they fire)
+  * never returns the same tool twice (static + observed dedupe)
+  * carries `uses` + `last_ts` derived from the ring
+  * sorts observed-only extras most-recently-used first
+"""
+
+from __future__ import annotations
+
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from dragon_voice.api import agent_log as _alog
+from dragon_voice.api.agent_skills import (
+    AgentSkillsRoutes,
+    _STATIC_AGENT_SKILLS,
+    build_catalog,
+)
+
+
+class _BaseRingTest(unittest.TestCase):
+    """Snapshot + restore the process-global agent_log ring so each
+    test starts clean and doesn't bleed state into the next."""
+
+    def setUp(self):
+        with _alog._lock:
+            self._saved_ring = list(_alog._ring)
+            self._saved_next = _alog._next_id
+            _alog._ring.clear()
+            _alog._next_id = 1
+
+    def tearDown(self):
+        with _alog._lock:
+            _alog._ring.clear()
+            for item in self._saved_ring:
+                _alog._ring.append(item)
+            _alog._next_id = self._saved_next
+
+
+class TestBuildCatalog(_BaseRingTest):
+    def test_empty_ring_returns_full_static(self):
+        cat = build_catalog()
+        self.assertEqual(cat["count"], len(_STATIC_AGENT_SKILLS))
+        self.assertEqual(cat["static_count"], len(_STATIC_AGENT_SKILLS))
+        self.assertEqual(cat["observed_count"], 0)
+        names = {it["name"] for it in cat["items"]}
+        self.assertEqual(names, set(_STATIC_AGENT_SKILLS))
+        for it in cat["items"]:
+            self.assertEqual(it["source"], "static")
+            self.assertEqual(it["uses"], 0)
+            self.assertIsNone(it["last_ts"])
+
+    def test_observed_overrides_static_with_usage_stats(self):
+        # web_search is in the static list; fire it via the ring.
+        _alog.record_call("web_search", {"q": "weather"})
+        cat = build_catalog()
+        item = next(it for it in cat["items"] if it["name"] == "web_search")
+        self.assertEqual(item["source"], "static")  # still static-classified
+        self.assertEqual(item["uses"], 1)
+        self.assertIsNotNone(item["last_ts"])
+        # No duplicate entry in the observed section.
+        web_count = sum(1 for it in cat["items"] if it["name"] == "web_search")
+        self.assertEqual(web_count, 1)
+
+    def test_unknown_tool_surfaces_as_observed(self):
+        _alog.record_call("skill_xyz", {"a": 1})
+        cat = build_catalog()
+        # Static tools are still all there.
+        self.assertEqual(cat["static_count"], len(_STATIC_AGENT_SKILLS))
+        # And the new observed one too.
+        self.assertEqual(cat["observed_count"], 1)
+        skill = next(it for it in cat["items"] if it["name"] == "skill_xyz")
+        self.assertEqual(skill["source"], "observed")
+        self.assertEqual(skill["uses"], 1)
+
+    def test_multiple_calls_increment_uses(self):
+        for i in range(3):
+            _alog.record_call("bash", {"cmd": f"ls {i}"})
+        cat = build_catalog()
+        item = next(it for it in cat["items"] if it["name"] == "bash")
+        self.assertEqual(item["uses"], 3)
+
+    def test_observed_extras_sorted_recent_first(self):
+        # Two observed tools at different times.  Need to bypass the
+        # auto-ts-on-record by mutating the ring directly so we can
+        # control the ordering deterministically.
+        with _alog._lock:
+            _alog._ring.append({
+                "id": 1, "ts": 1000, "tool": "skill_old", "args": {},
+                "status": "done", "result": None, "execution_ms": None,
+            })
+            _alog._ring.append({
+                "id": 2, "ts": 2000, "tool": "skill_new", "args": {},
+                "status": "done", "result": None, "execution_ms": None,
+            })
+        cat = build_catalog()
+        observed = [it for it in cat["items"] if it["source"] == "observed"]
+        self.assertEqual([it["name"] for it in observed], ["skill_new", "skill_old"])
+
+    def test_malformed_ring_entries_silently_skipped(self):
+        with _alog._lock:
+            _alog._ring.append({"id": 1, "ts": 1000, "tool": None, "args": {}})
+            _alog._ring.append({"id": 2, "ts": 1000, "tool": "", "args": {}})
+            _alog._ring.append({"id": 3, "ts": 1000, "tool": "fine", "args": {}})
+        cat = build_catalog()
+        names = {it["name"] for it in cat["items"]}
+        self.assertIn("fine", names)
+        # The malformed ones never surface as observed entries.
+        observed = {it["name"] for it in cat["items"] if it["source"] == "observed"}
+        self.assertEqual(observed, {"fine"})
+
+
+class TestRouteRegistration(unittest.TestCase):
+    def test_register_adds_get_route(self):
+        app_mock = MagicMock()
+        AgentSkillsRoutes().register(app_mock)
+        # add_get called once with /api/v1/agent_skills as the path
+        app_mock.router.add_get.assert_called_once()
+        args, _kwargs = app_mock.router.add_get.call_args
+        self.assertEqual(args[0], "/api/v1/agent_skills")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- New `GET /api/v1/agent_skills` returns the merged static + observed agent-skill catalog for mode 3
- Static = hardcoded OpenClaw core tools (bash / browser / edit_file / memory / read_file / search_files / task / web_search) verified against upstream OpenClaw source 2026-05-12
- Observed = distinct tool names captured in the agent_log ring (Wave 12 + W7-A.b)
- Each entry carries `name`, `source` (static/observed), `uses`, `last_ts`
- Observed-only extras sort most-recently-used first

Dynamic live-discovery via gateway WS-RPC `skills.status` is W7-B.2 follow-up.

## Test plan
- [x] `pytest tests/test_agent_skills_api.py -v` → 7/7 PASS
- [x] Combined with W7-A tool-event suite: 21/21 PASS in 0.11 s
- [x] Ruff CI gate clean
- [x] Wired into `setup_all_routes()` + `ci.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)