### PR TITLE
W7-G: bucket gateway browser tool calls into agent_log gateway_browser source

### DIFF
--- a/dragon_voice/llm/tinkerclaw_llm.py
+++ b/dragon_voice/llm/tinkerclaw_llm.py
@@ -110,6 +110,26 @@ def sanitize_tinkerclaw_reply(text: str) -> str:
     return work
 
 
+def _classify_gateway_source(tool_name: str) -> str:
+    """W7-G: bucket gateway-routed tool calls so /api/v1/agent_log can
+    surface browser activity separately from generic gateway work.
+
+    OpenClaw exposes `browser` as its web-control tool (see
+    `openclaw/src/agents/tool-catalog.ts`), and the wider ecosystem
+    has variants (`browser_actions`, `browser.click`, etc.).  Treat
+    all of them as one bucket — `gateway_browser` — so operators see
+    a distinct counter for "the agent is on the web right now" vs
+    "the agent ran a shell command or RAG lookup."  Everything else
+    stays at the legacy `gateway` source.
+    """
+    name = (tool_name or "").strip().lower()
+    if not name:
+        return "gateway"
+    if name == "browser" or name.startswith("browser_") or name.startswith("browser."):
+        return "gateway_browser"
+    return "gateway"
+
+
 class TinkerClawBackend(LLMBackend):
     """LLM backend that proxies to a local TinkerClaw agent gateway."""
 
@@ -711,7 +731,7 @@ class TinkerClawBackend(LLMBackend):
                 _alog(
                     name,
                     args_obj if isinstance(args_obj, dict) else {},
-                    source="gateway",
+                    source=_classify_gateway_source(name),
                 )
             except Exception:
                 logger.debug(
@@ -761,7 +781,12 @@ class TinkerClawBackend(LLMBackend):
                     )
             try:
                 from dragon_voice.api.agent_log import record_result as _alog_res
