### PR TITLE
fix(dictation): local-mode summary synthesized + empty-transcript closes pipeline

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -19,6 +19,18 @@ sequentially across the whole file (don't restart per section).
 
 ---
 
+## 2026-05-15 — Local-mode dictation_summary hangs: Ollama 60-90 s vs ngrok / WS PONG timeout
+
+- **Date:** 2026-05-15
+- **Symptom:** Long-form dictation in Local mode (voice_mode=0) stays at TRANSCRIBING on Tab5 forever.  Empty/silent dictations also stay TRANSCRIBING with no resolution event ever sent back.
+- **Root Cause:**
+  1. `dictation_post.py::run_dictation_post_process` calls the resolved LLM unconditionally.  With `OllamaBackend` on Dragon CPU, the summary prompt takes 60-90 s — exceeding both aiohttp 30 s server-side PONG timeout *and* ngrok ~60 s idle-WS close.  By the time the LLM streams its reply, the WS is dead.
+  2. `pipeline.py::finish_dictation` gates the post-process call on `full_text.strip() and len(full_text) > 20`.  Empty/short STT emits nothing back to Tab5 — no `dictation_summary`, no `dictation_postprocessing_error` — leaving the pipeline in TRANSCRIBING limbo.
+- **Fix:**
+  1. `dictation_post.py`: detect `type(llm).__name__ == "OllamaBackend"` and synthesize title/summary directly from the transcript.  Solo/Cloud modes still call the LLM normally.
+  2. `pipeline.py`: when transcript is empty/short, emit `{"type":"dictation_summary","title":"","summary":""}` immediately.  Tab5 maps empty-fields → `DICT_FAILED/EMPTY` in <1 s.
+- **Prevention:** Any LLM call that blocks the WS event loop longer than the smallest keepalive in the network path (aiohttp 30 s, ngrok ~60 s) is a violation.  Either (a) skip the LLM, (b) use a faster model, or (c) emit progress frames during the call to keep the WS warm (see `_ws_keepalive_during_inference` for the conversation-engine version of (c)).
+
 ## Dragon/ARM64 Quirks
 
 ### 1. Piper TTS model permissions

--- a/dragon_voice/dictation_post.py
+++ b/dragon_voice/dictation_post.py
@@ -97,6 +97,36 @@ _DEFAULT_TITLE = "Untitled Note"
 _DEFAULT_SUMMARY_TRUNCATE = 200
 
 
+# PR 2 polish (long-form cross-network resilience):
+# When the resolved LLM is the local Ollama backend, skip the LLM call
+# and synthesize the title + summary directly from the transcript.
+# Ollama on Dragon's CPU takes 60-90 s for the 'TITLE: ... SUMMARY: ...'
+# prompt — long enough that ngrok closes the idle WS tunnel before the
+# response is ready, leaving Tab5 stuck at TRANSCRIBING forever.
+# The auto-created note's first-line-as-title is good enough for Local
+# mode; Solo / Cloud modes still go through the LLM (OpenRouter is fast).
+def _synthesize_local_title_summary(transcript: str) -> tuple[str, str]:
+    transcript = (transcript or '').strip() or 'Untitled'
+    words = transcript.split()
+    title = ''
+    for w in words:
+        if len(title) + len(w) + 1 > 50:
+            break
+        nxt = (title + ' ' + w).strip()
+        title = nxt
+        if title.count(' ') >= 7:
+            break
+    if not title:
+        title = transcript[:50].strip()
+    # Capitalize first letter for note title polish.
+    if title and not title[0].isupper():
+        title = title[0].upper() + title[1:]
+    summary = transcript[:200].strip()
+    if len(transcript) > 200:
+        summary = summary.rstrip() + '…'
+    return title, summary
+
+
 async def run_dictation_post_process(
     transcript: str,
     *,
@@ -143,6 +173,29 @@ async def run_dictation_post_process(
             message="Note saved — summary unavailable (LLM offline)",
             severity=Severity.TRANSIENT,
             scope=Scope.LLM,
+            emit_legacy=emit_legacy,
+        )
+        return
+
+
+    # PR 2 polish: short-circuit for Local mode (OllamaBackend).
+    # Synthesize title/summary from the transcript instead of calling
+    # the slow CPU LLM — fires dictation_summary immediately so the
+    # pipeline reaches SAVED before the ngrok WS idle-close window.
+    backend_name = type(llm).__name__
+    if backend_name == 'OllamaBackend':
+        title, summary = _synthesize_local_title_summary(transcript)
+        logger.info('Dictation summary (Local-mode synthesized): title=%r summary_len=%d', title, len(summary))
+        await emit_progress_pair(
+            on_event,
+            legacy={
+                'type': 'dictation_summary',
+                'title': title,
+                'summary': summary,
+            },
+            phase=Phase.DICTATION_POST,
+            stage=Stage.DONE,
+            payload={'title': title, 'summary': summary},
             emit_legacy=emit_legacy,
         )
         return

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -737,7 +737,17 @@ class VoicePipeline:
         self._dictation_mode = False
 
         # Post-process: generate title + summary via LLM (async, non-blocking)
-        # DQ22: store the task so it can be cancelled on shutdown/cancel
+        # DQ22: store the task so it can be cancelled on shutdown/cancel.
+        # PR 2 polish: when transcript is empty/short, emit a final
+        # dictation_summary with empty fields so Tab5's pipeline resolves
+        # (DICT_FAILED/EMPTY) instead of stalling at TRANSCRIBING forever.
+        if not (full_text.strip() and len(full_text) > 20):
+            await self._on_event({
+                "type": "dictation_summary",
+                "title": "",
+                "summary": "",
+            })
+            return full_text
         if full_text.strip() and len(full_text) > 20:
             # v4·D audit P1 fix: cancel any prior post-process task before
             # overwriting the handle.  Two rapid finish_dictation calls

--- a/tests/test_dictation_post.py
+++ b/tests/test_dictation_post.py
@@ -268,3 +268,87 @@ class TestEmitLegacyFlag:
         types = _emitted_types(on_event)
         # Legacy frame should NOT be present; progress.* frame should
         assert "dictation_summary" not in types
+
+
+# ── PR 2 polish: synthesized Local-mode title/summary ────────────────────
+
+from dragon_voice.dictation_post import _synthesize_local_title_summary
+
+
+def test_synthesize_local_long_transcript():
+    """Title is first ~50 chars at word boundary, capitalized; summary
+    is full transcript up to 200 chars."""
+    t = "hello world this is a test of long-form dictation across the network"
+    title, summary = _synthesize_local_title_summary(t)
+    assert title.startswith("Hello world")
+    assert len(title) <= 50
+    assert " " in title  # word boundary, not mid-word
+    assert summary == t  # under 200 chars, returned as-is
+
+
+def test_synthesize_local_short_transcript():
+    """Short transcripts: title is the whole transcript (capitalized)."""
+    title, summary = _synthesize_local_title_summary("short note")
+    assert title == "Short note"
+    assert summary == "short note"
+
+
+def test_synthesize_local_empty_transcript():
+    """Empty or whitespace transcript falls back to 'Untitled'."""
+    for empty in ("", "   ", "\n\t"):
+        title, summary = _synthesize_local_title_summary(empty)
+        assert title == "Untitled"
+        assert summary == "Untitled"
+
+
+def test_synthesize_local_long_summary_truncated_with_ellipsis():
+    """Summaries beyond 200 chars are truncated with an ellipsis."""
+    t = "word " * 100  # 500 chars
+    _title, summary = _synthesize_local_title_summary(t)
+    assert len(summary) <= 201  # 200 chars + 1-char ellipsis
+    assert summary.endswith("…")
+
+
+def test_synthesize_local_word_boundary_in_title():
+    """Title truncation respects word boundaries (no mid-word cuts)."""
+    t = "supercalifragilisticexpialidocious is a long word that should be word-broken"
+    title, _summary = _synthesize_local_title_summary(t)
+    # Either the whole long word fits, or we stop before it.
+    # Either way, no mid-word truncation.
+    assert title == "Supercalifragilisticexpialidocious" or \
+           not title.endswith(("supercalif", "supercalifragili"))
+
+
+@pytest.mark.asyncio
+async def test_ollama_backend_bypasses_llm_for_synthesis():
+    """When the LLM backend is OllamaBackend, dictation_post should
+    skip the LLM call entirely and emit a dictation_summary built from
+    the transcript directly (no slow CPU LLM round-trip)."""
+    events: list[dict] = []
+
+    async def on_event(e: dict) -> None:
+        events.append(e)
+
+    # Mock that *looks* like OllamaBackend by name — that's the gate
+    # we use to distinguish Local mode from Solo/Cloud (which use
+    # OpenRouter and are fast enough to call directly).
+    llm = MagicMock()
+    llm.__class__.__name__ = "OllamaBackend"
+
+    await run_dictation_post_process(
+        "hello world testing cross-network dictation",
+        llm=llm,
+        on_event=on_event,
+        emit_legacy=True,
+    )
+
+    # The LLM should NOT have been called.
+    llm.generate_stream.assert_not_called()
+
+    # dictation_summary event must have been emitted with the
+    # synthesized title + non-empty summary.
+    summaries = [e for e in events if e.get("type") == "dictation_summary"]
+    assert len(summaries) >= 1
+    final = summaries[-1]
+    assert final["title"].startswith("Hello world")
+    assert "cross-network dictation" in final["summary"]


### PR DESCRIPTION
## Summary

Long-form dictation in Local mode was stuck at `TRANSCRIBING` forever on Tab5.  Two root causes, both Dragon-side:

1. `dictation_post.run_dictation_post_process` calls the resolved LLM unconditionally.  With `OllamaBackend` on Dragon's CPU, the summary prompt takes 60-90 s — exceeding aiohttp's 30 s server-side PONG timeout AND ngrok's ~60 s idle-WS close window.  WS dies, response goes to the void, pipeline never resolves.
2. `pipeline.finish_dictation` gates post-process on `len > 20`.  Empty / silent dictations emit nothing back to Tab5 → same TRANSCRIBING-limbo failure.

## Fix

- **`dictation_post.py`**: When `type(llm).__name__ == "OllamaBackend"`, synthesize title + summary directly from the transcript instead of calling the LLM.  Solo (vmode=5) / Cloud (vmode=2) modes still call the LLM normally — OpenRouter latency is well inside the keepalive window.
- **`pipeline.py`**: When transcript is empty/short, emit `{"type":"dictation_summary","title":"","summary":""}` immediately.  Tab5's existing handler maps empty-fields → `DICT_FAILED/EMPTY` in <1 s.

## Live verification

Tab5 192.168.1.90 ↔ Dragon 192.168.1.91:

| Scenario | Before | After |
|---|---|---|
| Empty dictation (silence) | Hangs at TRANSCRIBING forever | `FAILED/EMPTY` in <1 s |
| Real dictation (podcast STT, 108 chars) | Hangs / WS times out | `SAVED` in ~2 s with synthesized title `"Operate the ship that it is. like a"` and full transcript as summary |

## Tests

- 6 new unit tests in `tests/test_dictation_post.py` covering the synthesis helper + OllamaBackend bypass
- Existing 22 dictation-post tests still pass
- Ruff narrow-gate clean

## LEARNINGS.md

Updated with root-cause + prevention entry.

closes #326