### PR TITLE
feat: W7-C memory bridge — mirror gateway 'remember' into local memory_facts

### DIFF
--- a/dragon_voice/gateway_memory_mirror.py
+++ b/dragon_voice/gateway_memory_mirror.py
@@ -1,0 +1,96 @@
+"""W7-C: mirror gateway-side `remember` tool calls into Dragon's local memory.
+
+In voice mode 3 the LLM lives on the OpenClaw gateway agent and runs its own
+tools — Dragon doesn't see the tool *execution*, only the SSE-streamed
+`delta.tool_calls` events.  When the gateway agent calls ``remember`` to
+store a user fact, that fact lands in the *gateway's* private agent memory
+(workspace files), not in Dragon's ``memory_facts`` table.
+
+The "memory bridge" the W7-C audit slot called for can't route to a
+``gateway.memory.*`` RPC because OpenClaw's gateway has no such verb (see
+``openclaw/src/gateway/server-methods-list.ts``).  What we *can* do is
+mirror the user-facing intent: when the gateway emits a ``remember`` tool
+call, also store the same fact locally with ``source="gateway"`` so:
+
+  * the dashboard / Tab5 memory browser sees what the user told the
+    gateway agent
+  * future Dragon turns (e.g. if the user switches back to mode 0/1/2)
+    still have the fact in the augmented-context prompt
+  * the cross-stack provenance is explicit — mode-3 user statements are
+    bucketed separately from Dragon-conversation-derived memories
+
+The mirror is best-effort: any failure (memory service missing, embedding
+backend down, sqlite locked) is logged and swallowed.  Mode-3 LLM streaming
+must NEVER tear down because of a memory-mirror hiccup.
+
+Note: ``recall`` is intentionally *not* mirrored.  The gateway agent's
+recall queries the gateway's local memory; Dragon's memory may have
+different content and surfacing it would confuse the agent's reasoning.
+The agent_log W7-A.3 source-bucket already captures the recall *event*
+for observability; that's enough.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+async def mirror_gateway_tool_call(
+    tool: str,
+    args: Any,
+    memory_service: Optional[Any],
+    session_id: str = "",
+) -> bool:
+    """If `tool == "remember"` and a fact is present, store it locally with
+    ``source="gateway"``.
+
+    Returns:
+        True if a fact was mirrored, False if the call was skipped (not
+        remember, missing fact, no memory service, or error).  Callers
+        should ignore the return value in the hot path — it exists for
+        tests.
+    """
+    if memory_service is None:
+        # Memory subsystem disabled or not yet initialised.  Don't warn —
+        # this is expected during early boot before run_startup finishes.
+        return False
+
+    if tool != "remember":
+        # Only remember mirrors today.  Recall stays gateway-local for the
+        # reasons noted in the module docstring.
+        return False
+
+    fact: str = ""
+    if isinstance(args, dict):
+        # The remember tool's canonical arg is `fact`.  Some FC-trained
+        # models emit `content` or `text` instead; accept all three so
+        # we don't lose user intent to gateway-side variation.
+        for key in ("fact", "content", "text"):
+            v = args.get(key)
+            if isinstance(v, str) and v.strip():
+                fact = v.strip()
+                break
+
+    if not fact:
+        return False
+
+    try:
+        await memory_service.store_fact(
+            fact, source="gateway", session_id=session_id or None,
+        )
+    except Exception as e:  # noqa: BLE001 — best-effort, swallow + log
+        logger.warning(
+            "W7-C: gateway 'remember' mirror failed (fact=%.60s): %s",
+            fact, e,
+        )
+        return False
+
+    logger.info(
+        "W7-C: mirrored gateway 'remember' into local memory_facts "
+        "(source=gateway, session=%s, fact=%.60s)",
+        session_id or "<none>", fact,
+    )
+    return True

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -329,8 +329,45 @@ class VoicePipeline:
             self._on_tool_call is not None
             and hasattr(self._llm, "set_tool_event_handler")
         ):
+            # W7-C memory bridge: wrap the caller's on_tool_call so any
+            # gateway-side `remember` tool also mirrors into Dragon's
+            # local memory_facts with source="gateway".  See
+            # dragon_voice/gateway_memory_mirror.py for rationale (the
+            # gateway has no memory.* RPC verb; mirroring is the closest
+            # honest implementation of the "memory bridge" W7-C slot).
+            # Conversation engine carries the memory service handle; if
+            # it's None (no engine or engine without memory) the mirror
+            # is a no-op.
+            from dragon_voice.gateway_memory_mirror import (
+                mirror_gateway_tool_call,
+            )
+            outer_on_tool_call = self._on_tool_call
+            memory_svc = (
+                getattr(self._conversation_engine, "_memory_service", None)
+                if self._conversation_engine is not None
+                else None
+            )
+            session_id_for_mirror = self._session_id
+
+            async def _on_tool_call_with_mirror(call: dict) -> None:
+                # Mirror first so a slow forward (e.g. WS backpressure)
+                # doesn't delay the local write.  Mirror is best-effort;
+                # any failure is logged + swallowed inside the helper.
+                try:
+                    await mirror_gateway_tool_call(
+                        call.get("tool", ""),
+                        call.get("args", {}),
+                        memory_svc,
+                        session_id_for_mirror,
+                    )
+                except Exception:  # noqa: BLE001 — never block stream
+                    logger.exception(
+                        "W7-C: gateway_memory_mirror raised — swallowed",
+                    )
+                await outer_on_tool_call(call)
+
             self._llm.set_tool_event_handler(
-                self._on_tool_call, self._on_tool_result,
+                _on_tool_call_with_mirror, self._on_tool_result,
             )
 
     def set_uplink_codec(self, codec: str) -> str:

--- a/tests/test_gateway_memory_mirror.py
+++ b/tests/test_gateway_memory_mirror.py
@@ -1,0 +1,177 @@
+"""Tests for ``dragon_voice.gateway_memory_mirror`` (W7-C).
+
+Validates that gateway-emitted ``remember`` tool calls are mirrored into
+Dragon's local memory_service with ``source="gateway"``, and that all
+other inputs / failure modes are silently skipped so the LLM stream is
+never torn down by a mirror hiccup.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.gateway_memory_mirror import mirror_gateway_tool_call
+
+
+@pytest.fixture
+def memory_service() -> MagicMock:
+    """A minimal mock memory service whose store_fact is awaitable."""
+    svc = MagicMock()
+    svc.store_fact = AsyncMock(return_value={"id": "abc123"})
+    return svc
+
+
+# ── happy path ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_remember_with_fact_mirrors_to_memory_service(memory_service):
+    result = await mirror_gateway_tool_call(
+        "remember",
+        {"fact": "User prefers dark mode"},
+        memory_service,
+        session_id="sess-1",
+    )
+    assert result is True
+    memory_service.store_fact.assert_awaited_once_with(
+        "User prefers dark mode", source="gateway", session_id="sess-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_remember_accepts_content_alias(memory_service):
+    """Some FC-trained models emit `content` instead of `fact`."""
+    result = await mirror_gateway_tool_call(
+        "remember",
+        {"content": "User is allergic to peanuts"},
+        memory_service,
+    )
+    assert result is True
+    memory_service.store_fact.assert_awaited_once()
+    args, kwargs = memory_service.store_fact.call_args
+    assert args[0] == "User is allergic to peanuts"
+    assert kwargs["source"] == "gateway"
+
+
+@pytest.mark.asyncio
+async def test_remember_accepts_text_alias(memory_service):
+    result = await mirror_gateway_tool_call(
+        "remember",
+        {"text": "Stand-up is at 9 AM"},
+        memory_service,
+    )
+    assert result is True
+    args, _ = memory_service.store_fact.call_args
+    assert args[0] == "Stand-up is at 9 AM"
+
+
+@pytest.mark.asyncio
+async def test_empty_session_id_passes_none(memory_service):
+    """Empty string session_id should become None — store_fact accepts
+    both but None is the canonical 'no session' signal."""
+    await mirror_gateway_tool_call(
+        "remember", {"fact": "X"}, memory_service, session_id="",
+    )
+    _, kwargs = memory_service.store_fact.call_args
+    assert kwargs["session_id"] is None
+
+
+# ── skip cases ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_recall_not_mirrored(memory_service):
+    """recall stays gateway-local — module docstring rationale."""
+    result = await mirror_gateway_tool_call(
+        "recall", {"query": "what does the user like?"}, memory_service,
+    )
+    assert result is False
+    memory_service.store_fact.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_other_tool_not_mirrored(memory_service):
+    """web_search, datetime, etc. — only `remember` mirrors."""
+    for tool in ("web_search", "datetime", "calculator", "browser"):
+        result = await mirror_gateway_tool_call(
+            tool, {"query": "x"}, memory_service,
+        )
+        assert result is False, f"{tool} should not mirror"
+    memory_service.store_fact.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_remember_with_no_fact_skips(memory_service):
+    result = await mirror_gateway_tool_call(
+        "remember", {}, memory_service,
+    )
+    assert result is False
+    memory_service.store_fact.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_remember_with_empty_fact_skips(memory_service):
+    result = await mirror_gateway_tool_call(
+        "remember", {"fact": "   "}, memory_service,
+    )
+    assert result is False
+    memory_service.store_fact.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_remember_with_nondict_args_skips(memory_service):
+    """Streaming JSON parse may yield strings or lists when the model
+    emits malformed tool_calls.  Don't crash; just skip."""
+    for bad_args in ("not a dict", ["fact", "value"], None, 42):
+        result = await mirror_gateway_tool_call(
+            "remember", bad_args, memory_service,
+        )
+        assert result is False
+    memory_service.store_fact.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_no_memory_service_skips_silently():
+    """Pre-init path — memory service can legitimately be None."""
+    result = await mirror_gateway_tool_call(
+        "remember", {"fact": "X"}, None,
+    )
+    assert result is False  # no service = no mirror
+
+
+# ── failure isolation ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_memory_service_exception_swallowed():
+    """store_fact failures (sqlite locked, embedding backend down, etc.)
+    must NEVER propagate — they'd tear down the LLM stream."""
+    svc = MagicMock()
+    svc.store_fact = AsyncMock(
+        side_effect=RuntimeError("embedding backend offline"),
+    )
+    # Should not raise.
+    result = await mirror_gateway_tool_call(
+        "remember", {"fact": "X"}, svc,
+    )
+    assert result is False  # error path returns False
+    svc.store_fact.assert_awaited_once()  # but we did try
+
+
+@pytest.mark.asyncio
+async def test_multiple_remember_calls_all_mirrored(memory_service):
+    """Per-call independence — N remember calls land N facts."""
+    facts = ["fact 1", "fact 2", "fact 3"]
+    for f in facts:
+        await mirror_gateway_tool_call(
+            "remember", {"fact": f}, memory_service,
+        )
+    assert memory_service.store_fact.await_count == 3
+    actual_facts = [
+        call.args[0] for call in memory_service.store_fact.call_args_list
+    ]
+    assert actual_facts == facts


### PR DESCRIPTION
## Summary
Ships the W7-C "memory bridge" audit slot — but reframed honestly:  OpenClaw's gateway has **no** `memory.*` RPC (see [`server-methods-list.ts`](https://github.com/lorcan35/openclaw/blob/main/src/gateway/server-methods-list.ts)).  The closest practical equivalent: **mirror gateway-emitted `remember` tool calls into Dragon's local `memory_facts` table with `source="gateway"`.**

### Why mirror, not bridge
- Gateway agent runs its own LLM with its own tools — Dragon only observes the SSE-streamed `delta.tool_calls` events.
- The user-facing intent ("remember this for me") deserves to survive across modes — if a user asks the mode-3 agent to remember something, switches back to mode 0/1/2, that fact should still be in their memory-augmented context.
- Provenance: gateway-source memories are bucketed separately from `tool` (Dragon local) and `manual` (REST direct).  Dashboard + Tab5 memory browser see the split.

### What ships
- **NEW** `dragon_voice/gateway_memory_mirror.py` (~95 LOC) — `async mirror_gateway_tool_call(tool, args, memory_service, session_id="")`
  - Mirrors only when `tool=="remember"` and a fact is present
  - Accepts `fact` / `content` / `text` aliases (FC-model variation)
  - Best-effort: any failure is logged + swallowed.  Mode-3 LLM streaming MUST NEVER tear down because of a memory hiccup.
  - **NOT** mirrored: `recall` (gateway has its own; conflating would confuse the agent)
- **Wired** in `dragon_voice/pipeline.py` — wraps `on_tool_call` before `tinkerclaw_llm.set_tool_event_handler`. Mirror runs first so WS backpressure on the forward doesn't delay the local write.
- **Tests** `tests/test_gateway_memory_mirror.py` — 12 tests (happy paths × 4, skip cases × 5, failure isolation × 2, independence × 1)

### Live verification on Dragon 192.168.1.91
| Test | Result |
|---|---|
| Ruff narrow gate | ✅ |
| Unit tests (12) | ✅ all pass |
| Deploy + tinkerclaw-voice restart | active on 3502 |
| Direct in-process call on Dragon | `FACT='live deploy verify' source=gateway session=sess-live` → `mirrored: True`; `recall` → `False`; `content` alias → mirrored as `alias check` |
| REST round-trip | `POST /api/v1/memory source=gateway` stored + visible in GET (28→29 facts) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)