### PR TITLE
W4-D: Dragon-side Tab5 coredump scraper + listing endpoint

### DIFF
--- a/dragon_voice/api/__init__.py
+++ b/dragon_voice/api/__init__.py
@@ -22,6 +22,7 @@ from dragon_voice.api.completions import CompletionRoutes
 from dragon_voice.api.system import SystemRoutes
 from dragon_voice.api.debug_channel import DebugChannelRoutes
 from dragon_voice.api.video_inject import VideoInjectRoutes
+from dragon_voice.api.coredumps import CoredumpRoutes  # W4-D
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,7 @@ def setup_all_routes(
     scheduler_mgr: Any = None,
     get_active_conn_dict: Callable[[], dict[str, Any]] | None = None,  # #177
     get_gateway_connector: Callable[[], Any] | None = None,  # W7-B.2
+    server: Any = None,  # W4-D: coredump scraper config + LAST_RESULTS lookup
 ) -> None:
     """Register all API route modules on the aiohttp app.
 
@@ -70,6 +72,12 @@ def setup_all_routes(
     AgentSkillsRoutes(connector_getter=get_gateway_connector).register(app)
     # W5-A: daily spend rollup from api_usage events
     SpendRoutes(db).register(app)
+    # W4-D: Dragon-side coredump archive (populated by the scraper task).
+    # Registered unconditionally so the empty-list shape is queryable even
+    # when the scraper is disabled — operators can poke /api/v1/coredumps
+    # to confirm the route exists before flipping `coredump_scraper.enabled`.
+    if server is not None:
+        CoredumpRoutes(server).register(app)
 
     # Media endpoints (TTS synthesis, STT transcription, OTA)
     if voice_config:

--- a/dragon_voice/api/coredumps.py
+++ b/dragon_voice/api/coredumps.py
@@ -1,0 +1,81 @@
+"""W4-D: Coredump archive REST routes.
+
+Surfaces the on-disk coredumps pulled from Tab5 devices by the
+background scraper (`dragon_voice/coredump_scraper.py`).  Read-only
+for v1 — the scraper is the only writer.
+
+## Endpoints
+
+    GET /api/v1/coredumps                  → list all archived dumps
+    GET /api/v1/coredumps?device_id=foo    → filter by device
+
+Response shape (newest-first):
+
+```json
+{
+  "save_dir": "/home/radxa/tab5-coredumps",
+  "count": 2,
+  "items": [
+    {
+      "device_id": "tab5-aabbcc",
+      "filename":  "dump-1716000000.bin",
+      "path":      "/home/radxa/tab5-coredumps/tab5-aabbcc/dump-1716000000.bin",
+      "ts":        1716000000,
+      "bytes":     37540,
+      "sha256":    "5819c31f...",
+      "symbolicated": "/home/radxa/.../dump-1716000000.txt" | null
+    }
+  ],
+  "last_results": {
+    "tab5-aabbcc": {
+      "ok": true,
+      "coredump_present": true,
+      "saved_path": "...",
+      "deduped": false,
+      "sha256": "...",
+      "error": ""
+    }
+  }
+}
+```
+
+`last_results` is the most-recent `ScrapeResult` per target so
+operators can tell at a glance whether the loop is running.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from typing import Any
+
+from aiohttp import web
+
+from dragon_voice import coredump_scraper
+
+logger = logging.getLogger(__name__)
+
+
+class CoredumpRoutes:
+    def __init__(self, server: Any) -> None:
+        self._server = server
+
+    def register(self, app: web.Application) -> None:
+        app.router.add_get("/api/v1/coredumps", self.get_coredumps)
+
+    async def get_coredumps(self, request: web.Request) -> web.Response:
+        cfg = self._server._config.coredump_scraper
+        items = coredump_scraper.list_archived(cfg.save_dir)
+        device_filter = request.query.get("device_id", "").strip()
+        if device_filter:
+            items = [it for it in items if it["device_id"] == device_filter]
+        last_results = {
+            did: asdict(res)
+            for did, res in coredump_scraper.LAST_RESULTS.items()
+        }
+        return web.json_response({
+            "save_dir": cfg.save_dir,
+            "count": len(items),
+            "items": items,
+            "last_results": last_results,
+            "enabled": cfg.enabled,
+        })

--- a/dragon_voice/config.py
+++ b/dragon_voice/config.py
@@ -231,6 +231,46 @@ class ChannelGatewayConfig:
 
 
 @dataclass
+class CoredumpScraperTarget:
+    """W4-D: one Tab5 to poll for coredumps."""
+
+    device_id: str = ""              # Stable id (Tab5 NVS `device_id`); used as folder name + dedupe key
+    host: str = ""                    # LAN IP or hostname (e.g. "192.168.1.90")
+    port: int = 8080                  # Tab5 debug-server port
+    token: str = ""                   # Bearer for `/coredump` (Tab5 NVS `auth_tok`)
+
+
+@dataclass
+class CoredumpScraperConfig:
+    """W4-D (audit 2026-05-11): Dragon-side coredump scraper.
+
+    Periodically polls each Tab5 in `targets` for a coredump on flash.
+    When `coredump_present=true` per `/info`, pulls the body via
+    `/coredump` and archives it under `save_dir/{device_id}/`.  Pre-W4-D
+    coredumps only existed on Tab5 flash until a human manually curled
+    them — operators saw a `SW` reset and had no on-disk dump to symbolicate.
+
+    Default `enabled: false` so existing deploys stay unchanged.  Set
+    `enabled: true` + a non-empty `targets` list to opt in.
+    """
+
+    enabled: bool = False
+    poll_interval_s: float = 60.0     # one full target sweep per minute
+    request_timeout_s: float = 10.0   # per-request HTTP timeout (info + coredump)
+    # Default lives under /home/radxa/tinkerclaw/ because Dragon's systemd
+    # hardening drop-in (W14-H14) sets `ProtectHome=read-only` + a
+    # narrow `ReadWritePaths` whitelist; /home/radxa/tinkerclaw is on the
+    # list, /home/radxa/tab5-coredumps is not.  Operators on un-hardened
+    # deploys can override to anywhere.
+    save_dir: str = "/home/radxa/tinkerclaw/tab5-coredumps"
+    # Optional path to the deployed firmware ELF for auto-symbolicate.
+    # If empty or non-readable, the scraper still archives the raw bin
+    # — symbolication is a nice-to-have, not a gate.
+    firmware_elf: str = ""
+    targets: list[CoredumpScraperTarget] = field(default_factory=list)
+
+
+@dataclass
 class VoiceConfig:
     """Top-level configuration container."""
 
