### PR TITLE
W4-B: honest /health that probes STT/LLM/TTS subsystems

### DIFF
--- a/dragon_voice/handlers/status.py
+++ b/dragon_voice/handlers/status.py
@@ -14,10 +14,27 @@ count) are cheap attribute reads and live on the same instance.
 """
 from __future__ import annotations
 
+import asyncio
+import logging
 import time
 from typing import Any
 
 from aiohttp import web
+
+from dragon_voice.llm.base import LLMBackend
+from dragon_voice.stt.base import STTBackend
+from dragon_voice.tts.base import TTSBackend
+
+logger = logging.getLogger(__name__)
+
+# W4-B (audit 2026-05-11): per-subsystem probe budget for `/health`.
+# Each backend's `health_check(timeout_s)` is capped at this; the
+# overall handler also wraps the gather() with `_HEALTH_GATHER_BUDGET_S`
+# so a single stuck backend can never stall the response longer than
+# that.  Sized so ngrok healthchecks (default 5 s) and systemd
+# `TimeoutStartSec` (default 90 s) never trip.
+_HEALTH_PROBE_TIMEOUT_S = 2.0
+_HEALTH_GATHER_BUDGET_S = 3.0
 
 
 async def handle_status(request: web.Request, *, server: Any) -> web.Response:
@@ -53,22 +70,114 @@ async def handle_status(request: web.Request, *, server: Any) -> web.Response:
     return web.Response(text=html, content_type="text/html")
 
 
+def _pick_backend_to_probe(pool: dict, kind: type) -> Any:
+   """Return the first instance in `pool.values()` matching `kind`.
+
+   The pool stores STT/TTS/LLM backends side-by-side keyed by
+   signature tuple (see `pipeline._stt_sig` etc).  When a Tab5
+   connects in mode-2 (cloud) and another in mode-0 (local), each
+   subsystem may have multiple instances pooled.  For /health we
+   probe whichever one we find first — operators care about "is at
+   least one of each healthy."
+   """
+   for backend in pool.values():
+      if isinstance(backend, kind):
+         return backend
+   return None
+
+
+async def _probe(backend: Any, fallback_name: str, timeout_s: float) -> dict:
+   """Run a single backend's `health_check`, never raise.
+
+   Uses `backend.name` (the live instance's own name) over the
+   server's global-config `fallback_name` when a backend is present —
+   so /health reflects the *actually pooled* backend, not whichever
+   default appeared in `config.yaml` at boot.  After a hot config-
+   swap (mode-2 cloud) those two differ.
+
+   The W4-B contract guarantees `health_check` returns `(ok, detail)`
+   without raising.  We still defensive-wrap because backends pre-
+   dating W4-B inherit the ABC default but third-party / experimental
+   ones might not respect the no-raise rule.
+   """
+   if backend is None:
+      return {"name": "(none)", "ok": True, "detail": "no active backend"}
+   live_name = getattr(backend, "name", None) or fallback_name
+   try:
+      ok, detail = await asyncio.wait_for(
+          backend.health_check(timeout_s=timeout_s),
+          timeout=timeout_s + 0.5,
+      )
+   except asyncio.TimeoutError:
+      return {
+          "name": live_name, "ok": False,
+          "detail": f"health_check exceeded {timeout_s}s",
+      }
+   except Exception as e:  # noqa: BLE001 — must never tear down /health
+      logger.warning("health_check raised on %s: %s", live_name, e)
+      return {"name": live_name, "ok": False,
+              "detail": f"{type(e).__name__}: {e}"[:120]}
+   # Trim detail so a chatty backend can't blow the JSON budget.
+   return {"name": live_name, "ok": bool(ok),
+           "detail": str(detail or "")[:120]}
+
+
 async def handle_health(request: web.Request, *, server: Any) -> web.Response:
     """``GET /health`` — JSON liveness probe.
 
     Public endpoint; used by ops + ngrok healthcheck + the
     dashboard's status tile.  Returns uptime in seconds, active
-    connection count, and the three backend names.
+    connection count, and per-subsystem state for STT/LLM/TTS.
+
+    W4-B (audit 2026-05-11): probes each backend via the
+    `health_check` method added to the STT/TTS/LLM ABCs.  Pre-W4-B
+    this endpoint claimed `status: "ok"` unconditionally — ngrok +
+    dashboard + Tab5 reachability all saw green while the LLM
+    backend was offline.
+
+    The HTTP status code stays 200 regardless of subsystem state —
+    a 503 here would trip ngrok / systemd / Tab5 reconnect logic
+    even when the server itself is fine and one *optional* backend
+    is down.  The truth lives in the `status` field ("ok" vs
+    "degraded") and the per-backend `ok` booleans.
     """
+    stt = _pick_backend_to_probe(server._backend_pool, STTBackend)
+    tts = _pick_backend_to_probe(server._backend_pool, TTSBackend)
+    llm = _pick_backend_to_probe(server._backend_pool, LLMBackend)
+
+    # asyncio.gather concurrently — the slowest subsystem dictates
+    # response latency, not the sum.  Each probe is internally capped
+    # at _HEALTH_PROBE_TIMEOUT_S; the outer wait_for is a belt-and-
+    # suspenders cap in case a backend's wait_for somehow returned
+    # control to us late.
+    try:
+        results = await asyncio.wait_for(
+            asyncio.gather(
+                _probe(stt, server._stt_name, _HEALTH_PROBE_TIMEOUT_S),
+                _probe(tts, server._tts_name, _HEALTH_PROBE_TIMEOUT_S),
+                _probe(llm, server._llm_name, _HEALTH_PROBE_TIMEOUT_S),
+            ),
+            timeout=_HEALTH_GATHER_BUDGET_S,
+        )
+        stt_state, tts_state, llm_state = results
+    except asyncio.TimeoutError:
+        stt_state = {"name": server._stt_name, "ok": False,
+                     "detail": "gather timeout"}
+        tts_state = {"name": server._tts_name, "ok": False,
+                     "detail": "gather timeout"}
+        llm_state = {"name": server._llm_name, "ok": False,
+                     "detail": "gather timeout"}
+
+    all_ok = stt_state["ok"] and tts_state["ok"] and llm_state["ok"]
     return web.json_response(
         {
-            "status": "ok",
+            "status": "ok" if all_ok else "degraded",
             "uptime_seconds": round(time.time() - server._start_time, 1),
             "active_connections": len(server._active_connections),
             "backends": {
-                "stt": server._stt_name,
-                "tts": server._tts_name,
-                "llm": server._llm_name,
+                "stt": stt_state,
+                "tts": tts_state,
+                "llm": llm_state,
             },
         }
     )

--- a/dragon_voice/llm/base.py
+++ b/dragon_voice/llm/base.py
@@ -130,6 +130,26 @@ class LLMBackend(ABC):
         """
         return frozenset({Modality.TEXT})
 
+    async def health_check(self, timeout_s: float = 2.0) -> tuple[bool, str]:
+        """W4-B: cheap reachability probe surfaced by `GET /health`.
+
+        Default returns `(True, "no probe")` so local/in-process backends
+        (e.g. NPU Genie) don't need to override — they're considered
+        healthy as long as `initialize()` returned without raising.
+        Network-backed backends (Ollama, OpenRouter, TinkerClaw) override
+        to actually round-trip a cheap request within `timeout_s`.
+
+        Returns
+        -------
+        (ok, detail)
+            ok=True  → probe succeeded or none implemented
+            ok=False → reachability failed; `detail` is the error string
+                       (≤ ~120 chars; truncated by the caller for display)
+
+        Must never raise — wrap exceptions and report as (False, str(e)).
+        """
+        return True, "no probe"
+
 
 # ─────────────────────────────────────────────────────────────────────
 # Optional-feature Protocol mixins (#204, Wave 21b).

--- a/dragon_voice/llm/ollama_llm.py
+++ b/dragon_voice/llm/ollama_llm.py
@@ -174,6 +174,30 @@ class OllamaBackend(LLMBackend):
                 e,
             )
 
