### PR TITLE
fix: wire channel_gateway yaml section into VoiceConfig

### DIFF
--- a/dragon_voice/config.py
+++ b/dragon_voice/config.py
@@ -369,7 +369,10 @@ def load_config(path: Optional[str] = None) -> VoiceConfig:
         )
 
     # Ensure all sections exist
-    for section in ("server", "stt", "tts", "llm", "audio", "tools", "memory", "database"):
+    for section in (
+        "server", "stt", "tts", "llm", "audio", "tools", "memory",
+        "database", "channel_gateway",
+    ):
         raw.setdefault(section, {})
 
     # Apply environment variable overrides
@@ -385,6 +388,9 @@ def load_config(path: Optional[str] = None) -> VoiceConfig:
         tools=_dict_to_dataclass(ToolsConfig, raw["tools"]),
         memory=_dict_to_dataclass(MemoryConfig, raw["memory"]),
         database=_dict_to_dataclass(DatabaseConfig, raw["database"]),
+        channel_gateway=_dict_to_dataclass(
+            ChannelGatewayConfig, raw["channel_gateway"],
+        ),
     )
 
     # Wave 13 C2: DRAGON_API_TOKEN env var sets the REST bearer token without


### PR DESCRIPTION
## Summary

- Real W7-F.2 deploy bug surfaced live on Dragon: setting \`channel_gateway.enabled=true\` in config.yaml had no effect because \`load_config\` never passed the section into the \`VoiceConfig()\` constructor.
- Fix: add \`"channel_gateway"\` to the section \`setdefault\` loop and pass \`channel_gateway=_dict_to_dataclass(ChannelGatewayConfig, raw["channel_gateway"])\`.

## Test plan
- [x] 54/54 W7-F tests still green (\`tests/test_gateway_connector.py\` + \`test_channels_mock.py\` + \`test_channel_reply_handler.py\` + \`test_debug_channel_push.py\`).
- [x] \`ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/config.py\` clean.
- [x] Local \`load_config\` round-trip with a yaml that has the block: \`ChannelGatewayConfig(enabled=True, url=..., token='', client_id='tinkerbox-dragon')\` returned (verified at workstation).
- [ ] Re-verify on Dragon: introspect \`channel_reply_handler.get_connector()\` returns \`GatewayConnector\` after restart with this PR deployed (next step in the same session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)