-                _alog_res(name, result=None, execution_ms=None, source="gateway")
+                _alog_res(
+                    name,
+                    result=None,
+                    execution_ms=None,
+                    source=_classify_gateway_source(name),
+                )
             except Exception:
                 logger.debug(
                     "agent_log record_result suppressed for gateway tool %s",

--- a/tests/test_tinkerclaw_tool_events.py
+++ b/tests/test_tinkerclaw_tool_events.py
@@ -402,5 +402,169 @@ class TestAgentLogBridge(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(entries), 1)
 
 
+# ── W7-G: gateway browser source bucketing ────────────────────────────
+
+
+class TestGatewayBrowserSourceClassifier(unittest.TestCase):
+    """W7-G: pure-function classifier maps gateway tool names to a
+    bucketed source string.  Pulled out as a tiny unit so we can lock
+    the contract before exercising it end-to-end through the SSE
+    flush helpers (covered in TestGatewayBrowserSource below)."""
+
+    def test_bare_browser_is_browser_bucket(self):
+        from dragon_voice.llm.tinkerclaw_llm import _classify_gateway_source
+        self.assertEqual(_classify_gateway_source("browser"), "gateway_browser")
+
+    def test_underscore_namespace_is_browser_bucket(self):
+        from dragon_voice.llm.tinkerclaw_llm import _classify_gateway_source
+        # OpenClaw + tooling test fixtures show `browser_actions` as a
+        # real surface (see tool-mutation.test.ts).
+        self.assertEqual(
+            _classify_gateway_source("browser_actions"), "gateway_browser",
+        )
+        self.assertEqual(
+            _classify_gateway_source("browser_open"), "gateway_browser",
+        )
+
+    def test_dotted_namespace_is_browser_bucket(self):
+        from dragon_voice.llm.tinkerclaw_llm import _classify_gateway_source
+        # Forward-compat for "browser.click", "browser.navigate", etc.
+        self.assertEqual(
+            _classify_gateway_source("browser.click"), "gateway_browser",
+        )
+        self.assertEqual(
+            _classify_gateway_source("browser.navigate"), "gateway_browser",
+        )
+
+    def test_case_insensitive_match(self):
+        from dragon_voice.llm.tinkerclaw_llm import _classify_gateway_source
+        self.assertEqual(_classify_gateway_source("Browser"), "gateway_browser")
+        self.assertEqual(_classify_gateway_source("BROWSER"), "gateway_browser")
+        self.assertEqual(
+            _classify_gateway_source("Browser_Actions"), "gateway_browser",
+        )
+
+    def test_unrelated_tools_stay_in_gateway_bucket(self):
+        from dragon_voice.llm.tinkerclaw_llm import _classify_gateway_source
+        self.assertEqual(_classify_gateway_source("bash"), "gateway")
+        self.assertEqual(_classify_gateway_source("web_search"), "gateway")
+        self.assertEqual(_classify_gateway_source("remember"), "gateway")
+        self.assertEqual(_classify_gateway_source("read_file"), "gateway")
+        # `browser`-prefixed but NOT a browser tool — must not false-fire.
+        # The rule is exact match or `browser_`/`browser.` separator.
+        self.assertEqual(_classify_gateway_source("browserify"), "gateway")
+        self.assertEqual(_classify_gateway_source("browseractivity"), "gateway")
+
+    def test_empty_and_none_fall_through_to_gateway(self):
+        from dragon_voice.llm.tinkerclaw_llm import _classify_gateway_source
+        self.assertEqual(_classify_gateway_source(""), "gateway")
+        self.assertEqual(_classify_gateway_source("   "), "gateway")
+        # Tolerate None — the SSE buffer can hand us empty names if the
+        # upstream stream drops mid-frame.
+        self.assertEqual(_classify_gateway_source(None), "gateway")  # type: ignore[arg-type]
+
+
+class TestGatewayBrowserSourceEndToEnd(unittest.IsolatedAsyncioTestCase):
+    """W7-G: when the SSE parser flushes a tool call whose name is
+    `browser` (or a `browser_*` / `browser.*` namespace), the
+    agent_log ring records source=gateway_browser so /api/v1/agent_log
+    can bucket browser activity separately from generic gateway work.
+    """
+
+    async def asyncSetUp(self):
+        from dragon_voice.api import agent_log as _alog
+        self._alog = _alog
+        with _alog._lock:
+            self._saved_ring = list(_alog._ring)
+            self._saved_next = _alog._next_id
+            _alog._ring.clear()
+            _alog._next_id = 1
+
+    async def asyncTearDown(self):
+        with self._alog._lock:
+            self._alog._ring.clear()
+            for item in self._saved_ring:
+                self._alog._ring.append(item)
+            self._alog._next_id = self._saved_next
+
+    async def test_browser_flush_records_browser_source(self):
+        be = _NoInitBackend()
+        buf = {0: {"id": "x", "name": "browser",
+                   "arguments": '{"action":"tabs"}'}}
+        await be._flush_tool_calls(buf, set())
+        with self._alog._lock:
+            entries = list(self._alog._ring)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "browser")
+        self.assertEqual(entries[0]["source"], "gateway_browser")
+        self.assertEqual(entries[0]["status"], "running")
+
+    async def test_browser_actions_flush_records_browser_source(self):
+        be = _NoInitBackend()
+        buf = {0: {"id": "x", "name": "browser_actions",
+                   "arguments": '{"action":"list"}'}}
+        await be._flush_tool_calls(buf, set())
+        with self._alog._lock:
+            entries = list(self._alog._ring)
+        self.assertEqual(entries[0]["source"], "gateway_browser")
+
+    async def test_dotted_browser_flush_records_browser_source(self):
+        be = _NoInitBackend()
+        buf = {0: {"id": "x", "name": "browser.click",
+                   "arguments": '{"selector":"#submit"}'}}
+        await be._flush_tool_calls(buf, set())
+        with self._alog._lock:
+            entries = list(self._alog._ring)
+        self.assertEqual(entries[0]["source"], "gateway_browser")
+
+    async def test_non_browser_flush_stays_in_gateway_bucket(self):
+        # Sanity check: pre-W7-G behavior preserved for non-browser tools.
+        be = _NoInitBackend()
+        buf = {
+            0: {"id": "a", "name": "bash", "arguments": '{"cmd":"ls"}'},
+            1: {"id": "b", "name": "web_search", "arguments": '{"q":"x"}'},
+        }
+        await be._flush_tool_calls(buf, set())
+        with self._alog._lock:
+            entries = list(self._alog._ring)
+        sources = {e["tool"]: e["source"] for e in entries}
+        self.assertEqual(sources["bash"], "gateway")
+        self.assertEqual(sources["web_search"], "gateway")
+
+    async def test_synthetic_result_uses_browser_source(self):
+        # _emit_synthetic_results must classify the same way so the
+        # done-marker flips the matching gateway_browser running entry,
+        # NOT spawn a synthetic gateway-bucket entry alongside it.
+        be = _NoInitBackend()
+        # Seed a running browser call.
+        buf = {0: {"id": "x", "name": "browser", "arguments": "{}"}}
+        await be._flush_tool_calls(buf, set())
+        await be._emit_synthetic_results(["browser"])
+        with self._alog._lock:
+            entries = list(self._alog._ring)
+        # Exactly one entry, source=gateway_browser, status=done.
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["source"], "gateway_browser")
+        self.assertEqual(entries[0]["status"], "done")
+
+    async def test_mixed_burst_yields_two_source_buckets(self):
+        # Realistic mode-3 turn: gateway fires `browser` + `web_search`
+        # in the same flush.  agent_log must split them into two
+        # source buckets, both tagged as gateway-flavored.
+        be = _NoInitBackend()
+        buf = {
+            0: {"id": "a", "name": "browser",
+                "arguments": '{"action":"tabs"}'},
+            1: {"id": "b", "name": "web_search",
+                "arguments": '{"q":"esp32-p4"}'},
+        }
+        await be._flush_tool_calls(buf, set())
+        with self._alog._lock:
+            entries = list(self._alog._ring)
+        sources = {e["tool"]: e["source"] for e in entries}
+        self.assertEqual(sources["browser"], "gateway_browser")
+        self.assertEqual(sources["web_search"], "gateway")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #318.