+    async def health_check(self, timeout_s: float = 2.0) -> tuple[bool, str]:
+        """W4-B: cheap reachability probe — `GET {base_url}/api/tags`.
+
+        Cap at `timeout_s` so a stuck Ollama daemon can't stall `/health`.
+        Returns (False, error_text) on any non-200, connect refused, or
+        timeout; never raises.
+        """
+        if self._session is None or self._session.closed:
+            return False, "session not initialized"
+        try:
+            async with self._session.get(
+                f"{self._base_url}/api/tags",
+                timeout=aiohttp.ClientTimeout(total=timeout_s),
+            ) as resp:
+                if resp.status == 200:
+                    return True, f"{self._base_url}"
+                return False, f"HTTP {resp.status}"
+        except asyncio.TimeoutError:
+            return False, f"timeout after {timeout_s}s"
+        except aiohttp.ClientError as e:
+            return False, str(e)[:120]
+        except Exception as e:  # noqa: BLE001 — must never raise
+            return False, f"{type(e).__name__}: {e}"[:120]
+
     async def generate_stream(
         self, prompt: str, system_prompt: str = ""
     ) -> AsyncIterator[str]:

--- a/dragon_voice/llm/openrouter_llm.py
+++ b/dragon_voice/llm/openrouter_llm.py
@@ -79,6 +79,32 @@ class OpenRouterBackend(LLMBackend):
         except aiohttp.ClientError as e:
             logger.warning("Cannot reach OpenRouter: %s", e)
 
