### PR TITLE
feat(scheduler): parse weekday + time-of-day shapes

### DIFF
--- a/dragon_voice/scheduler/parser.py
+++ b/dragon_voice/scheduler/parser.py
@@ -47,6 +47,41 @@ _NATURAL = re.compile(
     re.IGNORECASE,
 )
 
+# #330: weekday + time, "Tuesday at 6 PM", "next monday at 9am", "wed at 14:30".
+# Three-letter abbreviations + full names both accepted.  "next" prefix
+# forces at least 7 days out (so "next monday" on a Monday means a week
+# from today, not today).
+_WEEKDAY_NATURAL = re.compile(
+    r"^\s*(?P<next>next\s+)?"
+    r"(?P<wday>mon(?:day)?|tue(?:s|sday)?|wed(?:nesday)?|thu(?:rs|rsday)?|"
+    r"fri(?:day)?|sat(?:urday)?|sun(?:day)?)"
+    r"\s+at\s+(?P<hour>\d{1,2})(?::(?P<min>\d{2}))?\s*(?P<ampm>am|pm)?\s*$",
+    re.IGNORECASE,
+)
+_WEEKDAY_INDEX = {
+    "mon": 0, "monday": 0,
+    "tue": 1, "tues": 1, "tuesday": 1,
+    "wed": 2, "wednesday": 2,
+    "thu": 3, "thurs": 3, "thursday": 3,
+    "fri": 4, "friday": 4,
+    "sat": 5, "saturday": 5,
+    "sun": 6, "sunday": 6,
+}
+
+# #330: time-of-day aliases.  "tomorrow morning" → 09:00, afternoon → 13:00,
+# evening → 19:00.  "tonight" is a synonym for "today evening".
+_TOD_NATURAL = re.compile(
+    r"^\s*(?P<day>today|tomorrow|tonight)"
+    r"(?:\s+(?P<tod>morning|afternoon|evening|night))?\s*$",
+    re.IGNORECASE,
+)
+_TOD_DEFAULT_HOUR = {
+    "morning": 9,
+    "afternoon": 13,
+    "evening": 19,
+    "night": 21,
+}
+
 # Verbose relative phrasing the LLM emits in practice (#136).  Either an
 # `in N <unit>` prefix OR an `N <unit> from now` / `N <unit> later`
 # suffix is required — bare `5 minutes` is intentionally rejected
