### PR TITLE
feat: W7-F.3 — gateway connect params match OpenClaw protocol v3

### DIFF
--- a/dragon_voice/channels/gateway.py
+++ b/dragon_voice/channels/gateway.py
@@ -49,10 +49,15 @@ from dragon_voice.channels.base import ChannelReplyResult
 
 logger = logging.getLogger(__name__)
 
-# OpenClaw gateway protocol version — must match ``PROTOCOL_VERSION``
-# in ``openclaw/src/gateway/protocol/index.ts``.  Bump in lockstep
-# with the gateway when the wire shape changes.
-GATEWAY_PROTOCOL_VERSION = 1
+# OpenClaw gateway protocol negotiation window.  The server enforces
+# ``maxProtocol >= PROTOCOL_VERSION >= minProtocol`` (see
+# ``openclaw/src/gateway/protocol/schema/protocol-schemas.ts``).
+# Quote a generous range so a server bump within the [MIN, MAX] window
+# doesn't require a connector redeploy.  ``MAX`` should be raised in
+# lockstep with the gateway when the wire shape changes incompatibly;
+# ``MIN`` stays at 1 (the lowest server-supported version).
+GATEWAY_PROTOCOL_MIN = 1
+GATEWAY_PROTOCOL_MAX = 3
 
 # Per-RPC budget.  Sends to Telegram/WhatsApp/etc. round-trip in
 # <1 s on the happy path; 15 s leaves comfortable headroom for cold
@@ -106,7 +111,7 @@ class GatewayConnector:
         *,
         url: str = "ws://127.0.0.1:18789",
         token: str,
-        client_id: str = "tinkerbox-dragon",
+        client_id: str = "gateway-client",
         client_version: str = "0.1.0",
         rpc_timeout_s: float = DEFAULT_RPC_TIMEOUT_S,
         session: Optional[aiohttp.ClientSession] = None,
@@ -241,17 +246,32 @@ class GatewayConnector:
         )
 
     async def _handshake(self) -> None:
+        # W7-F.3: role + client.id + scopes must satisfy the OpenClaw gateway
+        # validators (see openclaw src/gateway/protocol/client-info.ts +
+        # role-policy.ts + method-scopes.ts).
+        #   * role     ∈ {"operator", "node"}.  "operator" is the right
+        #                role for a backend that invokes operator-tier
+        #                methods like `send`.
+        #   * client.id ∈ GATEWAY_CLIENT_IDS enum.  "gateway-client" is
+        #                the generic backend id — matches what the OpenClaw
+        #                TypeScript reference client (gateway/client.ts:447)
+        #                uses by default for backend-mode connections.
+        #   * scopes   — `send` is gated on `operator.write`; include `read`
+        #                + `admin` too so future health / status probes don't
+        #                fail the gate.  (`operator.admin` does NOT
+        #                transitively grant `write` — they're independent
+        #                bags in METHOD_SCOPE_GROUPS.)
         connect_params = {
-            "minProtocol": GATEWAY_PROTOCOL_VERSION,
-            "maxProtocol": GATEWAY_PROTOCOL_VERSION,
+            "minProtocol": GATEWAY_PROTOCOL_MIN,
+            "maxProtocol": GATEWAY_PROTOCOL_MAX,
             "client": {
                 "id": self._client_id,
                 "version": self._client_version,
                 "platform": "linux",
                 "mode": "backend",
             },
-            "role": "agent.runner",
-            "scopes": ["operator.admin"],
+            "role": "operator",
+            "scopes": ["operator.read", "operator.write", "operator.admin"],
             "auth": {"token": self._token},
             "caps": [],
         }

--- a/dragon_voice/config.py
+++ b/dragon_voice/config.py
@@ -223,7 +223,11 @@ class ChannelGatewayConfig:
     # process.  Set explicitly only if the gateway is configured with
     # distinct tokens per client role.
     token: str = ""
-    client_id: str = "tinkerbox-dragon"
+    # Must match the OpenClaw `GATEWAY_CLIENT_IDS` enum
+    # (see openclaw/src/gateway/protocol/client-info.ts).  "gateway-client"
+    # is the generic backend id and matches the TypeScript reference client's
+    # default for backend-mode connections.
+    client_id: str = "gateway-client"
 
 
 @dataclass

--- a/tests/test_gateway_connector.py
+++ b/tests/test_gateway_connector.py
@@ -198,7 +198,14 @@ class TestGatewayConnectorIntegration(AioHTTPTestCase):
             cp = self.gateway.last_connect_params
             assert cp is not None
             assert cp["auth"]["token"] == "test-token"
-            assert cp["role"] == "agent.runner"
+            assert cp["role"] == "operator"
+            # `send` requires WRITE scope per openclaw method-scopes.ts;
+            # the connector includes WRITE alongside READ + ADMIN so
+            # ancillary probes don't fail the gate.
+            assert "operator.write" in cp["scopes"]
+            # client.id must be one of the OpenClaw enum values; the
+            # generic backend default is "gateway-client".
+            assert cp["client"]["id"] == "test-client"  # set in _make_connector
         finally:
             await connector.close()
 


### PR DESCRIPTION
## Summary

- Live verification of TB #310 against the real OpenClaw gateway surfaced 4 schema / protocol issues. Fixed all four.
- **Before this PR**: Tab5 `ack_fail` showed `gateway_unreachable: gateway connect rejected: invalid connect param…` (schema validation failed before role/auth checks).
- **After this PR**: Tab5 `ack_fail missing scope: operator.write` — handshake **succeeds**, only the server-side scope grant remains (gateway clears device-less clients' self-declared scopes; needs device-identity pairing in a follow-up W7-F.4).

## What changed

| Field | Before | After | Reason |
|---|---|---|---|
| `client.id` | `tinkerbox-dragon` | `gateway-client` | Must be a `GATEWAY_CLIENT_IDS` enum member |
| `role` | `agent.runner` | `operator` | Only `operator` or `node` valid |
| `scopes` | `[operator.admin]` | `[operator.read, operator.write, operator.admin]` | `send` requires `operator.write`; admin doesn't transitively grant |
| `minProtocol`/`maxProtocol` | both `1` | `1` / `3` | Gateway's `PROTOCOL_VERSION` is 3 today; quote a forward-compatible window |
| `ChannelGatewayConfig.client_id` default | `tinkerbox-dragon` | `gateway-client` | Match new connector default |

## Test plan

- [x] `pytest -q tests/test_gateway_connector.py tests/test_channels_mock.py tests/test_channel_reply_handler.py tests/test_debug_channel_push.py` → 54/54 green.
- [x] `ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/channels/ dragon_voice/config.py tests/test_gateway_connector.py` → clean.
- [x] Deployed to Dragon 192.168.1.91, restarted `tinkerclaw-voice`, verified live: Tab5 reply now surfaces `ack_fail missing scope: operator.write` (vs prior `invalid connect param`). Connect handshake confirmed succeeding.
- [ ] CI build.

## Follow-up

- **W7-F.4** (queued in memory) — device-identity ed25519 keypair + signed connect payload v3 to satisfy the gateway's `!isControlUi → clearUnboundScopes` rule (`message-handler.ts:L510-512`). Once green, real platform_message_id will flow back through the connector for configured channel plugins (Telegram, WhatsApp, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)