### PR TITLE
feat(integrations): Phase 1 — TinkerBox-native integrations + Google Calendar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,4 +136,8 @@ jobs:
             tests/test_channel_reply_handler.py \
             tests/test_debug_channel_push.py \
             tests/test_channels_mock.py \
-            tests/test_gateway_connector.py
+            tests/test_gateway_connector.py \
+            tests/test_integrations_registry.py \
+            tests/test_integrations_credentials.py \
+            tests/test_oauth_device_code.py \
+            tests/test_google_calendar_integration.py

--- a/dragon_voice/api/__init__.py
+++ b/dragon_voice/api/__init__.py
@@ -24,6 +24,7 @@ from dragon_voice.api.debug_channel import DebugChannelRoutes
 from dragon_voice.api.video_inject import VideoInjectRoutes
 from dragon_voice.api.coredumps import CoredumpRoutes  # W4-D
 from dragon_voice.api.logs_tail import LogsTailRoutes  # W4-C
+from dragon_voice.api.integrations import IntegrationRoutes  # #341 Phase 1
 
 logger = logging.getLogger(__name__)
 
@@ -138,5 +139,11 @@ def setup_all_routes(
             logger.info("Scheduler REST routes registered (5 endpoints)")
         except ImportError:
             logger.debug("Scheduler routes not available yet")
+
+    # #341 Phase 1: integrations REST surface (Google Calendar, etc.)
+    # Per-process singleton instances of each registered integration
+    # live inside IntegrationRoutes so in-flight OAuth device-code
+    # flows survive across requests.
+    IntegrationRoutes().register(app)
 
     logger.info("API routes registered (modular package)")

--- a/dragon_voice/api/integrations.py
+++ b/dragon_voice/api/integrations.py
@@ -1,0 +1,171 @@
+"""REST API routes for integrations (#341 / #342).
+
+Tab5's Settings → Integrations surface calls these:
+
+  * GET  /api/v1/integrations                     — list + connection state
+  * POST /api/v1/integrations/{name}/connect      — start auth flow
+  * GET  /api/v1/integrations/{name}/status/{request_id}  — poll flow
+  * POST /api/v1/integrations/{name}/disconnect   — revoke + delete
+  * GET  /api/v1/integrations/{name}/test         — smoke test
+
+All routes require bearer auth (the standard middleware covers it; no
+extra check here).  Errors are surfaced as JSON with a sensible HTTP
+status — Tab5 turns them into modal text.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aiohttp import web
+
+from dragon_voice.api.utils import json_error, parse_json_body
+from dragon_voice.tools.integrations import (
+    IntegrationBackend,
+    IntegrationState,
+    list_integrations,
+)
+from dragon_voice.tools.integrations.oauth import DeviceCodeError
+from dragon_voice.tools.integrations.registry import (
+    create_integration,
+    is_registered,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class IntegrationRoutes:
+    """Registers REST routes + holds one instance per integration so
+    in-flight auth flows survive across requests."""
+
+    def __init__(self) -> None:
+        # name -> backend instance (per-process singleton)
+        self._instances: dict[str, IntegrationBackend] = {}
+
+    def _get(self, name: str) -> IntegrationBackend:
+        key = (name or "").strip().lower()
+        if not is_registered(key):
+            raise KeyError(key)
+        if key not in self._instances:
+            self._instances[key] = create_integration(key)
+        return self._instances[key]
+
+    def register(self, app: web.Application) -> None:
+        app.router.add_get(
+            "/api/v1/integrations",
+            self.list_all,
+        )
+        app.router.add_post(
+            "/api/v1/integrations/{name}/connect",
+            self.connect,
+        )
+        app.router.add_get(
+            "/api/v1/integrations/{name}/status/{request_id}",
+            self.status,
+        )
+        app.router.add_post(
+            "/api/v1/integrations/{name}/disconnect",
+            self.disconnect,
+        )
+        app.router.add_get(
+            "/api/v1/integrations/{name}/test",
+            self.test,
+        )
+
+    # ── handlers ────────────────────────────────────────────────
+
+    async def list_all(self, request: web.Request) -> web.Response:
+        del request  # unused
+        out: list[dict[str, Any]] = []
+        for name in list_integrations():
+            integ = self._get(name)
+            connected = await integ.is_connected()
+            state = (
+                IntegrationState.CONNECTED.value
+                if connected else IntegrationState.DISCONNECTED.value
+            )
+            out.append({
+                "name": integ.name,
+                "display_name": integ.display_name,
+                "description": integ.description,
+                "auth_kind": integ.auth_kind,
+                "state": state,
+            })
+        return web.json_response({"integrations": out})
+
+    async def connect(self, request: web.Request) -> web.Response:
+        name = request.match_info["name"]
+        try:
+            integ = self._get(name)
+        except KeyError:
+            return json_error(f"Unknown integration '{name}'", 404)
+        body: dict[str, Any] = {}
+        if request.content_length and request.content_length > 0:
+            body, err = await parse_json_body(request)
+            if err:
+                return err
+        try:
+            chal = await integ.start_connect(params=body or None)
+        except DeviceCodeError as e:
+            status = 503 if e.code == "oauth_not_configured" else 502
+            return web.json_response(
+                {"error": e.code, "message": e.description},
+                status=status,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.exception("integration %s connect failed", name)
+            return json_error(f"Connect failed: {e}", 500)
+        return web.json_response({
+            "kind": chal.kind,
+            "request_id": chal.request_id,
+            "verification_url": chal.verification_url,
+            "user_code": chal.user_code,
+            "expires_in_s": chal.expires_in_s,
+            "interval_s": chal.interval_s,
+            "prompt_fields": chal.prompt_fields,
+        })
+
+    async def status(self, request: web.Request) -> web.Response:
+        name = request.match_info["name"]
+        request_id = request.match_info["request_id"]
+        try:
+            integ = self._get(name)
+        except KeyError:
+            return json_error(f"Unknown integration '{name}'", 404)
+        try:
+            status = await integ.poll_status(request_id)
+        except Exception as e:  # noqa: BLE001
+            logger.exception("integration %s poll_status failed", name)
+            return json_error(f"poll_status failed: {e}", 500)
+        return web.json_response({
+            "state": status.state,
+            "request_id": status.request_id,
+            "error": status.error,
+        })
+
+    async def disconnect(self, request: web.Request) -> web.Response:
+        name = request.match_info["name"]
+        try:
+            integ = self._get(name)
+        except KeyError:
+            return json_error(f"Unknown integration '{name}'", 404)
+        try:
+            await integ.disconnect()
+        except Exception as e:  # noqa: BLE001
+            logger.exception("integration %s disconnect failed", name)
+            return json_error(f"Disconnect failed: {e}", 500)
+        return web.json_response({"disconnected": True, "name": name})
+
+    async def test(self, request: web.Request) -> web.Response:
+        name = request.match_info["name"]
+        try:
+            integ = self._get(name)
+        except KeyError:
+            return json_error(f"Unknown integration '{name}'", 404)
+        ok, detail = await integ.health_check()
+        return web.json_response({
+            "ok": ok,
+            "detail": detail,
+            "name": name,
+        })

--- a/dragon_voice/tools/google_calendar_tool.py
+++ b/dragon_voice/tools/google_calendar_tool.py
@@ -1,0 +1,246 @@
+"""Voice-callable tools for Google Calendar (#341 / #342).
+
+Thin `Tool` wrappers around `GoogleCalendarIntegration` so the LLM in
+any vmode can call `calendar_today`, `calendar_week`, `calendar_create`,
+`calendar_cancel` via the existing ToolRegistry mechanism.
+
+Return shape mirrors the rest of `dragon_voice/tools/` — plain dicts
+that the LLM injects back into context.  `error` key absent = success.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from dragon_voice.tools.base import Tool
+from dragon_voice.tools.integrations.google.calendar import (
+    GoogleCalendarIntegration,
+)
+from dragon_voice.tools.integrations.oauth import DeviceCodeError
+
+logger = logging.getLogger(__name__)
+
+
+_shared_instance: Optional[GoogleCalendarIntegration] = None
+
+
+def _shared_integration() -> GoogleCalendarIntegration:
+    """Process-wide singleton so token cache + cred-store load are
+    amortized.  Concurrency safe: each `_authed_*` call opens its own
+    aiohttp session."""
+    global _shared_instance
+    if _shared_instance is None:
+        _shared_instance = GoogleCalendarIntegration()
+    return _shared_instance
+
+
+def _not_connected(action: str) -> dict[str, Any]:
+    return {
+        "error": "not_connected",
+        "message": (
+            f"Google Calendar isn't connected yet, so I can't {action}.  "
+            "Tap Settings → Integrations → Connect Google on the Tab5 to "
+            "set it up."
+        ),
+    }
+
+
+class CalendarTodayTool(Tool):
+    """List today's events."""
+
+    priority = 30  # surface in compact prompt for local models
+
+    @property
+    def name(self) -> str:
+        return "calendar_today"
+
+    @property
+    def description(self) -> str:
+        return (
+            "List today's events from the user's primary Google Calendar.  "
+            "Use when the user asks 'what's on my calendar today' or 'what "
+            "do I have going on today'."
+        )
+
+    @property
+    def parameters_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "max_results": {
+                    "type": "integer",
+                    "description": "Max events to return (default 10).",
+                },
+            },
+        }
+
+    async def execute(self, args: dict) -> dict:
+        integ = _shared_integration()
+        if not await integ.is_connected():
+            return _not_connected("read your calendar")
+        now = datetime.now(timezone.utc)
+        start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        end = start + timedelta(days=1)
+        try:
+            events = await integ.list_events(
+                time_min=start, time_max=end,
+                max_results=int(args.get("max_results", 10)),
+            )
+        except DeviceCodeError as e:
+            return {"error": e.code, "message": e.description}
+        return {
+            "count": len(events),
+            "events": events,
+        }
+
+
+class CalendarWeekTool(Tool):
+    """List events for the next 7 days."""
+
+    @property
+    def name(self) -> str:
+        return "calendar_week"
+
+    @property
+    def description(self) -> str:
+        return (
+            "List events for the next 7 days from the user's primary Google "
+            "Calendar.  Use when the user asks 'what's on this week' or "
+            "'what's coming up'."
+        )
+
+    @property
+    def parameters_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "max_results": {
+                    "type": "integer",
+                    "description": "Max events to return (default 20).",
+                },
+            },
+        }
+
+    async def execute(self, args: dict) -> dict:
+        integ = _shared_integration()
+        if not await integ.is_connected():
+            return _not_connected("read your calendar")
+        now = datetime.now(timezone.utc)
+        end = now + timedelta(days=7)
+        try:
+            events = await integ.list_events(
+                time_min=now, time_max=end,
+                max_results=int(args.get("max_results", 20)),
+            )
+        except DeviceCodeError as e:
+            return {"error": e.code, "message": e.description}
+        return {"count": len(events), "events": events}
+
+
+class CalendarCreateTool(Tool):
+    """Create a calendar event.  Agent should confirm with user first."""
+
+    @property
+    def name(self) -> str:
+        return "calendar_create"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Create an event on the user's primary Google Calendar.  Use "
+            "when the user explicitly asks to schedule / add / book a "
+            "calendar event.  Confirm details with the user BEFORE calling; "
+            "calendar writes are not undoable by voice except via "
+            "calendar_cancel."
+        )
+
+    @property
+    def parameters_schema(self) -> dict:
+        return {
+            "type": "object",
+            "required": ["summary", "start_iso", "end_iso"],
+            "properties": {
+                "summary": {
+                    "type": "string",
+                    "description": "Event title (e.g. 'Dentist appointment').",
+                },
+                "start_iso": {
+                    "type": "string",
+                    "description": "Start as ISO 8601 with timezone (e.g. '2026-05-17T14:00:00+02:00').",
+                },
+                "end_iso": {
+                    "type": "string",
+                    "description": "End as ISO 8601 with timezone.",
+                },
+                "location": {
+                    "type": "string",
+                    "description": "Optional venue or address.",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Optional longer description.",
+                },
+            },
+        }
+
+    async def execute(self, args: dict) -> dict:
+        integ = _shared_integration()
+        if not await integ.is_connected():
+            return _not_connected("create an event")
+        try:
+            start = datetime.fromisoformat(args["start_iso"])
+            end = datetime.fromisoformat(args["end_iso"])
+        except (ValueError, KeyError) as e:
+            return {"error": "bad_args", "message": str(e)}
+        try:
+            ev = await integ.create_event(
+                summary=args["summary"],
+                start=start,
+                end=end,
+                location=args.get("location"),
+                description=args.get("description"),
+            )
+        except DeviceCodeError as e:
+            return {"error": e.code, "message": e.description}
+        return {"event": ev, "created": True}
+
+
+class CalendarCancelTool(Tool):
+    """Delete an event by id."""
+
+    @property
+    def name(self) -> str:
+        return "calendar_cancel"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Delete an event from the user's primary Google Calendar.  Use "
+            "when the user explicitly asks to cancel / delete / remove an "
+            "event.  Confirm the event id (from a previous calendar_today "
+            "or calendar_week result) with the user before calling."
+        )
+
+    @property
+    def parameters_schema(self) -> dict:
+        return {
+            "type": "object",
+            "required": ["event_id"],
+            "properties": {
+                "event_id": {
+                    "type": "string",
+                    "description": "Event id from a previous calendar_today or calendar_week result.",
+                },
+            },
+        }
+
+    async def execute(self, args: dict) -> dict:
+        integ = _shared_integration()
+        if not await integ.is_connected():
+            return _not_connected("cancel an event")
+        ok = await integ.cancel_event(args["event_id"])
+        if not ok:
+            return {"error": "cancel_failed", "event_id": args["event_id"]}
+        return {"cancelled": True, "event_id": args["event_id"]}

