### PR TITLE
feat(dictation): heuristic classifier → proposed_action chip

### DIFF
--- a/dragon_voice/dictation_classifier.py
+++ b/dragon_voice/dictation_classifier.py
@@ -1,0 +1,217 @@
+"""Dictation classifier — Dragon side of TinkerTab PR 4 action chips.
+
+After `_post_process_dictation` lands the title + summary, this module
+inspects the transcript for reminder / list cues and returns a
+`{kind, confidence, payload}` hint that gets attached to the
+`dictation_summary` WS frame as `proposed_action`.  Tab5 (#539) renders
+an action chip below the row body when confidence ≥ 0.75.
+
+## Design
+
+v1 is heuristic + scheduler/parser-based — no LLM round-trip.  Two
+reasons:
+
+1. Local mode already short-circuits the LLM summary (Ollama is too slow
+   for the ngrok WS idle-close window).  Adding another LLM call here
+   would re-introduce the same hang class.
+2. Reminder + list cues are well-served by keyword + comma-count
+   heuristics; the false-positive rate of a small local LLM (ministral
+   on Dragon CPU) isn't obviously lower than a tight regex.
+
+Future work: an LLM classifier could slot in here behind a feature flag
+when a fast cloud LLM is the resolved backend.
+
+## Output shape
+
+```python
+{
+    "kind": "reminder" | "list" | "none",
+    "confidence": 0.0-1.0,
+    "payload": {
+        "when":  "ISO-8601",  # reminders only, possibly empty
+        "label": "...",        # reminders only, possibly empty
+    } or {}
+}
+```
+
+Tab5 enforces the 0.75 floor — emitting low-confidence results is fine
+(saves another roundtrip later if the threshold changes).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from datetime import datetime
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+from dragon_voice.scheduler.parser import parse_when
+
+logger = logging.getLogger(__name__)
+
+
+# ── Heuristic patterns ───────────────────────────────────────────────
+
+_REMINDER_KEYWORDS = re.compile(
+    r"\b(remind|reminder|call|email|text|meet|meeting|appointment|"
+    r"schedule|book|pickup|pick\s?up|drop\s?off|deadline|due|"
+    r"don'?t\s+forget|need\s+to|have\s+to|gotta)\b",
+    re.IGNORECASE,
+)
+
+_LIST_KEYWORDS = re.compile(
+    r"\b(grocer\w*|buy|shopping|todo|to-?do|list|items?|"
+    r"errands?|tasks?|stuff|things)\b",
+    re.IGNORECASE,
+)
+
+# Any of these in the transcript significantly bumps the reminder
+# confidence (date / time anchors).
+_TIME_CUE = re.compile(
+    r"\b("
+    r"today|tonight|tomorrow|yesterday|"
+    r"mon(day)?|tue(s|sday)?|wed(nesday)?|thu(rs|rsday)?|fri(day)?|sat(urday)?|sun(day)?|"
+    r"morning|afternoon|evening|night|noon|midnight|"
+    r"\d{1,2}\s*(am|pm|:\d{2})|"
+    r"in\s+\d+\s+(minute|hour|day|week|month)s?|"
+    r"next\s+(week|month|year|monday|tuesday|wednesday|thursday|friday|saturday|sunday)|"
+    r"this\s+(week|weekend|evening|afternoon|morning)"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+# ── Public API ───────────────────────────────────────────────────────
+
+
+def classify_dictation(transcript: str, *, tz_name: str = "UTC") -> dict:
+    """Heuristically classify a transcript for the Tab5 action chip.
+
+    Args:
+        transcript: Full dictation transcript.  May be empty.
+        tz_name: IANA timezone name for natural-language date parsing.
+            Defaults to UTC if the caller doesn't provide one.
+
+    Returns:
+        ``{"kind", "confidence", "payload"}`` dict.  Always returns a
+        well-formed dict — never raises.
+
+    Examples:
+        >>> classify_dictation("Call mom Tuesday at 6pm")["kind"]
+        'reminder'
+        >>> classify_dictation("eggs, bread, butter, oat milk")["kind"]
+        'list'
+        >>> classify_dictation("Random thought about my day")["kind"]
+        'none'
+    """
+    text = (transcript or "").strip()
+    if not text:
+        return {"kind": "none", "confidence": 0.0, "payload": {}}
+
+    # ── Reminder scoring ────────────────────────────────────────────
+    reminder_score = 0.0
+    if _REMINDER_KEYWORDS.search(text):
+        reminder_score += 0.40
+    has_time_cue = bool(_TIME_CUE.search(text))
+    if has_time_cue:
+        reminder_score += 0.40
+
+    parsed_when: Optional[str] = None
+    parsed_label: Optional[str] = None
+    if reminder_score > 0:
+        try:
+            tz = ZoneInfo(tz_name) if tz_name and tz_name != "UTC" else ZoneInfo("UTC")
+        except Exception:
+            tz = ZoneInfo("UTC")
+        now_epoch = time.time()
+        # The scheduler/parser only accepts an isolated when-phrase, not
+        # full prose.  Pull out the time cue + try to resolve it.
+        cue_match = _TIME_CUE.search(text)
+        if cue_match:
+            cue = cue_match.group(0)
+            # Allow phrases like "Tuesday at 6pm" — pull a few extra words
+            # of context around the match to feed the natural parser.
+            ctx = _expand_time_context(text, cue_match.start(), cue_match.end())
+            try:
+                fire_at = parse_when(ctx, now=now_epoch, tz=tz)
+                parsed_when = (
+                    datetime.fromtimestamp(fire_at, tz=tz)
+                    .replace(microsecond=0)
+                    .isoformat(timespec="minutes")
+                )
+                # Tab5 strips the offset for display — keep it for
+                # downstream POST /api/v1/scheduler/notifications.
+                reminder_score += 0.20
+            except Exception as e:
+                logger.debug("classify_dictation: parse_when(%r) failed: %s", ctx, e)
+        # Derive a short label from the first 8 words of the transcript.
+        parsed_label = _short_label(text, max_words=8)
+
+    # ── List scoring ────────────────────────────────────────────────
+    list_score = 0.0
+    if _LIST_KEYWORDS.search(text):
+        list_score += 0.35
+    items = [p.strip() for p in text.split(",") if p.strip()]
+    comma_count = max(0, len(items) - 1)
+    if comma_count >= 3:
+        list_score += 0.65
+    elif comma_count == 2:
+        list_score += 0.40
+    elif comma_count == 1:
+        list_score += 0.15
+    if comma_count >= 2:
+        avg_words = sum(len(it.split()) for it in items) / max(1, len(items))
+        if avg_words <= 3:
+            list_score += 0.20
+
+    reminder_score = min(reminder_score, 0.99)
+    list_score = min(list_score, 0.99)
+
+    # ── Pick higher-confidence option (one chip per note max) ───────
+    if reminder_score >= list_score and reminder_score > 0:
+        return {
+            "kind": "reminder",
+            "confidence": round(reminder_score, 2),
+            "payload": {
+                "when": parsed_when or "",
+                "label": parsed_label or "",
+            },
+        }
+    if list_score > 0:
+        return {
+            "kind": "list",
+            "confidence": round(list_score, 2),
+            "payload": {},
+        }
+    return {"kind": "none", "confidence": 0.0, "payload": {}}
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _expand_time_context(text: str, start: int, end: int) -> str:
+    """Return the time cue with one word of context on each side.
+
+    "I'll meet you Tuesday at 6pm." → "Tuesday at 6pm"
+    Helps the natural-language parser resolve "Tuesday at 6pm" rather
+    than just "Tuesday".
+    """
+    # Pull a small window around the match.
+    left = text.rfind(" ", 0, start)
+    if left < 0:
+        left = 0
+    right = text.find(" ", end + 8)
+    if right < 0:
+        right = len(text)
+    chunk = text[left:right].strip()
+    # Strip trailing punctuation that parse_when chokes on.
+    return chunk.rstrip(".,;:!?")
+
+
+def _short_label(text: str, *, max_words: int = 8) -> str:
+    """First N words, lower-cased prepositions stripped from the end."""
+    words = text.split()
+    label = " ".join(words[:max_words]).rstrip(".,;:!?")
+    return label

--- a/dragon_voice/dictation_post.py
+++ b/dragon_voice/dictation_post.py
@@ -63,13 +63,40 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import Any, Awaitable, Callable, Optional
 
+from dragon_voice.dictation_classifier import classify_dictation
 from dragon_voice.errors import Scope, Severity
 from dragon_voice.progress import Phase, Stage
 from dragon_voice.progress_emit import emit_progress_pair
 
 logger = logging.getLogger(__name__)
+
+
+def _classify_safe(transcript: str) -> dict:
+    """Run the heuristic classifier with a wall-clock guard + fail-soft.
+
+    The classifier is meant to be ~10 ms; if it ever wanders into the
+    hundred-millisecond range we want to know AND we want to keep
+    dictation_summary flowing.  Returns the empty result on any error.
+    """
+    started = time.monotonic()
+    try:
+        # Local TZ for "Tuesday at 6 PM"-style parsing.  Dragon runs in
+        # the user's local zone; pull it from /etc/timezone-ish.
+        try:
+            tz_name = time.tzname[time.daylight] if time.daylight else time.tzname[0]
+        except Exception:
+            tz_name = "UTC"
+        result = classify_dictation(transcript, tz_name=tz_name)
+    except Exception:
+        logger.exception("classify_dictation crashed — skipping proposed_action")
+        return {"kind": "none", "confidence": 0.0, "payload": {}}
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+    if elapsed_ms > 50:
+        logger.warning("classify_dictation took %d ms (target <10 ms)", elapsed_ms)
+    return result
 
 
 OnEvent = Callable[[dict], Awaitable[None]]
@@ -185,17 +212,25 @@ async def run_dictation_post_process(
     backend_name = type(llm).__name__
     if backend_name == 'OllamaBackend':
         title, summary = _synthesize_local_title_summary(transcript)
-        logger.info('Dictation summary (Local-mode synthesized): title=%r summary_len=%d', title, len(summary))
+        # PR 4: heuristic classifier → optional proposed_action chip.
+        proposed = _classify_safe(transcript)
+        logger.info(
+            'Dictation summary (Local-mode synthesized): title=%r summary_len=%d kind=%s conf=%.2f',
+            title, len(summary), proposed['kind'], proposed['confidence'],
+        )
+        legacy_frame: dict[str, Any] = {
+            'type': 'dictation_summary',
+            'title': title,
+            'summary': summary,
+        }
+        if proposed['kind'] != 'none':
+            legacy_frame['proposed_action'] = proposed
         await emit_progress_pair(
             on_event,
-            legacy={
-                'type': 'dictation_summary',
-                'title': title,
-                'summary': summary,
-            },
+            legacy=legacy_frame,
             phase=Phase.DICTATION_POST,
             stage=Stage.DONE,
-            payload={'title': title, 'summary': summary},
+            payload={'title': title, 'summary': summary, 'proposed_action': proposed},
             emit_legacy=emit_legacy,
         )
         return
@@ -211,20 +246,28 @@ async def run_dictation_post_process(
 
         title, summary = _parse_title_summary(response, transcript)
 
-        logger.info("Dictation summary: title='%s'", title)
+        # PR 4: heuristic classifier → optional proposed_action chip.
+        proposed = _classify_safe(transcript)
+        logger.info(
+            "Dictation summary: title='%s' kind=%s conf=%.2f",
+            title, proposed['kind'], proposed['confidence'],
+        )
+        legacy_frame: dict[str, Any] = {
+            "type": "dictation_summary",
+            "title": title,
+            "summary": summary,
+        }
+        if proposed['kind'] != 'none':
+            legacy_frame['proposed_action'] = proposed
         # β-arch (#123): legacy `dictation_summary` carries
         # title/summary at the top level; the new progress
         # frame nests them in `payload` so the bus is uniform.
         await emit_progress_pair(
             on_event,
-            legacy={
-                "type": "dictation_summary",
-                "title": title,
-                "summary": summary,
-            },
+            legacy=legacy_frame,
             phase=Phase.DICTATION_POST,
             stage=Stage.DONE,
-            payload={"title": title, "summary": summary},
+            payload={"title": title, "summary": summary, "proposed_action": proposed},
             emit_legacy=emit_legacy,
         )
     except asyncio.CancelledError:

--- a/tests/test_dictation_classifier.py
+++ b/tests/test_dictation_classifier.py
@@ -1,0 +1,140 @@
+"""Tests for the PR 4 dictation classifier.
+
+Run from repo root:
+    python3 -m pytest tests/test_dictation_classifier.py -q
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dragon_voice.dictation_classifier import classify_dictation
+
+
+# ── Reminder detection ───────────────────────────────────────────────
+
+
+def test_reminder_with_time_cue():
+    r = classify_dictation("Call mom Tuesday at 6 PM")
+    assert r["kind"] == "reminder"
+    assert r["confidence"] >= 0.75
+    assert "label" in r["payload"]
+
+
+def test_reminder_with_in_phrase():
+    r = classify_dictation("Remind me to take out the trash in 2 hours")
+    assert r["kind"] == "reminder"
+    assert r["confidence"] >= 0.75
+
+
+def test_reminder_with_tomorrow():
+    r = classify_dictation("Schedule dentist appointment tomorrow morning")
+    assert r["kind"] == "reminder"
+    assert r["confidence"] >= 0.75
+
+
+def test_reminder_payload_when_parseable():
+    r = classify_dictation("Call mom Tuesday at 6 PM")
+    # parsed_when may or may not resolve depending on TZ + parser
+    # heuristics, but the payload shape must be present.
+    assert "when" in r["payload"]
+    assert "label" in r["payload"]
+
+
+# ── List detection ───────────────────────────────────────────────────
+
+
+def test_list_comma_separated_short_items():
+    r = classify_dictation("eggs, bread, butter, oat milk")
+    assert r["kind"] == "list"
+    assert r["confidence"] >= 0.75
+
+
+def test_list_with_shopping_keyword():
+    r = classify_dictation("shopping list: apples, oranges, bananas")
+    assert r["kind"] == "list"
+    assert r["confidence"] >= 0.75
+
+
+def test_list_with_grocer_keyword():
+    r = classify_dictation("grocery items I need to pick up: milk, cheese, butter")
+    assert r["kind"] == "list"
+    assert r["confidence"] >= 0.75
+
+
+# ── None / low-confidence ────────────────────────────────────────────
+
+
+def test_random_thought_is_none():
+    r = classify_dictation(
+        "I was thinking about how the weather has been weird this week"
+    )
+    # No keyword hit, no commas → confidence below floor.
+    assert r["confidence"] < 0.75
+
+
+def test_empty_transcript():
+    r = classify_dictation("")
+    assert r == {"kind": "none", "confidence": 0.0, "payload": {}}
+
+
+def test_none_transcript():
+    r = classify_dictation(None)  # type: ignore[arg-type]
+    assert r == {"kind": "none", "confidence": 0.0, "payload": {}}
+
+
+def test_single_comma_is_not_a_list():
+    # One comma alone shouldn't trigger the list classification — too
+    # common in normal prose ("Hello, world").
+    r = classify_dictation("Hello, friend")
+    assert r["kind"] == "none" or r["confidence"] < 0.75
+
+
+# ── Reminder vs list disambiguation ─────────────────────────────────
+
+
+def test_reminder_wins_when_time_cue_present():
+    # Time cue + commas — reminder should win.
+    r = classify_dictation("Meeting Tuesday at 6pm with Alice, Bob, Carol")
+    assert r["kind"] == "reminder"
+
+
+def test_list_wins_when_no_time_cue():
+    # Lots of commas, no time cue — list wins.
+    r = classify_dictation("Items: pencil, paper, eraser, ruler")
+    assert r["kind"] == "list"
+
+
+# ── Output shape ────────────────────────────────────────────────────
+
+
+def test_output_shape_invariants():
+    r = classify_dictation("Call mom Tuesday at 6 PM")
+    assert set(r.keys()) == {"kind", "confidence", "payload"}
+    assert r["kind"] in {"reminder", "list", "none"}
+    assert 0.0 <= r["confidence"] <= 1.0
+    assert isinstance(r["payload"], dict)
+
+
+def test_confidence_clamped_to_below_one():
+    # Stack as many positive signals as possible — should not exceed 0.99.
+    r = classify_dictation(
+        "Remind me to email John tomorrow morning at 9am about the meeting"
+    )
+    assert r["confidence"] <= 0.99
+
+
+# ── Sad-path / robustness ───────────────────────────────────────────
+
+
+def test_handles_unicode_transcript():
+    r = classify_dictation("Llámame mañana — recoge los huevos, pan, leche")
+    # Spanish doesn't hit our English keywords; should fall to "none" or
+    # match the comma list heuristic.  Either is fine, just shouldn't crash.
+    assert r["kind"] in {"none", "list", "reminder"}
+
+
+def test_handles_very_long_transcript():
+    text = "buy " + ", ".join([f"item{i}" for i in range(50)])
+    r = classify_dictation(text)
+    assert r["kind"] == "list"


