### PR TITLE
feat: W7-F follow-up — record channel_reply in agent_log feed

### DIFF
--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -832,13 +832,39 @@ class VoiceServer:
                             "channel_reply RX: ws=%s ch=%s thread=%s text=%.60s in_reply_to=%s",
                             ws_id, ch, thread, text, in_reply_to,
                         )
-                        import secrets as _secrets
+                        # W7-F follow-up: record the reply in the cross-session
+                        # agent_log feed so it surfaces in Tab5's Agents overlay
+                        # alongside Dragon + gateway tool calls.  source="user_reply"
+                        # bucket separates these from auto-fired tool calls so
+                        # the dashboard can render them differently if it wants
+                        # (Tab5 already has the dragon/gateway/other source
+                        # counter from W7-A.3 + W7-A.3-Tab5).
+                        from dragon_voice.api import agent_log
+                        platform_msg_id = f"stub:{__import__('secrets').token_hex(6)}"
+                        agent_log.record_call(
+                            "channel_reply",
+                            {
+                                "channel": ch,
+                                "thread_id": thread,
+                                "text_preview": text[:80],
+                            },
+                            source="user_reply",
+                        )
+                        agent_log.record_result(
+                            "channel_reply",
+                            {
+                                "ok": True,
+                                "platform_message_id": platform_msg_id,
+                            },
+                            execution_ms=0,
+                            source="user_reply",
+                        )
                         ack = {
                             "type": "channel_reply_ack",
                             "channel": ch,
                             "thread_id": thread,
                             "ok": True,
-                            "platform_message_id": f"stub:{_secrets.token_hex(6)}",
+                            "platform_message_id": platform_msg_id,
                         }
                         await ws.send_json(ack)
 


### PR DESCRIPTION
## Summary
Extends the W7-F stub channel_reply handler to record the reply in the cross-session `agent_log` ring so it surfaces alongside Dragon + gateway tool calls. Refs #304.

### What's new
`dragon_voice/server.py` channel_reply handler now calls:
- `agent_log.record_call("channel_reply", {channel, thread_id, text_preview}, source="user_reply")`
- `agent_log.record_result("channel_reply", {ok, platform_message_id}, execution_ms=0, source="user_reply")`

New `user_reply` bucket; Tab5's existing W7-A.3 source-counter renders it as "other".

### Live verification on Tab5 192.168.1.90 ↔ Dragon 192.168.1.91
```json
GET /api/v1/agent_log →
{
  "items": [{
    "tool": "channel_reply",
    "source": "user_reply",
    "status": "done",
    "args": {"channel":"tg","thread_id":"tg:al:1","text_preview":"agent log entry test"},
    "result": "{\"ok\":true,\"platform_message_id\":\"stub:9d65216fa9b8\"}",
    "execution_ms": 0
  }],
  "sources": {"user_reply": 1}
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)