+    async def health_check(self, timeout_s: float = 2.0) -> tuple[bool, str]:
+        """W4-B: cheap reachability probe — `GET {base_url}/models`.
+
+        Bearer-authed via the session's stored Authorization header.  A
+        non-200 surfaces as not-ok with the status code; auth misconfig
+        bubbles up here too (401 → operators see it in /health).
+        """
+        if not self._api_key:
+            return False, "no api key"
+        if self._session is None or self._session.closed:
+            return False, "session not initialized"
+        try:
+            async with self._session.get(
+                f"{self._base_url}/models",
+                timeout=aiohttp.ClientTimeout(total=timeout_s),
+            ) as resp:
+                if resp.status == 200:
+                    return True, f"{self._base_url}"
+                return False, f"HTTP {resp.status}"
+        except asyncio.TimeoutError:
+            return False, f"timeout after {timeout_s}s"
+        except aiohttp.ClientError as e:
+            return False, str(e)[:120]
+        except Exception as e:  # noqa: BLE001 — must never raise
+            return False, f"{type(e).__name__}: {e}"[:120]
+
     async def _stream_messages(
         self, messages: list[dict], _retried: bool = False,
     ) -> AsyncIterator[str]:

--- a/dragon_voice/llm/tinkerclaw_llm.py
+++ b/dragon_voice/llm/tinkerclaw_llm.py
@@ -265,6 +265,27 @@ class TinkerClawBackend(LLMBackend):
         self._health_cache_until = now + HEALTH_CACHE_TTL_S
         return ok
 
