### PR TITLE
feat(api): source field on agent_log entries (closes #301, refs W7-A)

### DIFF
--- a/dragon_voice/api/agent_log.py
+++ b/dragon_voice/api/agent_log.py
@@ -73,9 +73,26 @@ def _preview(result: Any) -> Optional[str]:
    return s
 
 
-def record_call(tool: str, args: Optional[dict] = None) -> int:
-   """Append a "running" entry to the ring.  Returns the assigned id."""
+def record_call(
+    tool: str,
+    args: Optional[dict] = None,
+    source: str = "dragon",
+) -> int:
+   """Append a "running" entry to the ring.  Returns the assigned id.
+
+   `source` distinguishes the call's surface (added W7-A.3,
+   2026-05-12):
+     * "dragon"  — invoked by Dragon's own ToolRegistry (default;
+                   preserves the pre-W7-A.3 behaviour for the
+                   ToolRegistry chokepoint in tools/registry.py)
+     * "gateway" — invoked by the TinkerClaw agent gateway,
+                   surfaced via the W7-A SSE tool_call delta path
+                   in dragon_voice/llm/tinkerclaw_llm.py
+   Unknown sources are stored as-is so a future surface (e.g. MCP
+   skill bridge) can name itself without an API change.
+   """
    global _next_id
+   src = str(source or "dragon").strip() or "dragon"
    with _lock:
       entry_id = _next_id
       _next_id += 1
@@ -85,6 +102,7 @@ def record_call(tool: str, args: Optional[dict] = None) -> int:
               "ts": int(time.time()),
               "tool": str(tool or "unknown"),
               "args": dict(args or {}),
+              "source": src,
               "status": "running",
               "result": None,
               "execution_ms": None,
@@ -97,19 +115,27 @@ def record_result(
     tool: str,
     result: Any = None,
     execution_ms: Optional[int] = None,
+    source: str = "dragon",
 ) -> None:
    """Mark the most-recent matching `running` entry done.
 
    Walks newest-first so same-tool-twice-in-one-turn still maps 1:1 to
-   the calls.  If no running entry matches (e.g., the call hook never
-   fired because of an early-error path), append a synthetic done entry
-   so the result still surfaces.
+   the calls.  Matching considers both `tool` and `source` — a
+   gateway-side `web_search` and a Dragon-side `web_search` don't
+   collide.  If no matching running entry exists (e.g., the call hook
+   never fired because of an early-error path), append a synthetic
+   done entry tagged with the same source so the result still surfaces.
    """
    global _next_id
    preview = _preview(result)
+   src = str(source or "dragon").strip() or "dragon"
    with _lock:
       for rec in reversed(_ring):
-         if rec.get("status") == "running" and rec.get("tool") == tool:
+         if (
+             rec.get("status") == "running"
+             and rec.get("tool") == tool
+             and rec.get("source", "dragon") == src
+         ):
             rec["status"] = "done"
             rec["result"] = preview
             rec["execution_ms"] = execution_ms
@@ -123,6 +149,7 @@ def record_result(
               "ts": int(time.time()),
               "tool": str(tool or "unknown"),
               "args": {},
+              "source": src,
               "status": "done",
               "result": preview,
               "execution_ms": execution_ms,
@@ -178,6 +205,16 @@ class AgentLogRoutes:
       limit = max(1, min(limit, _RING_SIZE))
 
       items = snapshot(since_id=since_id, limit=limit)
+      # W7-A.3: pre-bucketed source counts for clients that want to
+      # render Dragon vs gateway activity separately without re-
+      # walking `items` themselves.  Walks the live ring (not the
+      # paginated snapshot) so the totals are stable across calls.
+      with _lock:
+         all_items = list(_ring)
+      sources: dict[str, int] = {}
+      for rec in all_items:
+         s = str(rec.get("source") or "dragon")
+         sources[s] = sources.get(s, 0) + 1
       return web.json_response(
           {
               "items": items,
@@ -185,5 +222,6 @@ class AgentLogRoutes:
               "head_id": head_id(),
               "tail_id": tail_id(),
               "ring_size": _RING_SIZE,
+              "sources": sources,
           }
       )

--- a/dragon_voice/llm/tinkerclaw_llm.py
+++ b/dragon_voice/llm/tinkerclaw_llm.py
@@ -708,7 +708,11 @@ class TinkerClawBackend(LLMBackend):
             # tear down LLM streaming.
             try:
                 from dragon_voice.api.agent_log import record_call as _alog
-                _alog(name, args_obj if isinstance(args_obj, dict) else {})
+                _alog(
+                    name,
+                    args_obj if isinstance(args_obj, dict) else {},
+                    source="gateway",
+                )
             except Exception:
                 logger.debug(
                     "agent_log record_call suppressed for gateway tool %s",
@@ -757,7 +761,7 @@ class TinkerClawBackend(LLMBackend):
                     )
             try:
                 from dragon_voice.api.agent_log import record_result as _alog_res
-                _alog_res(name, result=None, execution_ms=None)
+                _alog_res(name, result=None, execution_ms=None, source="gateway")
             except Exception:
                 logger.debug(
                     "agent_log record_result suppressed for gateway tool %s",

--- a/tests/test_agent_log.py
+++ b/tests/test_agent_log.py
@@ -177,5 +177,75 @@ class TestEndpoint(unittest.TestCase):
         self._run(go())
 
 
+class TestSourceField(unittest.TestCase):
+    """W7-A.3: every entry carries a source field so consumers can
+    distinguish Dragon-side tools from gateway-routed ones."""
+
+    def setUp(self) -> None:
+        agent_log.reset_for_tests()
+
+    def test_record_call_defaults_to_dragon(self):
+        agent_log.record_call("web_search", {"q": "esp32"})
+        items = agent_log.snapshot()
+        self.assertEqual(items[0]["source"], "dragon")
+
+    def test_record_call_accepts_gateway_source(self):
+        agent_log.record_call("bash", {"cmd": "ls"}, source="gateway")
+        items = agent_log.snapshot()
+        self.assertEqual(items[0]["source"], "gateway")
+
+    def test_empty_source_defaults_to_dragon(self):
+        agent_log.record_call("x", source="")
+        items = agent_log.snapshot()
+        self.assertEqual(items[0]["source"], "dragon")
+
+    def test_result_matches_within_source_scope(self):
+        """Same tool name from different sources must not collide on
+        result match.  Dragon's web_search and gateway's web_search
+        are independent entries even if firing in the same window."""
+        agent_log.record_call("web_search", {"q": "a"}, source="dragon")
+        agent_log.record_call("web_search", {"q": "b"}, source="gateway")
+        agent_log.record_result("web_search", "dragon-done", source="dragon")
+        items = agent_log.snapshot()
+        # newest-first, so [0] = gateway (still running), [1] = dragon (done)
+        self.assertEqual(items[0]["source"], "gateway")
+        self.assertEqual(items[0]["status"], "running")
+        self.assertEqual(items[1]["source"], "dragon")
+        self.assertEqual(items[1]["status"], "done")
+        self.assertEqual(items[1]["result"], "dragon-done")
+
+    def test_unknown_source_preserved(self):
+        """API doesn't gatekeep source values — a future surface like
+        'mcp' or 'skill_bridge' can self-identify without a code
+        change."""
+        agent_log.record_call("x", source="mcp")
+        items = agent_log.snapshot()
+        self.assertEqual(items[0]["source"], "mcp")
+
+    def test_endpoint_returns_source_bucket_counts(self):
+        """GET /api/v1/agent_log returns a `sources` dict with per-
+        source counts (Dragon vs gateway vs others)."""
+        agent_log.record_call("a", source="dragon")
+        agent_log.record_call("b", source="dragon")
+        agent_log.record_call("c", source="gateway")
+
+        async def go():
+            app = web.Application()
+            agent_log.AgentLogRoutes().register(app)
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.get("/api/v1/agent_log")
+                self.assertEqual(resp.status, 200)
+                body = await resp.json()
+                self.assertIn("sources", body)
+                self.assertEqual(body["sources"].get("dragon"), 2)
+                self.assertEqual(body["sources"].get("gateway"), 1)
+
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(go())
+        finally:
+            loop.close()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tinkerclaw_tool_events.py
+++ b/tests/test_tinkerclaw_tool_events.py
@@ -275,12 +275,15 @@ class TestSyntheticToolResult(unittest.IsolatedAsyncioTestCase):
     async def test_emit_marks_agent_log_done(self):
         """Synthetic result must flip the corresponding agent_log
         ring entry from running → done so /api/v1/agent_log is
-        accurate post-completion."""
-        # Record a running call manually
-        self._alog.record_call("search", {"q": "weather"})
+        accurate post-completion.  W7-A.3: source must match — a
+        gateway-side flush only closes gateway-source entries."""
+        # Record a running call from the gateway surface (mirroring
+        # what W7-A.b's bridge does).
+        self._alog.record_call("search", {"q": "weather"}, source="gateway")
         with self._alog._lock:
             initial = list(self._alog._ring)
         self.assertEqual(initial[0]["status"], "running")
+        self.assertEqual(initial[0]["source"], "gateway")
 
         be = _NoInitBackend()
         await be._emit_synthetic_results(["search"])
@@ -288,6 +291,7 @@ class TestSyntheticToolResult(unittest.IsolatedAsyncioTestCase):
         with self._alog._lock:
             after = list(self._alog._ring)
         self.assertEqual(after[0]["status"], "done")
+        self.assertEqual(after[0]["source"], "gateway")
 
     async def test_empty_pending_is_noop(self):
         # No callback, no pending → must not raise + must not emit
@@ -303,8 +307,9 @@ class TestSyntheticToolResult(unittest.IsolatedAsyncioTestCase):
 
     async def test_no_handler_still_records_to_agent_log(self):
         """The agent_log surface should work even when the WS callback
-        isn't wired (e.g., transient handler clear during backend swap)."""
-        self._alog.record_call("search", {"q": "weather"})
+        isn't wired (e.g., transient handler clear during backend swap).
+        W7-A.3: gateway-source matching."""
+        self._alog.record_call("search", {"q": "weather"}, source="gateway")
         be = _NoInitBackend()
         self.assertIsNone(be._on_tool_result)
         await be._emit_synthetic_results(["search"])


### PR DESCRIPTION
## Summary
- `record_call()` + `record_result()` gain `source: str = "dragon"` kwarg
- W7-A.b bridge + W7-A.2 synthetic-result emitter now pass `source="gateway"`
- Result matching considers source — Dragon `web_search` and gateway `web_search` don't collide
- `GET /api/v1/agent_log` response gains a `sources` dict with per-source counts

## Test plan
- [x] 6 new tests + 2 updated existing tests
- [x] `pytest tests/test_agent_log.py tests/test_tinkerclaw_tool_events.py -v` → 41/41 PASS
- [x] Ruff CI gate clean
- [x] Backward-compatible (pre-W7-A.3 entries treated as `dragon`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)