### PR TITLE
feat: W7-F.4 — ed25519 device identity + challenge-nonce handshake

### DIFF
--- a/dragon_voice/channels/device_identity.py
+++ b/dragon_voice/channels/device_identity.py
@@ -1,0 +1,277 @@
+"""Ed25519 device identity for the OpenClaw gateway handshake (W7-F.4).
+
+Without a device identity in the connect frame, the gateway clears the
+client's self-declared scopes (see
+``openclaw/src/gateway/server/ws-connection/message-handler.ts:L510-512``),
+which made every ``send`` RPC fail with ``missing scope: operator.write``
+after W7-F.3 fixed the schema-level connect rejections.
+
+This module mirrors the OpenClaw TypeScript helpers in
+``openclaw/src/infra/device-identity.ts`` so the gateway's signature
+verifier accepts our connect frame.  Specifically:
+
+  * ed25519 keypair, persisted as PEM in
+    ``~/.dragon/identity/device.json`` (mode 0o600).
+  * ``device_id = sha256(raw_public_key_bytes).hexdigest()`` — matches
+    ``deriveDeviceIdFromPublicKey``.
+  * ``public_key_b64url`` = base64url(no padding) of the raw 32-byte
+    ed25519 public key extracted from the SPKI PEM — matches
+    ``publicKeyRawBase64UrlFromPem``.
+  * ``sign_payload`` = base64url(no padding) of the 64-byte ed25519
+    signature over the UTF-8 payload — matches ``signDevicePayload``.
+  * ``build_v3_payload`` = pipe-delimited canonical string identical to
+    ``buildDeviceAuthPayloadV3``.
+
+Once these match byte-for-byte, the gateway's loopback "skip backend
+self-pairing" rule (``shouldSkipBackendSelfPairing`` in
+``handshake-auth-helpers.ts``) admits us as a paired peer for
+``gateway-client`` + ``backend`` mode + token auth, without requiring
+operator approval through the pairing UI.  The device identity is then
+the cryptographic binding that lets the gateway grant the requested
+scopes.
+"""
+
+from __future__ import annotations
+
+import base64
+import dataclasses
+import hashlib
+import json
+import logging
+import os
+from typing import Optional
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+logger = logging.getLogger(__name__)
+
+# The 12-byte DER SPKI prefix that wraps a raw ed25519 public key.  Used
+# to strip the prefix when extracting the 32-byte raw key from a SPKI
+# encoding, matching the OpenClaw helper's algorithm exactly.
+_ED25519_SPKI_PREFIX = bytes.fromhex("302a300506032b6570032100")
+
+# Storage version — bump only on incompatible on-disk format changes.
+_STORED_FORMAT_VERSION = 1
+
+
+def _default_identity_path() -> str:
+    """Default location for the persisted device identity.
+
+    Lives outside the repo (``~/.dragon/identity/device.json``) so a
+    ``git pull`` or container redeploy doesn't clobber it — losing the
+    keypair would force a re-pair with the gateway.
+    """
+    home = os.path.expanduser("~")
+    return os.path.join(home, ".dragon", "identity", "device.json")
+
+
+def _b64url_encode(data: bytes) -> str:
+    """Base64url encoding without padding — matches OpenClaw's TS helper."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _derive_raw_public_key(public_key_pem: str) -> bytes:
+    """Return the 32-byte raw ed25519 public key from a SPKI PEM string."""
+    key = serialization.load_pem_public_key(public_key_pem.encode("ascii"))
+    if not isinstance(key, Ed25519PublicKey):
+        raise ValueError("public key is not ed25519")
+    return key.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+
+
+def _fingerprint_public_key(public_key_pem: str) -> str:
+    return hashlib.sha256(_derive_raw_public_key(public_key_pem)).hexdigest()
+
+
+def _normalize_metadata(value: Optional[str]) -> str:
+    """ASCII-lowercase + trim, matching ``normalizeDeviceMetadataForAuth``."""
+    if value is None:
+        return ""
+    trimmed = value.strip()
+    if not trimmed:
+        return ""
+    # Only ASCII letters get lowercased on the TS side to keep the
+    # canonical form deterministic across runtimes.  ``str.lower()`` in
+    # Python applies Unicode lowercasing too — close enough for the
+    # ASCII metadata fields we actually emit (linux, x86_64, etc.).
+    return trimmed.lower()
+
+
+@dataclasses.dataclass(frozen=True)
+class DeviceIdentity:
+    """An ed25519 keypair + the sha256-derived device id.
+
+    Construct via :func:`load_or_create_identity` rather than manually —
+    the persistence + permission handling lives there.
+    """
+
+    device_id: str
+    public_key_pem: str
+    private_key_pem: str
+
+    def public_key_b64url(self) -> str:
+        """Raw ed25519 public key, base64url-encoded (no padding)."""
+        return _b64url_encode(_derive_raw_public_key(self.public_key_pem))
+
+    def sign(self, payload: str) -> str:
+        """Sign ``payload`` (UTF-8) and return base64url(no-padding) signature."""
+        key = serialization.load_pem_private_key(
+            self.private_key_pem.encode("ascii"), password=None,
+        )
+        if not isinstance(key, Ed25519PrivateKey):
+            raise ValueError("private key is not ed25519")
+        sig = key.sign(payload.encode("utf-8"))
+        return _b64url_encode(sig)
+
+
+def build_v3_payload(
+    *,
+    device_id: str,
+    client_id: str,
+    client_mode: str,
+    role: str,
+    scopes: list[str],
+    signed_at_ms: int,
+    token: Optional[str],
+    nonce: str,
+    platform: Optional[str] = None,
+    device_family: Optional[str] = None,
+) -> str:
+    """Canonical v3 payload string — pipe-delimited, joined-comma scopes.
+
+    Mirrors ``buildDeviceAuthPayloadV3`` in
+    ``openclaw/src/gateway/device-auth.ts``.  The gateway verifies the
+    signature against this exact string, so every component must be
+    byte-identical to the TS implementation: comma-joined scopes (no
+    spaces), millisecond timestamp as decimal string, empty-string
+    fallback for ``token`` when None, lower-ascii metadata.
+    """
+    return "|".join(
+        [
+            "v3",
+            device_id,
+            client_id,
+            client_mode,
+            role,
+            ",".join(scopes),
+            str(signed_at_ms),
+            token or "",
+            nonce,
+            _normalize_metadata(platform),
+            _normalize_metadata(device_family),
+        ]
+    )
+
+
+def load_or_create_identity(
+    path: Optional[str] = None,
+) -> DeviceIdentity:
+    """Load the persisted identity, or generate + save a fresh one.
+
+    The keypair is regenerated only on first call (or after the on-disk
+    file is deleted) — subsequent calls return the same identity so the
+    gateway's pairing record stays valid across Dragon restarts.
+
+    Permissions: the JSON file is written with mode 0o600 since it
+    contains the ed25519 private key.  ``chmod`` is best-effort — if it
+    fails (e.g. NFS share), the file write itself still succeeds.
+
+    If the on-disk file's stored ``device_id`` no longer matches the
+    sha256 of its public key, the record is rewritten with the
+    fingerprint-derived id.  This guards against accidental edits.
+    """
+    file_path = path or _default_identity_path()
+    try:
+        with open(file_path) as f:
+            stored = json.load(f)
+        if (
+            isinstance(stored, dict)
+            and stored.get("version") == _STORED_FORMAT_VERSION
+            and isinstance(stored.get("deviceId"), str)
+            and isinstance(stored.get("publicKeyPem"), str)
+            and isinstance(stored.get("privateKeyPem"), str)
+        ):
+            public_pem = stored["publicKeyPem"]
+            stored_id = stored["deviceId"]
+            derived_id = _fingerprint_public_key(public_pem)
+            if derived_id != stored_id:
+                logger.warning(
+                    "device_identity: stored deviceId %s != sha256(publicKey) %s — rewriting",
+                    stored_id[:8], derived_id[:8],
+                )
+                _write_identity(
+                    file_path,
+                    DeviceIdentity(
+                        device_id=derived_id,
+                        public_key_pem=public_pem,
+                        private_key_pem=stored["privateKeyPem"],
+                    ),
+                )
+                stored_id = derived_id
+            return DeviceIdentity(
+                device_id=stored_id,
+                public_key_pem=public_pem,
+                private_key_pem=stored["privateKeyPem"],
+            )
+    except (OSError, ValueError, json.JSONDecodeError):
+        # Fall through to regenerate.  Malformed records are replaced
+        # rather than blocking boot — losing an identity matters only if
+        # the gateway has a paired record for it (in which case
+        # re-pairing is the recovery path).
+        pass
+
+    identity = _generate_identity()
+    _write_identity(file_path, identity)
+    logger.info(
+        "device_identity: generated fresh ed25519 keypair, device_id=%s",
+        identity.device_id[:12],
+    )
+    return identity
+
+
+def _generate_identity() -> DeviceIdentity:
+    private_key = Ed25519PrivateKey.generate()
+    public_key = private_key.public_key()
+    public_key_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("ascii")
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+    device_id = _fingerprint_public_key(public_key_pem)
+    return DeviceIdentity(
+        device_id=device_id,
+        public_key_pem=public_key_pem,
+        private_key_pem=private_key_pem,
+    )
+
+
+def _write_identity(path: str, identity: DeviceIdentity) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    payload = {
+        "version": _STORED_FORMAT_VERSION,
+        "deviceId": identity.device_id,
+        "publicKeyPem": identity.public_key_pem,
+        "privateKeyPem": identity.private_key_pem,
+    }
+    # Write to a temp path + rename for atomic replacement so a crash
+    # mid-write doesn't leave a half-written identity file.
+    tmp_path = path + ".tmp"
+    with open(tmp_path, "w") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
+    try:
+        os.chmod(tmp_path, 0o600)
+    except OSError:
+        # best-effort — keep going even if chmod fails (e.g. NFS).
+        pass
+    os.replace(tmp_path, path)

--- a/dragon_voice/channels/gateway.py
+++ b/dragon_voice/channels/gateway.py
@@ -46,6 +46,11 @@ from typing import Any, Optional
 import aiohttp
 
 from dragon_voice.channels.base import ChannelReplyResult
+from dragon_voice.channels.device_identity import (
+    DeviceIdentity,
+    build_v3_payload,
+    load_or_create_identity,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -115,6 +120,7 @@ class GatewayConnector:
         client_version: str = "0.1.0",
         rpc_timeout_s: float = DEFAULT_RPC_TIMEOUT_S,
         session: Optional[aiohttp.ClientSession] = None,
+        identity: Optional[DeviceIdentity] = None,
     ) -> None:
         if not token:
             raise ValueError(
@@ -127,6 +133,13 @@ class GatewayConnector:
         self._client_id = client_id
         self._client_version = client_version
         self._rpc_timeout_s = rpc_timeout_s
+        # W7-F.4: ed25519 device identity that lets the gateway grant the
+        # requested scopes without a manual pairing approval (loopback
+        # backend-self-pairing path — see device_identity.py docstring).
+        # Tests may inject a pre-built identity to avoid filesystem
+        # writes; production callers pass None and we load (or generate)
+        # the persistent ``~/.dragon/identity/device.json`` keypair.
+        self._identity = identity if identity is not None else load_or_create_identity()
 
         # Allow tests to inject a shared aiohttp session so they don't
         # have to spin up a real TCP listener.  Production callers
@@ -138,6 +151,13 @@ class GatewayConnector:
         self._pending: dict[str, _PendingCall] = {}
         self._connect_lock = asyncio.Lock()
         self._connected = False
+        # W7-F.4: gateway sends ``event: connect.challenge`` with a nonce
+        # immediately after the WS opens; the device.nonce field in our
+        # connect-req must echo that exact nonce or the gateway rejects
+        # the handshake with "device nonce mismatch".  The reader loop
+        # fulfills this future when the challenge arrives; the handshake
+        # waits on it before signing the v3 payload.
+        self._connect_challenge_nonce: Optional[asyncio.Future[str]] = None
 
     # ── public API ──────────────────────────────────────────────────
 
@@ -226,11 +246,17 @@ class GatewayConnector:
         if self._session is None or self._session.closed:
             self._session = aiohttp.ClientSession()
             self._owned_session = True
+        # W7-F.4: prepare the connect-challenge future BEFORE opening the
+        # WS so the reader's dispatch path can always fulfill it without
+        # racing with our `await` below.
+        loop = asyncio.get_event_loop()
+        self._connect_challenge_nonce = loop.create_future()
         self._ws = await self._session.ws_connect(
             self._url, heartbeat=WS_HEARTBEAT_S,
         )
         # Start the reader BEFORE the handshake so the connect response
-        # has a future waiting for it.
+        # — and the connect.challenge event that PRECEDES it — has a
+        # future waiting for it.
         self._reader_task = asyncio.create_task(self._reader_loop())
         try:
             await self._handshake()
@@ -246,34 +272,71 @@ class GatewayConnector:
         )
 
     async def _handshake(self) -> None:
-        # W7-F.3: role + client.id + scopes must satisfy the OpenClaw gateway
-        # validators (see openclaw src/gateway/protocol/client-info.ts +
-        # role-policy.ts + method-scopes.ts).
-        #   * role     ∈ {"operator", "node"}.  "operator" is the right
-        #                role for a backend that invokes operator-tier
-        #                methods like `send`.
-        #   * client.id ∈ GATEWAY_CLIENT_IDS enum.  "gateway-client" is
-        #                the generic backend id — matches what the OpenClaw
-        #                TypeScript reference client (gateway/client.ts:447)
-        #                uses by default for backend-mode connections.
-        #   * scopes   — `send` is gated on `operator.write`; include `read`
-        #                + `admin` too so future health / status probes don't
-        #                fail the gate.  (`operator.admin` does NOT
-        #                transitively grant `write` — they're independent
-        #                bags in METHOD_SCOPE_GROUPS.)
+        # W7-F.3 + W7-F.4: connect-param contract for the OpenClaw gateway.
+        #   * role / client.id / scopes / protocol — covered in W7-F.3.
+        #   * device — W7-F.4: the ed25519 identity binds the connect frame
+        #                so the gateway's scope-grant rule
+        #                (``message-handler.ts:L510-512``) doesn't clear
+        #                the self-declared scopes.  Loopback + gateway-client
+        #                + backend mode + token auth additionally satisfies
+        #                ``shouldSkipBackendSelfPairing`` in
+        #                handshake-auth-helpers.ts, so no manual pairing
+        #                approval is needed for a fresh keypair.
+        #   * nonce  — W7-F.4: gateway sends a connect.challenge event
+        #                immediately after WS open with a server-issued
+        #                nonce; the device.nonce field MUST echo that
+        #                value (``message-handler.ts:L611``) or the gateway
+        #                rejects with "device nonce mismatch".
+        scopes = ["operator.read", "operator.write", "operator.admin"]
+        role = "operator"
+        client_mode = "backend"
+        platform = "linux"
+        device_family: str = ""
+        signed_at_ms = int(time.time() * 1000)
+        # Wait up to half the RPC budget for the connect.challenge event —
+        # cheap event from the server, but bound the wait so a silent or
+        # broken gateway doesn't hang send_reply forever.
+        assert self._connect_challenge_nonce is not None
+        try:
+            nonce = await asyncio.wait_for(
+                self._connect_challenge_nonce,
+                timeout=max(2.0, self._rpc_timeout_s / 2),
+            )
+        except asyncio.TimeoutError as e:
+            raise RuntimeError("gateway never sent connect.challenge") from e
+        payload = build_v3_payload(
+            device_id=self._identity.device_id,
+            client_id=self._client_id,
+            client_mode=client_mode,
+            role=role,
+            scopes=scopes,
+            signed_at_ms=signed_at_ms,
+            token=self._token,
+            nonce=nonce,
+            platform=platform,
+            device_family=device_family,
+        )
+        signature = self._identity.sign(payload)
         connect_params = {
             "minProtocol": GATEWAY_PROTOCOL_MIN,
             "maxProtocol": GATEWAY_PROTOCOL_MAX,
             "client": {
                 "id": self._client_id,
                 "version": self._client_version,
-                "platform": "linux",
-                "mode": "backend",
+                "platform": platform,
+                "mode": client_mode,
             },
-            "role": "operator",
-            "scopes": ["operator.read", "operator.write", "operator.admin"],
+            "role": role,
+            "scopes": scopes,
             "auth": {"token": self._token},
             "caps": [],
+            "device": {
+                "id": self._identity.device_id,
+                "publicKey": self._identity.public_key_b64url(),
+                "signature": signature,
+                "signedAt": signed_at_ms,
+                "nonce": nonce,
+            },
         }
         result = await self._rpc("connect", connect_params, ensure_connected=False)
         if not result.ok:
@@ -365,6 +428,21 @@ class GatewayConnector:
         if frame_type == "res":
             self._dispatch_response(frame)
         elif frame_type == "event":
+            # W7-F.4: the very first event after WS open is
+            # ``connect.challenge`` carrying the server-issued nonce
+            # that our device.nonce field must echo.  Hand it to the
+            # handshake's pending future.
+            if frame.get("event") == "connect.challenge":
+                payload = frame.get("payload") or {}
+                challenge_nonce = payload.get("nonce")
+                if (
+                    isinstance(challenge_nonce, str)
+                    and challenge_nonce
+                    and self._connect_challenge_nonce is not None
+                    and not self._connect_challenge_nonce.done()
+                ):
+                    self._connect_challenge_nonce.set_result(challenge_nonce.strip())
+                return
             # W7-G will handle inbound platform messages.  For now,
             # log + drop so the WS stays healthy.
             logger.debug(

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ numpy>=1.24
 # OPUS codec for the voice WS (#173 / TinkerTab #262).  ctypes wrapper
 # around libopus — apt-get install libopus0 on Dragon if needed.
 opuslib>=3.0.1
+# W7-F.4: ed25519 device identity for the OpenClaw gateway WS-RPC
+# handshake (see dragon_voice/channels/device_identity.py).
+cryptography>=42.0.0

--- a/tests/test_gateway_connector.py
+++ b/tests/test_gateway_connector.py
@@ -33,12 +33,50 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import AioHTTPTestCase
 
+from dragon_voice.channels.device_identity import (
+    DeviceIdentity,
+    _b64url_encode,
+    _derive_raw_public_key,
+    _fingerprint_public_key,
+    _normalize_metadata,
+    build_v3_payload,
+    load_or_create_identity,
+)
 from dragon_voice.channels.gateway import (
     GatewayConnector,
     _extract_platform_id,
     _extract_recipient,
     _idem_key,
 )
+
+
+def _make_test_identity() -> DeviceIdentity:
+    """Generate a throwaway identity without touching disk.
+
+    Re-using ``load_or_create_identity`` here would persist to
+    ``~/.dragon/identity/`` on the test runner, which is hostile to CI
+    isolation and slow.  Generating in-memory keeps each test self-
+    contained.
+    """
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+    )
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("ascii")
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+    return DeviceIdentity(
+        device_id=_fingerprint_public_key(pub_pem),
+        public_key_pem=pub_pem,
+        private_key_pem=priv_pem,
+    )
 
 
 # ── Fake gateway WS handler ─────────────────────────────────────────
@@ -69,6 +107,7 @@ class FakeGateway:
         # Captured for assertions.
         self.last_connect_params: Optional[dict] = None
         self.last_send_params: Optional[dict] = None
+        self.last_challenge_nonce: str = ""
         self.connect_count: int = 0
         self.send_count: int = 0
 
@@ -80,6 +119,15 @@ class FakeGateway:
     async def handle(self, request: web.Request) -> web.WebSocketResponse:
         ws = web.WebSocketResponse()
         await ws.prepare(request)
+        # W7-F.4: gateway sends connect.challenge immediately after WS
+        # open — the client uses that nonce in its device.nonce field.
+        # Record what we issued so tests can check the connector echoed it.
+        self.last_challenge_nonce = f"test-nonce-{uuid.uuid4().hex[:8]}"
+        await ws.send_json({
+            "type": "event",
+            "event": "connect.challenge",
+            "payload": {"nonce": self.last_challenge_nonce, "ts": 0},
+        })
         async for msg in ws:
             if msg.type != web.WSMsgType.TEXT:
                 continue
@@ -170,6 +218,9 @@ class TestGatewayConnectorIntegration(AioHTTPTestCase):
             token=token,
             client_id="test-client",
             rpc_timeout_s=timeout,
+            # Injected throwaway identity — keeps the test from writing
+            # to ``~/.dragon/identity/``.
+            identity=_make_test_identity(),
         )
 
     async def test_send_reply_happy_path(self) -> None:
@@ -206,6 +257,16 @@ class TestGatewayConnectorIntegration(AioHTTPTestCase):
             # client.id must be one of the OpenClaw enum values; the
             # generic backend default is "gateway-client".
             assert cp["client"]["id"] == "test-client"  # set in _make_connector
+            # W7-F.4 device identity present + signature shape sane.
+            dev = cp["device"]
+            assert isinstance(dev["id"], str) and len(dev["id"]) == 64  # sha256 hex
+            assert isinstance(dev["publicKey"], str) and len(dev["publicKey"]) > 30
+            assert isinstance(dev["signature"], str) and len(dev["signature"]) > 60
+            assert isinstance(dev["signedAt"], int) and dev["signedAt"] > 0
+            # The nonce MUST echo the server-issued connect.challenge nonce,
+            # not a client-generated one.  Pre-W7-F.4 the connector
+            # generated its own nonce → gateway rejected "device nonce mismatch".
+            assert dev["nonce"] == self.gateway.last_challenge_nonce
         finally:
             await connector.close()
 
@@ -344,14 +405,148 @@ class TestRequiresToken:
 
     def test_blank_token_raises(self) -> None:
         with pytest.raises(ValueError) as exc:
-            GatewayConnector(token="")
+            GatewayConnector(token="", identity=_make_test_identity())
         assert "token" in str(exc.value).lower()
 
     def test_whitespace_token_accepted_then_strips(self) -> None:
         # The constructor itself doesn't strip — that's the operator's
         # job in config wiring.  Make sure we at least don't crash on
         # an unusual but technically non-empty token.
-        connector = GatewayConnector(token="  abc  ")
+        connector = GatewayConnector(
+            token="  abc  ", identity=_make_test_identity(),
+        )
         assert connector is not None
+
+
+# ── W7-F.4: device_identity helpers ─────────────────────────────────
+
+
+class TestBuildV3Payload:
+    """Canonical pipe-delimited payload — must match OpenClaw byte-for-byte."""
+
+    def test_basic_shape(self) -> None:
+        out = build_v3_payload(
+            device_id="abc123",
+            client_id="gateway-client",
+            client_mode="backend",
+            role="operator",
+            scopes=["operator.read", "operator.write"],
+            signed_at_ms=1700000000000,
+            token="tok",
+            nonce="n1",
+            platform="linux",
+            device_family="",
+        )
+        assert out == (
+            "v3|abc123|gateway-client|backend|operator|"
+            "operator.read,operator.write|1700000000000|tok|n1|linux|"
+        )
+
+    def test_token_none_becomes_empty(self) -> None:
+        out = build_v3_payload(
+            device_id="d", client_id="c", client_mode="m", role="r",
+            scopes=[], signed_at_ms=0, token=None, nonce="n",
+            platform=None, device_family=None,
+        )
+        # Empty scopes -> empty segment; None token -> empty.
+        assert "||" in out  # token segment is empty
+
+    def test_scopes_comma_joined_no_spaces(self) -> None:
+        out = build_v3_payload(
+            device_id="d", client_id="c", client_mode="m", role="r",
+            scopes=["a", "b", "c"], signed_at_ms=1, token="t", nonce="n",
+        )
+        assert "|a,b,c|" in out
+
+    def test_metadata_lowercased(self) -> None:
+        out = build_v3_payload(
+            device_id="d", client_id="c", client_mode="m", role="r",
+            scopes=[], signed_at_ms=1, token="t", nonce="n",
+            platform="LINUX", device_family="X86_64",
+        )
+        # Trailing fields: platform + device_family, both lowercased.
+        parts = out.rsplit("|", 2)
+        assert parts[-2] == "linux"
+        assert parts[-1] == "x86_64"
+
+
+class TestDeviceIdentityHelpers:
+    """Identity round-trip + crypto helpers match OpenClaw's TS encoding."""
+
+    def test_device_id_is_sha256_hex_of_raw_public_key(self) -> None:
+        ident = _make_test_identity()
+        import hashlib
+        raw = _derive_raw_public_key(ident.public_key_pem)
+        assert len(raw) == 32  # ed25519 public key is 32 bytes
+        assert ident.device_id == hashlib.sha256(raw).hexdigest()
+
+    def test_public_key_b64url_strips_padding(self) -> None:
+        ident = _make_test_identity()
+        encoded = ident.public_key_b64url()
+        assert "=" not in encoded
+        assert "+" not in encoded
+        assert "/" not in encoded
+        # 32 raw bytes → 43-char base64url (no padding)
+        assert len(encoded) == 43
+
+    def test_signature_verifies_against_payload(self) -> None:
+        """Round-trip: sign with our DeviceIdentity, verify with cryptography."""
+        from cryptography.hazmat.primitives import serialization
+        ident = _make_test_identity()
+        payload = "v3|fake|fake|backend|operator|x|1|tok|n||"
+        sig_b64u = ident.sign(payload)
+        # Decode signature (add padding for stdlib decoder)
+        import base64
+        pad = "=" * ((4 - len(sig_b64u) % 4) % 4)
+        sig = base64.urlsafe_b64decode(sig_b64u + pad)
+        assert len(sig) == 64  # ed25519 signatures are 64 bytes
+        # Verify with the public key (mirrors gateway's verifyDeviceSignature).
+        pub = serialization.load_pem_public_key(ident.public_key_pem.encode())
+        pub.verify(sig, payload.encode("utf-8"))  # raises if bad
+
+    def test_b64url_encoder_matches_known_vector(self) -> None:
+        # Known test vector from RFC 4648 §10 examples (URL-safe variant).
+        assert _b64url_encode(b"") == ""
+        assert _b64url_encode(b"f") == "Zg"
+        assert _b64url_encode(b"foobar") == "Zm9vYmFy"
+
+    def test_normalize_metadata_handles_none_and_whitespace(self) -> None:
+        assert _normalize_metadata(None) == ""
+        assert _normalize_metadata("") == ""
+        assert _normalize_metadata("   ") == ""
+        assert _normalize_metadata("  Linux  ") == "linux"
+
+
+class TestLoadOrCreateIdentityPersistence:
+    """Persisted identity survives a process restart at the same path."""
+
+    def test_first_call_creates_file(self, tmp_path: Any) -> None:
+        path = str(tmp_path / "device.json")
+        ident = load_or_create_identity(path=path)
+        import os
+        assert os.path.exists(path)
+        # File permissions are 0o600 (best-effort).
+        mode = os.stat(path).st_mode & 0o777
+        assert mode == 0o600
+        assert len(ident.device_id) == 64
+        assert "BEGIN PRIVATE KEY" in ident.private_key_pem
+        assert "BEGIN PUBLIC KEY" in ident.public_key_pem
+
+    def test_second_call_returns_same_identity(self, tmp_path: Any) -> None:
+        path = str(tmp_path / "device.json")
+        a = load_or_create_identity(path=path)
+        b = load_or_create_identity(path=path)
+        assert a.device_id == b.device_id
+        assert a.public_key_pem == b.public_key_pem
+        assert a.private_key_pem == b.private_key_pem
+
+    def test_corrupt_file_regenerates(self, tmp_path: Any) -> None:
+        path = str(tmp_path / "device.json")
+        # Write garbage that's neither valid JSON nor matches schema.
+        with open(path, "w") as f:
+            f.write("{this is not JSON")
+        ident = load_or_create_identity(path=path)
+        # Should succeed by regenerating, not raise.
+        assert len(ident.device_id) == 64
 
 


