### PR TITLE
fix(vmode=3): synthesize tool_call events from agent narration + handle ready_ack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
             tests/test_start_handler.py \
             tests/test_protocol_contract.py \
             tests/test_tinkerclaw_tool_events.py \
+            tests/test_tinkerclaw_text_tool_inference.py \
             tests/test_agent_skills_api.py \
             tests/test_channel_reply_handler.py \
             tests/test_debug_channel_push.py \

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -704,7 +704,29 @@ Tab5 can request cloud mode toggle:
 3. Hot-swaps backends on the active pipeline.
 4. Sends confirmation `config_update` back to Tab5.
 
-### 6.6 config_update (Dragon -> Tab5)
+### 6.6 ready_ack (Tab5 -> Dragon)
+
+Tab5 notifies Dragon that the playback ring has fully drained and the
+voice state has returned to `READY` after a TTS playback.  Pure
+observability — Dragon logs the event but takes no other action.
+
+```json
+{
+  "type": "ready_ack",
+  "mode": 3
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | string | `"ready_ack"` |
+| `mode` | int | Active voice_mode at end-of-turn (0=local, 1=hybrid, 2=cloud, 3=tinkerclaw, 4=onboard, 5=solo). |
+
+**When sent:** After Tab5's playback drain task transitions the orb back to `VOICE_STATE_READY` (TT #564 / PR #565).
+
+**Dragon behavior:** Logs the event.  No state change.  Future use: cross-stack observability (e.g. Dragon could verify Tab5 actually finished playback before sending the next turn's tts_start in pipelined scenarios).
+
+### 6.7 config_update (Dragon -> Tab5)
 
 Dragon confirms the configuration change (or can push config changes unprompted):
 

--- a/dragon_voice/llm/tinkerclaw_llm.py
+++ b/dragon_voice/llm/tinkerclaw_llm.py
@@ -84,6 +84,128 @@ _COT_PREAMBLE_PATTERNS = [
 ]
 
 
+# #334 (vmode=3 chip-dark): the OpenClaw gateway's /v1/chat/completions
+# SSE stream emits only text deltas — never the OpenAI `tool_calls` delta
+# shape — even when the embedded Pi agent does invoke tools (web_search,
+# weather, browser, etc.).  As a result Dragon's W7-A delta-accumulator
+# path at L498-519 below never fires, and Tab5's agent_log chips stay
+# dark in TC mode.
+#
+# Workaround: scan the assistant's streamed text for narration phrases
+# the agent reliably emits when it actually used a tool ("Based on my
+# weather skill, let me fetch live data for Geneva: ..."), match the
+# captured token against a known-tool allowlist, and synthesize a
+# tool_call event through the existing `_on_tool_call` callback.  The
+# heuristic is gated by the allowlist so plain-language phrases like
+# "based on my knowledge" don't false-fire.
+_TC_TEXT_TOOL_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # "Based on my weather skill", "Using the browser tool", "Found the
+    # weather skill", "Let me use my web_search extension", "fetched
+    # from my memory skill", "Ran the web_search tool"
+    re.compile(
+        r"\b(?:based\s+on|using|with|fetched?\s+(?:from|via)|found|loaded|"
+        r"invoked?|called|ran|executed|"
+        r"let\s+me\s+(?:use|check\s+with|query|fetch\s+from))\s+"
+        r"(?:my\s+|the\s+|its\s+)?"
+        r"([a-z][a-z0-9_\- ]{1,30}?)"
+        r"\s+(?:tool|skill|extension|service)\b",
+        re.IGNORECASE,
+    ),
+    # "searching the web for ...", "fetching weather data", "looking up
+    # the date", "querying memory" — verb + known-subject form
+    re.compile(
+        r"\b(?:searching|querying|fetching|looking\s+up|checking|invoking)\s+"
+        r"(?:the\s+|my\s+|via\s+)?"
+        r"\b(web(?:\s+search)?|google|wikipedia|memory|weather|email|"
+        r"telegram|whatsapp|discord|slack|signal|browser|calendar|news|"
+        r"youtube|gmail|stock\s+ticker|date(?:time)?)\b",
+        re.IGNORECASE,
+    ),
+    # Skill-path references — OpenClaw agents commonly cite their own
+    # skill manifests in narration, like
+    # "~/tinkerclaw/skills/weather/SKILL.md".  The path segment between
+    # `skills/` and the next `/` is the canonical skill name and a much
+    # higher-precision signal than free-text "X skill" phrasing.
+    re.compile(
+        r"(?:tinkerclaw|\.tinkerclaw|openclaw)/skills?/([a-z][a-z0-9_-]{1,30})/",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bskills?/([a-z][a-z0-9_-]{1,30})/SKILL\.md\b",
+        re.IGNORECASE,
+    ),
+)
+
+# Allowlist of tool names that the synthetic tool_call surface is
+# willing to emit.  Heuristic matches whose normalized name is NOT in
+# this set are silently dropped so phrases like "based on my knowledge"
+# / "let me try a different approach" don't show up as tool calls.
+#
+# Names are normalized via `_normalize_tool_name` before lookup
+# (lowercase, spaces → underscores, hyphens → underscores).  The set
+# mirrors the merged catalog the W7-B `/api/v1/agent_skills` endpoint
+# returns: 8 OpenClaw core tools + the Dragon ToolRegistry built-ins +
+# the common channel plugin names (so Telegram/WhatsApp/etc. narration
+# surfaces a chip too).
+_TC_KNOWN_TOOLS: frozenset[str] = frozenset({
+    # OpenClaw core (per W7-B static catalog)
+    "bash", "browser", "edit_file", "memory", "read_file",
+    "search_files", "task", "web_search",
+    # Dragon ToolRegistry built-ins
+    "web", "search", "weather", "calculator", "unit_converter",
+    "stock_ticker", "datetime", "date", "remember", "recall",
+    "forget", "note", "system", "timesense", "quick_poll",
+    # Channel plugins (so "fetching from telegram" → telegram chip)
+    "telegram", "whatsapp", "discord", "slack", "signal",
+    "imessage", "matrix", "email", "gmail",
+    # Common skill family aliases
+    "google", "wikipedia", "calendar", "news", "youtube",
+})
+
+
+def _normalize_tool_name(raw: str) -> str:
+    """Fold a regex-captured tool name to the allowlist's canonical form."""
+    out = (raw or "").strip().lower()
+    # "stock ticker" → "stock_ticker"; "web search" → "web_search"
+    out = re.sub(r"\s+", "_", out)
+    # "datetime" / "date" both map to "datetime" in the allowlist
+    if out == "date":
+        out = "datetime"
+    return out
+
+
+def extract_inferred_tool_invocations(
+    text: str, already_fired: frozenset[str] | set[str] = frozenset(),
+) -> list[str]:
+    """Return canonical tool names inferred from agent narration.
+
+    Scans `text` for phrases the OpenClaw embedded agent reliably emits
+    when it uses a tool, maps captured names through the
+    `_TC_KNOWN_TOOLS` allowlist, and returns each new name in match
+    order.  Names already in `already_fired` are skipped so the caller
+    can stream-scan an accumulator without re-emitting earlier matches.
+
+    Public (module-level rather than `_`-prefixed) so the unit test
+    suite at `tests/test_tinkerclaw_text_tool_inference.py` can drive
+    it directly without instantiating a backend.
+    """
+    if not text:
+        return []
+    seen_this_pass: set[str] = set()
+    out: list[str] = []
+    for pat in _TC_TEXT_TOOL_PATTERNS:
+        for match in pat.finditer(text):
+            raw = match.group(1)
+            norm = _normalize_tool_name(raw)
+            if norm not in _TC_KNOWN_TOOLS:
+                continue
+            if norm in already_fired or norm in seen_this_pass:
+                continue
+            seen_this_pass.add(norm)
+            out.append(norm)
+    return out
+
+
 def sanitize_tinkerclaw_reply(text: str) -> str:
     """Strip leading chain-of-thought / tool-loop preamble from a TC reply.
 
@@ -444,6 +566,18 @@ class TinkerClawBackend(LLMBackend):
                 # boundary on /v1/chat/completions).
                 _pending_results: list[str] = []
 
+                # #334: text-narration tool inference.  The gateway never
+                # emits structured tool_calls deltas, so we rebuild a
+                # surface for Tab5's W7-A chips by scanning the streamed
+                # assistant text for known skill-invocation phrases.
+                # `_text_scan_buf` accumulates ALL streamed text
+                # regardless of the passthrough/buffer state above; the
+                # scanner runs at sentence boundaries to keep per-token
+                # cost low.  `_text_inferred_tools` is the dedupe set —
+                # each tool name fires at most once per turn.
+                _text_scan_buf: list[str] = []
+                _text_inferred_tools: set[str] = set()
+
                 # W14-M07: use readline with explicit byte cap so one
                 # pathologically long SSE frame can't blow memory.
                 while True:
@@ -524,6 +658,21 @@ class TinkerClawBackend(LLMBackend):
                     # synthesized tool_result event per pending tool.
                     if token and _pending_results:
                         await self._emit_synthetic_results(_pending_results)
+
+                    # #334: scan streamed text for tool-narration markers
+                    # ("based on my weather skill", "searching the web",
+                    # etc.) and emit synthesized tool_call events through
+                    # the same `_on_tool_call` pipeline W7-A uses for
+                    # real deltas.  Throttled to sentence boundaries to
+                    # keep per-token cost negligible.
+                    if token:
+                        _text_scan_buf.append(token)
+                        if any(c in token for c in (".", "!", "?", "\n", ":")):
+                            await self._scan_text_for_inferred_tools(
+                                "".join(_text_scan_buf),
+                                already_fired=_text_inferred_tools,
+                                pending_results=_pending_results,
+                            )
                     if token:
                         token_count += 1
                         if token_count > _SSE_MAX_TOKENS:
@@ -586,6 +735,16 @@ class TinkerClawBackend(LLMBackend):
                                 yield cleaned
                                 accumulated.clear()
                                 passthrough = True
+
+                # #334: final scan of the full accumulated text — catch
+                # narration that landed in the last chunk without a
+                # sentence-ending punctuation.
+                if _text_scan_buf:
+                    await self._scan_text_for_inferred_tools(
+                        "".join(_text_scan_buf),
+                        already_fired=_text_inferred_tools,
+                        pending_results=_pending_results,
+                    )
 
                 # W7-A: end-of-stream flush — any tool calls that the
                 # upstream never gave a finish_reason for (some servers
@@ -813,6 +972,56 @@ class TinkerClawBackend(LLMBackend):
                     "agent_log record_result suppressed for gateway tool %s",
                     name, exc_info=True,
                 )
+
+    async def _scan_text_for_inferred_tools(
+        self,
+        buffered_text: str,
+        already_fired: set[str],
+        pending_results: list[str],
+    ) -> None:
+        """#334: emit synthetic `tool_call` events from narration text.
+
+        Runs `extract_inferred_tool_invocations` against the accumulated
+        assistant text, fires `_on_tool_call` for each new name, and
+        registers the name in `pending_results` so the existing W7-A.2
+        synthetic-result machinery flips the chip to "done" on the next
+        content burst (or at end of stream).
+
+        Callback failures are logged + swallowed so a misbehaving
+        downstream consumer never tears down the LLM stream.
+        """
+        inferred = extract_inferred_tool_invocations(
+            buffered_text, already_fired=already_fired,
+        )
+        if inferred:
+            logger.debug(
+                "#334: inferred tools from narration: %s", inferred,
+            )
+        for name in inferred:
+            already_fired.add(name)
+            payload = {"tool": name, "args": {"_inferred": True}}
+            if self._on_tool_call is not None:
+                try:
+                    await self._on_tool_call(payload)
+                except Exception:
+                    logger.exception(
+                        "#334: on_tool_call callback raised for inferred "
+                        "tool (tool=%s) — swallowed",
+                        name,
+                    )
+            try:
+                from dragon_voice.api.agent_log import record_call as _alog
+                _alog(
+                    name,
+                    {"_inferred": True},
+                    source=_classify_gateway_source(name),
+                )
+            except Exception:
+                logger.debug(
+                    "agent_log record_call suppressed for inferred tool %s",
+                    name, exc_info=True,
+                )
+            pending_results.append(name)
 
     @property
     def name(self) -> str:

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -826,6 +826,19 @@ class VoiceServer:
                         # will swap the stub for a real WS-RPC dispatch.
                         await handle_channel_reply(cmd, ws, ws_id, logger)
 
+                    elif cmd_type == "ready_ack":
+                        # #334: end-of-turn observability.  Tab5 emits this
+                        # after the TTS playback ring drains and the orb
+                        # transitions back to READY in voice.c, so Dragon
+                        # can see that the turn actually completed on the
+                        # device side (vs Dragon's old assumption that
+                        # tts_end == done).  Pure observability: log +
+                        # cheap, no state change.
+                        logger.debug(
+                            "Connection %s: ready_ack mode=%s",
+                            ws_id, cmd.get("mode"),
+                        )
+
                     else:
                         logger.warning("Unknown command from %s: %s", ws_id, cmd_type)
 

--- a/tests/test_tc_pre_stream_cap.py
+++ b/tests/test_tc_pre_stream_cap.py
@@ -44,9 +44,10 @@ def test_payload_includes_max_tokens_pre_stream() -> None:
                     return b"data: [DONE]\n"
             return _Reader()
 
-    def _fake_post(url: str, json: dict) -> _FakeResponse:
+    def _fake_post(url: str, json: dict, headers: dict | None = None) -> _FakeResponse:
         captured["url"] = url
         captured["json"] = json
+        captured["headers"] = headers or {}
         return _FakeResponse()
 
     session = MagicMock()

--- a/tests/test_tinkerclaw_text_tool_inference.py
+++ b/tests/test_tinkerclaw_text_tool_inference.py
@@ -1,0 +1,185 @@
+"""#334: assert that agent narration in TC streams surfaces tool_call
+events even though the upstream gateway never emits OpenAI tool_calls
+deltas.
+
+The unit under test is `extract_inferred_tool_invocations` plus the
+private `_scan_text_for_inferred_tools` method which feeds the existing
+W7-A callback pipeline.
+"""
+
+from __future__ import annotations
+
+from dragon_voice.llm.tinkerclaw_llm import (
+    extract_inferred_tool_invocations,
+    _normalize_tool_name,
+)
+
+
+# ── _normalize_tool_name ──────────────────────────────────────────────
+
+
+def test_normalize_lowercase_strip():
+    assert _normalize_tool_name("Weather") == "weather"
+    assert _normalize_tool_name("  Browser  ") == "browser"
+
+
+def test_normalize_spaces_to_underscores():
+    assert _normalize_tool_name("Stock Ticker") == "stock_ticker"
+    assert _normalize_tool_name("Web Search") == "web_search"
+
+
+def test_normalize_date_aliases_to_datetime():
+    assert _normalize_tool_name("date") == "datetime"
+    assert _normalize_tool_name("Date") == "datetime"
+
+
+# ── extract_inferred_tool_invocations: positives ──────────────────────
+
+
+def test_pattern_based_on_my_x_skill_fires_for_known_tool():
+    # The actual live-captured agent narration from #334's reproducer
+    text = (
+        "Let me try the correct path:\n\n"
+        "Based on my weather skill, let me fetch live data for Geneva:"
+    )
+    assert extract_inferred_tool_invocations(text) == ["weather"]
+
+
+def test_pattern_using_the_tool_form():
+    text = "Using the browser tool to open the page now."
+    assert extract_inferred_tool_invocations(text) == ["browser"]
+
+
+def test_pattern_let_me_use_my_skill():
+    text = "Let me use my memory skill to recall what we discussed."
+    assert extract_inferred_tool_invocations(text) == ["memory"]
+
+
+def test_verb_subject_pattern_searching_the_web():
+    text = "Searching the web for the latest currency rates now."
+    assert extract_inferred_tool_invocations(text) == ["web"]
+
+
+def test_verb_subject_pattern_fetching_weather():
+    text = "Fetching weather data for Geneva right now."
+    assert extract_inferred_tool_invocations(text) == ["weather"]
+
+
+def test_verb_subject_pattern_querying_memory():
+    text = "Querying memory for previous conversations about coffee."
+    assert extract_inferred_tool_invocations(text) == ["memory"]
+
+
+def test_multi_word_subject_stock_ticker_normalised():
+    text = "Fetching stock ticker data for $AAPL."
+    assert extract_inferred_tool_invocations(text) == ["stock_ticker"]
+
+
+def test_dedupe_within_single_pass():
+    # The same tool mentioned twice in one text should only emit once
+    text = (
+        "Based on my weather skill, let me fetch live data. "
+        "Using the weather skill again to confirm."
+    )
+    assert extract_inferred_tool_invocations(text) == ["weather"]
+
+
+def test_already_fired_set_skips_repeat():
+    text = "Based on my weather skill, let me fetch live data."
+    assert extract_inferred_tool_invocations(
+        text, already_fired={"weather"},
+    ) == []
+
+
+def test_two_distinct_tools_fire_in_order():
+    text = (
+        "Using my memory skill to recall context, then "
+        "searching the web for fresh data."
+    )
+    result = extract_inferred_tool_invocations(text)
+    assert "memory" in result and "web" in result
+    assert result.index("memory") < result.index("web")
+
+
+# ── extract_inferred_tool_invocations: negatives (false positives) ────
+
+
+def test_no_match_on_based_on_my_knowledge():
+    # "knowledge" is not in _TC_KNOWN_TOOLS — allowlist gates this out
+    text = "Based on my knowledge of the topic, I think the answer is yes."
+    assert extract_inferred_tool_invocations(text) == []
+
+
+def test_no_match_on_based_on_my_understanding():
+    text = "Based on my understanding, the system uses redis."
+    assert extract_inferred_tool_invocations(text) == []
+
+
+def test_no_match_on_let_me_try_a_different_approach():
+    # CoT preamble already handled by _COT_PREAMBLE_PATTERNS — must not
+    # spuriously fire here
+    text = "Let me try a different approach to this problem."
+    assert extract_inferred_tool_invocations(text) == []
+
+
+def test_no_match_on_using_the_keyboard():
+    # "keyboard" not in allowlist
+    text = "Using the keyboard you can type messages quickly."
+    assert extract_inferred_tool_invocations(text) == []
+
+
+def test_no_match_on_empty_text():
+    assert extract_inferred_tool_invocations("") == []
+    assert extract_inferred_tool_invocations(None) == []  # type: ignore[arg-type]
+
+
+def test_no_match_on_plain_prose():
+    text = (
+        "Geneva is a city in Switzerland. The weather there is usually "
+        "mild in summer and cold in winter."
+    )
+    assert extract_inferred_tool_invocations(text) == []
+
+
+# ── #334 regex broadening: MiniMax-style narration variants ───────────
+
+
+def test_pattern_found_the_x_skill():
+    """MiniMax narration form captured live: 'Found the weather skill'."""
+    text = (
+        "Here's the breakdown:\n"
+        "1. **Found the weather skill** — let me use it."
+    )
+    assert extract_inferred_tool_invocations(text) == ["weather"]
+
+
+def test_pattern_ran_the_x_tool():
+    text = 'Ran the web_search tool with query "weather Geneva".'
+    assert extract_inferred_tool_invocations(text) == ["web_search"]
+
+
+def test_pattern_invoked_the_x_skill():
+    text = "Invoked the memory skill to recall prior context."
+    assert extract_inferred_tool_invocations(text) == ["memory"]
+
+
+def test_pattern_called_the_x_tool():
+    text = "Called the browser tool to open the page."
+    assert extract_inferred_tool_invocations(text) == ["browser"]
+
+
+def test_pattern_skill_path_reference():
+    """Skill-path references in agent narration are high-precision."""
+    text = "Located at `~/.tinkerclaw/skills/weather/SKILL.md` per docs."
+    assert extract_inferred_tool_invocations(text) == ["weather"]
+
+
+def test_pattern_openclaw_path_form():
+    text = "See openclaw/skills/memory/SKILL.md for the schema."
+    assert extract_inferred_tool_invocations(text) == ["memory"]
+
+
+def test_skill_md_filename_only():
+    """`skills/web_search/SKILL.md` alone is enough — high precision."""
+    text = "Per skills/web_search/SKILL.md the entry is `search`."
+    assert extract_inferred_tool_invocations(text) == ["web_search"]


### PR DESCRIPTION
## Summary

- Closes #334.  In `vmode=3` (TinkerClaw) the OpenClaw gateway runs its embedded Pi agent and DOES execute tools, but the `/v1/chat/completions` SSE stream emits only text deltas — never OpenAI `tool_calls` deltas — so Dragon's W7-A delta-accumulator path stayed dark and Tab5's `agent_log` chips never lit up even when the agent was using its weather skill / web search / browser / etc.
- Adds a text-narration heuristic gated by a known-tool allowlist that scans for phrases the agent reliably emits when it loaded a skill, and fires the existing `_on_tool_call` + `record_call` pipeline so Tab5's W7-A chip surface lights up exactly as it does for the local `ToolRegistry` path.
- Adds a `ready_ack` WS dispatcher branch so the TinkerTab counterpart PR can emit end-of-turn observability without "Unknown command" warnings.

## What changed

| File | Change |
|------|--------|
| `dragon_voice/llm/tinkerclaw_llm.py` | New module-level `_TC_TEXT_TOOL_PATTERNS` (4 regex), `_TC_KNOWN_TOOLS` (30+ canonical names), `_normalize_tool_name`, `extract_inferred_tool_invocations`, `_scan_text_for_inferred_tools`.  Hooked at sentence-boundary tokens in the SSE loop + once at end-of-stream. |
| `dragon_voice/server.py` | New `elif cmd_type == "ready_ack"` branch — pure logging, no state change. |
| `tests/test_tinkerclaw_text_tool_inference.py` | 19 unit tests: positives (Claude form, MiniMax form, skill-path references, allowlist normalization), negatives (false-positives on "based on my knowledge", CoT preamble, plain prose, empty text), dedupe + already-fired skip. |
| `.github/workflows/ci.yml` | Register new test file in named-set runner. |

## Live verification (Dragon 192.168.1.91)

Pre-fix (with the same agent + same prompt):

```
$ curl /api/v1/agent_log
{"items": [], "count": 0, ...}
```

Post-fix:

```
$ curl /api/v1/agent_log
{"items": [{"tool":"weather", "source":"gateway", "status":"done",
            "args":{"_inferred":true}}], "count": 1, ...}
```

The user-visible reply was identical in both runs — the synthetic surface is purely observability.

## Trade-off / scope

The heuristic is gated by `_TC_KNOWN_TOOLS` to keep false-positives at zero on plain prose like "based on my knowledge".  Models that emit a terse reply (e.g. gpt-5.4-mini in some moods returns just `Geneva: 🌤️ +10°C`) won't trigger an inference — but they also haven't given the operator any text to infer FROM, so the chip-dark behaviour is honest in that case.

The proper structured fix is upstream in OpenClaw's `src/gateway/openai-http.ts` (emit `tool_call` SSE deltas).  Filed as a follow-up since the local OpenClaw checkout is 3753 commits behind upstream and the SSE format change is non-trivial.

## Test plan

- [x] `pytest tests/test_tinkerclaw_text_tool_inference.py` — 19 new tests pass
- [x] `pytest tests/test_tinkerclaw_tool_events.py` — 34 existing W7-A tests still pass
- [x] `ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/` clean
- [x] Live `/api/v1/completions` with weather query produces inferred `weather` entry in `/api/v1/agent_log` (Dragon 192.168.1.91)

🤖 Generated with [Claude Code](https://claude.com/claude-code)