### PR DESCRIPTION
## Summary
Dragon side of TinkerTab's PR 4 action-chip surface ([lorcan35/TinkerTab#539](https://github.com/lorcan35/TinkerTab/pull/540)). After \`_post_process_dictation\` lands title + summary, classify the transcript as reminder / list / none and attach \`proposed_action: {kind, confidence, payload}\` to the \`dictation_summary\` WS frame.

- **Heuristic, not LLM.** Local mode already short-circuits the LLM summary step because Ollama on Dragon CPU takes 60-90s (longer than the ngrok WS idle-close window). Adding another LLM call would re-introduce the same hang class. Heuristic is ~10ms, deterministic, and handles the common reminder/list cases without a model.
- **Detection rules.** Reminder = keyword match (remind/call/email/meet/schedule/deadline) + time cue (today/tomorrow/weekday/Xpm/in N units) + optional scheduler parser hit. List = keyword match (grocer/buy/shopping/list/items/errands) + comma count with short-item bonus. Higher-confidence kind wins (one chip per note max).
- **Forward-compatible.** Legacy Tab5 ignores unknown \`proposed_action\` field; modern Tab5 (#540) renders the chip if confidence ≥ 0.75.
- **Both emit paths covered.** Ollama-bypass synthesize path AND real-LLM success path attach the chip.

Closes #328.

## Known limitation
\`scheduler/parser.parse_when\` only accepts a narrow grammar (\"tomorrow at 9am\", \"in N hours\", \"5m\", ISO 8601). It doesn't handle weekday names (\"Tuesday at 6 PM\") or partial cues (\"tomorrow morning\"). When parsing fails the chip still surfaces (Tab5 renders kind + label) but \`when\` is empty — tap ✓ won't schedule successfully yet. Follow-up: extend the parser or pre-resolve weekday cues in the classifier.

## Test plan
- [x] \`pytest tests/test_dictation_classifier.py\` — 17/17 passing
- [x] Ruff gate green
- [x] Deployed to Dragon, service restarted clean
- [x] Live smoke test on Dragon:
  - \"Call mom Tuesday at 6 PM\" → reminder 0.80
  - \"eggs, bread, butter, oat milk\" → list 0.85
  - \"random thought about my day\" → none 0.00
  - \"Schedule dentist tomorrow morning at 9am\" → reminder 0.80
- [ ] End-to-end through real dictation needs a human speaking into the Tab5 mic — punt to next session

🤖 Generated with [Claude Code](https://claude.com/claude-code)