### PR TITLE
feat: W7-F.2 — OpenClaw gateway WS-RPC connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,4 +134,5 @@ jobs:
             tests/test_agent_skills_api.py \
             tests/test_channel_reply_handler.py \
             tests/test_debug_channel_push.py \
-            tests/test_channels_mock.py
+            tests/test_channels_mock.py \
+            tests/test_gateway_connector.py

--- a/dragon_voice/channels/__init__.py
+++ b/dragon_voice/channels/__init__.py
@@ -31,10 +31,12 @@ from dragon_voice.channels.base import (
     ChannelConnector,
     ChannelReplyResult,
 )
+from dragon_voice.channels.gateway import GatewayConnector
 from dragon_voice.channels.mock import MockConnector
 
 __all__ = [
     "ChannelConnector",
     "ChannelReplyResult",
+    "GatewayConnector",
     "MockConnector",
 ]

--- a/dragon_voice/channels/gateway.py
+++ b/dragon_voice/channels/gateway.py
@@ -1,0 +1,421 @@
+"""OpenClaw gateway WS-RPC connector — W7-F.2.
+
+Persistent WebSocket to the OpenClaw gateway (boots on ``localhost:18789``)
+that forwards Tab5-originated `channel_reply` text to a real messaging
+platform (Telegram, WhatsApp, Discord, …) by invoking the gateway's
+``send`` RPC method.
+
+Auth model: plain bearer token in the ``connect`` request's
+``auth.token``.  No HMAC device-identity handshake — the gateway runs
+as a sibling process on the same Dragon machine and the WS bind is
+loopback-only (see TinkerBox CLAUDE.md ▸ Service Map, port 18789
+localhost-only).  Anything that can reach 127.0.0.1:18789 already has
+root-equivalent on the device.
+
+Wire frames (see openclaw protocol/schema/frames.ts):
+  Client → Server   ``{"type":"req", "id":"<uuid>", "method":"<name>", "params":{...}}``
+  Server → Client   ``{"type":"res", "id":"<uuid>", "ok":bool, "payload":?, "error":?}``
+  Server → Client   ``{"type":"event", "event":"<name>", "payload":?}``  (ignored here)
+
+Per-call flow:
+  1. ``send_reply`` calls ``_ensure_connected`` (lazy open + handshake).
+  2. Builds a ``send`` RPC ``req`` with a fresh idempotency key.
+  3. Awaits the matching ``res``; maps payload/error → ChannelReplyResult.
+
+We deliberately keep this connector *minimal*:
+  * One persistent WS, single in-flight queue, no client-side retry.
+  * No outbound events emitted (the gateway pushes events for incoming
+    platform messages — those are W7-G's concern, not the reply path).
+  * Reconnect = drop + lazy reconnect on next ``send_reply``; we do
+    not transparently retry an in-flight send because the caller
+    (channel_reply_handler) already ACKs the user via Tab5 and a
+    retried send could double-deliver.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import secrets
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import aiohttp
+
+from dragon_voice.channels.base import ChannelReplyResult
+
+logger = logging.getLogger(__name__)
+
+# OpenClaw gateway protocol version — must match ``PROTOCOL_VERSION``
+# in ``openclaw/src/gateway/protocol/index.ts``.  Bump in lockstep
+# with the gateway when the wire shape changes.
+GATEWAY_PROTOCOL_VERSION = 1
+
+# Per-RPC budget.  Sends to Telegram/WhatsApp/etc. round-trip in
+# <1 s on the happy path; 15 s leaves comfortable headroom for cold
+# auth probes (first send after the gateway boots can be slower while
+# the channel plugin warms up).
+DEFAULT_RPC_TIMEOUT_S = 15.0
+
+# WS ping interval.  aiohttp's heartbeat=N sends a ping every N seconds
+# and treats a missing pong as the connection being dead.  30 s is well
+# under typical NAT/firewall idle timeouts (60-300 s) and matches the
+# gateway's own tick interval.
+WS_HEARTBEAT_S = 30.0
+
+
+@dataclass
+class _RpcResult:
+    """Internal result envelope for a single RPC round-trip."""
+
+    ok: bool
+    payload: Any = None
+    error: str = ""
+    error_code: str = ""
+
+
+@dataclass
+class _PendingCall:
+    """Tracks one in-flight request by its frame ``id``."""
+
+    future: asyncio.Future
+    method: str
+    sent_at: float = field(default_factory=time.monotonic)
+
+
+class GatewayConnector:
+    """WS-RPC connector to a loopback OpenClaw gateway.
+
+    Public surface mirrors the ``ChannelConnector`` Protocol (see
+    ``channels/base.py``) — one async ``send_reply`` returning a
+    ``ChannelReplyResult``.  Construct with the gateway URL + bearer
+    token; the actual WS connection is opened lazily on first call so
+    Dragon can instantiate this at startup without blocking boot if
+    the gateway is briefly unreachable.
+
+    Thread-safety: one connector instance is meant to be used by the
+    asyncio loop that owns it.  All public methods are coroutines;
+    there are no synchronous accessors that could race.
+    """
+
+    def __init__(
+        self,
+        *,
+        url: str = "ws://127.0.0.1:18789",
+        token: str,
+        client_id: str = "tinkerbox-dragon",
+        client_version: str = "0.1.0",
+        rpc_timeout_s: float = DEFAULT_RPC_TIMEOUT_S,
+        session: Optional[aiohttp.ClientSession] = None,
+    ) -> None:
+        if not token:
+            raise ValueError(
+                "GatewayConnector requires a bearer token — set "
+                "channel_gateway.token in config.yaml or "
+                "CHANNEL_GATEWAY_TOKEN in env."
+            )
+        self._url = url
+        self._token = token
+        self._client_id = client_id
+        self._client_version = client_version
+        self._rpc_timeout_s = rpc_timeout_s
+
+        # Allow tests to inject a shared aiohttp session so they don't
+        # have to spin up a real TCP listener.  Production callers
+        # leave this None and we create our own.
+        self._owned_session = session is None
+        self._session: Optional[aiohttp.ClientSession] = session
+        self._ws: Optional[aiohttp.ClientWebSocketResponse] = None
+        self._reader_task: Optional[asyncio.Task] = None
+        self._pending: dict[str, _PendingCall] = {}
+        self._connect_lock = asyncio.Lock()
+        self._connected = False
+
+    # ── public API ──────────────────────────────────────────────────
+
+    async def send_reply(
+        self,
+        channel: str,
+        thread_id: str,
+        text: str,
+        in_reply_to: str = "",
+    ) -> ChannelReplyResult:
+        """Forward a single reply via the gateway ``send`` method."""
+        try:
+            await self._ensure_connected()
+        except Exception as e:  # noqa: BLE001 — surface to ACK, not crash
+            logger.warning("gateway: connect failed for send_reply: %s", e)
+            return ChannelReplyResult(
+                ok=False,
+                platform_message_id="",
+                error=f"gateway_unreachable: {e}",
+            )
+
+        to = _extract_recipient(thread_id)
+        if not to:
+            return ChannelReplyResult(
+                ok=False,
+                platform_message_id="",
+                error=f"unparseable_thread_id: {thread_id!r}",
+            )
+
+        params: dict[str, Any] = {
+            "to": to,
+            "channel": channel,
+            "message": text,
+            "idempotencyKey": _idem_key(),
+        }
+        # Pass thread_id through so the gateway can group replies in
+        # the same conversation (Telegram message_thread_id, Discord
+        # thread, etc.).  Optional in the gateway schema.
+        if thread_id and thread_id != to:
+            params["threadId"] = thread_id
+
+        result = await self._rpc("send", params)
+        if not result.ok:
+            return ChannelReplyResult(
+                ok=False,
+                platform_message_id="",
+                error=result.error or "send_failed",
+            )
+
+        payload = result.payload or {}
+        platform_id = _extract_platform_id(payload)
+        return ChannelReplyResult(
+            ok=True,
+            platform_message_id=platform_id,
+        )
+
+    async def close(self) -> None:
+        """Tear down the WS + any pending RPCs.  Idempotent."""
+        if self._reader_task is not None and not self._reader_task.done():
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+        self._reader_task = None
+        if self._ws is not None and not self._ws.closed:
+            await self._ws.close()
+        self._ws = None
+        if self._owned_session and self._session is not None and not self._session.closed:
+            await self._session.close()
+            self._session = None
+        self._connected = False
+        self._fail_pending("connector closed")
+
+    # ── connect / handshake ─────────────────────────────────────────
+
+    async def _ensure_connected(self) -> None:
+        if self._connected and self._ws is not None and not self._ws.closed:
+            return
+        async with self._connect_lock:
+            if self._connected and self._ws is not None and not self._ws.closed:
+                return
+            await self._connect_locked()
+
+    async def _connect_locked(self) -> None:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+            self._owned_session = True
+        self._ws = await self._session.ws_connect(
+            self._url, heartbeat=WS_HEARTBEAT_S,
+        )
+        # Start the reader BEFORE the handshake so the connect response
+        # has a future waiting for it.
+        self._reader_task = asyncio.create_task(self._reader_loop())
+        try:
+            await self._handshake()
+        except Exception:
+            # Handshake failed — tear the connection down so the next
+            # send_reply gets a clean lazy-reconnect attempt.
+            await self._teardown_after_failure()
+            raise
+        self._connected = True
+        logger.info(
+            "GatewayConnector: connected to %s as %s",
+            self._url, self._client_id,
+        )
+
+    async def _handshake(self) -> None:
+        connect_params = {
+            "minProtocol": GATEWAY_PROTOCOL_VERSION,
+            "maxProtocol": GATEWAY_PROTOCOL_VERSION,
+            "client": {
+                "id": self._client_id,
+                "version": self._client_version,
+                "platform": "linux",
+                "mode": "backend",
+            },
+            "role": "agent.runner",
+            "scopes": ["operator.admin"],
+            "auth": {"token": self._token},
+            "caps": [],
+        }
+        result = await self._rpc("connect", connect_params, ensure_connected=False)
+        if not result.ok:
+            raise RuntimeError(
+                f"gateway connect rejected: {result.error or result.error_code or 'unknown'}"
+            )
+
+    async def _teardown_after_failure(self) -> None:
+        if self._reader_task is not None and not self._reader_task.done():
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+        self._reader_task = None
+        if self._ws is not None and not self._ws.closed:
+            await self._ws.close()
+        self._ws = None
+        self._connected = False
+        self._fail_pending("connect failed")
+
+    # ── RPC core ────────────────────────────────────────────────────
+
+    async def _rpc(
+        self,
+        method: str,
+        params: dict,
+        *,
+        ensure_connected: bool = True,
+    ) -> _RpcResult:
+        if ensure_connected:
+            await self._ensure_connected()
+        if self._ws is None or self._ws.closed:
+            return _RpcResult(ok=False, error="ws_not_open")
+
+        req_id = uuid.uuid4().hex
+        loop = asyncio.get_event_loop()
+        fut: asyncio.Future = loop.create_future()
+        self._pending[req_id] = _PendingCall(future=fut, method=method)
+
+        try:
+            await self._ws.send_json(
+                {"type": "req", "id": req_id, "method": method, "params": params},
+            )
+        except (aiohttp.ClientError, ConnectionError) as e:
+            self._pending.pop(req_id, None)
+            return _RpcResult(ok=False, error=f"send_failed: {e}")
+
+        try:
+            return await asyncio.wait_for(fut, timeout=self._rpc_timeout_s)
+        except asyncio.TimeoutError:
+            self._pending.pop(req_id, None)
+            return _RpcResult(ok=False, error="rpc_timeout")
+
+    # ── reader loop ─────────────────────────────────────────────────
+
+    async def _reader_loop(self) -> None:
+        ws = self._ws
+        if ws is None:
+            return
+        try:
+            async for msg in ws:
+                if msg.type == aiohttp.WSMsgType.TEXT:
+                    self._handle_text_frame(msg.data)
+                elif msg.type == aiohttp.WSMsgType.BINARY:
+                    # Gateway uses JSON-only frames; binaries are unexpected.
+                    logger.debug("gateway: ignoring binary frame (%d bytes)", len(msg.data))
+                elif msg.type in (
+                    aiohttp.WSMsgType.CLOSED,
+                    aiohttp.WSMsgType.CLOSING,
+                    aiohttp.WSMsgType.ERROR,
+                ):
+                    break
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("gateway: reader loop crashed")
+        finally:
+            self._connected = False
+            self._fail_pending("gateway disconnected")
+
+    def _handle_text_frame(self, data: str) -> None:
+        try:
+            frame = json.loads(data)
+        except json.JSONDecodeError:
+            logger.warning("gateway: bad JSON frame: %.120s", data)
+            return
+        frame_type = frame.get("type")
+        if frame_type == "res":
+            self._dispatch_response(frame)
+        elif frame_type == "event":
+            # W7-G will handle inbound platform messages.  For now,
+            # log + drop so the WS stays healthy.
+            logger.debug(
+                "gateway: dropping event=%s payload=%.120s",
+                frame.get("event"), str(frame.get("payload")),
+            )
+        else:
+            logger.debug("gateway: ignoring frame type=%s", frame_type)
+
+    def _dispatch_response(self, frame: dict) -> None:
+        req_id = frame.get("id")
+        pending = self._pending.pop(req_id, None) if req_id else None
+        if pending is None or pending.future.done():
+            return
+        ok = bool(frame.get("ok"))
+        err = frame.get("error") or {}
+        pending.future.set_result(
+            _RpcResult(
+                ok=ok,
+                payload=frame.get("payload"),
+                error=str(err.get("message", "")),
+                error_code=str(err.get("code", "")),
+            )
+        )
+
+    def _fail_pending(self, reason: str) -> None:
+        for pending in list(self._pending.values()):
+            if not pending.future.done():
+                pending.future.set_result(
+                    _RpcResult(ok=False, error=reason),
+                )
+        self._pending.clear()
+
+
+# ── helpers ─────────────────────────────────────────────────────────
+
+
+def _idem_key() -> str:
+    """Idempotency key for a single ``send`` invocation.
+
+    Gateway's dedupe ring keys on this — same key within the ring's
+    TTL returns the cached result.  Format: ``dragon:<epoch-ms>:<rand>``.
+    """
+    return f"dragon:{int(time.time() * 1000)}:{secrets.token_hex(4)}"
+
+
+def _extract_recipient(thread_id: str) -> str:
+    """Pull the platform recipient out of Tab5's thread_id.
+
+    Tab5 emits thread ids in the form ``<channel>:<kind>:<id>`` —
+    e.g. ``tg:thread:42``, ``wa:chat:6053954118``.  The platform
+    recipient is the last colon-segment.  If the thread_id has no
+    colons we treat it as already-resolved and pass it through.
+    """
+    if not thread_id:
+        return ""
+    if ":" not in thread_id:
+        return thread_id
+    return thread_id.rsplit(":", 1)[-1]
+
+
+def _extract_platform_id(payload: dict) -> str:
+    """Best-effort: find the platform-specific message id in a send res.
+
+    Different gateway channel plugins return the id under different
+    keys (``messageId``, ``id``, ``platform_message_id``).  We try
+    them in order; falling back to an empty string is fine — the
+    user-facing ACK can still report ``ok=true`` without an id.
+    """
+    for key in ("messageId", "platform_message_id", "id", "platformMessageId"):
+        val = payload.get(key)
+        if isinstance(val, (str, int)) and str(val).strip():
+            return str(val)
+    return ""

--- a/dragon_voice/config.py
+++ b/dragon_voice/config.py
@@ -203,6 +203,30 @@ class MemoryConfig:
 
 
 @dataclass
+class ChannelGatewayConfig:
+    """W7-F.2: OpenClaw gateway WS-RPC connector settings.
+
+    The gateway runs as a sibling process on the Dragon machine (port
+    18789, loopback-only).  When ``enabled`` is True, server startup
+    swaps ``MockConnector`` for ``GatewayConnector`` so Tab5-originated
+    ``channel_reply`` frames actually forward to Telegram/WhatsApp/etc.
+
+    Default is OFF — keeping the existing mock-only behavior until an
+    operator deliberately turns it on.  This lets the connector ship
+    without disrupting any active session.
+    """
+
+    enabled: bool = False
+    url: str = "ws://127.0.0.1:18789"
+    # Reuses the same shared secret as ``llm.tinkerclaw_token`` by
+    # default when blank — both auth surfaces target the same gateway
+    # process.  Set explicitly only if the gateway is configured with
+    # distinct tokens per client role.
+    token: str = ""
+    client_id: str = "tinkerbox-dragon"
+
+
+@dataclass
 class VoiceConfig:
     """Top-level configuration container."""
 
@@ -215,6 +239,9 @@ class VoiceConfig:
     memory: MemoryConfig = field(default_factory=MemoryConfig)
     database: DatabaseConfig = field(default_factory=DatabaseConfig)
     billing: BillingConfig = field(default_factory=BillingConfig)
+    channel_gateway: ChannelGatewayConfig = field(
+        default_factory=ChannelGatewayConfig,
+    )
 
     # β-arch (issue #123): protocol-level transition flag for the
     # progress event bus.  When True (default), migrated emitters

--- a/dragon_voice/lifecycle/shutdown.py
+++ b/dragon_voice/lifecycle/shutdown.py
@@ -114,6 +114,16 @@ async def run_shutdown(server: Any, app: web.Application) -> None:
     if server._proxy_session and not server._proxy_session.closed:
         await server._proxy_session.close()
 
+    # W7-F.2: close the gateway connector's WS + session if it was
+    # opted-in at startup.  No-op when MockConnector is still active.
+    _gw = getattr(server, "_gateway_connector", None)
+    if _gw is not None:
+        try:
+            await _gw.close()
+        except Exception:
+            logger.debug("GatewayConnector shutdown raised", exc_info=True)
+        server._gateway_connector = None
+
     # Shut down foundation
     if server._notes_svc:
         await server._notes_svc.shutdown()

--- a/dragon_voice/lifecycle/startup.py
+++ b/dragon_voice/lifecycle/startup.py
@@ -157,4 +157,47 @@ async def run_startup(server: Any, app: web.Application) -> None:
     )
     init_background_tasks(server)
 
+    # W7-F.2: swap the boot-default MockConnector for a real WS-RPC
+    # gateway connector when channel_gateway.enabled is set.  Lazy
+    # connect — failure here is only logged so a downed gateway
+    # doesn't block Dragon boot; send_reply() will retry per-call.
+    _init_channel_gateway(server)
+
     logger.info("Foundation modules initialized")
+
+
+def _init_channel_gateway(server: Any) -> None:
+    """Wire the gateway connector if channel_gateway.enabled is True.
+
+    Reads ``channel_gateway.token`` (falling back to
+    ``llm.tinkerclaw_token`` since both point at the same loopback
+    gateway process).  Failure to construct the connector — missing
+    token, bad URL — logs at WARNING and leaves the default
+    MockConnector in place so reply ACKs still succeed locally.
+    """
+    cg = getattr(server._config, "channel_gateway", None)
+    if cg is None or not getattr(cg, "enabled", False):
+        return
+    token = (cg.token or "").strip() or (server._config.llm.tinkerclaw_token or "").strip()
+    if not token:
+        logger.warning(
+            "channel_gateway.enabled=True but no token configured "
+            "(channel_gateway.token / llm.tinkerclaw_token both empty) — "
+            "staying on MockConnector",
+        )
+        return
+    try:
+        from dragon_voice.channel_reply_handler import set_connector
+        from dragon_voice.channels import GatewayConnector
+        connector = GatewayConnector(
+            url=cg.url,
+            token=token,
+            client_id=cg.client_id,
+        )
+        set_connector(connector)
+        server._gateway_connector = connector
+        logger.info("W7-F.2: channel_reply connector swapped to GatewayConnector(url=%s)", cg.url)
+    except Exception:
+        logger.exception(
+            "channel_gateway init failed — staying on MockConnector",
+        )

--- a/tests/test_gateway_connector.py
+++ b/tests/test_gateway_connector.py
@@ -1,0 +1,350 @@
+"""W7-F.2 — GatewayConnector tests.
+
+Exercises the connector end-to-end against an in-process aiohttp
+WebSocket server that speaks the OpenClaw gateway frame protocol
+(``req`` / ``res`` JSON envelopes).  The fake gateway is intentionally
+the minimum needed to validate the connector's contract:
+
+  * ``connect`` request → ``{ok: True}`` response (token-mode auth).
+  * ``send``    request → echo-style ``{ok: True, payload: {...}}`` with
+    a synthesized platform_message_id, or a configurable failure.
+  * Optional silent mode that ignores requests so timeout paths trigger.
+
+Tests cover the surface the W7-F handler depends on:
+
+  * Successful happy-path send → ChannelReplyResult(ok=True, id=...).
+  * Connect rejection (bad token) → ChannelReplyResult(ok=False, error=...).
+  * Send failure response → ok=False with error message.
+  * Unparseable thread_id → ok=False without WS round-trip.
+  * RPC timeout → ok=False with rpc_timeout error.
+  * close() is idempotent.
+  * Helper extractors (`_extract_recipient`, `_extract_platform_id`,
+    `_idem_key`) cover the edge cases that the integration tests can't.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from typing import Any, Callable, Optional
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import AioHTTPTestCase
+
+from dragon_voice.channels.gateway import (
+    GatewayConnector,
+    _extract_platform_id,
+    _extract_recipient,
+    _idem_key,
+)
+
+
+# ── Fake gateway WS handler ─────────────────────────────────────────
+
+
+class FakeGateway:
+    """In-process gateway impostor for connector integration tests.
+
+    Behavior toggles live on the instance so each test can configure
+    the same handler differently:
+
+      * ``connect_ok`` — whether the ``connect`` request returns ok=True
+      * ``send_handler`` — callable returning the (ok, payload, error)
+        triple for each ``send`` request; default returns ok=True with
+        a synthesized platform id.
+      * ``silent_methods`` — set of method names the gateway should
+        accept but never reply to (for testing the connector's RPC
+        timeout path).
+    """
+
+    def __init__(self) -> None:
+        self.connect_ok: bool = True
+        self.connect_error: str = ""
+        self.silent_methods: set[str] = set()
+        self.send_handler: Callable[[dict], tuple[bool, Optional[dict], str]] = (
+            self._default_send_handler
+        )
+        # Captured for assertions.
+        self.last_connect_params: Optional[dict] = None
+        self.last_send_params: Optional[dict] = None
+        self.connect_count: int = 0
+        self.send_count: int = 0
+
+    def _default_send_handler(
+        self, params: dict
+    ) -> tuple[bool, Optional[dict], str]:
+        return True, {"messageId": f"fake-{uuid.uuid4().hex[:8]}"}, ""
+
+    async def handle(self, request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        async for msg in ws:
+            if msg.type != web.WSMsgType.TEXT:
+                continue
+            try:
+                frame = json.loads(msg.data)
+            except json.JSONDecodeError:
+                continue
+            if frame.get("type") != "req":
+                continue
+            method = frame.get("method", "")
+            req_id = frame.get("id", "")
+            params = frame.get("params") or {}
+            if method in self.silent_methods:
+                # Accept the request, never reply — connector should time
+                # out per its rpc_timeout_s.
+                continue
+            if method == "connect":
+                self.connect_count += 1
+                self.last_connect_params = params
+                if self.connect_ok:
+                    await ws.send_json({
+                        "type": "res", "id": req_id, "ok": True,
+                        "payload": {
+                            "type": "hello-ok", "protocol": 1,
+                            "server": {"version": "test", "connId": "c1"},
+                            "features": {"methods": ["send"], "events": []},
+                            "snapshot": {},
+                            "policy": {
+                                "maxPayload": 1 << 20,
+                                "maxBufferedBytes": 1 << 22,
+                                "tickIntervalMs": 30_000,
+                            },
+                        },
+                    })
+                else:
+                    await ws.send_json({
+                        "type": "res", "id": req_id, "ok": False,
+                        "error": {"code": "AUTH_TOKEN_MISMATCH",
+                                  "message": self.connect_error or "bad token"},
+                    })
+            elif method == "send":
+                self.send_count += 1
+                self.last_send_params = params
+                ok, payload, err = self.send_handler(params)
+                if ok:
+                    await ws.send_json({
+                        "type": "res", "id": req_id, "ok": True,
+                        "payload": payload or {},
+                    })
+                else:
+                    await ws.send_json({
+                        "type": "res", "id": req_id, "ok": False,
+                        "error": {"code": "SEND_FAILED",
+                                  "message": err or "send failed"},
+                    })
+            else:
+                # Unknown method — return generic failure
+                await ws.send_json({
+                    "type": "res", "id": req_id, "ok": False,
+                    "error": {"code": "UNKNOWN_METHOD",
+                              "message": f"unknown method: {method}"},
+                })
+        return ws
+
+
+# ── Integration tests (real WS round-trip) ──────────────────────────
+
+
+class TestGatewayConnectorIntegration(AioHTTPTestCase):
+    """End-to-end tests with an in-process aiohttp WS server.
+
+    Each test creates a fresh GatewayConnector pointed at the
+    in-process server, exercises one behavior, then closes the
+    connector to free its background reader task.
+    """
+
+    async def get_application(self) -> web.Application:
+        self.gateway = FakeGateway()
+        app = web.Application()
+        app.router.add_get("/", self.gateway.handle)
+        return app
+
+    def _make_connector(self, *, token: str = "test-token", timeout: float = 2.0) -> GatewayConnector:
+        # ``self.server.port`` is provided by AioHTTPTestCase.
+        url = f"ws://127.0.0.1:{self.server.port}/"
+        return GatewayConnector(
+            url=url,
+            token=token,
+            client_id="test-client",
+            rpc_timeout_s=timeout,
+        )
+
+    async def test_send_reply_happy_path(self) -> None:
+        connector = self._make_connector()
+        try:
+            result = await connector.send_reply(
+                channel="tg",
+                thread_id="tg:thread:42",
+                text="hello world",
+            )
+            assert result.ok is True
+            assert result.platform_message_id.startswith("fake-")
+            assert result.error == ""
+            # Connector forwarded the right shape to the gateway:
+            params = self.gateway.last_send_params
+            assert params is not None
+            assert params["to"] == "42"
+            assert params["channel"] == "tg"
+            assert params["message"] == "hello world"
+            assert params["threadId"] == "tg:thread:42"
+            assert params["idempotencyKey"].startswith("dragon:")
+            # And the connect handshake ran exactly once even though
+            # the connector was constructed fresh.
+            assert self.gateway.connect_count == 1
+            # Token + role made it into the connect params.
+            cp = self.gateway.last_connect_params
+            assert cp is not None
+            assert cp["auth"]["token"] == "test-token"
+            assert cp["role"] == "agent.runner"
+        finally:
+            await connector.close()
+
+    async def test_connect_rejected_returns_ack_not_crash(self) -> None:
+        self.gateway.connect_ok = False
+        self.gateway.connect_error = "AUTH_TOKEN_MISMATCH"
+        connector = self._make_connector(token="wrong-token")
+        try:
+            result = await connector.send_reply(
+                channel="tg", thread_id="tg:thread:42", text="hi",
+            )
+            assert result.ok is False
+            assert "gateway_unreachable" in result.error or "AUTH" in result.error
+            # Send was never attempted because connect failed first.
+            assert self.gateway.send_count == 0
+        finally:
+            await connector.close()
+
+    async def test_send_failure_response_surfaces(self) -> None:
+        self.gateway.send_handler = (
+            lambda _params: (False, None, "platform_blocked_user")
+        )
+        connector = self._make_connector()
+        try:
+            result = await connector.send_reply(
+                channel="tg", thread_id="tg:thread:42", text="hi",
+            )
+            assert result.ok is False
+            assert result.platform_message_id == ""
+            assert "platform_blocked_user" in result.error
+        finally:
+            await connector.close()
+
+    async def test_rpc_timeout_returns_clean_error(self) -> None:
+        # Let connect succeed, then the SEND will hang silently.
+        self.gateway.silent_methods = {"send"}
+        connector = self._make_connector(timeout=0.5)
+        try:
+            result = await connector.send_reply(
+                channel="tg", thread_id="tg:thread:42", text="hi",
+            )
+            assert result.ok is False
+            assert "rpc_timeout" in result.error
+        finally:
+            await connector.close()
+
+    async def test_thread_id_without_colon_passes_through_as_to(self) -> None:
+        connector = self._make_connector()
+        try:
+            await connector.send_reply(
+                channel="tg", thread_id="6053954118", text="hi",
+            )
+            params = self.gateway.last_send_params
+            assert params is not None
+            # Plain numeric id → both `to` and (no separate) threadId
+            assert params["to"] == "6053954118"
+            # threadId is omitted when it equals `to` (avoid redundancy).
+            assert "threadId" not in params
+        finally:
+            await connector.close()
+
+    async def test_close_is_idempotent(self) -> None:
+        connector = self._make_connector()
+        await connector.send_reply(
+            channel="tg", thread_id="tg:thread:42", text="hi",
+        )
+        await connector.close()
+        # Second close must not raise.
+        await connector.close()
+
+    async def test_unparseable_thread_id_short_circuits(self) -> None:
+        connector = self._make_connector()
+        try:
+            result = await connector.send_reply(
+                channel="tg", thread_id="", text="hi",
+            )
+            assert result.ok is False
+            assert "unparseable_thread_id" in result.error
+            # Connect happened (lazy connect runs first), but no `send`
+            # round-trip because the recipient is empty.
+            assert self.gateway.send_count == 0
+        finally:
+            await connector.close()
+
+
+# ── Pure-unit tests for the helper extractors ───────────────────────
+
+
+class TestExtractRecipient:
+    """`tg:thread:42` → `42`; passthrough when no separator."""
+
+    def test_canonical_three_part(self) -> None:
+        assert _extract_recipient("tg:thread:42") == "42"
+
+    def test_two_part(self) -> None:
+        assert _extract_recipient("wa:6053954118") == "6053954118"
+
+    def test_no_colon_is_passthrough(self) -> None:
+        assert _extract_recipient("6053954118") == "6053954118"
+
+    def test_empty(self) -> None:
+        assert _extract_recipient("") == ""
+
+
+class TestExtractPlatformId:
+    """First-key-wins lookup across the gateway's id field variants."""
+
+    def test_messageId_preferred(self) -> None:
+        assert _extract_platform_id(
+            {"messageId": "mid-1", "id": "id-1"}
+        ) == "mid-1"
+
+    def test_falls_back_to_id(self) -> None:
+        assert _extract_platform_id({"id": "abc"}) == "abc"
+
+    def test_int_coerced_to_str(self) -> None:
+        assert _extract_platform_id({"messageId": 17}) == "17"
+
+    def test_no_id_returns_empty(self) -> None:
+        assert _extract_platform_id({"unrelated": "x"}) == ""
+
+
+class TestIdemKey:
+    """Idempotency keys are unique + monotonic-ish per call."""
+
+    def test_starts_with_dragon_prefix(self) -> None:
+        assert _idem_key().startswith("dragon:")
+
+    def test_unique_across_calls(self) -> None:
+        keys = {_idem_key() for _ in range(10)}
+        assert len(keys) == 10
+
+
+class TestRequiresToken:
+    """Constructor rejects empty tokens — the gateway would 401 every call."""
+
+    def test_blank_token_raises(self) -> None:
+        with pytest.raises(ValueError) as exc:
+            GatewayConnector(token="")
+        assert "token" in str(exc.value).lower()
+
+    def test_whitespace_token_accepted_then_strips(self) -> None:
+        # The constructor itself doesn't strip — that's the operator's
+        # job in config wiring.  Make sure we at least don't crash on
+        # an unusual but technically non-empty token.
+        connector = GatewayConnector(token="  abc  ")
+        assert connector is not None
+
+


### PR DESCRIPTION
## Summary

- Real outbound path for `channel_reply`: `GatewayConnector` opens a persistent WS to the OpenClaw gateway on `ws://127.0.0.1:18789`, handshakes with the existing bearer token, and forwards Tab5-dictated replies via the gateway's `send` RPC.
- Opt-in via new `channel_gateway` config block — defaults stay on `MockConnector` so all 35 existing W7-F tests pass unchanged. Operator flips `channel_gateway.enabled: true` to swap in the real connector.
- Failure modes (connect rejected, RPC timeout, send-side failure, bad thread_id) all surface as `ChannelReplyResult(ok=False, error=...)` so Tab5 always receives a truthful ACK frame.

## Test plan

- [x] `pytest tests/test_gateway_connector.py` — 19 new tests green (7 integration vs in-process aiohttp WS impostor + 12 helper/unit tests).
- [x] `pytest tests/test_channels_mock.py tests/test_channel_reply_handler.py tests/test_debug_channel_push.py` — 35 existing W7-F tests still green.
- [x] `ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ dashboard.py tests/` — clean.
- [ ] Live deploy + flip `channel_gateway.enabled=true` on Dragon (follow-up — kept out of this PR so a green CI lands first).

## Next slice

W7-G inbound platform messages → Tab5 will reuse the gateway WS already opened here; the reader_loop currently drops `event` frames and is the natural extension point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)