## What changes
- `_classify_gateway_source(name)` in `dragon_voice/llm/tinkerclaw_llm.py` maps gateway-routed browser tool names to a distinct `gateway_browser` source bucket; everything else stays at `gateway`
- Applied at both `record_call` and `record_result` sites in `_flush_tool_calls` + `_emit_synthetic_results` so the running→done flip stays inside the same source bucket
- 12 new tests in `tests/test_tinkerclaw_tool_events.py` covering classifier behavior + end-to-end through the SSE flush helpers

## Why
Pre-W7-G, every gateway-routed tool call landed in agent_log with `source="gateway"`. When the OpenClaw agent ran a browser action it got lumped together with bash / web_search / etc — operators couldn't tell at a glance whether the agent was on the web.

W7-G adds `gateway_browser` as a distinct source string. The `/api/v1/agent_log` endpoint's `sources` bucket dict (which already passes arbitrary source strings through verbatim) now surfaces it automatically. No schema change. Tab5's `ui_agents.c` and the dashboard activity feed gain a third bucket counter once they choose to render it.

## Classifier rule
Case-insensitive, applied to the tool name after trim:
- `browser` exactly → `gateway_browser`
- `browser_*` (e.g. `browser_actions`, `browser_open`) → `gateway_browser`
- `browser.*` (e.g. `browser.click`, `browser.navigate`) → `gateway_browser`
- Everything else (incl. `browserify`, empty, None) → `gateway`

## Tests
86/86 green across `test_tinkerclaw_tool_events.py` + `test_agent_log.py` + `test_agent_skills_api.py` + `test_gateway_memory_mirror.py` + `test_voice_path_tool_callbacks.py`. Ruff narrow gate passes.

## Deploy verification
- Pushed `dragon_voice/llm/tinkerclaw_llm.py` to Dragon 192.168.1.91
- `tinkerclaw-voice.service` restarted, status active
- `python3 -c 'from dragon_voice.llm.tinkerclaw_llm import _classify_gateway_source'` confirms helper available with correct outputs (`browser`/`browser.click`/`browser_actions` → `gateway_browser`; `bash`/`web_search` → `gateway`)
- `GET /api/v1/agent_log` returns 200 with the expected shape ready to fan out the new bucket once a real mode-3 browser action fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)