--- a/dragon_voice/tools/integrations/__init__.py
+++ b/dragon_voice/tools/integrations/__init__.py
@@ -1,0 +1,58 @@
+"""TinkerBox integrations layer (#341 / Phase 1 #342).
+
+Per-integration adapters that own OAuth lifecycle, credential storage,
+and expose Dragon `Tool` instances usable across all voice modes.  See
+`docs/PLAN-tinkerbox-integrations.md` for the architecture; this
+package's __init__ just exposes the public surface + triggers
+side-effect imports so the registry self-populates.
+
+Public API:
+  * `IntegrationBackend` — ABC every integration implements
+  * `register_integration(name)` — decorator, mirrors `tts/registry.py`
+  * `create_integration(name)` — factory by registered name
+  * `list_integrations()` — registered names
+  * `OAuthDeviceCodeClient` — shared device-code flow client
+  * `CredentialStore` — per-integration JSON cred file (0o600)
+"""
+
+from __future__ import annotations
+
+from dragon_voice.tools.integrations.base import (
+    ConnectChallenge,
+    ConnectionStatus,
+    IntegrationBackend,
+    IntegrationState,
+)
+from dragon_voice.tools.integrations.credentials import CredentialStore
+from dragon_voice.tools.integrations.oauth import (
+    DeviceCodeError,
+    OAuthDeviceCodeClient,
+    OAuthTokens,
+)
+from dragon_voice.tools.integrations.registry import (
+    create_integration,
+    get_integration_class,
+    is_registered,
+    list_integrations,
+    register_integration,
+)
+
+# Side-effect imports so backends self-register on package load.
+# Adding a new integration = drop a module + decorator + one import line.
+from dragon_voice.tools.integrations.google import calendar as _google_calendar  # noqa: F401
+
+__all__ = [
+    "ConnectChallenge",
+    "ConnectionStatus",
+    "CredentialStore",
+    "DeviceCodeError",
+    "IntegrationBackend",
+    "IntegrationState",
+    "OAuthDeviceCodeClient",
+    "OAuthTokens",
+    "create_integration",
+    "get_integration_class",
+    "is_registered",
+    "list_integrations",
+    "register_integration",
+]

--- a/dragon_voice/tools/integrations/base.py
+++ b/dragon_voice/tools/integrations/base.py
@@ -1,0 +1,166 @@
+"""IntegrationBackend ABC + lifecycle types (#341 / #342).
+
+Every TinkerBox integration (Google Calendar, Gmail, Home Assistant,
+Spotify, ...) implements this interface.  The methods are deliberately
+narrow:
+
+  * `display_name`, `description` — UI metadata for Tab5 Settings.
+  * `auth_kind` — drives the Tab5 connect-modal shape.
+  * `start_connect` — initiates the auth flow, returns the challenge
+    the user needs to complete on their phone (device-code) or the
+    fields they need to fill (static-token).
+  * `poll_status` — Tab5 polls until `connected: true` or expiry.
+  * `disconnect` — revoke + delete tokens.
+  * `health_check` — smoke test; the REST `/test` endpoint calls this.
+
+State persistence lives in `CredentialStore` (see credentials.py); the
+backend owns the schema of what gets stored.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal, Optional
+
+
+class IntegrationState(str, Enum):
+    """Top-level integration state for the Tab5 UI badge."""
+
+    DISCONNECTED = "disconnected"
+    CONNECTING = "connecting"
+    CONNECTED = "connected"
+    NEEDS_REAUTH = "needs_reauth"
+    ERROR = "error"
+
+
+@dataclass
+class ConnectChallenge:
+    """Returned by `start_connect` — what Tab5 should show the user.
+
+    For OAuth device-code:
+      * `verification_url` — what the QR code encodes (with `user_code`
+        embedded as a query param so the phone autofills it).
+      * `user_code` — the human-readable fallback ("ABC-123").
+      * `expires_in_s` — countdown for the modal.
+      * `interval_s` — how often Tab5 should poll the status endpoint.
+      * `request_id` — opaque server-side handle.  Tab5 echoes this
+        back to `/status` so the backend knows which in-flight flow.
+
+    For static-token:
+      * `prompt_fields` — list of field names Tab5 should render as
+        text inputs (e.g. `["base_url", "long_lived_token"]`).
+      * `verification_url` / `user_code` / `expires_in_s` / `interval_s`
+        all unset.
+    """
+
+    kind: Literal["oauth-device", "static-token", "none"]
+    request_id: str
+    verification_url: Optional[str] = None
+    user_code: Optional[str] = None
+    expires_in_s: Optional[int] = None
+    interval_s: Optional[int] = None
+    prompt_fields: Optional[list[str]] = None
+
+
+@dataclass
+class ConnectionStatus:
+    """Returned by `poll_status` — Tab5 keeps polling until terminal.
+
+    * `state` — `connecting` while OAuth flow is mid-flight, `connected`
+      on success, `error` on a non-recoverable failure, `expired` when
+      the device-code timed out (Tab5 should close the modal).
+    * `error` — human-readable string when `state` is `error` or
+      `expired`.  Tab5 surfaces this in the modal.
+    """
+
+    state: Literal["connecting", "connected", "error", "expired"]
+    request_id: str
+    error: Optional[str] = None
+
+
+class IntegrationBackend(ABC):
+    """Interface every integration implements."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Stable id used in REST routes + registry lookup.
+
+        Examples: ``"google-calendar"``, ``"gmail"``, ``"homeassistant"``.
+        Lower-kebab-case; no spaces.
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def display_name(self) -> str:
+        """User-facing name shown in Tab5 Settings.
+
+        Examples: ``"Google Calendar"``, ``"Gmail"``, ``"Home Assistant"``.
+        """
+        ...
+
+    @property
+    def description(self) -> str:
+        """Optional longer description for Tab5 Settings.  Default
+        returns the display name; subclasses can override."""
+        return self.display_name
+
+    @property
+    @abstractmethod
+    def auth_kind(self) -> Literal["oauth-device", "static-token", "none"]:
+        """Drives the Tab5 connect-modal shape."""
+        ...
+
+    @abstractmethod
+    async def is_connected(self) -> bool:
+        """True when credentials exist + are usable.  No network call
+        — read-only.  For network reachability use `health_check`."""
+        ...
+
+    @abstractmethod
+    async def start_connect(self, params: Optional[dict] = None) -> ConnectChallenge:
+        """Initiate the auth flow.
+
+        Args:
+            params: For ``static-token`` integrations Tab5 posts the
+                completed field values here (e.g. ``{"base_url": "...",
+                "long_lived_token": "..."}``).  For OAuth device-code
+                it's typically unused.
+        """
+        ...
+
+    @abstractmethod
+    async def poll_status(self, request_id: str) -> ConnectionStatus:
+        """Tab5 polls every few seconds while the user completes the
+        OAuth flow on their phone.  Returns terminal state when done.
+        """
+        ...
+
+    @abstractmethod
+    async def disconnect(self) -> None:
+        """Revoke + delete stored credentials.
+
+        Best-effort: if the provider's revoke endpoint fails (network
+        down, token already invalid), still delete the local creds —
+        the user explicitly asked to disconnect.
+        """
+        ...
+
+    @abstractmethod
+    async def health_check(self, timeout_s: float = 5.0) -> tuple[bool, str]:
+        """Cheap reachability probe.
+
+        Returns ``(ok, detail)``.  REST ``GET /api/v1/integrations/{name}/test``
+        calls this.  `ok=False` with a short detail when the provider
+        is unreachable or our credentials are stale.
+        """
+        ...
+
+    async def shutdown(self) -> None:
+        """Release any held connections (HTTP sessions, etc.)  Default
+        is a no-op; integrations with persistent connections override.
+        """
+        return None