+    async def health_check(self, timeout_s: float = 2.0) -> tuple[bool, str]:
+        """W4-B: surface the cached gateway-health probe to `/health`.
+
+        Reuses the existing `is_healthy()` 30 s cache so a /health hit
+        every few seconds doesn't re-probe the gateway each time — the
+        operator gets a near-realtime answer with stable load.
+        `timeout_s` is informational here (the underlying probe budget
+        is `HEALTH_CHECK_TIMEOUT_S=5`); we honor `timeout_s` only for
+        the cache-lookup path (which is sub-ms anyway).
+        """
+        try:
+            ok = await asyncio.wait_for(
+                self.is_healthy(force=False),
+                timeout=max(timeout_s, HEALTH_CHECK_TIMEOUT_S + 0.5),
+            )
+        except asyncio.TimeoutError:
+            return False, f"timeout after {timeout_s}s"
+        except Exception as e:  # noqa: BLE001 — must never raise
+            return False, f"{type(e).__name__}: {e}"[:120]
+        return (True, f"{self._url}") if ok else (False, "gateway /health not 200")
+
     def set_session_key(self, session_key: str) -> None:
         """Set the session key for conversation continuity.
 

--- a/dragon_voice/stt/base.py
+++ b/dragon_voice/stt/base.py
@@ -34,3 +34,16 @@ class STTBackend(ABC):
     def name(self) -> str:
         """Human-readable backend name for logging and status pages."""
         ...
+
+    async def health_check(self, timeout_s: float = 2.0) -> tuple[bool, str]:
+        """W4-B: cheap reachability probe surfaced by `GET /health`.
+
+        Default returns `(True, "no probe")` so local/in-process backends
+        (Moonshine, Whisper.cpp, Vosk) don't need to override — they're
+        considered healthy as long as `initialize()` returned without
+        raising.  Network-backed backends (OpenRouter STT) override to
+        actually round-trip a cheap request within `timeout_s`.
+
+        Must never raise — wrap exceptions and report as (False, str(e)).
+        """
+        return True, "no probe"

--- a/dragon_voice/stt/openrouter_stt.py
+++ b/dragon_voice/stt/openrouter_stt.py
@@ -124,3 +124,29 @@ class OpenRouterSTTBackend(STTBackend):
     @property
     def name(self) -> str:
         return f"OpenRouter STT ({MODEL})"
+
+    async def health_check(self, timeout_s: float = 2.0) -> tuple[bool, str]:
+        """W4-B: cheap reachability probe — `GET {base_url}/models`.
+
+        Same probe as the LLM backend; bearer-authed via session header.
+        Catches auth misconfig (401) + transport errors so operators see
+        the OpenRouter side of the cloud-mode stack honestly.
+        """
+        if not self._api_key:
+            return False, "no api key"
+        if self._session is None or self._session.closed:
+            return False, "session not initialized"
+        try:
+            async with self._session.get(
+                f"{self._base_url}/models",
+                timeout=aiohttp.ClientTimeout(total=timeout_s),
+            ) as resp:
+                if resp.status == 200:
+                    return True, f"{self._base_url}"
+                return False, f"HTTP {resp.status}"
+        except asyncio.TimeoutError:
+            return False, f"timeout after {timeout_s}s"
+        except aiohttp.ClientError as e:
+            return False, str(e)[:120]
+        except Exception as e:  # noqa: BLE001
+            return False, f"{type(e).__name__}: {e}"[:120]

--- a/dragon_voice/tts/base.py
+++ b/dragon_voice/tts/base.py
@@ -40,3 +40,16 @@ class TTSBackend(ABC):
     def name(self) -> str:
         """Human-readable backend name for logging and status pages."""
         ...
+
+    async def health_check(self, timeout_s: float = 2.0) -> tuple[bool, str]:
+        """W4-B: cheap reachability probe surfaced by `GET /health`.
+
+        Default returns `(True, "no probe")` so local/in-process backends
+        (Piper, Kokoro) don't need to override — they're considered
+        healthy as long as `initialize()` returned without raising.
+        Network-backed backends (OpenRouter TTS, Edge TTS) override to
+        actually round-trip a cheap request within `timeout_s`.
+
+        Must never raise — wrap exceptions and report as (False, str(e)).
+        """
+        return True, "no probe"

--- a/dragon_voice/tts/openrouter_tts.py
+++ b/dragon_voice/tts/openrouter_tts.py
@@ -4,6 +4,7 @@ Sends text to OpenRouter's gpt-audio-mini model with audio modality,
 streams pcm16 audio chunks via SSE, returns raw PCM int16 at 24kHz.
 """
 
+import asyncio
 import base64
 import json
 import logging
@@ -144,3 +145,28 @@ class OpenRouterTTSBackend(TTSBackend):
     @property
     def name(self) -> str:
         return f"OpenRouter TTS ({MODEL}, {self._voice})"
+
+    async def health_check(self, timeout_s: float = 2.0) -> tuple[bool, str]:
+        """W4-B: cheap reachability probe — `GET {base_url}/models`.
+
+        Same shape as the LLM + STT OpenRouter backends so all three
+        cloud-mode subsystems share one probe path.
+        """
+        if not self._api_key:
+            return False, "no api key"
+        if self._session is None or self._session.closed:
+            return False, "session not initialized"
+        try:
+            async with self._session.get(
+                f"{self._base_url}/models",
+                timeout=aiohttp.ClientTimeout(total=timeout_s),
+            ) as resp:
+                if resp.status == 200:
+                    return True, f"{self._base_url}"
+                return False, f"HTTP {resp.status}"
+        except asyncio.TimeoutError:
+            return False, f"timeout after {timeout_s}s"
+        except aiohttp.ClientError as e:
+            return False, str(e)[:120]
+        except Exception as e:  # noqa: BLE001
+            return False, f"{type(e).__name__}: {e}"[:120]