### PR DESCRIPTION
## Summary

Closes the W7-F connector contract for the OpenClaw gateway. After W7-F.3 the handshake succeeded schema-wise but every send hit `missing scope: operator.write` because the gateway clears device-less clients' self-declared scopes ([message-handler.ts:L510-512](https://github.com/openclaw/openclaw/blob/main/src/gateway/server/ws-connection/message-handler.ts#L510-L512)).

W7-F.4 binds an ed25519 device identity to the connect frame so:
1. The scope-clearing path skips (we satisfy `!device` guard).
2. `shouldSkipBackendSelfPairing` admits us as a paired peer for `gateway-client` + `backend` + token-auth on loopback — no manual operator approval needed.
3. The `connect.challenge` nonce round-trip prevents replay: gateway emits the nonce on WS open, connector captures + echoes it in `device.nonce`, signature binds connect to that specific WS session.

## Diff at a glance

| Concern | Before | After |
|---|---|---|
| Persistence | none | `~/.dragon/identity/device.json` (mode 0o600, atomic write) |
| Device ID | absent from connect | `sha256(raw_public_key_32_bytes).hex()` (matches `deriveDeviceIdFromPublicKey`) |
| Signature | absent | ed25519 over `buildDeviceAuthPayloadV3` (base64url no padding) |
| Nonce | none in connect | server-issued via `event: connect.challenge`, echoed in `device.nonce` |
| Tests | 54 | **66** (+12 across 3 new test classes) |

## Live verification

Tab5 192.168.1.90 ↔ Dragon 192.168.1.91:

```
Pre-W7-F.4:  ack_fail "missing scope: operator.write"
Post-W7-F.4: ack_fail "unsupported channel: tg"
             (connect SUCCEEDS, scope GRANTED, send INVOKED;
              remaining is operator-level channel plugin config)
```

The W7-F connector is **fully functional** for any channel the gateway actually has enabled.

## Test plan

- [x] 66/66 W7-F tests green.
- [x] `ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/channels/ tests/test_gateway_connector.py` clean.
- [x] Persistent identity round-trip: 2nd call returns the same keypair.
- [x] Corrupt-file regenerates without raising.
- [x] Signature verifies via stdlib `cryptography` against the public key (round-trip check in `test_signature_verifies_against_payload`).
- [x] Live deploy + standalone probe + Tab5 user-story flow all green up to channel-config wall.

## Next slice queued

- **W7-F.5** — operator-level OpenClaw channel-plugin config (enable Telegram with real bot token) so `send` round-trips with a real `platform_message_id`. Outside the connector contract — just `openclaw config set channels.telegram.token=...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)