--- a/dragon_voice/tools/integrations/credentials.py
+++ b/dragon_voice/tools/integrations/credentials.py
@@ -1,0 +1,120 @@
+"""Per-integration credential storage (#341).
+
+Each integration owns a small JSON file under
+``~/.tinkerclaw/integrations/{name}.json`` (mode ``0o600``).  Schema is
+opaque to this layer — the integration backend defines what gets
+stored (OAuth tokens + expiry + refresh, or a static long-lived
+token, etc.).
+
+Atomic write: writes to ``{name}.json.tmp`` then ``os.replace`` so a
+crash mid-write doesn't corrupt the cred file.  Read returns ``None``
+when the file is missing OR malformed — caller treats that as "not
+connected" and prompts the user to reconnect.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import stat
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Default location.  Override via TINKERCLAW_INTEGRATIONS_DIR env var
+# (used by tests to redirect to a temp dir).
+_DEFAULT_DIR = Path.home() / ".tinkerclaw" / "integrations"
+
+
+def _resolve_dir() -> Path:
+    override = os.environ.get("TINKERCLAW_INTEGRATIONS_DIR")
+    if override:
+        return Path(override).expanduser()
+    return _DEFAULT_DIR
+
+
+class CredentialStore:
+    """Per-integration cred file at ``{base}/{name}.json``.
+
+    Thread-safe via a per-instance asyncio.Lock — writes are serialized
+    but reads run unlocked (file-level atomic).  Cross-process safety
+    is not a goal: a single dragon_voice process owns its creds.
+    """
+
+    def __init__(self, name: str, base_dir: Optional[Path] = None) -> None:
+        self._name = name
+        self._dir = base_dir if base_dir is not None else _resolve_dir()
+        self._path = self._dir / f"{name}.json"
+        self._lock = asyncio.Lock()
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    async def load(self) -> Optional[dict[str, Any]]:
+        """Read credentials.  Returns None on missing OR malformed file.
+
+        Malformed-file path also logs a warning so an operator sees the
+        corruption rather than silently treating it as "disconnected".
+        """
+        if not self._path.exists():
+            return None
+        try:
+            with self._path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, dict):
+                logger.warning(
+                    "Credential file %s is not a JSON object — ignoring",
+                    self._path,
+                )
+                return None
+            return data
+        except json.JSONDecodeError:
+            logger.warning(
+                "Credential file %s is corrupt JSON — ignoring (operator "
+                "should delete the file + reconnect)",
+                self._path,
+            )
+            return None
+        except OSError as e:
+            logger.warning("Failed to read %s: %s", self._path, e)
+            return None
+
+    async def save(self, data: dict[str, Any]) -> None:
+        """Atomic write + chmod 0o600.
+
+        Creates the parent dir if missing.  Raises OSError on
+        underlying filesystem failure — caller decides whether that's
+        fatal (probably yes; if we can't persist creds the user has to
+        reconnect every restart).
+        """
+        async with self._lock:
+            await asyncio.to_thread(self._save_sync, data)
+
+    def _save_sync(self, data: dict[str, Any]) -> None:
+        self._dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        # Make sure the directory itself isn't world-readable.
+        try:
+            os.chmod(self._dir, 0o700)
+        except OSError:
+            pass
+        tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+        with tmp.open("w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+        # Mode 0o600 — owner-only read+write.
+        os.chmod(tmp, stat.S_IRUSR | stat.S_IWUSR)
+        os.replace(tmp, self._path)
+
+    async def delete(self) -> None:
+        """Remove the credential file.  No-op if already missing."""
+        async with self._lock:
+            try:
+                self._path.unlink(missing_ok=True)
+            except OSError as e:
+                logger.warning("Failed to delete %s: %s", self._path, e)
+
+    async def exists(self) -> bool:
+        return self._path.exists()

--- a/dragon_voice/tools/integrations/google/__init__.py
+++ b/dragon_voice/tools/integrations/google/__init__.py
@@ -1,0 +1,1 @@
+"""Google Workspace integrations — Calendar + Gmail share OAuth."""

--- a/dragon_voice/tools/integrations/google/auth.py
+++ b/dragon_voice/tools/integrations/google/auth.py
@@ -1,0 +1,149 @@
+"""Google OAuth (device-code grant) — shared by Calendar + Gmail.
+
+Single Google OAuth client_id covers all Google services we use.  The
+flow uses the device authorization grant per RFC 8628; Google's
+endpoints:
+  * device-code:  https://oauth2.googleapis.com/device/code
+  * token:        https://oauth2.googleapis.com/token
+
+The client_id (and optional client_secret) come from environment:
+  * GOOGLE_OAUTH_CLIENT_ID — required for `start_connect` to work.
+    Created by the user at https://console.cloud.google.com/ →
+    APIs & Services → Credentials → Create OAuth client ID → "TVs and
+    Limited Input devices" application type.
+  * GOOGLE_OAUTH_CLIENT_SECRET — required when the OAuth client was
+    issued one (Google's "TVs and Limited Input" type ships with both
+    a client_id AND client_secret).  Optional otherwise.
+
+When the env vars are missing, `start_connect` raises a structured
+error so the Tab5 UI can surface a "Set up Google OAuth first"
+explainer instead of failing silently.
+
+This module is intentionally not an `IntegrationBackend` itself — it's
+a shared auth helper that Calendar + Gmail backends compose.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Optional
+
+from dragon_voice.tools.integrations.oauth import (
+    DeviceCodeError,
+    OAuthDeviceCodeClient,
+    OAuthTokens,
+)
+
+logger = logging.getLogger(__name__)
+
+# Google OAuth endpoints — per Google's official documentation for the
+# OAuth 2.0 Device Authorization Grant.
+GOOGLE_DEVICE_CODE_URL = "https://oauth2.googleapis.com/device/code"
+GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke"
+
+# Scopes are space-separated when sent to Google.  The Calendar +
+# Gmail backends each declare what they need; auth.py just collects.
+SCOPE_CALENDAR_READ = "https://www.googleapis.com/auth/calendar.readonly"
+SCOPE_CALENDAR_EVENTS = "https://www.googleapis.com/auth/calendar.events"
+SCOPE_GMAIL_READ = "https://www.googleapis.com/auth/gmail.readonly"
+SCOPE_GMAIL_MODIFY = "https://www.googleapis.com/auth/gmail.modify"
+SCOPE_GMAIL_SEND = "https://www.googleapis.com/auth/gmail.send"
+
+
+@dataclass
+class GoogleOAuthConfig:
+    """Provider-level OAuth config + scope union.
+
+    `scopes` defaults to read-only Calendar — explicit at construction
+    so a single Google credential file can grow scopes incrementally
+    (Calendar first; then Gmail later expands the set).
+    """
+
+    client_id: str
+    client_secret: Optional[str] = None
+    scopes: list[str] = field(default_factory=lambda: [SCOPE_CALENDAR_READ])
+
+    @classmethod
+    def from_env(cls, scopes: Optional[list[str]] = None) -> "GoogleOAuthConfig":
+        client_id = os.environ.get("GOOGLE_OAUTH_CLIENT_ID", "").strip()
+        if not client_id:
+            raise GoogleOAuthNotConfiguredError(
+                "GOOGLE_OAUTH_CLIENT_ID env var is not set.  Create an "
+                "OAuth client at https://console.cloud.google.com/ "
+                '(application type "TVs and Limited Input devices") and '
+                "set GOOGLE_OAUTH_CLIENT_ID + GOOGLE_OAUTH_CLIENT_SECRET "
+                "in Dragon's environment."
+            )
+        client_secret = (
+            os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET", "").strip() or None
+        )
+        return cls(
+            client_id=client_id,
+            client_secret=client_secret,
+            scopes=list(scopes) if scopes is not None else [SCOPE_CALENDAR_READ],
+        )
+
+    def scope_string(self) -> str:
+        return " ".join(self.scopes)
+
+
+class GoogleOAuthNotConfiguredError(DeviceCodeError):
+    """Raised when GOOGLE_OAUTH_CLIENT_ID is missing.
+
+    Inherits DeviceCodeError so the REST layer can render the same
+    error shape for "no client_id set" vs "user denied authorization".
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(code="oauth_not_configured", description=message)
+
+
+def make_google_client(config: GoogleOAuthConfig) -> OAuthDeviceCodeClient:
+    """Build a Google-specific OAuthDeviceCodeClient."""
+    return OAuthDeviceCodeClient(
+        client_id=config.client_id,
+        client_secret=config.client_secret,
+        scope=config.scope_string(),
+        device_code_url=GOOGLE_DEVICE_CODE_URL,
+        token_url=GOOGLE_TOKEN_URL,
+    )
+
+
+async def revoke_google_token(token: str, session) -> bool:  # noqa: ANN001
+    """POST to Google's revoke endpoint.  Returns True on 200.
+
+    Per Google: revoking the refresh token invalidates BOTH the refresh
+    token AND any access tokens minted from it — call this with the
+    refresh_token when disconnecting.
+    """
+    try:
+        async with session.post(
+            GOOGLE_REVOKE_URL, data={"token": token},
+        ) as resp:
+            return resp.status == 200
+    except Exception:  # noqa: BLE001
+        logger.warning("Google revoke endpoint unreachable", exc_info=True)
+        return False
+
+
+# Re-export OAuthTokens here so Calendar + Gmail can import a single
+# Google-flavored auth module without poking into the generic oauth
+# module.
+__all__ = [
+    "GoogleOAuthConfig",
+    "GoogleOAuthNotConfiguredError",
+    "OAuthTokens",
+    "make_google_client",
+    "revoke_google_token",
+    "SCOPE_CALENDAR_READ",
+    "SCOPE_CALENDAR_EVENTS",
+    "SCOPE_GMAIL_READ",
+    "SCOPE_GMAIL_MODIFY",
+    "SCOPE_GMAIL_SEND",
+    "GOOGLE_DEVICE_CODE_URL",
+    "GOOGLE_TOKEN_URL",
+    "GOOGLE_REVOKE_URL",
+]

--- a/dragon_voice/tools/integrations/google/calendar.py
+++ b/dragon_voice/tools/integrations/google/calendar.py
@@ -1,0 +1,433 @@
+"""Google Calendar integration — first proof-of-concept (#341 / #342).
+
+Implements `IntegrationBackend` using the shared Google device-code
+auth (`google/auth.py`) and the Calendar v3 REST API.
+
+Public methods used by tools:
+  * `list_events(time_min, time_max, max_results)` → list[dict]
+  * `create_event(...)` → dict
+  * `cancel_event(event_id)` → bool
+
+OAuth state lives in `~/.tinkerclaw/integrations/google-calendar.json`
+managed by the shared `CredentialStore`.  The cred file holds the
+OAuthTokens dict + the active OAuth config snapshot (so we know which
+scopes were granted).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Literal, Optional
+
+import aiohttp
+
+from dragon_voice.tools.integrations.base import (
+    ConnectChallenge,
+    ConnectionStatus,
+    IntegrationBackend,
+)
+from dragon_voice.tools.integrations.credentials import CredentialStore
+from dragon_voice.tools.integrations.google.auth import (
+    GoogleOAuthConfig,
+    GoogleOAuthNotConfiguredError,
+    OAuthTokens,
+    SCOPE_CALENDAR_EVENTS,
+    SCOPE_CALENDAR_READ,
+    make_google_client,
+    revoke_google_token,
+)
+from dragon_voice.tools.integrations.oauth import DeviceCodeError
+from dragon_voice.tools.integrations.registry import register_integration
+
+logger = logging.getLogger(__name__)
+
+CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3"
+
+
+@register_integration("google-calendar")
+class GoogleCalendarIntegration(IntegrationBackend):
+    """Google Calendar read + write via Calendar API v3."""
+
+    # Scopes we request when initiating connect.  Read + write events
+    # on the user's primary calendar — both fit in a single consent
+    # screen so the device-flow UX stays one-step.
+    _SCOPES = [SCOPE_CALENDAR_READ, SCOPE_CALENDAR_EVENTS]
+
+    def __init__(self) -> None:
+        self._store = CredentialStore("google-calendar")
+        # In-flight device-code flows, keyed by request_id.  A flow
+        # lives in this dict from `start_connect` to either successful
+        # `poll_status` (terminal `connected`) or expiry/cancellation.
+        self._flows: dict[str, _DeviceFlow] = {}
+        # Lazily-loaded token cache; written through to `_store` on
+        # every refresh.  None means "not loaded yet" — load on first
+        # use.
+        self._tokens: Optional[OAuthTokens] = None
+        self._tokens_loaded = False
+        # Background flow tasks — keep handles so we don't drop them
+        # (RUF006 lint catches asyncio-dangling-task).
+        self._tasks: set[asyncio.Task] = set()
+
+    # ── IntegrationBackend interface ────────────────────────────
+
+    @property
+    def name(self) -> str:
+        return "google-calendar"
+
+    @property
+    def display_name(self) -> str:
+        return "Google Calendar"
+
+    @property
+    def description(self) -> str:
+        return "Read and create events on your primary Google Calendar."
+
+    @property
+    def auth_kind(self) -> Literal["oauth-device", "static-token", "none"]:
+        return "oauth-device"
+
+    async def is_connected(self) -> bool:
+        await self._ensure_tokens_loaded()
+        return self._tokens is not None
+
+    async def start_connect(self, params: Optional[dict] = None) -> ConnectChallenge:
+        del params  # unused for OAuth device flow
+        try:
+            cfg = GoogleOAuthConfig.from_env(scopes=self._SCOPES)
+        except GoogleOAuthNotConfiguredError:
+            raise
+
+        request_id = uuid.uuid4().hex
+        flow = _DeviceFlow(request_id=request_id, cfg=cfg)
+        self._flows[request_id] = flow
+
+        # Kick off the device-code flow.  `start` returns the
+        # challenge synchronously; `poll_until_done` runs in a
+        # background task and parks the result on the flow object so
+        # `poll_status` can read it without re-issuing requests.
+        flow.challenge = await flow.start()
+        flow.poll_task = asyncio.create_task(self._run_flow(flow))
+        self._tasks.add(flow.poll_task)
+        flow.poll_task.add_done_callback(self._tasks.discard)
+
+        return ConnectChallenge(
+            kind="oauth-device",
+            request_id=request_id,
+            verification_url=(
+                flow.challenge.verification_url_complete
+                or flow.challenge.verification_url
+            ),
+            user_code=flow.challenge.user_code,
+            expires_in_s=flow.challenge.expires_in,
+            interval_s=flow.challenge.interval,
+        )
+
+    async def poll_status(self, request_id: str) -> ConnectionStatus:
+        flow = self._flows.get(request_id)
+        if flow is None:
+            return ConnectionStatus(
+                state="error",
+                request_id=request_id,
+                error="unknown request_id",
+            )
+        if flow.tokens is not None:
+            return ConnectionStatus(state="connected", request_id=request_id)
+        if flow.error is not None:
+            state = "expired" if flow.error.code == "expired_token" else "error"
+            return ConnectionStatus(
+                state=state,  # type: ignore[arg-type]
+                request_id=request_id,
+                error=flow.error.description,
+            )
+        return ConnectionStatus(state="connecting", request_id=request_id)
+
+    async def disconnect(self) -> None:
+        await self._ensure_tokens_loaded()
+        if self._tokens is not None and self._tokens.refresh_token:
+            # Best-effort revoke — delete local creds regardless.
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as session:
+                await revoke_google_token(self._tokens.refresh_token, session)
+        await self._store.delete()
+        self._tokens = None
+        self._tokens_loaded = True  # stays loaded (just empty)
+
+    async def health_check(self, timeout_s: float = 5.0) -> tuple[bool, str]:
+        await self._ensure_tokens_loaded()
+        if self._tokens is None:
+            return False, "not connected"
+        try:
+            events = await self._authed_get(
+                f"{CALENDAR_API_BASE}/calendars/primary",
+                timeout_s=timeout_s,
+            )
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            return False, f"{type(e).__name__}: {e}"[:120]
+        except DeviceCodeError as e:
+            return False, f"auth: {e.description[:120]}"
+        cal_id = events.get("id") if isinstance(events, dict) else None
+        return True, f"connected to {cal_id or 'primary calendar'}"
+
+    # ── Calendar-specific public API used by the tool wrappers ──
+
+    async def list_events(
+        self,
+        time_min: Optional[datetime] = None,
+        time_max: Optional[datetime] = None,
+        max_results: int = 10,
+    ) -> list[dict[str, Any]]:
+        """List events on the user's primary calendar between
+        `time_min` and `time_max`.  Defaults to "from now, no upper
+        bound, 10 results."
+
+        Returns a normalized list of event dicts:
+          {id, summary, location, start_iso, end_iso, all_day, attendees, hangout_link}
+        """
+        params = {
+            "singleEvents": "true",
+            "orderBy": "startTime",
+            "maxResults": str(max_results),
+        }
+        if time_min is not None:
+            params["timeMin"] = time_min.astimezone(timezone.utc).isoformat()
+        else:
+            params["timeMin"] = datetime.now(timezone.utc).isoformat()
+        if time_max is not None:
+            params["timeMax"] = time_max.astimezone(timezone.utc).isoformat()
+        raw = await self._authed_get(
+            f"{CALENDAR_API_BASE}/calendars/primary/events", params=params,
+        )
+        items = raw.get("items", []) if isinstance(raw, dict) else []
+        return [self._normalize_event(it) for it in items]
+
+    async def create_event(
+        self,
+        summary: str,
+        start: datetime,
+        end: datetime,
+        location: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Create an event on the primary calendar."""
+        body = {
+            "summary": summary,
+            "start": {"dateTime": start.astimezone(timezone.utc).isoformat()},
+            "end": {"dateTime": end.astimezone(timezone.utc).isoformat()},
+        }
+        if location:
+            body["location"] = location
+        if description:
+            body["description"] = description
+        raw = await self._authed_post(
+            f"{CALENDAR_API_BASE}/calendars/primary/events", body=body,
+        )
+        return self._normalize_event(raw)
+
+    async def cancel_event(self, event_id: str) -> bool:
+        """Delete an event from the primary calendar.  Returns True
+        on success."""
+        try:
+            await self._authed_delete(
+                f"{CALENDAR_API_BASE}/calendars/primary/events/{event_id}",
+            )
+        except aiohttp.ClientResponseError as e:
+            logger.warning("cancel_event %s failed: %s", event_id, e)
+            return False
+        return True
+
+    # ── Internals ───────────────────────────────────────────────
+
+    async def _run_flow(self, flow: "_DeviceFlow") -> None:
+        """Background coroutine: poll until tokens or terminal error,
+        then persist tokens to the store."""
+        try:
+            async with make_google_client(flow.cfg) as client:
+                tokens = await client.poll_until_done(flow.challenge)
+            await self._persist_tokens(tokens)
+            flow.tokens = tokens
+        except DeviceCodeError as e:
+            flow.error = e
+        except Exception as e:  # noqa: BLE001
+            flow.error = DeviceCodeError(
+                code="poll_failed",
+                description=f"{type(e).__name__}: {e}"[:120],
+            )
+
+    async def _persist_tokens(self, tokens: OAuthTokens) -> None:
+        await self._store.save({"tokens": tokens.to_dict()})
+        self._tokens = tokens
+        self._tokens_loaded = True
+
+    async def _ensure_tokens_loaded(self) -> None:
+        if self._tokens_loaded:
+            return
+        data = await self._store.load()
+        if data and "tokens" in data:
+            try:
+                self._tokens = OAuthTokens.from_dict(data["tokens"])
+            except (KeyError, ValueError, TypeError) as e:
+                logger.warning(
+                    "Stored Google Calendar tokens malformed (%s) — "
+                    "treating as disconnected.  User should reconnect.",
+                    e,
+                )
+                self._tokens = None
+        else:
+            self._tokens = None
+        self._tokens_loaded = True
+
+    async def _get_access_token(self) -> str:
+        """Return a valid access token, refreshing if necessary."""
+        await self._ensure_tokens_loaded()
+        if self._tokens is None:
+            raise DeviceCodeError(
+                code="not_connected",
+                description="Google Calendar is not connected.  Visit Tab5 "
+                "Settings → Integrations → Connect Google.",
+            )
+        if not self._tokens.is_expired():
+            return self._tokens.access_token
+        # Refresh.
+        if not self._tokens.refresh_token:
+            raise DeviceCodeError(
+                code="needs_reauth",
+                description="No refresh token — please reconnect Google.",
+            )
+        cfg = GoogleOAuthConfig.from_env(scopes=self._tokens.scopes or self._SCOPES)
+        async with make_google_client(cfg) as client:
+            new_tokens = await client.refresh(self._tokens.refresh_token)
+        await self._persist_tokens(new_tokens)
+        return new_tokens.access_token
+
+    async def _authed_get(
+        self,
+        url: str,
+        params: Optional[dict] = None,
+        timeout_s: float = 15.0,
+    ) -> Any:
+        token = await self._get_access_token()
+        timeout = aiohttp.ClientTimeout(total=timeout_s)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(
+                url,
+                params=params,
+                headers={"Authorization": f"Bearer {token}"},
+            ) as resp:
+                if resp.status == 401:
+                    # Token rejected — try one refresh, then retry once.
+                    await self._force_refresh()
+                    token = await self._get_access_token()
+                    async with session.get(
+                        url,
+                        params=params,
+                        headers={"Authorization": f"Bearer {token}"},
+                    ) as resp2:
+                        resp2.raise_for_status()
+                        return await resp2.json()
+                resp.raise_for_status()
+                return await resp.json()
+
+    async def _authed_post(self, url: str, body: dict) -> Any:
+        token = await self._get_access_token()
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=15),
+        ) as session:
+            async with session.post(
+                url,
+                json=body,
+                headers={"Authorization": f"Bearer {token}"},
+            ) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+
+    async def _authed_delete(self, url: str) -> None:
+        token = await self._get_access_token()
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=15),
+        ) as session:
+            async with session.delete(
+                url,
+                headers={"Authorization": f"Bearer {token}"},
+            ) as resp:
+                resp.raise_for_status()
+
+    async def _force_refresh(self) -> None:
+        """Force a refresh even if our cached `expires_at` says it's
+        still good.  Used when the API returned 401 unexpectedly."""
+        if self._tokens is None or not self._tokens.refresh_token:
+            return
+        # Set expiry to a past time so the next `_get_access_token`
+        # call triggers refresh.
+        self._tokens.expires_at = int(time.time()) - 1
+
+    @staticmethod
+    def _normalize_event(raw: dict) -> dict[str, Any]:
+        """Reduce Google's verbose event payload to what voice + chat
+        UIs actually need."""
+        start = raw.get("start", {})
+        end = raw.get("end", {})
+        all_day = "date" in start and "dateTime" not in start
+        return {
+            "id": raw.get("id"),
+            "summary": raw.get("summary", "(no title)"),
+            "location": raw.get("location"),
+            "start_iso": start.get("dateTime") or start.get("date"),
+            "end_iso": end.get("dateTime") or end.get("date"),
+            "all_day": all_day,
+            "attendees": [
+                a.get("email") for a in raw.get("attendees", [])
+                if isinstance(a, dict) and a.get("email")
+            ],
+            "hangout_link": raw.get("hangoutLink"),
+            "html_link": raw.get("htmlLink"),
+        }
+
+
+class _DeviceFlow:
+    """Internal: in-flight device-code flow state."""
+
+    __slots__ = ("request_id", "cfg", "challenge", "tokens", "error", "poll_task")
+
+    def __init__(self, *, request_id: str, cfg: GoogleOAuthConfig) -> None:
+        self.request_id = request_id
+        self.cfg = cfg
+        self.challenge: Optional[Any] = None  # DeviceCodeChallenge
+        self.tokens: Optional[OAuthTokens] = None
+        self.error: Optional[DeviceCodeError] = None
+        self.poll_task: Optional[asyncio.Task] = None
+
+    async def start(self):  # noqa: ANN201
+        """Kick off the device-code endpoint call.  Returns the
+        challenge that becomes the `verification_url` + `user_code`
+        Tab5 will render."""
+        async with make_google_client(self.cfg) as client:
+            return await client.start()
+
+
+def helpful_relative_time(target: datetime, now: Optional[datetime] = None) -> str:
+    """"in 2 hours" / "yesterday" / "next Tuesday at 9am" — used by the
+    tool wrappers to phrase replies naturally for TTS.
+
+    Kept small + deterministic; for richer phrasing the LLM can
+    rewrite the tool result before speaking."""
+    now = now or datetime.now(timezone.utc)
+    target = target.astimezone(timezone.utc)
+    delta = target - now
+    if delta < timedelta(0):
+        delta = -delta
+        direction = "ago"
+    else:
+        direction = "from now"
+    secs = int(delta.total_seconds())
+    if secs < 60:
+        return f"{secs} seconds {direction}"
+    if secs < 3600:
+        return f"{secs // 60} minutes {direction}"
+    if secs < 86400:
+        return f"{secs // 3600} hours {direction}"
+    return f"{secs // 86400} days {direction}"

--- a/dragon_voice/tools/integrations/oauth.py
+++ b/dragon_voice/tools/integrations/oauth.py
@@ -1,0 +1,298 @@
+"""OAuth 2.0 Device Authorization Grant (RFC 8628) client (#341).
+
+Dragon runs headless — there's no browser, no local web server with a
+redirect URI for the standard OAuth code flow.  The device
+authorization grant is designed exactly for this case:
+
+  1. Client (Dragon) hits the provider's device-code endpoint, gets
+     back a `device_code`, a `user_code`, and a `verification_url`.
+  2. Dragon shows the user the URL + code (Tab5 renders as QR).
+  3. User completes the OAuth dance on their phone.
+  4. Dragon polls the token endpoint with `device_code` until the
+     provider returns access + refresh tokens.
+
+Supported by Google, Spotify, GitHub, and many others.
+
+This module is provider-agnostic — provider-specific bits
+(client_id, scopes, endpoint URLs) are passed in.  See
+``google/auth.py`` for the Google-specific wrapper.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+class DeviceCodeError(Exception):
+    """Raised when the device-code flow fails terminally.
+
+    Distinct from `aiohttp.ClientError` so callers can catch only the
+    flow-specific errors (`expired_token`, `access_denied`, etc.).
+    """
+
+    def __init__(self, code: str, description: str) -> None:
+        self.code = code
+        self.description = description
+        super().__init__(f"{code}: {description}")
+
+
+@dataclass
+class DeviceCodeChallenge:
+    """The triple returned by the device-code endpoint.
+
+    All fields per RFC 8628 §3.2.  `interval` is the recommended poll
+    interval (seconds); providers can ask the client to back off by
+    returning `slow_down` from the token endpoint, but we honor the
+    initial `interval` unless slow_down arrives.
+    """
+
+    device_code: str
+    user_code: str
+    verification_url: str
+    expires_in: int
+    interval: int = 5
+    # Some providers (Google) also return verification_url_complete
+    # which embeds the user_code as a query param — convenient for QR.
+    verification_url_complete: Optional[str] = None
+
+
+@dataclass
+class OAuthTokens:
+    """Token bundle returned by the token endpoint.
+
+    `expires_at` is an absolute unix timestamp so refresh logic doesn't
+    need to track issue time separately.  `refresh_token` may be None
+    if the provider doesn't issue one (rare for device flow).  `scopes`
+    is the granted scope set returned by the provider — may differ from
+    requested if the user denied some scopes.
+    """
+
+    access_token: str
+    refresh_token: Optional[str]
+    token_type: str
+    expires_at: int  # absolute unix timestamp
+    scopes: list[str]
+    extra: dict = None  # type: ignore[assignment]
+
+    def is_expired(self, skew_s: int = 60) -> bool:
+        """Treat the token as expired `skew_s` seconds before its
+        actual expiry to avoid in-flight 401s during a refresh window.
+        """
+        return time.time() + skew_s >= self.expires_at
+
+    def to_dict(self) -> dict:
+        return {
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+            "token_type": self.token_type,
+            "expires_at": self.expires_at,
+            "scopes": self.scopes,
+            "extra": self.extra or {},
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "OAuthTokens":
+        return cls(
+            access_token=data["access_token"],
+            refresh_token=data.get("refresh_token"),
+            token_type=data.get("token_type", "Bearer"),
+            expires_at=int(data["expires_at"]),
+            scopes=list(data.get("scopes", [])),
+            extra=dict(data.get("extra", {})),
+        )
+
+
+class OAuthDeviceCodeClient:
+    """Provider-agnostic device-code OAuth client.
+
+    One instance per provider (Google, Spotify, etc.) — the
+    `client_id`, `scope`, `device_code_url`, and `token_url` are
+    provider-specific.  `client_secret` is optional (Google's device
+    flow uses a client secret, Spotify's doesn't).
+    """
+
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        scope: str,
+        device_code_url: str,
+        token_url: str,
+        client_secret: Optional[str] = None,
+        session: Optional[aiohttp.ClientSession] = None,
+    ) -> None:
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._scope = scope
+        self._device_code_url = device_code_url
+        self._token_url = token_url
+        self._session = session
+        self._owns_session = session is None
+
+    async def __aenter__(self) -> "OAuthDeviceCodeClient":
+        if self._session is None:
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=30),
+            )
+            self._owns_session = True
+        return self
+
+    async def __aexit__(self, *exc_info) -> None:  # noqa: ANN001
+        if self._owns_session and self._session is not None and not self._session.closed:
+            await self._session.close()
+
+    async def start(self) -> DeviceCodeChallenge:
+        """POST to the device-code endpoint, return the challenge.
+
+        Raises DeviceCodeError when the provider returns a non-2xx
+        response with a structured error body (rare at this stage —
+        usually only happens if the `client_id` is invalid).
+        """
+        assert self._session is not None, "Use 'async with OAuthDeviceCodeClient(...)'"
+        payload = {"client_id": self._client_id, "scope": self._scope}
+        async with self._session.post(self._device_code_url, data=payload) as resp:
+            data = await resp.json()
+            if resp.status != 200:
+                raise DeviceCodeError(
+                    code=data.get("error", "unknown_error"),
+                    description=data.get(
+                        "error_description", "Failed to start device-code flow",
+                    ),
+                )
+        return DeviceCodeChallenge(
+            device_code=data["device_code"],
+            user_code=data["user_code"],
+            verification_url=data["verification_url"],
+            verification_url_complete=data.get("verification_url_complete"),
+            expires_in=int(data.get("expires_in", 1800)),
+            interval=int(data.get("interval", 5)),
+        )
+
+    async def poll_once(self, device_code: str) -> Optional[OAuthTokens]:
+        """One poll of the token endpoint.
+
+        Returns:
+            * `OAuthTokens` — flow completed, user authorized.
+            * `None` — still pending (RFC 8628 `authorization_pending`
+              or `slow_down`).  Caller should sleep and try again.
+
+        Raises:
+            DeviceCodeError — terminal failure (`expired_token`,
+            `access_denied`, etc.).  Caller stops polling.
+        """
+        assert self._session is not None, "Use 'async with OAuthDeviceCodeClient(...)'"
+        payload = {
+            "client_id": self._client_id,
+            "device_code": device_code,
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+        }
+        if self._client_secret:
+            payload["client_secret"] = self._client_secret
+
+        async with self._session.post(self._token_url, data=payload) as resp:
+            data = await resp.json()
+            if resp.status == 200:
+                return self._tokens_from_response(data)
+            err = data.get("error", "")
+            if err in ("authorization_pending", "slow_down"):
+                # Not done yet.
+                return None
+            raise DeviceCodeError(
+                code=err or "unknown_error",
+                description=data.get(
+                    "error_description", "Device-code poll failed"
+                ),
+            )
+
+    async def poll_until_done(
+        self,
+        challenge: DeviceCodeChallenge,
+        cancel_event: Optional[asyncio.Event] = None,
+    ) -> OAuthTokens:
+        """Convenience: poll on `challenge.interval` until terminal.
+
+        Honors `expires_in` from the challenge — raises
+        ``DeviceCodeError("expired_token", ...)`` when the device-code
+        TTL is up.  Cancel via `cancel_event` (Tab5 closing the modal).
+        """
+        deadline = time.time() + challenge.expires_in
+        interval = challenge.interval
+        while True:
+            if cancel_event and cancel_event.is_set():
+                raise DeviceCodeError("cancelled", "user cancelled flow")
+            if time.time() >= deadline:
+                raise DeviceCodeError(
+                    "expired_token", "device-code expired before user completed flow"
+                )
+            try:
+                tokens = await self.poll_once(challenge.device_code)
+            except DeviceCodeError as e:
+                if e.code == "slow_down":
+                    # Provider asked us to back off; bump interval.
+                    interval += 5
+                    await asyncio.sleep(interval)
+                    continue
+                # Anything else is terminal.
+                raise
+            if tokens is not None:
+                return tokens
+            await asyncio.sleep(interval)
+
+    async def refresh(self, refresh_token: str) -> OAuthTokens:
+        """Exchange a refresh token for a new access token.
+
+        Raises DeviceCodeError on terminal failure (refresh token
+        revoked / expired — user has to reconnect).
+        """
+        assert self._session is not None, "Use 'async with OAuthDeviceCodeClient(...)'"
+        payload = {
+            "client_id": self._client_id,
+            "refresh_token": refresh_token,
+            "grant_type": "refresh_token",
+        }
+        if self._client_secret:
+            payload["client_secret"] = self._client_secret
+
+        async with self._session.post(self._token_url, data=payload) as resp:
+            data = await resp.json()
+            if resp.status != 200:
+                raise DeviceCodeError(
+                    code=data.get("error", "refresh_failed"),
+                    description=data.get(
+                        "error_description", "Refresh token rejected"
+                    ),
+                )
+        # Refresh responses may omit `refresh_token` — providers expect
+        # the client to reuse the old one.
+        tokens = self._tokens_from_response(data)
+        if not tokens.refresh_token:
+            tokens.refresh_token = refresh_token
+        return tokens
+
+    @staticmethod
+    def _tokens_from_response(data: dict) -> OAuthTokens:
+        expires_in = int(data.get("expires_in", 3600))
+        scope_str = data.get("scope", "")
+        scopes = scope_str.split() if scope_str else []
+        return OAuthTokens(
+            access_token=data["access_token"],
+            refresh_token=data.get("refresh_token"),
+            token_type=data.get("token_type", "Bearer"),
+            expires_at=int(time.time()) + expires_in,
+            scopes=scopes,
+            extra={
+                k: v for k, v in data.items()
+                if k not in {
+                    "access_token", "refresh_token", "token_type",
+                    "expires_in", "scope",
+                }
+            },
+        )

--- a/dragon_voice/tools/integrations/registry.py
+++ b/dragon_voice/tools/integrations/registry.py
@@ -1,0 +1,87 @@
+"""Integration registry — decorator-driven plugin surface (#341).
+
+Mirrors the TTS registry pattern from PR #339.  Adding a new
+integration (e.g. ``OutlookCalendarIntegration``) is a one-decorator
+drop-in:
+
+    @register_integration("outlook-calendar")
+    class OutlookCalendarIntegration(IntegrationBackend): ...
+
+Then add the side-effect import to
+``dragon_voice/tools/integrations/__init__.py`` so the decorator runs
+on package load.
+
+The registry intentionally stores **classes**, not instances — callers
+construct the instance at use time, passing any needed deps (e.g. an
+aiohttp session).
+"""
+
+from __future__ import annotations
+
+from typing import Callable, TypeVar
+
+from dragon_voice.tools.integrations.base import IntegrationBackend
+
+_T = TypeVar("_T", bound=type[IntegrationBackend])
+
+_REGISTRY: dict[str, type[IntegrationBackend]] = {}
+
+
+def register_integration(name: str) -> Callable[[_T], _T]:
+    """Decorator: register an IntegrationBackend subclass under `name`.
+
+    Names are lower-cased on registration and lookup so config values
+    match case-insensitively.  Re-registering the same name silently
+    overrides (lets tests patch in a fake).  TypeError raised at import
+    time if applied to a non-subclass — fails-fast.
+    """
+    key = name.strip().lower()
+    if not key:
+        raise ValueError("register_integration: name must be non-empty")
+
+    def _decorator(cls: _T) -> _T:
+        if not isinstance(cls, type) or not issubclass(cls, IntegrationBackend):
+            raise TypeError(
+                f"register_integration('{key}') applied to {cls!r}, which is "
+                f"not an IntegrationBackend subclass."
+            )
+        _REGISTRY[key] = cls
+        return cls
+
+    return _decorator
+
+
+def get_integration_class(name: str) -> type[IntegrationBackend]:
+    """Look up a registered integration class.  Raises KeyError with
+    the full list of registered names in the message if `name` is
+    unknown."""
+    key = (name or "").strip().lower()
+    if key not in _REGISTRY:
+        available = ", ".join(sorted(_REGISTRY.keys())) or "(none)"
+        raise KeyError(
+            f"Unknown integration '{name}'. Available: {available}"
+        )
+    return _REGISTRY[key]
+
+
+def create_integration(name: str) -> IntegrationBackend:
+    """Instantiate a registered integration by name.  No constructor
+    args supported here — for integrations with config deps, look up
+    the class via `get_integration_class` and instantiate explicitly.
+    """
+    cls = get_integration_class(name)
+    return cls()
+
+
+def list_integrations() -> list[str]:
+    """Return registered integration names, alphabetically sorted."""
+    return sorted(_REGISTRY.keys())
+
+
+def is_registered(name: str) -> bool:
+    return (name or "").strip().lower() in _REGISTRY
+
+
+def _reset_for_tests() -> None:
+    """Clear the registry — only used by unit tests."""
+    _REGISTRY.clear()

--- a/tests/test_google_calendar_integration.py
+++ b/tests/test_google_calendar_integration.py
@@ -1,0 +1,234 @@
+"""#341 / #342 — Google Calendar integration tests.
+
+Stubs the Google OAuth + Calendar API via aiohttp session mocks.
+Asserts:
+  * `is_connected` is False initially, True after token persist
+  * `start_connect` returns a verification_url + user_code from the
+    mocked device-code endpoint
+  * `list_events` builds the right URL + params, normalizes payload
+  * `create_event` + `cancel_event` round-trip
+  * `disconnect` calls revoke + deletes creds
+  * Expired access token triggers refresh-on-401
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dragon_voice.tools.integrations.credentials import CredentialStore
+from dragon_voice.tools.integrations.google.calendar import (
+    GoogleCalendarIntegration,
+)
+from dragon_voice.tools.integrations.oauth import OAuthTokens
+
+
+@pytest.fixture(autouse=True)
+def _redirect_cred_store(tmp_path, monkeypatch):
+    """Make all CredentialStore writes land in a per-test tmp dir."""
+    monkeypatch.setenv("TINKERCLAW_INTEGRATIONS_DIR", str(tmp_path))
+
+
+@pytest.fixture
+def integration(tmp_path):
+    integ = GoogleCalendarIntegration()
+    # Replace the store with an explicit tmp_path-backed one to make
+    # the redirect deterministic even if env-var lookup races.
+    integ._store = CredentialStore("google-calendar", base_dir=tmp_path)
+    return integ
+
+
+@pytest.fixture
+def valid_tokens():
+    return OAuthTokens(
+        access_token="AT-fresh",
+        refresh_token="RT-1",
+        token_type="Bearer",
+        expires_at=int(time.time()) + 3600,
+        scopes=[
+            "https://www.googleapis.com/auth/calendar.readonly",
+            "https://www.googleapis.com/auth/calendar.events",
+        ],
+    )
+
+
+def _make_mock_response(json_data, status=200):
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=MagicMock(
+        status=status,
+        json=AsyncMock(return_value=json_data),
+        raise_for_status=MagicMock(),
+    ))
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return cm
+
+
+@pytest.mark.asyncio
+async def test_initial_state_is_disconnected(integration):
+    assert await integration.is_connected() is False
+
+
+@pytest.mark.asyncio
+async def test_is_connected_true_after_persist(integration, valid_tokens):
+    await integration._persist_tokens(valid_tokens)
+    assert await integration.is_connected() is True
+
+
+@pytest.mark.asyncio
+async def test_start_connect_requires_oauth_env(integration, monkeypatch):
+    """No GOOGLE_OAUTH_CLIENT_ID → raises a structured error so the
+    REST layer can surface a 503 + actionable message."""
+    monkeypatch.delenv("GOOGLE_OAUTH_CLIENT_ID", raising=False)
+    from dragon_voice.tools.integrations.google.auth import (
+        GoogleOAuthNotConfiguredError,
+    )
+    with pytest.raises(GoogleOAuthNotConfiguredError):
+        await integration.start_connect()
+
+
+@pytest.mark.asyncio
+async def test_health_check_returns_false_when_disconnected(integration):
+    ok, detail = await integration.health_check()
+    assert ok is False
+    assert "not connected" in detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_list_events_returns_normalized_shape(integration, valid_tokens):
+    """The Calendar API returns verbose payloads — we normalize down
+    to {id, summary, location, start_iso, end_iso, all_day, ...}."""
+    await integration._persist_tokens(valid_tokens)
+
+    fake_session = MagicMock()
+    fake_session.closed = False
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=None)
+    fake_session.get = MagicMock(return_value=_make_mock_response({
+        "items": [
+            {
+                "id": "evt-1",
+                "summary": "Dentist",
+                "location": "Geneva",
+                "start": {"dateTime": "2026-05-17T14:00:00Z"},
+                "end": {"dateTime": "2026-05-17T15:00:00Z"},
+            },
+            {
+                "id": "evt-2",
+                "summary": "Conference",
+                "start": {"date": "2026-05-18"},
+                "end": {"date": "2026-05-19"},
+            },
+        ],
+    }))
+
+    with patch(
+        "dragon_voice.tools.integrations.google.calendar.aiohttp.ClientSession",
+        return_value=fake_session,
+    ):
+        events = await integration.list_events()
+
+    assert len(events) == 2
+    assert events[0]["id"] == "evt-1"
+    assert events[0]["summary"] == "Dentist"
+    assert events[0]["location"] == "Geneva"
+    assert events[0]["all_day"] is False
+    assert events[1]["all_day"] is True
+    assert events[1]["start_iso"] == "2026-05-18"
+
+
+@pytest.mark.asyncio
+async def test_create_event_posts_with_auth_header(integration, valid_tokens):
+    await integration._persist_tokens(valid_tokens)
+
+    fake_session = MagicMock()
+    fake_session.closed = False
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=None)
+    fake_session.post = MagicMock(return_value=_make_mock_response({
+        "id": "evt-new",
+        "summary": "Lunch",
+        "start": {"dateTime": "2026-05-17T12:00:00Z"},
+        "end": {"dateTime": "2026-05-17T13:00:00Z"},
+    }))
+
+    with patch(
+        "dragon_voice.tools.integrations.google.calendar.aiohttp.ClientSession",
+        return_value=fake_session,
+    ):
+        ev = await integration.create_event(
+            summary="Lunch",
+            start=datetime(2026, 5, 17, 12, 0, tzinfo=timezone.utc),
+            end=datetime(2026, 5, 17, 13, 0, tzinfo=timezone.utc),
+        )
+
+    assert ev["id"] == "evt-new"
+    assert ev["summary"] == "Lunch"
+    # Verify the POST was authed.
+    call_kwargs = fake_session.post.call_args.kwargs
+    assert call_kwargs["headers"]["Authorization"] == "Bearer AT-fresh"
+
+
+@pytest.mark.asyncio
+async def test_disconnect_clears_creds(integration, valid_tokens):
+    await integration._persist_tokens(valid_tokens)
+    assert await integration.is_connected()
+
+    # Mock the revoke endpoint as a no-op success.
+    fake_session = MagicMock()
+    fake_session.closed = False
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=None)
+    fake_session.post = MagicMock(return_value=_make_mock_response({}, status=200))
+
+    with patch(
+        "dragon_voice.tools.integrations.google.calendar.aiohttp.ClientSession",
+        return_value=fake_session,
+    ):
+        await integration.disconnect()
+
+    assert await integration.is_connected() is False
+    assert not await integration._store.exists()
+
+
+@pytest.mark.asyncio
+async def test_expired_token_triggers_refresh(integration, monkeypatch):
+    """When the cached `expires_at` is past, `_get_access_token` must
+    refresh via the OAuth client before returning the new access token."""
+    expired = OAuthTokens(
+        access_token="AT-OLD",
+        refresh_token="RT-1",
+        token_type="Bearer",
+        expires_at=int(time.time()) - 10,  # already expired
+        scopes=["https://www.googleapis.com/auth/calendar.readonly"],
+    )
+    await integration._persist_tokens(expired)
+
+    # Mock GoogleOAuthConfig.from_env to skip env-var check.
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "csec")
+
+    new_tokens = OAuthTokens(
+        access_token="AT-NEW",
+        refresh_token="RT-1",
+        token_type="Bearer",
+        expires_at=int(time.time()) + 3600,
+        scopes=["https://www.googleapis.com/auth/calendar.readonly"],
+    )
+
+    refresh_mock = AsyncMock(return_value=new_tokens)
+    fake_client = MagicMock()
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+    fake_client.refresh = refresh_mock
+
+    with patch(
+        "dragon_voice.tools.integrations.google.calendar.make_google_client",
+        return_value=fake_client,
+    ):
+        token = await integration._get_access_token()
+
+    assert token == "AT-NEW"
+    refresh_mock.assert_awaited_once_with("RT-1")

--- a/tests/test_integrations_credentials.py
+++ b/tests/test_integrations_credentials.py
@@ -1,0 +1,103 @@
+"""#341 / #342 — CredentialStore: atomic JSON cred file with 0o600 mode."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+
+import pytest
+
+from dragon_voice.tools.integrations.credentials import CredentialStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return CredentialStore("test-integration", base_dir=tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_load_returns_none_when_file_missing(store):
+    assert (await store.load()) is None
+    assert not (await store.exists())
+
+
+@pytest.mark.asyncio
+async def test_save_then_load_roundtrip(store):
+    payload = {"access_token": "abc", "refresh_token": "xyz", "expires_at": 12345}
+    await store.save(payload)
+    assert await store.exists()
+    loaded = await store.load()
+    assert loaded == payload
+
+
+@pytest.mark.asyncio
+async def test_save_writes_mode_0600(store):
+    await store.save({"token": "x"})
+    mode = stat.S_IMODE(os.stat(store.path).st_mode)
+    assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+
+
+@pytest.mark.asyncio
+async def test_save_creates_parent_dir(tmp_path):
+    nested = tmp_path / "deep" / "nest"
+    store = CredentialStore("nested-test", base_dir=nested)
+    await store.save({"k": "v"})
+    assert nested.exists()
+    # Parent dir 0o700 — owner-only.
+    mode = stat.S_IMODE(os.stat(nested).st_mode)
+    assert mode == 0o700
+
+
+@pytest.mark.asyncio
+async def test_corrupt_file_treated_as_missing(store, caplog):
+    store.path.parent.mkdir(parents=True, exist_ok=True)
+    store.path.write_text("not valid JSON {{{", encoding="utf-8")
+    with caplog.at_level("WARNING"):
+        result = await store.load()
+    assert result is None
+    assert any("corrupt JSON" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_non_object_file_treated_as_missing(store):
+    store.path.parent.mkdir(parents=True, exist_ok=True)
+    store.path.write_text("[1, 2, 3]", encoding="utf-8")
+    assert (await store.load()) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_file(store):
+    await store.save({"k": "v"})
+    assert await store.exists()
+    await store.delete()
+    assert not await store.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_idempotent(store):
+    await store.delete()  # no-op when missing
+    assert not await store.exists()
+
+
+@pytest.mark.asyncio
+async def test_atomic_write_no_partial_on_failure(store, monkeypatch):
+    """If json.dump crashes mid-write, the original file (if any) is
+    intact because we write to a temp first then os.replace."""
+    await store.save({"v": 1})
+    # First read confirms baseline.
+    assert (await store.load()) == {"v": 1}
+
+    # Force json.dump to raise so the write fails after temp open.
+    real_dump = json.dump
+
+    def broken_dump(*a, **kw):
+        raise RuntimeError("simulated disk full")
+
+    monkeypatch.setattr(json, "dump", broken_dump)
+    with pytest.raises(RuntimeError):
+        await store.save({"v": 2})
+
+    monkeypatch.setattr(json, "dump", real_dump)
+    # Original payload still intact — temp file never got swapped in.
+    assert (await store.load()) == {"v": 1}

--- a/tests/test_integrations_registry.py
+++ b/tests/test_integrations_registry.py
@@ -1,0 +1,78 @@
+"""#341 / #342 — IntegrationBackend ABC + registry decorator behavior.
+
+Mirrors the shape of `tests/test_tts_registry.py` since the
+registry is intentionally the same pattern.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dragon_voice.tools.integrations import (
+    IntegrationBackend,
+    create_integration,
+    get_integration_class,
+    is_registered,
+    list_integrations,
+    register_integration,
+)
+from dragon_voice.tools.integrations.registry import _REGISTRY, _reset_for_tests
+
+
+def test_google_calendar_registered_on_import():
+    """Side-effect import in __init__.py must register the bundled
+    integrations on package load."""
+    assert "google-calendar" in list_integrations()
+    cls = get_integration_class("google-calendar")
+    assert issubclass(cls, IntegrationBackend)
+
+
+def test_decorator_rejects_non_subclass():
+    with pytest.raises(TypeError, match="not an IntegrationBackend"):
+
+        @register_integration("bogus-not-an-integration")
+        class NotAnIntegration:
+            pass
+
+    assert not is_registered("bogus-not-an-integration")
+
+
+def test_decorator_requires_nonempty_name():
+    with pytest.raises(ValueError):
+        register_integration("")
+    with pytest.raises(ValueError):
+        register_integration("   ")
+
+
+def test_lookup_is_case_insensitive():
+    assert is_registered("Google-Calendar")
+    assert is_registered("GOOGLE-CALENDAR")
+    assert is_registered("google-calendar")
+
+
+def test_get_unknown_raises_with_available_list():
+    with pytest.raises(KeyError) as excinfo:
+        get_integration_class("does-not-exist")
+    assert "does-not-exist" in str(excinfo.value)
+    assert "google-calendar" in str(excinfo.value).lower()
+
+
+def test_create_integration_returns_instance():
+    integ = create_integration("google-calendar")
+    assert isinstance(integ, IntegrationBackend)
+    assert integ.name == "google-calendar"
+    assert integ.display_name == "Google Calendar"
+    assert integ.auth_kind == "oauth-device"
+
+
+def test_reset_clears_then_restores_from_snapshot():
+    """The reset helper used by tests must allow restoring after."""
+    snapshot = dict(_REGISTRY)
+    try:
+        _reset_for_tests()
+        assert list_integrations() == []
+        with pytest.raises(KeyError):
+            get_integration_class("google-calendar")
+    finally:
+        _REGISTRY.update(snapshot)
+    assert "google-calendar" in list_integrations()

--- a/tests/test_oauth_device_code.py
+++ b/tests/test_oauth_device_code.py
@@ -1,0 +1,205 @@
+"""#341 / #342 — OAuth Device Authorization Grant client.
+
+Uses aioresponses to mock the device-code + token endpoints.  Verifies
+the full flow:
+
+  1. POST device-code endpoint returns the challenge.
+  2. First poll returns `authorization_pending` (200 with error body
+     OR per RFC, 400 with structured error).
+  3. Second poll returns tokens.
+  4. `expires_in` is converted to absolute `expires_at`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dragon_voice.tools.integrations.oauth import (
+    DeviceCodeChallenge,
+    DeviceCodeError,
+    OAuthDeviceCodeClient,
+    OAuthTokens,
+)
+
+
+@pytest.fixture
+def fake_session():
+    """Stand-in aiohttp ClientSession that records POSTs + returns
+    pre-canned responses."""
+    session = MagicMock()
+    session.closed = False
+    return session
+
+
+def _mock_response(json_data: dict, status: int = 200):
+    """Context-manager-shaped mock matching aiohttp.ClientSession.post()."""
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=MagicMock(
+        status=status,
+        json=AsyncMock(return_value=json_data),
+    ))
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return cm
+
+
+@pytest.mark.asyncio
+async def test_start_returns_challenge(fake_session):
+    fake_session.post = MagicMock(return_value=_mock_response({
+        "device_code": "DEV-CODE-1",
+        "user_code": "ABC-123",
+        "verification_url": "https://example.com/device",
+        "verification_url_complete": "https://example.com/device?code=ABC-123",
+        "expires_in": 1800,
+        "interval": 5,
+    }))
+    client = OAuthDeviceCodeClient(
+        client_id="cid",
+        scope="scope-x",
+        device_code_url="https://oauth.example.com/device",
+        token_url="https://oauth.example.com/token",
+        session=fake_session,
+    )
+    chal = await client.start()
+    assert chal.device_code == "DEV-CODE-1"
+    assert chal.user_code == "ABC-123"
+    assert chal.verification_url_complete is not None
+    assert chal.expires_in == 1800
+    assert chal.interval == 5
+
+
+@pytest.mark.asyncio
+async def test_poll_once_pending_returns_none(fake_session):
+    fake_session.post = MagicMock(return_value=_mock_response(
+        {"error": "authorization_pending"}, status=428,
+    ))
+    client = OAuthDeviceCodeClient(
+        client_id="cid", scope="s",
+        device_code_url="https://x", token_url="https://x",
+        session=fake_session,
+    )
+    result = await client.poll_once("DEV-CODE-1")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_poll_once_success_returns_tokens(fake_session):
+    fake_session.post = MagicMock(return_value=_mock_response({
+        "access_token": "AT-1",
+        "refresh_token": "RT-1",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "scope": "scope-a scope-b",
+    }))
+    client = OAuthDeviceCodeClient(
+        client_id="cid", scope="s",
+        device_code_url="https://x", token_url="https://x",
+        session=fake_session,
+    )
+    t0 = time.time()
+    tokens = await client.poll_once("DEV-CODE-1")
+    assert tokens is not None
+    assert tokens.access_token == "AT-1"
+    assert tokens.refresh_token == "RT-1"
+    assert tokens.token_type == "Bearer"
+    assert tokens.expires_at >= t0 + 3500
+    assert tokens.scopes == ["scope-a", "scope-b"]
+
+
+@pytest.mark.asyncio
+async def test_poll_once_terminal_error_raises(fake_session):
+    fake_session.post = MagicMock(return_value=_mock_response({
+        "error": "access_denied",
+        "error_description": "user said no",
+    }, status=400))
+    client = OAuthDeviceCodeClient(
+        client_id="cid", scope="s",
+        device_code_url="https://x", token_url="https://x",
+        session=fake_session,
+    )
+    with pytest.raises(DeviceCodeError) as excinfo:
+        await client.poll_once("DEV-CODE-1")
+    assert excinfo.value.code == "access_denied"
+
+
+@pytest.mark.asyncio
+async def test_refresh_returns_new_tokens(fake_session):
+    fake_session.post = MagicMock(return_value=_mock_response({
+        "access_token": "AT-2",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "scope": "s",
+        # NOTE: no refresh_token in response — provider expects client
+        # to reuse the old one.
+    }))
+    client = OAuthDeviceCodeClient(
+        client_id="cid", scope="s",
+        device_code_url="https://x", token_url="https://x",
+        session=fake_session,
+    )
+    new_tokens = await client.refresh("RT-OLD")
+    assert new_tokens.access_token == "AT-2"
+    # Refresh-token-preservation invariant.
+    assert new_tokens.refresh_token == "RT-OLD"
+
+
+def test_is_expired_with_skew():
+    t = OAuthTokens(
+        access_token="x", refresh_token=None, token_type="Bearer",
+        expires_at=int(time.time()) + 30, scopes=[],
+    )
+    # 60s skew window → 30s remaining counts as expired.
+    assert t.is_expired(skew_s=60)
+    # 10s skew → not yet expired.
+    assert not t.is_expired(skew_s=10)
+
+
+def test_oauth_tokens_serialization_roundtrip():
+    original = OAuthTokens(
+        access_token="AT",
+        refresh_token="RT",
+        token_type="Bearer",
+        expires_at=1234567890,
+        scopes=["a", "b"],
+        extra={"id_token": "jwt..."},
+    )
+    revived = OAuthTokens.from_dict(original.to_dict())
+    assert revived.access_token == original.access_token
+    assert revived.refresh_token == original.refresh_token
+    assert revived.expires_at == original.expires_at
+    assert revived.scopes == original.scopes
+    assert revived.extra == original.extra
+
+
+@pytest.mark.asyncio
+async def test_poll_until_done_loops_until_success(fake_session, monkeypatch):
+    """Verify the convenience loop: pending → pending → success."""
+    responses = [
+        _mock_response({"error": "authorization_pending"}, status=428),
+        _mock_response({"error": "authorization_pending"}, status=428),
+        _mock_response({
+            "access_token": "AT", "refresh_token": "RT",
+            "token_type": "Bearer", "expires_in": 3600, "scope": "s",
+        }),
+    ]
+    fake_session.post = MagicMock(side_effect=responses)
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())  # don't actually sleep
+
+    chal = DeviceCodeChallenge(
+        device_code="DC",
+        user_code="UC",
+        verification_url="https://x",
+        expires_in=1800,
+        interval=1,  # cuts the poll budget
+    )
+    client = OAuthDeviceCodeClient(
+        client_id="cid", scope="s",
+        device_code_url="https://x", token_url="https://x",
+        session=fake_session,
+    )
+    tokens = await client.poll_until_done(chal)
+    assert tokens.access_token == "AT"
+    assert tokens.refresh_token == "RT"


### PR DESCRIPTION
## Summary

Closes #342.  Refs program tracking #341.

First phase of the TinkerBox-native integrations program (see [PLAN-tinkerbox-integrations.md](../blob/main/docs/PLAN-tinkerbox-integrations.md)).  Ships the per-process plugin layer + Google Calendar as the proof-of-concept integration so vmodes 0/1/2 can be agentic without OpenClaw.

## What's in

| Layer | Module | LOC |
|-------|--------|-----|
| ABC | `dragon_voice/tools/integrations/base.py` | ~150 |
| Registry | `dragon_voice/tools/integrations/registry.py` | ~80 |
| Cred store | `dragon_voice/tools/integrations/credentials.py` | ~120 |
| OAuth device-code | `dragon_voice/tools/integrations/oauth.py` | ~220 |
| Google auth (shared) | `dragon_voice/tools/integrations/google/auth.py` | ~100 |
| Google Calendar | `dragon_voice/tools/integrations/google/calendar.py` | ~320 |
| Tool wrappers | `dragon_voice/tools/google_calendar_tool.py` | ~220 |
| REST routes | `dragon_voice/api/integrations.py` | ~180 |
| `api/__init__.py` | 1 import + 1 register line | +6 |
| **Tests** | 4 new files, **32 tests pass** | ~580 |

## How it works

1. Tab5 hits `POST /api/v1/integrations/google-calendar/connect`
2. Dragon calls Google's device-code endpoint → returns `verification_url` + `user_code` + `request_id`
3. Tab5 displays QR + code; user authorizes on phone
4. Tab5 polls `GET /api/v1/integrations/google-calendar/status/{request_id}` every ~2s
5. Background poll task on Dragon hits Google's token endpoint until success → persists `OAuthTokens` to `~/.tinkerclaw/integrations/google-calendar.json` (mode 0o600)
6. `calendar_today` / `calendar_week` / `calendar_create` / `calendar_cancel` tools now work in any vmode

## Setup

Operators enable Google integrations by:
1. https://console.cloud.google.com/ → APIs & Services → Credentials → OAuth client ID type "TVs and Limited Input"
2. Enable Google Calendar API on the same project
3. `GOOGLE_OAUTH_CLIENT_ID` + `GOOGLE_OAUTH_CLIENT_SECRET` in Dragon's `/home/radxa/.env`
4. Restart `tinkerclaw-voice`

If env vars are missing, `POST /connect` returns a 503 with `error: "oauth_not_configured"` and an actionable message — Tab5 surfaces this in the connect modal.

## Out of scope (deferred to follow-up PRs)

- **Gmail** (Phase 2 — reuses Google auth from this PR)
- **Tab5 Settings → Integrations UI** ([TinkerTab #571](../../TinkerTab/issues/571))
- **`tinkerbox-mcp` server for vmode=3 cross-exposure** (Phase 1.5)
- **Auto-register the four calendar tools in `ToolRegistry`** — caller currently must explicitly register; ConvEngine wiring lands when the W4 tool-registration plumbing is updated.

## Test plan

- [x] `pytest tests/test_integrations_registry.py tests/test_integrations_credentials.py tests/test_oauth_device_code.py tests/test_google_calendar_integration.py` → 32/32 pass
- [x] `ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/` → clean
- [x] CI tests registered in `.github/workflows/ci.yml`
- [ ] Live verify on Dragon (needs OAuth client_id provisioned — operator follow-up)

## References

- Plan doc: [`docs/PLAN-tinkerbox-integrations.md`](../blob/main/docs/PLAN-tinkerbox-integrations.md)
- LEARNINGS entry: "Architecture decision 2026-05-16 — TinkerBox builds its own integrations layer"
- Parent program issue: #341
- Phase 1 issue: #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)