--- a/tests/test_status_handlers.py
+++ b/tests/test_status_handlers.py
@@ -19,7 +19,7 @@ from dragon_voice.handlers import status as status_mod
 
 
 def _make_server(*, start_time=1000.0, stt="moonshine", tts="piper", llm="qwen",
-                 active=0, sessions=42) -> MagicMock:
+                 active=0, sessions=42, backend_pool=None) -> MagicMock:
     s = MagicMock()
     s._start_time = start_time
     s._stt_name = stt
@@ -27,6 +27,10 @@ def _make_server(*, start_time=1000.0, stt="moonshine", tts="piper", llm="qwen",
     s._llm_name = llm
     s._active_connections = {f"conn{i}": {} for i in range(active)}
     s._session_count = sessions
+    # W4-B (audit 2026-05-11): handle_health probes backends out of
+    # this pool.  Default = empty so legacy tests still see "no active
+    # backend" rather than tripping on a MagicMock.
+    s._backend_pool = backend_pool if backend_pool is not None else {}
     return s
 
 
@@ -60,8 +64,14 @@ class StatusHandlerTests(unittest.TestCase):
 
 
 class HealthHandlerTests(unittest.TestCase):
-    def test_health_returns_json_with_expected_shape(self):
-        server = _make_server(start_time=0.0, stt="stt_x", tts="tts_y", llm="llm_z", active=5)
+    """Pre-W4-B shape coverage.  When `_backend_pool` is empty (the
+    test default), each subsystem renders as `"(none)" ok=true detail=
+    "no active backend"` — operators see "server up, no backends to
+    probe yet" which is the honest answer when no Tab5 has connected."""
+
+    def test_health_returns_json_with_per_subsystem_shape(self):
+        server = _make_server(start_time=0.0, stt="stt_x", tts="tts_y",
+                              llm="llm_z", active=5)
         req = MagicMock()
 
         async def go():
@@ -72,11 +82,270 @@ class HealthHandlerTests(unittest.TestCase):
         payload = json.loads(resp.body)
         self.assertEqual(payload["status"], "ok")
         self.assertEqual(payload["active_connections"], 5)
-        self.assertEqual(payload["backends"], {"stt": "stt_x", "tts": "tts_y", "llm": "llm_z"})
-        # uptime_seconds should be a non-negative number (we set
-        # start_time=0 so it's the epoch-relative time).
+        # New W4-B shape: per-subsystem dict, not flat strings.
+        for sub in ("stt", "tts", "llm"):
+            self.assertIn(sub, payload["backends"])
+            entry = payload["backends"][sub]
+            self.assertIn("name", entry)
+            self.assertIn("ok", entry)
+            self.assertIn("detail", entry)
+            self.assertIs(entry["ok"], True)  # empty pool → no probe
+            self.assertEqual(entry["detail"], "no active backend")
         self.assertIsInstance(payload["uptime_seconds"], float)
         self.assertGreater(payload["uptime_seconds"], 0.0)
+
+
+# ── W4-B: per-subsystem honest probes ───────────────────────────────
+
+from dragon_voice.llm.base import LLMBackend, Modality
+from dragon_voice.stt.base import STTBackend
+from dragon_voice.tts.base import TTSBackend
+
+
+class _FakeSTT(STTBackend):
+    """In-process STT backend with a tunable health_check."""
+
+    def __init__(self, *, ok=True, detail="ok-stt", raise_=None, sleep=0.0):
+        self._ok = ok
+        self._detail = detail
+        self._raise = raise_
+        self._sleep = sleep
+
+    async def initialize(self): pass
+    async def transcribe(self, audio_bytes, sample_rate=16000): return ""
+    async def shutdown(self): pass
+
+    @property
+    def name(self): return "fake-stt"
+
+    async def health_check(self, timeout_s=2.0):
+        if self._sleep:
+            await asyncio.sleep(self._sleep)
+        if self._raise is not None:
+            raise self._raise
+        return self._ok, self._detail
+
+
+class _FakeTTS(TTSBackend):
+    def __init__(self, *, ok=True, detail="ok-tts", raise_=None, sleep=0.0):
+        self._ok = ok
+        self._detail = detail
+        self._raise = raise_
+        self._sleep = sleep
+
+    async def initialize(self): pass
+    async def synthesize(self, text): return b""
+    async def shutdown(self): pass
+
+    @property
+    def sample_rate(self): return 22050
+
+    @property
+    def name(self): return "fake-tts"
+
+    async def health_check(self, timeout_s=2.0):
+        if self._sleep:
+            await asyncio.sleep(self._sleep)
+        if self._raise is not None:
+            raise self._raise
+        return self._ok, self._detail
+
+
+class _FakeLLM(LLMBackend):
+    def __init__(self, *, ok=True, detail="ok-llm", raise_=None, sleep=0.0):
+        self._ok = ok
+        self._detail = detail
+        self._raise = raise_
+        self._sleep = sleep
+
+    async def initialize(self): pass
+
+    async def generate_stream(self, prompt, system_prompt=""):
+        yield ""
+
+    async def shutdown(self): pass
+
+    @property
+    def name(self): return "fake-llm"
+
+    @property
+    def capabilities(self): return frozenset({Modality.TEXT})
+
+    async def health_check(self, timeout_s=2.0):
+        if self._sleep:
+            await asyncio.sleep(self._sleep)
+        if self._raise is not None:
+            raise self._raise
+        return self._ok, self._detail
+
+
+def _pool_with(stt=None, tts=None, llm=None) -> dict:
+    """Build a backend_pool dict like the live server's.  Keys mirror
+    the real signature-tuple convention; values are the backends."""
+    pool: dict = {}
+    if stt is not None:
+        pool[("stt", "fake")] = stt
+    if tts is not None:
+        pool[("tts", "fake")] = tts
+    if llm is not None:
+        pool[("llm", "fake")] = llm
+    return pool
+
+
+class HealthProbeIntegrationTests(unittest.TestCase):
+    def test_all_three_backends_ok_returns_status_ok(self):
+        server = _make_server(backend_pool=_pool_with(
+            stt=_FakeSTT(ok=True, detail="up"),
+            tts=_FakeTTS(ok=True, detail="up"),
+            llm=_FakeLLM(ok=True, detail="up"),
+        ))
+        resp = asyncio.run(status_mod.handle_health(MagicMock(), server=server))
+        payload = json.loads(resp.body)
+        self.assertEqual(payload["status"], "ok")
+        for sub in ("stt", "tts", "llm"):
+            self.assertTrue(payload["backends"][sub]["ok"])
+            self.assertEqual(payload["backends"][sub]["detail"], "up")
+
+    def test_one_backend_down_returns_degraded(self):
+        server = _make_server(backend_pool=_pool_with(
+            stt=_FakeSTT(ok=True),
+            tts=_FakeTTS(ok=True),
+            llm=_FakeLLM(ok=False, detail="connect refused: 11434"),
+        ))
+        resp = asyncio.run(status_mod.handle_health(MagicMock(), server=server))
+        payload = json.loads(resp.body)
+        self.assertEqual(payload["status"], "degraded")
+        self.assertTrue(payload["backends"]["stt"]["ok"])
+        self.assertTrue(payload["backends"]["tts"]["ok"])
+        self.assertFalse(payload["backends"]["llm"]["ok"])
+        self.assertIn("connect refused", payload["backends"]["llm"]["detail"])
+
+    def test_probe_that_raises_treated_as_not_ok(self):
+        server = _make_server(backend_pool=_pool_with(
+            stt=_FakeSTT(ok=True),
+            tts=_FakeTTS(ok=True),
+            llm=_FakeLLM(raise_=RuntimeError("kaboom")),
+        ))
+        resp = asyncio.run(status_mod.handle_health(MagicMock(), server=server))
+        payload = json.loads(resp.body)
+        self.assertEqual(payload["status"], "degraded")
+        self.assertFalse(payload["backends"]["llm"]["ok"])
+        # Exception class name + message surface in detail so operators
+        # can see what blew up without reading server logs.
+        self.assertIn("RuntimeError", payload["backends"]["llm"]["detail"])
+        self.assertIn("kaboom", payload["backends"]["llm"]["detail"])
+
+    def test_probe_slower_than_timeout_reports_timeout(self):
+        # _FakeSTT sleeps 3 s; probe budget is 2 s.  Must short-circuit.
+        slow = _FakeSTT(sleep=3.0, ok=True, detail="should not appear")
+        server = _make_server(backend_pool=_pool_with(
+            stt=slow,
+            tts=_FakeTTS(ok=True),
+            llm=_FakeLLM(ok=True),
+        ))
+        # Patch the module's probe budget down so the test doesn't take
+        # 3 s.  Sleep MUST exceed (probe_timeout + 0.5 s) — that's the
+        # outer wait_for budget — or the backend returns OK before we
+        # interrupt it.  0.05 s probe + 0.5 s buffer = 0.55 s; use 1.5 s
+        # sleep so we're well over.
+        slow._sleep = 1.5
+        orig_probe = status_mod._HEALTH_PROBE_TIMEOUT_S
+        orig_gather = status_mod._HEALTH_GATHER_BUDGET_S
+        try:
+            status_mod._HEALTH_PROBE_TIMEOUT_S = 0.05
+            status_mod._HEALTH_GATHER_BUDGET_S = 2.5
+            resp = asyncio.run(
+                status_mod.handle_health(MagicMock(), server=server),
+            )
+        finally:
+            status_mod._HEALTH_PROBE_TIMEOUT_S = orig_probe
+            status_mod._HEALTH_GATHER_BUDGET_S = orig_gather
+        payload = json.loads(resp.body)
+        self.assertEqual(payload["status"], "degraded")
+        self.assertFalse(payload["backends"]["stt"]["ok"])
+        self.assertIn("exceeded", payload["backends"]["stt"]["detail"])
+
+    def test_status_code_stays_200_even_when_degraded(self):
+        # Critical contract: ngrok/systemd/Tab5 healthchecks treat any
+        # non-2xx as "server gone."  Subsystem failure must NOT trip that
+        # — the truth lives in the JSON body.
+        server = _make_server(backend_pool=_pool_with(
+            stt=_FakeSTT(ok=False),
+            tts=_FakeTTS(ok=False),
+            llm=_FakeLLM(ok=False),
+        ))
+        resp = asyncio.run(status_mod.handle_health(MagicMock(), server=server))
+        self.assertEqual(resp.status, 200)
+        payload = json.loads(resp.body)
+        self.assertEqual(payload["status"], "degraded")
+
+    def test_only_llm_in_pool_yields_synthetic_no_probe_for_others(self):
+        # Active session is mode-3 (TinkerClaw) where Dragon's STT/TTS
+        # are bypassed.  Only the LLM lands in the pool.  STT/TTS get
+        # "no active backend" + ok=true (correct: nothing to probe).
+        server = _make_server(backend_pool=_pool_with(
+            llm=_FakeLLM(ok=True, detail="gateway up"),
+        ))
+        resp = asyncio.run(status_mod.handle_health(MagicMock(), server=server))
+        payload = json.loads(resp.body)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["backends"]["stt"]["detail"], "no active backend")
+        self.assertEqual(payload["backends"]["tts"]["detail"], "no active backend")
+        self.assertEqual(payload["backends"]["llm"]["detail"], "gateway up")
+
+    def test_uptime_and_active_connections_still_surface(self):
+        server = _make_server(
+            start_time=0.0, active=7,
+            backend_pool=_pool_with(stt=_FakeSTT(), tts=_FakeTTS(), llm=_FakeLLM()),
+        )
+        resp = asyncio.run(status_mod.handle_health(MagicMock(), server=server))
+        payload = json.loads(resp.body)
+        self.assertEqual(payload["active_connections"], 7)
+        self.assertIsInstance(payload["uptime_seconds"], float)
+        self.assertGreater(payload["uptime_seconds"], 0.0)
+
+
+class BackendABCDefaultHealthCheckTests(unittest.TestCase):
+    """Each backend ABC's default health_check returns (True, 'no probe').
+    Local backends (Moonshine/Piper/Vosk/Kokoro) inherit this so they
+    don't need overrides — they're healthy as long as initialize()
+    completed."""
+
+    def test_stt_default_health_check(self):
+        class _MinSTT(STTBackend):
+            async def initialize(self): pass
+            async def transcribe(self, audio_bytes, sample_rate=16000): return ""
+            async def shutdown(self): pass
+            @property
+            def name(self): return "min"
+        ok, detail = asyncio.run(_MinSTT().health_check())
+        self.assertTrue(ok)
+        self.assertEqual(detail, "no probe")
+
+    def test_tts_default_health_check(self):
+        class _MinTTS(TTSBackend):
+            async def initialize(self): pass
+            async def synthesize(self, text): return b""
+            async def shutdown(self): pass
+            @property
+            def sample_rate(self): return 22050
+            @property
+            def name(self): return "min"
+        ok, detail = asyncio.run(_MinTTS().health_check())
+        self.assertTrue(ok)
+        self.assertEqual(detail, "no probe")
+
+    def test_llm_default_health_check(self):
+        class _MinLLM(LLMBackend):
+            async def initialize(self): pass
+            async def generate_stream(self, prompt, system_prompt=""):
+                yield ""
+            async def shutdown(self): pass
+            @property
+            def name(self): return "min"
+        ok, detail = asyncio.run(_MinLLM().health_check())
+        self.assertTrue(ok)
+        self.assertEqual(detail, "no probe")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #320.

