### PR TITLE
feat: W7-F connector scaffold (prepares W7-F.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,4 +133,5 @@ jobs:
             tests/test_tinkerclaw_tool_events.py \
             tests/test_agent_skills_api.py \
             tests/test_channel_reply_handler.py \
-            tests/test_debug_channel_push.py
+            tests/test_debug_channel_push.py \
+            tests/test_channels_mock.py

--- a/dragon_voice/channel_reply_handler.py
+++ b/dragon_voice/channel_reply_handler.py
@@ -1,42 +1,66 @@
-"""W7-F channel_reply WS command handler (extracted from server.py).
+"""W7-F channel_reply WS command handler.
 
 Tab5 emits `channel_reply` frames (per TinkerTab PR #471, W7-E.4b real
 voice-dictated reply path).  Dragon's job is to:
 
-  1. Record the reply in the cross-session agent_log ring with
+  1. Forward the reply via a `ChannelConnector` (boot default:
+     `MockConnector` — stub:<hex> message id, no network I/O).
+     W7-F.2 will swap in a real gateway WS-RPC connector or per-
+     platform direct connectors without touching this handler.
+
+  2. Record the reply in the cross-session agent_log ring with
      source="user_reply" so it surfaces in Tab5's Agents overlay
      alongside Dragon + gateway tool calls.
-  2. ACK back with a `channel_reply_ack` JSON frame containing
-     ok=true + a stub `platform_message_id`.  Real platform
-     forwarding (Telegram/WhatsApp/etc.) lands in W7-F.2 — needs
-     the Python WS-RPC client to OpenClaw.
 
-The handler is intentionally synchronous: the ACK fires in the same
-tick as the receive, no async deferred state, and `record_call` +
-`record_result` both run so the agent_log entry transitions
-running→done atomically.
+  3. ACK back with a `channel_reply_ack` JSON frame carrying the
+     connector's result (ok / platform_message_id / error).
+
+The handler is intentionally synchronous (with respect to the WS-task):
+record_call + record_result both fire so the agent_log entry
+transitions running→done in one tick, and the ACK ships before the
+next WS frame is read.
 
 Extracted to allow standalone unit testing (see
 `tests/test_channel_reply_handler.py`).  server.py's WS read loop
-simply calls `handle_channel_reply(cmd, ws, ws_id, logger)`.
+calls `handle_channel_reply(cmd, ws, ws_id, logger)` and the handler
+uses a module-level connector singleton — tests override via
+`set_connector` so the default mock can be swapped for a recording
+fake.
 """
 
 from __future__ import annotations
 
 import logging
-import secrets
-from typing import Any, Protocol
+from typing import Any, Optional, Protocol
 
 from dragon_voice.api import agent_log
+from dragon_voice.channels import ChannelConnector, MockConnector
 
 
 class _WSLike(Protocol):
     async def send_json(self, data: dict, **kwargs: Any) -> None: ...
 
 
-def _make_platform_message_id() -> str:
-    """Generate the stub:<hex> id used until real platform forwarding lands."""
-    return f"stub:{secrets.token_hex(6)}"
+# Module-level connector singleton.  server.py's startup chain can
+# override via `set_connector(GatewayConnector(...))` when W7-F.2
+# lands; until then the mock is the boot default.
+_connector: ChannelConnector = MockConnector()
+
+
+def set_connector(connector: ChannelConnector) -> None:
+    """Replace the active connector.
+
+    Used by:
+      * server.py startup (when a non-mock connector is configured)
+      * tests/test_channel_reply_handler.py (inject recording fakes)
+    """
+    global _connector
+    _connector = connector
+
+
+def get_connector() -> ChannelConnector:
+    """Return the active connector — handy for tests to assert on."""
+    return _connector
 
 
 async def handle_channel_reply(
@@ -44,8 +68,12 @@ async def handle_channel_reply(
     ws: _WSLike,
     ws_id: str,
     logger: logging.Logger,
+    connector: Optional[ChannelConnector] = None,
 ) -> dict:
     """Dispatch a single `channel_reply` WS command.
+
+    `connector` overrides the module-level singleton for this call
+    only — useful for tests that want isolation without `set_connector`.
 
     Returns the ACK dict that was sent back to the client (also useful
     for tests that don't want to mock send_json).
@@ -59,7 +87,14 @@ async def handle_channel_reply(
         ws_id, ch, thread, text, in_reply_to,
     )
 
-    platform_msg_id = _make_platform_message_id()
+    # Forward via the active connector.  Mock returns ok=true; real
+    # connectors might fail (network, auth, rate limit) — the result
+    # carries ok + error so the ACK + agent_log entry tell the truth.
+    active = connector if connector is not None else _connector
+    result = await active.send_reply(
+        channel=ch, thread_id=thread, text=text, in_reply_to=in_reply_to
+    )
+
     agent_log.record_call(
         "channel_reply",
         {
@@ -72,18 +107,21 @@ async def handle_channel_reply(
     agent_log.record_result(
         "channel_reply",
         {
-            "ok": True,
-            "platform_message_id": platform_msg_id,
+            "ok": result.ok,
+            "platform_message_id": result.platform_message_id,
+            "error": result.error,
         },
         execution_ms=0,
         source="user_reply",
     )
-    ack = {
+    ack: dict = {
         "type": "channel_reply_ack",
         "channel": ch,
         "thread_id": thread,
-        "ok": True,
-        "platform_message_id": platform_msg_id,
+        "ok": result.ok,
+        "platform_message_id": result.platform_message_id,
     }
+    if not result.ok and result.error:
+        ack["error"] = result.error
     await ws.send_json(ack)
     return ack

--- a/dragon_voice/channels/__init__.py
+++ b/dragon_voice/channels/__init__.py
@@ -1,0 +1,40 @@
+"""Channel connector abstraction.
+
+Tab5 emits `channel_reply` frames; Dragon's job is to forward them to
+the actual messaging platform (Telegram, WhatsApp, Discord, etc.).
+The forwarding step is currently a stub (W7-F PR #305) — this package
+sets up the swap-in seam so W7-F.2 (real gateway WS-RPC client) can
+replace the mock without touching the WS dispatcher in server.py.
+
+Design rules:
+  * `ChannelConnector` is an abstract Protocol — no required state,
+    one async method `send_reply` returning `ChannelReplyResult`.
+  * `MockConnector` is the boot-default — logs + returns ok=true with
+    a `stub:<hex>` platform_message_id (matches what the inline W7-F
+    stub does today).  Useful for dev + tests.
+  * Future connectors (`GatewayConnector`, direct `TelegramConnector`)
+    live as sibling modules so the import surface stays clean.
+
+Usage:
+    from dragon_voice.channels import MockConnector, ChannelReplyResult
+
+    connector = MockConnector()
+    result = await connector.send_reply(
+        channel="tg",
+        thread_id="tg:thread:42",
+        text="ok, see you Sunday",
+    )
+    assert result.ok
+"""
+
+from dragon_voice.channels.base import (
+    ChannelConnector,
+    ChannelReplyResult,
+)
+from dragon_voice.channels.mock import MockConnector
+
+__all__ = [
+    "ChannelConnector",
+    "ChannelReplyResult",
+    "MockConnector",
+]

--- a/dragon_voice/channels/base.py
+++ b/dragon_voice/channels/base.py
@@ -1,0 +1,55 @@
+"""Abstract base for channel connectors.
+
+A `ChannelConnector` represents a single outbound transport for
+Tab5-originated replies.  Real implementations (gateway WS-RPC,
+direct Telegram bot, etc.) plug in here and the channel_reply
+handler dispatches through them.
+
+The abstraction is intentionally minimal — one async method,
+one result dataclass.  Future capabilities (delivery receipts,
+typing indicators, attachment uploads) get added when there's
+a second concrete connector that actually needs them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass
+class ChannelReplyResult:
+    """Outcome of dispatching a reply to a connector.
+
+    The fields mirror what Tab5's `channel_reply_ack` JSON frame
+    expects so the handler can pass them straight through to
+    `ws.send_json` without translation.
+    """
+
+    ok: bool
+    platform_message_id: str
+    error: str = ""
+
+
+class ChannelConnector(Protocol):
+    """Outbound transport for a single user-dictated reply.
+
+    Implementations:
+      * `MockConnector` — boot-default, returns ok=true with a
+        `stub:<hex>` platform_message_id.  No network I/O.
+      * `GatewayConnector` (W7-F.2) — forwards via OpenClaw WS-RPC.
+      * Direct connectors (Telegram, WhatsApp, etc.) — bypass the
+        gateway when a platform-specific token is configured.
+
+    `channel` is the canonical short name Tab5 emits (`tg`, `wa`,
+    `dc`, etc.).  Implementations are responsible for mapping that
+    to a platform-specific identifier.
+    """
+
+    async def send_reply(
+        self,
+        channel: str,
+        thread_id: str,
+        text: str,
+        in_reply_to: str = "",
+    ) -> ChannelReplyResult: ...

--- a/dragon_voice/channels/mock.py
+++ b/dragon_voice/channels/mock.py
@@ -1,0 +1,39 @@
+"""In-process mock connector — boot default until W7-F.2 lands."""
+
+from __future__ import annotations
+
+import logging
+import secrets
+
+from dragon_voice.channels.base import ChannelReplyResult
+
+logger = logging.getLogger(__name__)
+
+
+class MockConnector:
+    """No-op connector for dev + tests.
+
+    Mints a `stub:<hex>` platform_message_id and returns ok=true.
+    The actual reply text never leaves Dragon — useful for exercising
+    the Tab5↔Dragon round-trip without real platform credentials.
+
+    Substitute with a real connector (gateway WS-RPC, direct
+    Telegram, etc.) in production once W7-F.2 lands.
+    """
+
+    def __init__(self, *, prefix: str = "stub") -> None:
+        self._prefix = prefix
+
+    async def send_reply(
+        self,
+        channel: str,
+        thread_id: str,
+        text: str,
+        in_reply_to: str = "",
+    ) -> ChannelReplyResult:
+        pmid = f"{self._prefix}:{secrets.token_hex(6)}"
+        logger.debug(
+            "MockConnector: channel=%s thread=%s text=%.40s → %s",
+            channel, thread_id, text, pmid,
+        )
+        return ChannelReplyResult(ok=True, platform_message_id=pmid)

--- a/tests/test_channel_reply_handler.py
+++ b/tests/test_channel_reply_handler.py
@@ -127,6 +127,69 @@ class TestAgentLogIntegration(_BaseRingTest):
         self.assertIn(ack["platform_message_id"], entry["result"])
         self.assertIn('"ok": true', entry["result"])
 
+
+class TestConnectorDispatch(_BaseRingTest):
+    """W7-F.2 scaffold: handler dispatches via injected ChannelConnector."""
+
+    async def test_connector_override_param_used(self):
+        from dragon_voice.channels import ChannelReplyResult
+
+        class RecordingConnector:
+            def __init__(self) -> None:
+                self.calls: list = []
+
+            async def send_reply(self, channel, thread_id, text, in_reply_to=""):
+                self.calls.append((channel, thread_id, text, in_reply_to))
+                return ChannelReplyResult(
+                    ok=True, platform_message_id="recorded:abc123"
+                )
+
+        rec = RecordingConnector()
+        cmd = {
+            "channel": "wa",
+            "thread_id": "wa:99",
+            "text": "via recorder",
+            "in_reply_to": "wa:99:42",
+        }
+        ack = await handle_channel_reply(
+            cmd, self.ws, "ws", self.logger, connector=rec
+        )
+        self.assertEqual(len(rec.calls), 1)
+        self.assertEqual(rec.calls[0], ("wa", "wa:99", "via recorder", "wa:99:42"))
+        self.assertEqual(ack["platform_message_id"], "recorded:abc123")
+        self.assertTrue(ack["ok"])
+
+    async def test_connector_failure_surfaces_in_ack(self):
+        from dragon_voice.channels import ChannelReplyResult
+
+        class FailingConnector:
+            async def send_reply(self, channel, thread_id, text, in_reply_to=""):
+                return ChannelReplyResult(
+                    ok=False,
+                    platform_message_id="",
+                    error="rate limit hit",
+                )
+
+        cmd = {"channel": "tg", "thread_id": "t", "text": "hi"}
+        ack = await handle_channel_reply(
+            cmd, self.ws, "ws", self.logger, connector=FailingConnector()
+        )
+        self.assertFalse(ack["ok"])
+        self.assertEqual(ack["error"], "rate limit hit")
+        # agent_log result must also record the failure for visibility.
+        with _alog._lock:
+            entry = list(_alog._ring)[0]
+        self.assertIn("rate limit hit", entry["result"])
+        self.assertIn('"ok": false', entry["result"])
+
+    async def test_default_module_connector_is_mock(self):
+        from dragon_voice.channel_reply_handler import get_connector
+        from dragon_voice.channels import MockConnector
+
+        # Module-level singleton initialises to MockConnector — the
+        # boot default until W7-F.2 swaps in a real one.
+        self.assertIsInstance(get_connector(), MockConnector)
+
     async def test_source_bucket_appears_in_feed_summary(self):
         cmd = {"channel": "tg", "thread_id": "t", "text": "hi"}
         await handle_channel_reply(cmd, self.ws, "ws", self.logger)

--- a/tests/test_channels_mock.py
+++ b/tests/test_channels_mock.py
@@ -1,0 +1,81 @@
+"""Tests for `dragon_voice.channels.MockConnector`.
+
+The mock is the boot default until W7-F.2 lands.  We pin its
+contract here so any future connector that subs in via
+`channel_reply_handler.set_connector(...)` knows exactly what to
+match:
+
+  * `send_reply` is async + returns a `ChannelReplyResult`
+  * `ok=true` always
+  * `platform_message_id` follows `stub:<12 hex>` shape (so Tab5's
+    existing W7-F UI never mistakes a stub for a real id — the
+    `stub:` prefix is the giveaway)
+  * Unique id per call (drives the `test_ack_platform_message_id_is_unique`
+    case in test_channel_reply_handler)
+  * Custom prefix supported (for future connectors that want the
+    same shape but a different platform tag)
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+
+from dragon_voice.channels import ChannelReplyResult, MockConnector
+
+
+class TestMockConnector(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_ok_result(self):
+        c = MockConnector()
+        r = await c.send_reply(channel="tg", thread_id="t", text="hi")
+        self.assertIsInstance(r, ChannelReplyResult)
+        self.assertTrue(r.ok)
+        self.assertEqual(r.error, "")
+
+    async def test_platform_message_id_shape(self):
+        c = MockConnector()
+        r = await c.send_reply(channel="tg", thread_id="t", text="hi")
+        # `stub:<12 hex>` — 6 bytes via secrets.token_hex(6) = 12 hex chars
+        self.assertRegex(r.platform_message_id, r"^stub:[0-9a-f]{12}$")
+
+    async def test_unique_id_per_call(self):
+        c = MockConnector()
+        ids = set()
+        for _ in range(10):
+            r = await c.send_reply(channel="x", thread_id="y", text="z")
+            ids.add(r.platform_message_id)
+        self.assertEqual(len(ids), 10)
+
+    async def test_custom_prefix(self):
+        c = MockConnector(prefix="recorded")
+        r = await c.send_reply(channel="tg", thread_id="t", text="hi")
+        self.assertTrue(r.platform_message_id.startswith("recorded:"))
+        # Hex tail unchanged.
+        self.assertRegex(r.platform_message_id, r"^recorded:[0-9a-f]{12}$")
+
+    async def test_accepts_in_reply_to_optional(self):
+        c = MockConnector()
+        # in_reply_to defaults to "" — test both shapes still return ok.
+        r1 = await c.send_reply(channel="tg", thread_id="t", text="hi")
+        r2 = await c.send_reply(
+            channel="tg", thread_id="t", text="hi", in_reply_to="ref"
+        )
+        self.assertTrue(r1.ok)
+        self.assertTrue(r2.ok)
+
+
+class TestChannelReplyResult(unittest.TestCase):
+    def test_fields_default(self):
+        r = ChannelReplyResult(ok=True, platform_message_id="x")
+        self.assertEqual(r.error, "")
+
+    def test_failure_carries_error(self):
+        r = ChannelReplyResult(
+            ok=False, platform_message_id="", error="auth failed"
+        )
+        self.assertFalse(r.ok)
+        self.assertEqual(r.error, "auth failed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Sets up the swap-in seam for W7-F.2's real gateway/platform connectors. Refs #304.

### Changes
- **`dragon_voice/channels/`** (NEW package): `ChannelConnector` Protocol + `ChannelReplyResult` dataclass + `MockConnector` (boot default).
- **`dragon_voice/channel_reply_handler.py`**: module-level connector singleton + `set_connector()` / `get_connector()` + optional per-call `connector` kwarg. ACK now reflects connector result faithfully (`ok` + `platform_message_id` + optional `error`).
- **`tests/test_channels_mock.py`** (NEW, 7 tests) — pins MockConnector contract.
- **`tests/test_channel_reply_handler.py`** (+3 tests) — connector override routes the call, failure surfaces in ACK + agent_log, module default is MockConnector.
- **CI** — `test_channels_mock.py` added.

### Why
W7-F.2 (real platform forwarding) becomes a one-file slice: write `dragon_voice/channels/gateway.py` with a `GatewayConnector`, call `set_connector(GatewayConnector(...))` from startup. No changes needed to the WS dispatcher, the handler, or the existing 35 W7-F tests.

### Verified
- ruff CI gate clean
- `pytest tests/test_channels_mock.py tests/test_channel_reply_handler.py tests/test_debug_channel_push.py` → **35 passed in 0.18s** (was 25 pre-PR)
- Deployed to Dragon 192.168.1.91, service active, behaviour identical from Tab5 perspective

🤖 Generated with [Claude Code](https://claude.com/claude-code)