@@ -245,6 +285,9 @@ class VoiceConfig:
     billing: BillingConfig = field(default_factory=BillingConfig)
     channel_gateway: ChannelGatewayConfig = field(
         default_factory=ChannelGatewayConfig,
+    )
+    coredump_scraper: CoredumpScraperConfig = field(
+        default_factory=CoredumpScraperConfig,
     )
 
     # β-arch (issue #123): protocol-level transition flag for the
@@ -346,6 +389,25 @@ def _dict_to_dataclass(section_cls, data: dict):
     return section_cls(**filtered)
 
 
+def _build_coredump_scraper_cfg(data: dict) -> CoredumpScraperConfig:
+    """W4-D: build `CoredumpScraperConfig` with a typed `targets` list.
+
+    `_dict_to_dataclass` would leave `targets` as a list of plain dicts;
+    we need each entry to be a `CoredumpScraperTarget`.  Unknown
+    per-target keys are silently dropped (forward-compat).
+    """
+    targets_raw = data.get("targets") or []
+    targets: list[CoredumpScraperTarget] = []
+    if isinstance(targets_raw, list):
+        for t in targets_raw:
+            if isinstance(t, dict):
+                targets.append(_dict_to_dataclass(CoredumpScraperTarget, t))
+    base = {k: v for k, v in data.items() if k != "targets"}
+    cfg = _dict_to_dataclass(CoredumpScraperConfig, base)
+    cfg.targets = targets
+    return cfg
+
+
 def load_config(path: Optional[str] = None) -> VoiceConfig:
     """Load configuration from YAML file with environment variable overrides.
 
@@ -375,7 +437,7 @@ def load_config(path: Optional[str] = None) -> VoiceConfig:
     # Ensure all sections exist
     for section in (
         "server", "stt", "tts", "llm", "audio", "tools", "memory",
-        "database", "channel_gateway",
+        "database", "channel_gateway", "coredump_scraper",
     ):
         raw.setdefault(section, {})
 
@@ -395,6 +457,7 @@ def load_config(path: Optional[str] = None) -> VoiceConfig:
         channel_gateway=_dict_to_dataclass(
             ChannelGatewayConfig, raw["channel_gateway"],
         ),
+        coredump_scraper=_build_coredump_scraper_cfg(raw["coredump_scraper"]),
     )
 
     # Wave 13 C2: DRAGON_API_TOKEN env var sets the REST bearer token without

--- a/dragon_voice/coredump_scraper.py
+++ b/dragon_voice/coredump_scraper.py
@@ -1,0 +1,408 @@
+"""W4-D (cross-stack audit 2026-05-11): Dragon-side coredump scraper.
+
+Periodically polls each configured Tab5 for a coredump on flash and
+archives it under `save_dir/{device_id}/dump-{epoch}.bin` so operators
+have a durable record without manually curling Tab5 + running
+`espcoredump.py`.
+
+Pre-W4-D, coredumps lived only on Tab5 flash.  When Tab5 had an
+unexplained `SW` reset, the stale dump on flash was from a *prior*
+firmware build (SHA mismatch) — invisible to anyone not actively
+SSH-ing to Tab5 looking for it.
+
+## Loop semantics
+
+* `enabled=False` → loop never spawns (default).
+* `enabled=True` with empty `targets` → loop spawns, logs once, idles.
+* Each tick (`poll_interval_s`): probe each target's `/info`; if
+  `coredump_present` is true, GET `/coredump` with the target's
+  bearer + save the raw bytes.
+* **Dedupe by SHA-256:** if a dump with the same content hash already
+  exists on disk, skip — Tab5 holds the same blob across reboots until
+  it's cleared, so we don't want a new file every minute.
+* Best-effort symbolicate: if `firmware_elf` is set + readable, run
+  `espcoredump.py info_corefile --core <bin> --core-format raw <elf>`
+  in a subprocess.  Output (incl. SHA mismatch) lands in a sibling
+  `.txt` file.  Symbolication failure is logged + ignored — the raw
+  binary is always preserved.
+* Each successful pull writes a `tab5.coredump_pulled` event row so
+  the dashboard surfaces the pull alongside other system events.
+
+## What this is NOT
+
+* No automatic deletion from Tab5 flash — that's a separate ops
+  decision (Tab5's `coredump` partition is FIFO-ish; new dumps
+  overwrite old ones eventually).
+* No alerting / paging — just durable archival.  W4-D follow-up could
+  fire a notification when a *new* (different SHA) dump arrives.
+* No retroactive replay of old dumps from disk — the scraper is
+  forward-looking from the moment it starts.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ScrapeResult:
+    """One target-tick outcome.  Used by tests + dashboard."""
+
+    target_device_id: str
+    ok: bool                          # reached + parsed /info
+    coredump_present: bool             # what /info said
+    saved_path: Optional[str] = None
+    saved_bytes: int = 0
+    sha256: str = ""
+    deduped: bool = False              # True if SHA matched an existing file
+    symbolicated_path: Optional[str] = None
+    error: str = ""
+
+
+# Public so the lifecycle wiring + tests can introspect.
+LAST_RESULTS: dict[str, ScrapeResult] = {}
+
+
+async def probe_info(
+    session: aiohttp.ClientSession,
+    host: str,
+    port: int,
+    timeout_s: float,
+    token: str = "",
+) -> tuple[Optional[dict], str]:
+    """GET `/crashlog` on a Tab5 — surfaces `coredump_present` + reset
+    reason in one cheap JSON.  Bearer-auth gated.
+
+    NOTE: there's also a public `/info` endpoint, but it carries
+    heap/uptime/wifi state — NOT `coredump_present`.  Live-verified
+    on Tab5 192.168.1.90 (2026-05-13).  Using `/crashlog` (bearer)
+    is the only correct shape.
+
+    Returns (parsed_json_or_None, error_str).  Never raises.
+    """
+    url = f"http://{host}:{port}/crashlog"
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    try:
+        async with session.get(
+            url, headers=headers,
+            timeout=aiohttp.ClientTimeout(total=timeout_s),
+        ) as resp:
+            if resp.status != 200:
+                return None, f"crashlog HTTP {resp.status}"
+            return await resp.json(), ""
+    except asyncio.TimeoutError:
+        return None, f"crashlog timeout after {timeout_s}s"
+    except aiohttp.ClientError as e:
+        return None, f"crashlog {type(e).__name__}: {e}"[:200]
+    except Exception as e:  # noqa: BLE001
+        return None, f"crashlog unexpected {type(e).__name__}: {e}"[:200]
+
+
+async def pull_coredump(
+    session: aiohttp.ClientSession,
+    host: str,
+    port: int,
+    token: str,
+    timeout_s: float,
+) -> tuple[Optional[bytes], str]:
+    """GET `/coredump` with bearer auth.  Returns (bytes_or_None, error)."""
+    url = f"http://{host}:{port}/coredump"
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    try:
+        async with session.get(
+            url, headers=headers,
+            timeout=aiohttp.ClientTimeout(total=timeout_s),
+        ) as resp:
+            if resp.status != 200:
+                return None, f"coredump HTTP {resp.status}"
+            return await resp.read(), ""
+    except asyncio.TimeoutError:
+        return None, f"coredump timeout after {timeout_s}s"
+    except aiohttp.ClientError as e:
+        return None, f"coredump {type(e).__name__}: {e}"[:200]
+    except Exception as e:  # noqa: BLE001
+        return None, f"coredump unexpected {type(e).__name__}: {e}"[:200]
+
+
+def _dump_already_archived(device_dir: Path, sha256: str) -> Optional[str]:
+    """Walk `device_dir` looking for a saved dump with the same SHA.
+
+    Returns the existing file path if found; else None.  Dedupe key is
+    a `*.sha256` sidecar so we don't have to re-hash every file each
+    tick.
+    """
+    if not device_dir.exists():
+        return None
+    for sha_file in device_dir.glob("*.sha256"):
+        try:
+            if sha_file.read_text().strip() == sha256:
+                bin_path = sha_file.with_suffix(".bin")
+                if bin_path.exists():
+                    return str(bin_path)
+        except OSError:
+            continue
+    return None
+
+
+async def symbolicate(
+    bin_path: Path, elf_path: Path, timeout_s: float = 30.0,
+) -> tuple[Optional[str], str]:
+    """Best-effort `espcoredump.py info_corefile` invocation.
+
+    Returns (output_path, error_str).  Subprocess timeout-bounded to
+    avoid blocking the scraper loop on a stuck symbolicator.
+    """
+    if not elf_path.exists():
+        return None, f"elf not found: {elf_path}"
+    out_path = bin_path.with_suffix(".txt")
+    cmd = [
+        "espcoredump.py", "info_corefile",
+        "--core", str(bin_path),
+        "--core-format", "raw",
+        str(elf_path),
+    ]
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        try:
+            stdout, _ = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout_s,
+            )
+        except asyncio.TimeoutError:
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+            return None, f"symbolicate timeout after {timeout_s}s"
+    except FileNotFoundError:
+        return None, "espcoredump.py not on PATH"
+    except Exception as e:  # noqa: BLE001
+        return None, f"symbolicate {type(e).__name__}: {e}"[:200]
+    # Always write output — even SHA mismatch returns useful diagnostic.
+    out_path.write_bytes(stdout or b"")
+    return str(out_path), ""
+
+
+async def scrape_target(
+    session: aiohttp.ClientSession,
+    target: Any,
+    save_dir: str,
+    firmware_elf: str,
+    request_timeout_s: float,
+    db: Any = None,
+) -> ScrapeResult:
+    """One probe + pull cycle.  Never raises — wraps everything,
+    including filesystem errors like a sandbox-blocked save_dir."""
+    result = ScrapeResult(target_device_id=target.device_id,
+                          ok=False, coredump_present=False)
+    try:
+        return await _scrape_target_inner(
+            session, target, save_dir, firmware_elf,
+            request_timeout_s, db, result,
+        )
+    except Exception as e:  # noqa: BLE001 — keep loop alive
+        # Filesystem (EROFS on sandboxed save_dir), DB log_event raise,
+        # or any other unexpected raise lands here.  Preserve whatever
+        # the inner step already wrote into `result` and surface the
+        # exception text for the listing endpoint.
+        result.error = f"{type(e).__name__}: {e}"[:200]
+        return result
+
+
+async def _scrape_target_inner(
+    session: aiohttp.ClientSession,
+    target: Any,
+    save_dir: str,
+    firmware_elf: str,
+    request_timeout_s: float,
+    db: Any,
+    result: ScrapeResult,
+) -> ScrapeResult:
+    """W4-D: actual scrape body — outer `scrape_target` wraps in a
+    try/except so even hard raises still land in LAST_RESULTS."""
+    if not target.host or not target.device_id:
+        result.error = "incomplete target (missing host or device_id)"
+        return result
+
+    info, err = await probe_info(session, target.host, target.port,
+                                  request_timeout_s, token=target.token)
+    if info is None:
+        result.error = err
+        return result
+    result.ok = True
+    cd_present = bool(info.get("coredump_present"))
+    result.coredump_present = cd_present
+    if not cd_present:
+        return result
+
+    # Pull body.  If token is empty, /coredump will 401 — surface that.
+    body, err = await pull_coredump(session, target.host, target.port,
+                                     target.token, request_timeout_s)
+    if body is None or not body:
+        result.error = err or "empty coredump body"
+        return result
+
+    # Dedupe by SHA-256 against on-disk sidecars.
+    sha = hashlib.sha256(body).hexdigest()
+    result.sha256 = sha
+    result.saved_bytes = len(body)
+    device_dir = Path(save_dir) / target.device_id
+    existing = _dump_already_archived(device_dir, sha)
+    if existing is not None:
+        result.saved_path = existing
+        result.deduped = True
+        return result
+
+    # New dump — write atomically.
+    device_dir.mkdir(parents=True, exist_ok=True)
+    epoch = int(time.time())
+    bin_path = device_dir / f"dump-{epoch}.bin"
+    tmp_path = bin_path.with_suffix(".bin.tmp")
+    tmp_path.write_bytes(body)
+    os.replace(tmp_path, bin_path)
+    (device_dir / f"dump-{epoch}.sha256").write_text(sha)
+    result.saved_path = str(bin_path)
+
+    # Best-effort symbolicate.
+    if firmware_elf:
+        out_path, sym_err = await symbolicate(bin_path, Path(firmware_elf))
+        if out_path is not None:
+            result.symbolicated_path = out_path
+        elif sym_err:
+            # Don't let symbolicate failure mark the whole result as
+            # not-ok — the binary is saved.  Log + carry on.
+            logger.info("W4-D symbolicate skipped for %s: %s",
+                        target.device_id, sym_err)
+
+    # Record a dashboard event so /events surfaces the pull.
+    if db is not None:
+        with contextlib.suppress(Exception):
+            await db.log_event(
+                event_type="tab5.coredump_pulled",
+                session_id=None,
+                device_id=target.device_id,
+                payload={
+                    "path": result.saved_path,
+                    "bytes": result.saved_bytes,
+                    "sha256": sha,
+                    "symbolicated_path": result.symbolicated_path,
+                },
+            )
+    return result
+
+
+async def scraper_loop(server: Any) -> None:
+    """Periodic scrape over `server._config.coredump_scraper.targets`.
+
+    Sleeps `poll_interval_s` between full sweeps.  All target probes
+    in a sweep run concurrently via `asyncio.gather(return_exceptions
+    =True)` so one slow Tab5 doesn't stall the others.  Per-target
+    failures are logged + recorded in `LAST_RESULTS` so the listing
+    endpoint can surface them.
+    """
+    cfg = server._config.coredump_scraper
+    if not cfg.enabled:
+        logger.info("W4-D scraper not enabled — loop will not start")
+        return
+    if not cfg.targets:
+        logger.info(
+            "W4-D scraper enabled but no targets configured — loop idle")
+    logger.info(
+        "W4-D scraper starting: %d target(s), interval=%.0fs, save_dir=%s",
+        len(cfg.targets), cfg.poll_interval_s, cfg.save_dir,
+    )
+
+    async with aiohttp.ClientSession() as session:
+        while True:
+            try:
+                if cfg.targets:
+                    results = await asyncio.gather(
+                        *[
+                            scrape_target(
+                                session, t, cfg.save_dir,
+                                cfg.firmware_elf, cfg.request_timeout_s,
+                                db=getattr(server, "_db", None),
+                            ) for t in cfg.targets
+                        ],
+                        return_exceptions=True,
+                    )
+                    for t, r in zip(cfg.targets, results):
+                        if isinstance(r, ScrapeResult):
+                            LAST_RESULTS[t.device_id] = r
+                            if r.saved_path and not r.deduped:
+                                logger.info(
+                                    "W4-D pulled coredump from %s: %s "
+                                    "(%d bytes, sha=%s)",
+                                    t.device_id, r.saved_path,
+                                    r.saved_bytes, r.sha256[:12],
+                                )
+                            elif r.error:
+                                logger.debug(
+                                    "W4-D %s probe: %s",
+                                    t.device_id, r.error,
+                                )
+                        else:
+                            # scrape_target() promises never to raise,
+                            # but defensively record the surprise anyway
+                            # so /api/v1/coredumps reflects truth.
+                            LAST_RESULTS[t.device_id] = ScrapeResult(
+                                target_device_id=t.device_id,
+                                ok=False, coredump_present=False,
+                                error=f"unexpected raise: "
+                                      f"{type(r).__name__}: {r}"[:200],
+                            )
+                            logger.warning(
+                                "W4-D %s probe raised: %s",
+                                t.device_id, r,
+                            )
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                logger.exception("W4-D scraper sweep failed — continuing")
+            await asyncio.sleep(cfg.poll_interval_s)
+
+
+def list_archived(save_dir: str) -> list[dict]:
+    """List all dumps on disk for the `/api/v1/coredumps` endpoint.
+
+    Walks `save_dir/*/dump-*.bin`, sorts newest-first.  Returns
+    plain dicts — JSON-ready.
+    """
+    root = Path(save_dir)
+    if not root.exists():
+        return []
+    entries: list[dict] = []
+    for device_dir in root.iterdir():
+        if not device_dir.is_dir():
+            continue
+        for bin_path in device_dir.glob("dump-*.bin"):
+            try:
+                stat = bin_path.stat()
+            except OSError:
+                continue
+            sha_path = bin_path.with_suffix(".sha256")
+            txt_path = bin_path.with_suffix(".txt")
+            entries.append({
+                "device_id": device_dir.name,
+                "filename": bin_path.name,
+                "path": str(bin_path),
+                "ts": int(stat.st_mtime),
+                "bytes": stat.st_size,
+                "sha256": (sha_path.read_text().strip()
+                            if sha_path.exists() else ""),
+                "symbolicated": str(txt_path) if txt_path.exists() else None,
+            })
+    entries.sort(key=lambda e: e["ts"], reverse=True)
+    return entries