## What changes
Pre-W4-B `GET /health` claimed `status:"ok"` unconditionally even when the LLM backend was offline. Dashboard status tile, ngrok healthcheck, and Tab5 reachability all saw green while real turns timed out.

This PR adds an `async health_check(timeout_s=2.0) -> (ok, detail)` method to the STT/TTS/LLM base ABCs. Default returns `(True, "no probe")` so local backends (Moonshine, Piper, Vosk, Kokoro) inherit healthy-when-init-succeeded without needing overrides. Network-backed backends override to actually round-trip a cheap request:

- **Ollama**: `GET {base_url}/api/tags`
- **OpenRouter LLM/STT/TTS**: `GET {base_url}/models` (bearer-authed)
- **TinkerClaw**: reuses its existing 30 s-cached `is_healthy()`

`handle_health` walks the shared backend pool (W15-C01), isinstance-buckets per type, runs all three probes concurrently via `asyncio.gather` with an outer `_HEALTH_GATHER_BUDGET_S=3.0` cap so one stuck backend can't stall `/health`. HTTP 200 always — `status` flips to "degraded" when any subsystem reports not-ok, but ngrok/systemd/Tab5 healthchecks keep seeing 200 because the truth lives in the JSON body.

## New response shape

```json
{
  "status": "ok" | "degraded",
  "uptime_seconds": 35.0,
  "active_connections": 1,
  "backends": {
    "stt": {"name": "Moonshine (medium)",     "ok": true,  "detail": "no probe"},
    "tts": {"name": "Piper (en_US-lessac-medium)", "ok": true, "detail": "no probe"},
    "llm": {"name": "Ollama (ministral-3:3b)", "ok": false, "detail": "Cannot connect to host localhost:11434"}
  }
}
```

`name` uses the live backend's own `.name` (so post-config-swap reality, not the boot-time `server._llm_name`). Empty pool → synthetic `"(none)" / ok=true / "no active backend"` so freshly-started Dragon with no Tab5 connected reads as healthy, not as down.

## Live verification (Dragon 192.168.1.91)
- empty pool returns three `"(none)"` entries with `ok=true`
- Tab5 reconnect populates pool → Moonshine + Piper + Ollama all ok
- `sudo systemctl stop ollama` flips `llm.ok=false` + `status="degraded"` + detail surfaces the connection error
- `sudo systemctl start ollama` returns to `status="ok"` within 4 s

## Tests
13/13 in `tests/test_status_handlers.py` (was 3; +10 W4-B): ABC defaults, all-ok, single-down-degraded, raises-as-down, timeout-cancelled, status-stays-200-when-degraded, no-active-backend shape, uptime/active_connections preservation. Ruff narrow gate clean.

## Note on W4-A
W4-A (cross-system `turn_id` correlation) was already shipped in a prior session, but the audit-doc footer never reflected that. Discovered during W4 scoping. Audit doc + memory snapshot reconcile the state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)