@@ -132,9 +167,24 @@ def parse_when(
         _check_far_future(fire_at, now=now)
         return fire_at
 
+    # ── 3b. Weekday + time, "Tuesday at 6 PM" (#330) ────────────────
+    fire_at = _try_parse_weekday(s_clean, now=now, tz=tz)
+    if fire_at is not None:
+        _check_past(fire_at, now=now)
+        _check_far_future(fire_at, now=now)
+        return fire_at
+
+    # ── 3c. Time-of-day alias, "tomorrow morning" / "tonight" (#330) ─
+    fire_at = _try_parse_time_of_day(s_clean, now=now, tz=tz)
+    if fire_at is not None:
+        _check_past(fire_at, now=now)
+        _check_far_future(fire_at, now=now)
+        return fire_at
+
     raise ValueError(
         f"could not parse 'when': {s!r} — expected '5m', "
-        f"'in 5 minutes', ISO 8601 timestamp, or 'tomorrow at 3pm' shape"
+        f"'in 5 minutes', ISO 8601 timestamp, 'tomorrow at 3pm', "
+        f"'Tuesday at 6 PM', or 'tomorrow morning' shape"
     )
 
 
@@ -218,6 +268,90 @@ def _try_parse_natural(s: str, *, now: float, tz: tzinfo) -> Optional[float]:
     target_dt = datetime(
         target_date.year, target_date.month, target_date.day,
         hour, minute, 0, tzinfo=tz,
+    )
+    return target_dt.timestamp()
+
+
+def _resolve_clock(hour: int, minute: int, ampm: str, *, src: str) -> tuple[int, int]:
+    """Normalise (hour, minute, ampm) → (hour_24, minute) with bounds check."""
+    ampm = (ampm or "").lower()
+    if ampm == "pm" and hour != 12:
+        hour += 12
+    elif ampm == "am" and hour == 12:
+        hour = 0
+    if not (0 <= hour <= 23) or not (0 <= minute <= 59):
+        raise ValueError(f"invalid hour/minute in natural phrase: {src!r}")
+    return hour, minute
+
+
+def _try_parse_weekday(s: str, *, now: float, tz: tzinfo) -> Optional[float]:
+    """Parse "Tuesday at 6 PM" / "next monday at 9am" / "wed at 14:30".
+
+    Resolution rule: target weekday + time → next future occurrence.
+    "next <weekday>" adds 7 days when the bare resolution would land
+    today or earlier this week, so it's always at least a week out.
+    """
+    m = _WEEKDAY_NATURAL.match(s)
+    if not m:
+        return None
+    next_prefix = bool(m.group("next"))
+    wday_word = m.group("wday").lower()
+    target_wday = _WEEKDAY_INDEX[wday_word]
+    hour, minute = _resolve_clock(
+        int(m.group("hour")), int(m.group("min") or "0"),
+        m.group("ampm") or "", src=s,
+    )
+
+    today_local = datetime.fromtimestamp(now, tz=tz)
+    today_wday = today_local.weekday()  # Mon=0..Sun=6
+    days_ahead = (target_wday - today_wday) % 7
+    # If it's the same weekday AND the requested time is already past
+    # today, push to next week.  ("Monday at 6 PM" said at 8 PM Monday
+    # means a week from now.)
+    if days_ahead == 0:
+        candidate = today_local.replace(
+            hour=hour, minute=minute, second=0, microsecond=0,
+        )
+        if candidate.timestamp() <= now:
+            days_ahead = 7
+    if next_prefix and days_ahead < 7:
+        days_ahead += 7
+    target_date = today_local.date() + timedelta(days=days_ahead)
+    target_dt = datetime(
+        target_date.year, target_date.month, target_date.day,
+        hour, minute, 0, tzinfo=tz,
+    )
+    return target_dt.timestamp()
+
+
+def _try_parse_time_of_day(s: str, *, now: float, tz: tzinfo) -> Optional[float]:
+    """Parse "tomorrow morning" / "tonight" / "today evening".
+
+    Default hours: morning=09:00, afternoon=13:00, evening=19:00,
+    night=21:00.  "tonight" is shorthand for "today evening".  Bare
+    "today" / "tomorrow" without a TOD alias is intentionally rejected
+    here so the caller falls through to a more explicit error than
+    "today" alone could carry.
+    """
+    m = _TOD_NATURAL.match(s)
+    if not m:
+        return None
+    day_word = m.group("day").lower()
+    tod_word = (m.group("tod") or "").lower()
+    # "tonight" implies evening even without a TOD suffix.
+    if day_word == "tonight":
+        target_hour = _TOD_DEFAULT_HOUR["evening"]
+        day_offset = 0
+    else:
+        if not tod_word:
+            return None  # "today" / "tomorrow" alone — too ambiguous
+        target_hour = _TOD_DEFAULT_HOUR[tod_word]
+        day_offset = 1 if day_word == "tomorrow" else 0
+    today_local = datetime.fromtimestamp(now, tz=tz).date()
+    target_date = today_local + timedelta(days=day_offset)
+    target_dt = datetime(
+        target_date.year, target_date.month, target_date.day,
+        target_hour, 0, 0, tzinfo=tz,
     )
     return target_dt.timestamp()
 

--- a/tests/test_scheduler_parser_weekday.py
+++ b/tests/test_scheduler_parser_weekday.py
@@ -1,0 +1,113 @@
+"""Tests for the #330 weekday + time-of-day parser shapes.
+
+Sits alongside test_scheduler_when_parser.py but focuses only on the
+new grammar branches added for TinkerTab PR 4 reminder chips.
+
+Reference moment: 2026-05-19 14:00:00 UTC.  That's a Tuesday — pin so
+weekday-resolution tests have predictable today/tomorrow weekdays.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from dragon_voice.scheduler.parser import parse_when
+
+_UTC = timezone.utc
+# Tuesday 2026-05-19 14:00 UTC — keeps the math intuitive (Mon=0..Sun=6;
+# today.weekday() == 1).
+_NOW = datetime(2026, 5, 19, 14, 0, 0, tzinfo=_UTC).timestamp()
+
+
+# ── Weekday + time ───────────────────────────────────────────────────
+
+
+def test_weekday_future_today() -> None:
+    """\"Tuesday at 6 PM\" said on Tuesday at 14:00 → same day 18:00."""
+    fire_at = parse_when("Tuesday at 6 PM", now=_NOW, tz=_UTC)
+    expected = datetime(2026, 5, 19, 18, 0, 0, tzinfo=_UTC).timestamp()
+    assert fire_at == pytest.approx(expected)
+
+
+def test_weekday_past_today_rolls_to_next_week() -> None:
+    """\"Tuesday at 9 AM\" said on Tuesday at 14:00 — 9 AM already
+    passed today, so schedule next Tuesday."""
+    fire_at = parse_when("Tuesday at 9 AM", now=_NOW, tz=_UTC)
+    expected = datetime(2026, 5, 26, 9, 0, 0, tzinfo=_UTC).timestamp()
+    assert fire_at == pytest.approx(expected)
+
+
+def test_weekday_other_day() -> None:
+    """\"Friday at 14:30\" said Tue → that coming Friday."""
+    fire_at = parse_when("Friday at 14:30", now=_NOW, tz=_UTC)
+    expected = datetime(2026, 5, 22, 14, 30, 0, tzinfo=_UTC).timestamp()
+    assert fire_at == pytest.approx(expected)
+
+
+def test_weekday_short_form() -> None:
+    """\"wed at 9am\" — 3-letter abbreviation parses the same as
+    \"wednesday\"."""
+    fire_at = parse_when("wed at 9am", now=_NOW, tz=_UTC)
+    expected = datetime(2026, 5, 20, 9, 0, 0, tzinfo=_UTC).timestamp()
+    assert fire_at == pytest.approx(expected)
+
+
+def test_next_weekday_forces_next_week() -> None:
+    """\"next Tuesday at 6 PM\" said on Tuesday afternoon → +7 days,
+    not same day."""
+    fire_at = parse_when("next Tuesday at 6 PM", now=_NOW, tz=_UTC)
+    expected = datetime(2026, 5, 26, 18, 0, 0, tzinfo=_UTC).timestamp()
+    assert fire_at == pytest.approx(expected)
+
+
+def test_weekday_24h_clock() -> None:
+    """\"Saturday at 21:00\" — 24h clock with no AM/PM."""
+    fire_at = parse_when("Saturday at 21:00", now=_NOW, tz=_UTC)
+    expected = datetime(2026, 5, 23, 21, 0, 0, tzinfo=_UTC).timestamp()
+    assert fire_at == pytest.approx(expected)
+
+
+# ── Time-of-day aliases ──────────────────────────────────────────────
+
+
+def test_tomorrow_morning() -> None:
+    """\"tomorrow morning\" → tomorrow 09:00."""
+    fire_at = parse_when("tomorrow morning", now=_NOW, tz=_UTC)
+    expected = datetime(2026, 5, 20, 9, 0, 0, tzinfo=_UTC).timestamp()
+    assert fire_at == pytest.approx(expected)
+
+
+def test_tomorrow_afternoon() -> None:
+    """\"tomorrow afternoon\" → tomorrow 13:00."""
+    fire_at = parse_when("tomorrow afternoon", now=_NOW, tz=_UTC)
+    expected = datetime(2026, 5, 20, 13, 0, 0, tzinfo=_UTC).timestamp()
+    assert fire_at == pytest.approx(expected)
+
+
+def test_tomorrow_evening() -> None:
+    """\"tomorrow evening\" → tomorrow 19:00."""
+    fire_at = parse_when("tomorrow evening", now=_NOW, tz=_UTC)
+    expected = datetime(2026, 5, 20, 19, 0, 0, tzinfo=_UTC).timestamp()
+    assert fire_at == pytest.approx(expected)
+
+
+def test_tonight() -> None:
+    """\"tonight\" said at 14:00 → today 19:00."""
+    fire_at = parse_when("tonight", now=_NOW, tz=_UTC)
+    expected = datetime(2026, 5, 19, 19, 0, 0, tzinfo=_UTC).timestamp()
+    assert fire_at == pytest.approx(expected)
+
+
+def test_bare_today_rejected() -> None:
+    """\"today\" alone is too ambiguous — falls through to ValueError."""
+    with pytest.raises(ValueError):
+        parse_when("today", now=_NOW, tz=_UTC)
+
+
+def test_tonight_past_rejected() -> None:
+    """\"tonight\" said at 22:00 — 19:00 already passed; reject as past."""
+    late = datetime(2026, 5, 19, 22, 0, 0, tzinfo=_UTC).timestamp()
+    with pytest.raises(ValueError):
+        parse_when("tonight", now=late, tz=_UTC)


### PR DESCRIPTION
## Summary
Closes the round-trip on TinkerTab PR 4 reminder chips (lorcan35/TinkerTab#540). Before this PR the classifier extracted time cues like "Tuesday at 6 PM" but `parse_when` rejected them, so chips surfaced with empty `when` and tap ✓ shipped a notification POST that Dragon rejected.

### New grammar shapes
- `Tuesday at 6 PM` / `wed at 9am` / `Sat at 14:30` — weekday + time, resolves to next future occurrence (same day if time hasn't passed yet).
- `next monday at 6 PM` — always +7 days out.
- `tomorrow morning` / `afternoon` / `evening` → 09:00 / 13:00 / 19:00.
- `tonight` → today 19:00 (rejected as past if you say it after 7pm).

Bare `today` / `tomorrow` without a TOD alias still rejected — too ambiguous.

Closes #330. Refs lorcan35/TinkerTab#540, lorcan35/TinkerTab#539.

## Live verify
Deployed to Dragon, ran the classifier against:
- "Call mom Tuesday at 6 PM" → `when='2026-05-19T18:00+00:00'`
- "Schedule dentist tomorrow morning" → `when='2026-05-16T09:00+00:00'`
- "Pay rent Friday at 9am" → `when='2026-05-22T09:00+00:00'`

All non-empty `when` values are accepted by `parse_when` and will schedule successfully via `POST /api/v1/scheduler/notifications`.

## Test plan
- [x] 12/12 new unit tests pass
- [x] 23/23 existing parser tests still pass (no regression)
- [x] Ruff gate green
- [x] Live-verified on Dragon

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)