--- a/dragon_voice/lifecycle/background_tasks_init.py
+++ b/dragon_voice/lifecycle/background_tasks_init.py
@@ -93,6 +93,25 @@ def init_background_tasks(server: Any) -> None:
         rss, server._mem_warn_mb, server._mem_crit_mb,
     )
 
+    # W4-D (audit 2026-05-11): Dragon-side Tab5 coredump scraper.  Only
+    # spawned when `coredump_scraper.enabled=true` in config.yaml.
+    # `scraper_loop` self-no-ops when disabled, but we also gate here so
+    # the task handle isn't created at all on a disabled deploy.
+    server._coredump_scraper_task = None
+    if getattr(server._config, "coredump_scraper", None) and \
+       server._config.coredump_scraper.enabled:
+        from dragon_voice import coredump_scraper as _cd
+        server._coredump_scraper_task = asyncio.create_task(
+            _cd.scraper_loop(server)
+        )
+        n = len(server._config.coredump_scraper.targets)
+        logger.info(
+            "W4-D coredump scraper task spawned (%d target%s, "
+            "interval=%.0fs)",
+            n, "" if n == 1 else "s",
+            server._config.coredump_scraper.poll_interval_s,
+        )
+
 
 async def _run_startup_purge_then_loop(
     server: Any,

--- a/dragon_voice/lifecycle/shutdown.py
+++ b/dragon_voice/lifecycle/shutdown.py
@@ -66,6 +66,15 @@ async def run_shutdown(server: Any, app: web.Application) -> None:
         except (asyncio.CancelledError, Exception):
             pass
 
+    # W4-D: cancel coredump scraper.  Same cancel-then-await pattern.
+    cd_task = getattr(server, "_coredump_scraper_task", None)
+    if cd_task is not None and not cd_task.done():
+        cd_task.cancel()
+        try:
+            await cd_task
+        except (asyncio.CancelledError, Exception):
+            pass
+
     # Phase 5 ε1a (issue #128): cancel scheduler tasks BEFORE pipeline
     # drain so an in-flight notification fire doesn't race with a
     # closed WS.  Pattern matches the cancel-then-await discipline

--- a/dragon_voice/lifecycle/startup.py
+++ b/dragon_voice/lifecycle/startup.py
@@ -142,6 +142,10 @@ async def run_startup(server: Any, app: web.Application) -> None:
         # sees whatever connector is live at *that* moment — including
         # any future hot-swap.
         get_gateway_connector=lambda: getattr(server, "_gateway_connector", None),
+        # W4-D: pass the server handle so /api/v1/coredumps can read
+        # `_config.coredump_scraper.save_dir` + LAST_RESULTS for last
+        # per-target scrape outcomes.
+        server=server,
     )
 
     # SOLID-audit follow-up: notes module + tool registration

--- a/tests/test_coredump_scraper.py
+++ b/tests/test_coredump_scraper.py
@@ -1,0 +1,429 @@
+"""W4-D: Dragon-side coredump scraper tests.
+
+Exercises `dragon_voice/coredump_scraper.py` in isolation — no live
+Tab5 needed.  Uses an in-process aiohttp test server as the Tab5
+impostor so we can mock `/info` + `/coredump` responses.
+
+Run:
+    python3 -m pytest -v tests/test_coredump_scraper.py
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import aiohttp
+from aiohttp import web
+from aiohttp.test_utils import AioHTTPTestCase
+
+from dragon_voice import coredump_scraper as cs
+from dragon_voice.config import (
+    CoredumpScraperConfig,
+    CoredumpScraperTarget,
+)
+
+
+# Sample payload — small enough to hash quickly, big enough to be
+# recognisably non-trivial.
+_DUMP_BYTES = b"\xa4\x92\x00\x00" + bytes(range(256)) * 16  # 4100 bytes
+_DUMP_SHA256 = hashlib.sha256(_DUMP_BYTES).hexdigest()
+
+
+class _Tab5Impostor:
+    """Tiny aiohttp app that mimics Tab5's `/info` + `/coredump`."""
+
+    def __init__(self):
+        self.coredump_present = True
+        self.dump_body = _DUMP_BYTES
+        self.required_token = "test-token"
+        self.info_status = 200
+        self.coredump_status = 200
+
+    def routes(self) -> list:
+        async def crashlog(req: web.Request) -> web.Response:
+            # Bearer-gated, matches live Tab5 `/crashlog` shape.
+            if self.info_status != 200:
+                return web.Response(status=self.info_status)
+            auth = req.headers.get("Authorization", "")
+            if auth != f"Bearer {self.required_token}":
+                return web.Response(status=401)
+            return web.json_response({
+                "reset_reason": "SW",
+                "was_crash": False,
+                "coredump_present": self.coredump_present,
+                "exc_pc": 1234,
+                "exc_task": "heap_wd",
+            })
+
+        async def coredump(req: web.Request) -> web.Response:
+            if self.coredump_status != 200:
+                return web.Response(status=self.coredump_status)
+            auth = req.headers.get("Authorization", "")
+            if auth != f"Bearer {self.required_token}":
+                return web.Response(status=401)
+            return web.Response(body=self.dump_body)
+
+        return [
+            web.get("/crashlog", crashlog),
+            web.get("/coredump", coredump),
+        ]
+
+
+class _BaseScraperTest(AioHTTPTestCase):
+    """Spins up the Tab5 impostor + makes a fresh temp save_dir per test."""
+
+    async def get_application(self) -> web.Application:
+        self.tab5 = _Tab5Impostor()
+        app = web.Application()
+        app.add_routes(self.tab5.routes())
+        return app
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.save_dir = self._tmpdir.name
+        # Clear the process-global LAST_RESULTS so one test's outcome
+        # doesn't leak into the next.
+        cs.LAST_RESULTS.clear()
+
+    async def asyncTearDown(self):
+        self._tmpdir.cleanup()
+        cs.LAST_RESULTS.clear()
+        await super().asyncTearDown()
+
+    def _target(self, device_id="tab5-test", token="test-token") -> CoredumpScraperTarget:
+        return CoredumpScraperTarget(
+            device_id=device_id,
+            host=self.server.host,
+            port=self.server.port,
+            token=token,
+        )
+
+
+class TestProbeInfo(_BaseScraperTest):
+    async def test_returns_parsed_dict_on_200(self):
+        async with aiohttp.ClientSession() as s:
+            info, err = await cs.probe_info(
+                s, self.server.host, self.server.port, timeout_s=2.0,
+                token="test-token",
+            )
+        self.assertEqual(err, "")
+        self.assertIsInstance(info, dict)
+        self.assertTrue(info["coredump_present"])
+
+    async def test_returns_none_with_error_on_non_200(self):
+        self.tab5.info_status = 503
+        async with aiohttp.ClientSession() as s:
+            info, err = await cs.probe_info(
+                s, self.server.host, self.server.port, timeout_s=2.0,
+                token="test-token",
+            )
+        self.assertIsNone(info)
+        self.assertIn("HTTP 503", err)
+
+    async def test_401_on_wrong_token(self):
+        async with aiohttp.ClientSession() as s:
+            info, err = await cs.probe_info(
+                s, self.server.host, self.server.port, timeout_s=2.0,
+                token="wrong-token",
+            )
+        self.assertIsNone(info)
+        self.assertIn("401", err)
+
+
+class TestPullCoredump(_BaseScraperTest):
+    async def test_returns_bytes_on_200(self):
+        async with aiohttp.ClientSession() as s:
+            body, err = await cs.pull_coredump(
+                s, self.server.host, self.server.port,
+                token="test-token", timeout_s=2.0,
+            )
+        self.assertEqual(err, "")
+        self.assertEqual(body, _DUMP_BYTES)
+
+    async def test_401_on_wrong_token(self):
+        async with aiohttp.ClientSession() as s:
+            body, err = await cs.pull_coredump(
+                s, self.server.host, self.server.port,
+                token="wrong-token", timeout_s=2.0,
+            )
+        self.assertIsNone(body)
+        self.assertIn("401", err)
+
+
+class TestScrapeTarget(_BaseScraperTest):
+    async def test_happy_path_archives_dump(self):
+        async with aiohttp.ClientSession() as s:
+            res = await cs.scrape_target(
+                s, self._target(), self.save_dir,
+                firmware_elf="", request_timeout_s=2.0,
+            )
+        self.assertTrue(res.ok)
+        self.assertTrue(res.coredump_present)
+        self.assertFalse(res.deduped)
+        self.assertEqual(res.sha256, _DUMP_SHA256)
+        self.assertEqual(res.saved_bytes, len(_DUMP_BYTES))
+        # File actually written to disk under the device dir.
+        bin_path = Path(res.saved_path)
+        self.assertTrue(bin_path.exists())
+        self.assertEqual(bin_path.read_bytes(), _DUMP_BYTES)
+        # Sidecar .sha256 also written.
+        sha_path = bin_path.with_suffix(".sha256")
+        self.assertTrue(sha_path.exists())
+        self.assertEqual(sha_path.read_text().strip(), _DUMP_SHA256)
+
+    async def test_dedupes_when_sha_matches_existing(self):
+        # First scrape: writes the file.
+        async with aiohttp.ClientSession() as s:
+            first = await cs.scrape_target(
+                s, self._target(), self.save_dir,
+                firmware_elf="", request_timeout_s=2.0,
+            )
+            second = await cs.scrape_target(
+                s, self._target(), self.save_dir,
+                firmware_elf="", request_timeout_s=2.0,
+            )
+        self.assertFalse(first.deduped)
+        self.assertTrue(second.deduped)
+        # Both point at the same path — the existing file.
+        self.assertEqual(first.saved_path, second.saved_path)
+        # And the dir has exactly one .bin file (no duplicate).
+        device_dir = Path(self.save_dir) / "tab5-test"
+        bins = list(device_dir.glob("dump-*.bin"))
+        self.assertEqual(len(bins), 1)
+
+    async def test_skips_when_coredump_not_present(self):
+        self.tab5.coredump_present = False
+        async with aiohttp.ClientSession() as s:
+            res = await cs.scrape_target(
+                s, self._target(), self.save_dir,
+                firmware_elf="", request_timeout_s=2.0,
+            )
+        self.assertTrue(res.ok)
+        self.assertFalse(res.coredump_present)
+        self.assertIsNone(res.saved_path)
+        # Nothing written to disk.
+        device_dir = Path(self.save_dir) / "tab5-test"
+        self.assertFalse(device_dir.exists())
+
+    async def test_404_on_coredump_endpoint_surfaces_error(self):
+        # Tab5 says coredump_present=true but /coredump returns 404
+        # (race: dump was wiped between /info and /coredump).
+        self.tab5.coredump_status = 404
+        async with aiohttp.ClientSession() as s:
+            res = await cs.scrape_target(
+                s, self._target(), self.save_dir,
+                firmware_elf="", request_timeout_s=2.0,
+            )
+        self.assertTrue(res.ok)  # /info worked
+        self.assertTrue(res.coredump_present)  # /info said yes
+        self.assertIsNone(res.saved_path)
+        self.assertIn("404", res.error)
+
+    async def test_unreachable_host_caught(self):
+        # Use an obviously-unreachable port.
+        target = CoredumpScraperTarget(
+            device_id="tab5-test", host="127.0.0.1", port=1, token="x",
+        )
+        async with aiohttp.ClientSession() as s:
+            res = await cs.scrape_target(
+                s, target, self.save_dir,
+                firmware_elf="", request_timeout_s=0.5,
+            )
+        self.assertFalse(res.ok)
+        self.assertIn("crashlog ", res.error)
+        # No file written.
+        self.assertFalse((Path(self.save_dir) / "tab5-test").exists())
+
+    async def test_incomplete_target_short_circuits(self):
+        # Missing host — bail immediately, no HTTP attempted.
+        target = CoredumpScraperTarget(
+            device_id="tab5-test", host="", port=8080, token="x",
+        )
+        async with aiohttp.ClientSession() as s:
+            res = await cs.scrape_target(
+                s, target, self.save_dir,
+                firmware_elf="", request_timeout_s=2.0,
+            )
+        self.assertFalse(res.ok)
+        self.assertIn("incomplete", res.error)
+
+    async def test_db_event_logged_on_successful_pull(self):
+        # Mock the db so we can assert log_event was called.
+        db_calls = []
+
+        class _StubDB:
+            async def log_event(self_db, event_type, session_id, device_id, payload):
+                db_calls.append({
+                    "type": event_type, "session_id": session_id,
+                    "device_id": device_id, "payload": payload,
+                })
+
+        async with aiohttp.ClientSession() as s:
+            await cs.scrape_target(
+                s, self._target(), self.save_dir,
+                firmware_elf="", request_timeout_s=2.0,
+                db=_StubDB(),
+            )
+        self.assertEqual(len(db_calls), 1)
+        self.assertEqual(db_calls[0]["type"], "tab5.coredump_pulled")
+        self.assertEqual(db_calls[0]["device_id"], "tab5-test")
+        self.assertEqual(db_calls[0]["payload"]["bytes"], len(_DUMP_BYTES))
+        self.assertEqual(db_calls[0]["payload"]["sha256"], _DUMP_SHA256)
+
+    async def test_dedupe_does_not_log_event(self):
+        # Second scrape of the same blob is a no-op — no event row.
+        db_calls = []
+
+        class _StubDB:
+            async def log_event(self_db, event_type, session_id, device_id, payload):
+                db_calls.append(event_type)
+
+        async with aiohttp.ClientSession() as s:
+            await cs.scrape_target(
+                s, self._target(), self.save_dir,
+                firmware_elf="", request_timeout_s=2.0,
+                db=_StubDB(),
+            )
+            await cs.scrape_target(
+                s, self._target(), self.save_dir,
+                firmware_elf="", request_timeout_s=2.0,
+                db=_StubDB(),
+            )
+        self.assertEqual(len(db_calls), 1)  # only the first wrote
+
+
+class TestListArchived(unittest.TestCase):
+    """`list_archived` walks save_dir + emits the JSON-ready listing."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.save_dir = self._tmpdir.name
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def _write_dump(self, device_id: str, ts: int, body: bytes) -> Path:
+        device_dir = Path(self.save_dir) / device_id
+        device_dir.mkdir(parents=True, exist_ok=True)
+        bin_path = device_dir / f"dump-{ts}.bin"
+        bin_path.write_bytes(body)
+        bin_path.with_suffix(".sha256").write_text(
+            hashlib.sha256(body).hexdigest()
+        )
+        # set mtime to ts so newest-first ordering is deterministic
+        import os
+        os.utime(bin_path, (ts, ts))
+        return bin_path
+
+    def test_empty_dir_returns_empty_list(self):
+        self.assertEqual(cs.list_archived(self.save_dir), [])
+
+    def test_missing_dir_returns_empty_list(self):
+        self.assertEqual(cs.list_archived("/tmp/does-not-exist-w4d"), [])
+
+    def test_lists_dumps_newest_first(self):
+        self._write_dump("tab5-a", 1000, b"x" * 10)
+        self._write_dump("tab5-a", 2000, b"y" * 20)
+        self._write_dump("tab5-b", 1500, b"z" * 30)
+        items = cs.list_archived(self.save_dir)
+        self.assertEqual(len(items), 3)
+        # Newest first
+        self.assertEqual(items[0]["ts"], 2000)
+        self.assertEqual(items[1]["ts"], 1500)
+        self.assertEqual(items[2]["ts"], 1000)
+        # device_id correctly split out
+        self.assertEqual(items[0]["device_id"], "tab5-a")
+        self.assertEqual(items[1]["device_id"], "tab5-b")
+        # SHA + bytes surfaced
+        self.assertEqual(items[0]["bytes"], 20)
+        self.assertTrue(items[0]["sha256"])
+        # No symbolicate sidecar => null
+        self.assertIsNone(items[0]["symbolicated"])
+
+    def test_symbolicated_sidecar_surfaces(self):
+        bin_path = self._write_dump("tab5-a", 1000, b"x" * 10)
+        bin_path.with_suffix(".txt").write_text("decoded backtrace\n")
+        items = cs.list_archived(self.save_dir)
+        self.assertIsNotNone(items[0]["symbolicated"])
+        self.assertTrue(items[0]["symbolicated"].endswith(".txt"))
+
+
+# ── Config + loop gating ────────────────────────────────────────────
+
+
+class TestConfigDefaults(unittest.TestCase):
+    def test_disabled_by_default(self):
+        cfg = CoredumpScraperConfig()
+        self.assertFalse(cfg.enabled)
+        self.assertEqual(cfg.targets, [])
+
+    def test_target_defaults(self):
+        t = CoredumpScraperTarget()
+        self.assertEqual(t.device_id, "")
+        self.assertEqual(t.port, 8080)
+
+
+class TestLoadConfigFromYAML(unittest.TestCase):
+    """End-to-end: a yaml `coredump_scraper:` section parses into a
+    typed config with a typed targets list."""
+
+    def test_yaml_round_trip(self):
+        import yaml
+        from dragon_voice.config import load_config
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml",
+                                         delete=False) as f:
+            yaml.dump({
+                "server": {},
+                "stt": {"backend": "moonshine"},
+                "tts": {"backend": "piper"},
+                "llm": {"backend": "ollama"},
+                "audio": {},
+                "tools": {},
+                "memory": {},
+                "database": {},
+                "coredump_scraper": {
+                    "enabled": True,
+                    "poll_interval_s": 30.0,
+                    "save_dir": "/tmp/test-w4d",
+                    "targets": [
+                        {"device_id": "tab5-aaa", "host": "10.0.0.1",
+                         "port": 8080, "token": "tok-1"},
+                        {"device_id": "tab5-bbb", "host": "10.0.0.2",
+                         "port": 8081, "token": "tok-2"},
+                    ],
+                },
+            }, f)
+            cfg_path = f.name
+        cfg = load_config(cfg_path)
+        self.assertTrue(cfg.coredump_scraper.enabled)
+        self.assertEqual(cfg.coredump_scraper.poll_interval_s, 30.0)
+        self.assertEqual(len(cfg.coredump_scraper.targets), 2)
+        # Each is the typed dataclass, not a dict
+        t0 = cfg.coredump_scraper.targets[0]
+        self.assertIsInstance(t0, CoredumpScraperTarget)
+        self.assertEqual(t0.device_id, "tab5-aaa")
+        self.assertEqual(t0.token, "tok-1")
+
+
+class TestSymbolicateBestEffort(unittest.TestCase):
+    """`symbolicate` must never raise + handles missing elf."""
+
+    def test_missing_elf_returns_error(self):
+        import asyncio
+        out, err = asyncio.run(cs.symbolicate(
+            Path("/tmp/nonexistent.bin"),
+            Path("/tmp/nonexistent.elf"),
+            timeout_s=2.0,
+        ))
+        self.assertIsNone(out)
+        self.assertIn("elf not found", err)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #322.

## What changes
Periodic in-process asyncio task that polls each configured Tab5 target's `/crashlog` endpoint for `coredump_present`, pulls the body via `/coredump` with bearer auth, and archives it under `{save_dir}/{device_id}/dump-{epoch}.bin` with a sibling `.sha256` sidecar for content-hash dedupe.

**Real-world driver:** today's unexplained Tab5 SW reset left a stale coredump on flash from a prior firmware build (SHA mismatch). Pre-W4-D that dump was invisible to anyone not actively SSH-ing to Tab5 looking for it. Now it's archived to disk the moment the scraper sees it.

## Files
- `dragon_voice/coredump_scraper.py` (NEW, ~410 LOC)
- `dragon_voice/api/coredumps.py` (NEW) — `GET /api/v1/coredumps`
- `dragon_voice/config.py` — `CoredumpScraperConfig` + `CoredumpScraperTarget` (default `enabled=False`)
- `dragon_voice/lifecycle/background_tasks_init.py` — task spawn
- `dragon_voice/lifecycle/shutdown.py` — cancel + await
- `dragon_voice/lifecycle/startup.py` — wire `server` into route setup
- `dragon_voice/api/__init__.py` — register `CoredumpRoutes`
- `tests/test_coredump_scraper.py` (NEW, 21 tests)

## Tests
21/21 in `tests/test_coredump_scraper.py`: probe parsing, 401 on wrong token, SHA dedupe, /coredump race-404, unreachable host, incomplete-target short-circuit, db event logged on pull (skipped on dedupe), listing newest-first, symbolicate-when-no-elf, yaml round-trip, disabled-by-default. Ruff narrow gate clean.

## Two bugs caught during live deploy + fixed before merge
1. **Tab5's `/info` doesn't expose `coredump_present`** — that field lives on the bearer-gated `/crashlog`. Scraper rewritten to poll `/crashlog`. Caught on first deploy when `last_results.coredump_present=false` despite a real dump being on flash.
2. **Sandbox-friendly default save_dir** — Dragon's Wave-14 hardening drop-in (`hardening.conf`) sets `ProtectHome=read-only` with a narrow `ReadWritePaths` whitelist. The obvious `/home/radxa/tab5-coredumps` is NOT on it (EROFS). Default flipped to `/home/radxa/tinkerclaw/tab5-coredumps` (the `tinkerclaw` working tree is whitelisted). Also wrapped `scrape_target` in outer try/except so filesystem errors land in `LAST_RESULTS.error` instead of disappearing into `asyncio.gather`'s exception bucket.

## Live verification on Dragon 192.168.1.91 ↔ Tab5 192.168.1.90

**21/21 user-story test green** (`/tmp/w4d-userstory.sh`):
- baseline Tab5 + Dragon `/health` ok
- nav home → settings → home (TT #481 priority path preserved)
- voice mode cycle 0→1→2→3→4→5→0 (all 7 transitions NVS-confirmed)
- Telegram channel toggle round-trip (TT #484 settings POST)
- nav to camera + 133 KB JPEG frame fetched
- cross-stack chat turn ("7+11?" → Dragon LLM → "18")
- scraper iterated: real archived dump (37,540 B, SHA `26bf6b03...`, deduped on tick 2+)
- Tab5 obs ring fired `debug.coredump_pull bytes=37540` × 4 during test window
- final `/health` ok, no reset, uptime advanced 100s, heap_min drop -100 KB

Companion Tab5 PR (TT) adds the `debug.coredump_pull` obs event in `main/debug_server_obs.c` so the Tab5 obs ring has on-device fingerprint of every scrape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)