### PR TITLE
feat(integrations): pivot Google OAuth to authorization-code-with-PKCE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,4 +140,6 @@ jobs:
             tests/test_integrations_registry.py \
             tests/test_integrations_credentials.py \
             tests/test_oauth_device_code.py \
+            tests/test_oauth_auth_code.py \
+            tests/test_integrations_init.py \
             tests/test_google_calendar_integration.py

--- a/dragon_voice/api/integrations.py
+++ b/dragon_voice/api/integrations.py
@@ -16,7 +16,7 @@ status — Tab5 turns them into modal text.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from aiohttp import web
 
@@ -33,6 +33,27 @@ from dragon_voice.tools.integrations.registry import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _callback_html(message: str, success: bool) -> web.Response:
+    """Minimal HTML page rendered after Google's OAuth callback."""
+    color = "#0bf08c" if success else "#ff6b6b"
+    title = "Connected" if success else "Connection failed"
+    html = f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{title} — TinkerClaw</title>
+<style>
+  body {{ background:#0a0a0a; color:#e0e0e0; font-family:system-ui;
+         display:flex; align-items:center; justify-content:center;
+         min-height:100vh; margin:0; padding:32px; box-sizing:border-box; }}
+  .card {{ max-width:420px; padding:32px; border-radius:16px;
+          background:#141414; border:1px solid #2a2a2a; text-align:center; }}
+  h1 {{ color:{color}; margin:0 0 16px; font-size:22px; }}
+  p {{ margin:0; line-height:1.5; }}
+</style></head>
+<body><div class="card"><h1>{title}</h1><p>{message}</p></div></body></html>"""
+    return web.Response(text=html, content_type="text/html", charset="utf-8")
 
 
 class IntegrationRoutes:
@@ -72,6 +93,13 @@ class IntegrationRoutes:
             "/api/v1/integrations/{name}/test",
             self.test,
         )
+        # OAuth callback — public route (bearer-auth bypassed by the
+        # middleware's PUBLIC_PREFIXES list; the auth happens via the
+        # PKCE state parameter which only the originating Dragon
+        # process can decrypt).  Google posts the user here after
+        # consent.  Walks every registered integration to find the one
+        # holding this state.
+        app.router.add_get("/api/v1/oauth/callback", self.oauth_callback)
 
     # ── handlers ────────────────────────────────────────────────
 
@@ -169,3 +197,56 @@ class IntegrationRoutes:
             "detail": detail,
             "name": name,
         })
+
+    async def oauth_callback(self, request: web.Request) -> web.Response:
+        """Public OAuth redirect target.
+
+        Google sends the user here after consent:
+        ``?code=...&state=...`` on success or ``?error=...&state=...``
+        on denial.  We walk every instantiated integration looking for
+        one that recognizes the state, then hand the code off.
+
+        Responds with a tiny HTML page so the user's phone shows a
+        success/error message.  Tab5 has its own polling loop and
+        flips the modal independently.
+        """
+        params = request.query
+        state = params.get("state", "")
+        code = params.get("code")
+        error = params.get("error")
+
+        if not state:
+            return _callback_html(
+                "Missing state parameter — link may be malformed.", success=False,
+            )
+
+        # Find the integration holding this state.
+        matched: Optional[IntegrationBackend] = None
+        for integ in self._instances.values():
+            handler = getattr(integ, "handle_callback", None)
+            if handler is None:
+                continue
+            try:
+                flow = integ._find_flow_by_state(state)  # type: ignore[attr-defined]
+            except AttributeError:
+                flow = None
+            if flow is not None:
+                matched = integ
+                break
+        if matched is None:
+            return _callback_html(
+                "This authorization link has already been used or has expired.",
+                success=False,
+            )
+
+        await matched.handle_callback(state=state, code=code, error=error)  # type: ignore[attr-defined]
+        if error:
+            return _callback_html(
+                f"Google reported an error: {error}.  Go back to the Tab5 "
+                f"and try again.",
+                success=False,
+            )
+        return _callback_html(
+            "Connected ✓  You can close this tab and return to your Tab5.",
+            success=True,
+        )

--- a/dragon_voice/lifecycle/integrations_init.py
+++ b/dragon_voice/lifecycle/integrations_init.py
@@ -1,0 +1,46 @@
+"""Integrations layer + LLM-callable tools (#341 / #342).
+
+Registers tool wrappers for TinkerBox-native integrations on the
+existing ``_tool_registry``.  Mirrors ``notes_init.py``'s shape:
+optional dep, layered try/except so a missing integration package
+doesn't block boot.
+
+Today: Google Calendar.  Gmail / Home Assistant / Spotify drop in
+here as they land.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def init_integration_tools(server: Any) -> None:
+    """Register LLM-callable integration tools on ``server._tool_registry``.
+
+    Run AFTER ``init_agentic_modules`` (depends on the registry).
+    The integration *backend* itself is instantiated lazily by each
+    tool via ``_shared_integration()`` so REST connect/disconnect
+    routes and tool calls share a single in-process instance.
+
+    Failure isolation: each integration block is wrapped independently
+    so a broken Google import doesn't block Home Assistant tools.
+    """
+    if not server._tool_registry:
+        return
+
+    try:
+        from dragon_voice.tools.google_calendar_tool import (
+            CalendarCancelTool,
+            CalendarCreateTool,
+            CalendarTodayTool,
+            CalendarWeekTool,
+        )
+        server._tool_registry.register(CalendarTodayTool())
+        server._tool_registry.register(CalendarWeekTool())
+        server._tool_registry.register(CalendarCreateTool())
+        server._tool_registry.register(CalendarCancelTool())
+        logger.info("Google Calendar tools registered (4)")
+    except Exception as e:
+        logger.warning("Google Calendar tools not available: %s", e)

--- a/dragon_voice/lifecycle/startup.py
+++ b/dragon_voice/lifecycle/startup.py
@@ -153,6 +153,15 @@ async def run_startup(server: Any, app: web.Application) -> None:
     from dragon_voice.lifecycle.notes_init import init_notes_module
     await init_notes_module(server, app)
 
+    # #341: TinkerBox-native integration tools (Google Calendar
+    # today, plus Gmail / Home Assistant / Spotify as they land).
+    # Backend instances are created lazily by each tool so REST
+    # connect routes and tool calls share state.
+    from dragon_voice.lifecycle.integrations_init import (
+        init_integration_tools,
+    )
+    await init_integration_tools(server)
+
     # SOLID-audit follow-up: MCP server bridges extracted to
     # lifecycle/mcp_init.py.
     from dragon_voice.lifecycle.mcp_init import init_mcp_bridges

--- a/dragon_voice/middleware/auth.py
+++ b/dragon_voice/middleware/auth.py
@@ -31,6 +31,12 @@ PUBLIC_PREFIXES: tuple[str, ...] = (
     # under /api/v1/* which still gates auth.
     "/call",
     "/static/",
+    # #341 Phase 1: OAuth callback target.  Google redirects the
+    # user's phone browser here after consent — the browser has no
+    # bearer token, but the PKCE `state` parameter is what
+    # authenticates the request (Dragon process holds the only copy
+    # of the matching code_verifier).
+    "/api/v1/oauth/callback",
 )
 
 

--- a/dragon_voice/tools/integrations/google/auth.py
+++ b/dragon_voice/tools/integrations/google/auth.py
@@ -1,26 +1,21 @@
-"""Google OAuth (device-code grant) — shared by Calendar + Gmail.
+"""Google OAuth helpers — shared by Calendar + Gmail.
 
-Single Google OAuth client_id covers all Google services we use.  The
-flow uses the device authorization grant per RFC 8628; Google's
-endpoints:
-  * device-code:  https://oauth2.googleapis.com/device/code
-  * token:        https://oauth2.googleapis.com/token
+Pivoted from device-code to **authorization-code-with-PKCE** because
+Google's device-code allowed-scope list excludes Calendar + Gmail.
+See ``../oauth.py`` module docstring for the explanation.
 
-The client_id (and optional client_secret) come from environment:
-  * GOOGLE_OAUTH_CLIENT_ID — required for `start_connect` to work.
-    Created by the user at https://console.cloud.google.com/ →
-    APIs & Services → Credentials → Create OAuth client ID → "TVs and
-    Limited Input devices" application type.
-  * GOOGLE_OAUTH_CLIENT_SECRET — required when the OAuth client was
-    issued one (Google's "TVs and Limited Input" type ships with both
-    a client_id AND client_secret).  Optional otherwise.
+Single Google Web-application OAuth client (created in Google Cloud
+Console) is reused across all Google integrations.  The redirect URI
+must match what's registered in the Console:
+``https://tinkerclaw-voice.ngrok.dev/api/v1/oauth/callback``
+(reachable from any device via the existing TinkerClaw ngrok tunnel).
 
-When the env vars are missing, `start_connect` raises a structured
-error so the Tab5 UI can surface a "Set up Google OAuth first"
-explainer instead of failing silently.
+Env vars expected on Dragon:
 
-This module is intentionally not an `IntegrationBackend` itself — it's
-a shared auth helper that Calendar + Gmail backends compose.
+* ``GOOGLE_OAUTH_CLIENT_ID`` — required
+* ``GOOGLE_OAUTH_CLIENT_SECRET`` — required for web-application client
+* ``GOOGLE_OAUTH_REDIRECT_URI`` — optional override; defaults to the
+  ngrok URL.
 """
 
 from __future__ import annotations
@@ -32,20 +27,26 @@ from typing import Optional
 
 from dragon_voice.tools.integrations.oauth import (
     DeviceCodeError,
-    OAuthDeviceCodeClient,
+    OAuthAuthCodeClient,
     OAuthTokens,
 )
 
 logger = logging.getLogger(__name__)
 
-# Google OAuth endpoints — per Google's official documentation for the
-# OAuth 2.0 Device Authorization Grant.
-GOOGLE_DEVICE_CODE_URL = "https://oauth2.googleapis.com/device/code"
+# Endpoints.
+GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
 GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke"
 
-# Scopes are space-separated when sent to Google.  The Calendar +
-# Gmail backends each declare what they need; auth.py just collects.
+# Default redirect — ngrok tunnel that the existing tinkerclaw-ngrok
+# service maintains pointing at Dragon's port 3502.  Operator can
+# override via env var if running on a different network setup.
+DEFAULT_REDIRECT_URI = (
+    "https://tinkerclaw-voice.ngrok.dev/api/v1/oauth/callback"
+)
+
+# Scopes used by Calendar + Gmail.  Each integration only requests
+# what it needs; this module just collects the constants.
 SCOPE_CALENDAR_READ = "https://www.googleapis.com/auth/calendar.readonly"
 SCOPE_CALENDAR_EVENTS = "https://www.googleapis.com/auth/calendar.events"
 SCOPE_GMAIL_READ = "https://www.googleapis.com/auth/gmail.readonly"
@@ -53,36 +54,46 @@ SCOPE_GMAIL_MODIFY = "https://www.googleapis.com/auth/gmail.modify"
 SCOPE_GMAIL_SEND = "https://www.googleapis.com/auth/gmail.send"
 
 
+class GoogleOAuthNotConfiguredError(DeviceCodeError):
+    """Raised when env vars are missing.  Inherits DeviceCodeError so
+    REST handlers render a consistent error shape across all OAuth
+    failures."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(code="oauth_not_configured", description=message)
+
+
 @dataclass
 class GoogleOAuthConfig:
-    """Provider-level OAuth config + scope union.
-
-    `scopes` defaults to read-only Calendar — explicit at construction
-    so a single Google credential file can grow scopes incrementally
-    (Calendar first; then Gmail later expands the set).
-    """
+    """Provider-level OAuth config + scope union."""
 
     client_id: str
-    client_secret: Optional[str] = None
+    client_secret: Optional[str]
+    redirect_uri: str
     scopes: list[str] = field(default_factory=lambda: [SCOPE_CALENDAR_READ])
 
     @classmethod
     def from_env(cls, scopes: Optional[list[str]] = None) -> "GoogleOAuthConfig":
         client_id = os.environ.get("GOOGLE_OAUTH_CLIENT_ID", "").strip()
+        client_secret = os.environ.get(
+            "GOOGLE_OAUTH_CLIENT_SECRET", ""
+        ).strip() or None
+        redirect_uri = (
+            os.environ.get("GOOGLE_OAUTH_REDIRECT_URI", "").strip()
+            or DEFAULT_REDIRECT_URI
+        )
         if not client_id:
             raise GoogleOAuthNotConfiguredError(
-                "GOOGLE_OAUTH_CLIENT_ID env var is not set.  Create an "
-                "OAuth client at https://console.cloud.google.com/ "
-                '(application type "TVs and Limited Input devices") and '
-                "set GOOGLE_OAUTH_CLIENT_ID + GOOGLE_OAUTH_CLIENT_SECRET "
-                "in Dragon's environment."
+                "GOOGLE_OAUTH_CLIENT_ID is not set.  Create a Web-application "
+                "OAuth client at https://console.cloud.google.com/apis/credentials "
+                "(redirect URI: " + redirect_uri + ") then set "
+                "GOOGLE_OAUTH_CLIENT_ID + GOOGLE_OAUTH_CLIENT_SECRET in Dragon's "
+                "environment and restart tinkerclaw-voice."
             )
-        client_secret = (
-            os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET", "").strip() or None
-        )
         return cls(
             client_id=client_id,
             client_secret=client_secret,
+            redirect_uri=redirect_uri,
             scopes=list(scopes) if scopes is not None else [SCOPE_CALENDAR_READ],
         )
 
@@ -90,34 +101,23 @@ class GoogleOAuthConfig:
         return " ".join(self.scopes)
 
 
-class GoogleOAuthNotConfiguredError(DeviceCodeError):
-    """Raised when GOOGLE_OAUTH_CLIENT_ID is missing.
-
-    Inherits DeviceCodeError so the REST layer can render the same
-    error shape for "no client_id set" vs "user denied authorization".
-    """
-
-    def __init__(self, message: str) -> None:
-        super().__init__(code="oauth_not_configured", description=message)
-
-
-def make_google_client(config: GoogleOAuthConfig) -> OAuthDeviceCodeClient:
-    """Build a Google-specific OAuthDeviceCodeClient."""
-    return OAuthDeviceCodeClient(
+def make_google_client(config: GoogleOAuthConfig) -> OAuthAuthCodeClient:
+    """Build a Google-flavored authorization-code-with-PKCE client."""
+    return OAuthAuthCodeClient(
         client_id=config.client_id,
         client_secret=config.client_secret,
         scope=config.scope_string(),
-        device_code_url=GOOGLE_DEVICE_CODE_URL,
+        auth_url=GOOGLE_AUTH_URL,
         token_url=GOOGLE_TOKEN_URL,
+        redirect_uri=config.redirect_uri,
     )
 
 
 async def revoke_google_token(token: str, session) -> bool:  # noqa: ANN001
     """POST to Google's revoke endpoint.  Returns True on 200.
 
-    Per Google: revoking the refresh token invalidates BOTH the refresh
-    token AND any access tokens minted from it — call this with the
-    refresh_token when disconnecting.
+    Per Google: revoking the refresh token invalidates both the refresh
+    token AND any active access tokens minted from it.
     """
     try:
         async with session.post(
@@ -129,21 +129,19 @@ async def revoke_google_token(token: str, session) -> bool:  # noqa: ANN001
         return False
 
 
-# Re-export OAuthTokens here so Calendar + Gmail can import a single
-# Google-flavored auth module without poking into the generic oauth
-# module.
 __all__ = [
+    "DEFAULT_REDIRECT_URI",
+    "GOOGLE_AUTH_URL",
+    "GOOGLE_REVOKE_URL",
+    "GOOGLE_TOKEN_URL",
     "GoogleOAuthConfig",
     "GoogleOAuthNotConfiguredError",
     "OAuthTokens",
+    "SCOPE_CALENDAR_EVENTS",
+    "SCOPE_CALENDAR_READ",
+    "SCOPE_GMAIL_MODIFY",
+    "SCOPE_GMAIL_READ",
+    "SCOPE_GMAIL_SEND",
     "make_google_client",
     "revoke_google_token",
-    "SCOPE_CALENDAR_READ",
-    "SCOPE_CALENDAR_EVENTS",
-    "SCOPE_GMAIL_READ",
-    "SCOPE_GMAIL_MODIFY",
-    "SCOPE_GMAIL_SEND",
-    "GOOGLE_DEVICE_CODE_URL",
-    "GOOGLE_TOKEN_URL",
-    "GOOGLE_REVOKE_URL",
 ]

--- a/dragon_voice/tools/integrations/google/calendar.py
+++ b/dragon_voice/tools/integrations/google/calendar.py
@@ -1,17 +1,22 @@
-"""Google Calendar integration — first proof-of-concept (#341 / #342).
+"""Google Calendar integration — auth-code-with-PKCE flow (#342).
 
-Implements `IntegrationBackend` using the shared Google device-code
-auth (`google/auth.py`) and the Calendar v3 REST API.
+OAuth state machine:
 
-Public methods used by tools:
-  * `list_events(time_min, time_max, max_results)` → list[dict]
-  * `create_event(...)` → dict
-  * `cancel_event(event_id)` → bool
+  start_connect()
+    → creates AuthCodeChallenge (PKCE pair + state)
+    → stashes verifier + asyncio.Future in `self._flows[state]`
+    → returns ConnectChallenge with the authorization_url
+       (Tab5 shows QR + plain link)
 
-OAuth state lives in `~/.tinkerclaw/integrations/google-calendar.json`
-managed by the shared `CredentialStore`.  The cred file holds the
-OAuthTokens dict + the active OAuth config snapshot (so we know which
-scopes were granted).
+  user opens auth URL on phone, signs in, grants scopes
+
+  Google redirects to /api/v1/oauth/callback?code=…&state=…
+    → IntegrationRoutes.oauth_callback handler calls
+       integration.handle_callback(state, code, error)
+    → we exchange code+verifier for tokens, persist, mark future done
+
+  Tab5 polls /api/v1/integrations/google-calendar/status/{request_id}
+    → poll_status() reads the flow's future state, returns connected/expired/error
 """
 
 from __future__ import annotations
@@ -33,7 +38,6 @@ from dragon_voice.tools.integrations.base import (
 from dragon_voice.tools.integrations.credentials import CredentialStore
 from dragon_voice.tools.integrations.google.auth import (
     GoogleOAuthConfig,
-    GoogleOAuthNotConfiguredError,
     OAuthTokens,
     SCOPE_CALENDAR_EVENTS,
     SCOPE_CALENDAR_READ,
@@ -52,25 +56,15 @@ CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3"
 class GoogleCalendarIntegration(IntegrationBackend):
     """Google Calendar read + write via Calendar API v3."""
 
-    # Scopes we request when initiating connect.  Read + write events
-    # on the user's primary calendar — both fit in a single consent
-    # screen so the device-flow UX stays one-step.
     _SCOPES = [SCOPE_CALENDAR_READ, SCOPE_CALENDAR_EVENTS]
 
     def __init__(self) -> None:
         self._store = CredentialStore("google-calendar")
-        # In-flight device-code flows, keyed by request_id.  A flow
-        # lives in this dict from `start_connect` to either successful
-        # `poll_status` (terminal `connected`) or expiry/cancellation.
-        self._flows: dict[str, _DeviceFlow] = {}
-        # Lazily-loaded token cache; written through to `_store` on
-        # every refresh.  None means "not loaded yet" — load on first
-        # use.
+        # request_id → in-flight flow.  Survives across REST calls so
+        # Tab5 polling sees terminal state.
+        self._flows: dict[str, "_AuthFlow"] = {}
         self._tokens: Optional[OAuthTokens] = None
         self._tokens_loaded = False
-        # Background flow tasks — keep handles so we don't drop them
-        # (RUF006 lint catches asyncio-dangling-task).
-        self._tasks: set[asyncio.Task] = set()
 
     # ── IntegrationBackend interface ────────────────────────────
 
@@ -87,82 +81,125 @@ class GoogleCalendarIntegration(IntegrationBackend):
         return "Read and create events on your primary Google Calendar."
 
     @property
-    def auth_kind(self) -> Literal["oauth-device", "static-token", "none"]:
-        return "oauth-device"
+    def auth_kind(self) -> Literal["oauth-device", "oauth-authcode", "static-token", "none"]:  # type: ignore[override]
+        return "oauth-authcode"
 
     async def is_connected(self) -> bool:
         await self._ensure_tokens_loaded()
         return self._tokens is not None
 
     async def start_connect(self, params: Optional[dict] = None) -> ConnectChallenge:
-        del params  # unused for OAuth device flow
-        try:
-            cfg = GoogleOAuthConfig.from_env(scopes=self._SCOPES)
-        except GoogleOAuthNotConfiguredError:
-            raise
-
+        del params  # unused for auth-code flow
+        cfg = GoogleOAuthConfig.from_env(scopes=self._SCOPES)
         request_id = uuid.uuid4().hex
-        flow = _DeviceFlow(request_id=request_id, cfg=cfg)
+        # Build the auth URL.  Google needs access_type=offline +
+        # prompt=consent to mint a refresh_token on the first turn.
+        client = make_google_client(cfg)
+        chal = client.start(extra_params={
+            "access_type": "offline",
+            "prompt": "consent",
+            "include_granted_scopes": "true",
+        })
+        # `client.start` adds the entry to client._pending[state]
+        # already, but we don't own that lifecycle — Dragon process
+        # holds the entry until the callback resolves it.  We DO need
+        # our own flow record so poll_status finds it.
+        flow = _AuthFlow(
+            request_id=request_id,
+            state=chal.state,
+            code_verifier=chal.code_verifier,
+            cfg=cfg,
+        )
         self._flows[request_id] = flow
 
-        # Kick off the device-code flow.  `start` returns the
-        # challenge synchronously; `poll_until_done` runs in a
-        # background task and parks the result on the flow object so
-        # `poll_status` can read it without re-issuing requests.
-        flow.challenge = await flow.start()
-        flow.poll_task = asyncio.create_task(self._run_flow(flow))
-        self._tasks.add(flow.poll_task)
-        flow.poll_task.add_done_callback(self._tasks.discard)
-
         return ConnectChallenge(
-            kind="oauth-device",
+            kind="oauth-device",  # Tab5 modal reuses the QR/code UX shape
             request_id=request_id,
-            verification_url=(
-                flow.challenge.verification_url_complete
-                or flow.challenge.verification_url
-            ),
-            user_code=flow.challenge.user_code,
-            expires_in_s=flow.challenge.expires_in,
-            interval_s=flow.challenge.interval,
+            verification_url=chal.authorization_url,
+            user_code=None,  # auth-code flow doesn't have one
+            expires_in_s=600,
+            interval_s=2,
         )
 
     async def poll_status(self, request_id: str) -> ConnectionStatus:
         flow = self._flows.get(request_id)
         if flow is None:
             return ConnectionStatus(
-                state="error",
-                request_id=request_id,
-                error="unknown request_id",
+                state="error", request_id=request_id, error="unknown request_id",
             )
         if flow.tokens is not None:
             return ConnectionStatus(state="connected", request_id=request_id)
         if flow.error is not None:
-            state = "expired" if flow.error.code == "expired_token" else "error"
+            state_label = "expired" if flow.error.code == "expired_token" else "error"
             return ConnectionStatus(
-                state=state,  # type: ignore[arg-type]
+                state=state_label,  # type: ignore[arg-type]
                 request_id=request_id,
                 error=flow.error.description,
             )
+        if time.time() > flow.expires_at:
+            flow.error = DeviceCodeError(
+                "expired_token", "user did not complete authorization in time",
+            )
+            return ConnectionStatus(
+                state="expired", request_id=request_id, error=flow.error.description,
+            )
         return ConnectionStatus(state="connecting", request_id=request_id)
+
+    async def handle_callback(
+        self, state: str, code: Optional[str], error: Optional[str],
+    ) -> None:
+        """Called by the /api/v1/oauth/callback route handler.
+
+        Looks up the flow by `state`, exchanges code+verifier for
+        tokens, persists.  Best-effort: any exception becomes
+        `flow.error` so the next poll_status returns it.
+        """
+        flow = self._find_flow_by_state(state)
+        if flow is None:
+            logger.warning("OAuth callback for unknown state %r", state[:12])
+            return
+        if error:
+            flow.error = DeviceCodeError(code=error, description=error)
+            return
+        if not code:
+            flow.error = DeviceCodeError(
+                "missing_code", "callback missing both code and error",
+            )
+            return
+        try:
+            async with make_google_client(flow.cfg) as client:
+                tokens = await client.exchange_code_with_verifier(
+                    code=code, code_verifier=flow.code_verifier,
+                )
+        except DeviceCodeError as e:
+            flow.error = e
+            return
+        except Exception as e:  # noqa: BLE001
+            flow.error = DeviceCodeError(
+                code="exchange_failed",
+                description=f"{type(e).__name__}: {e}"[:120],
+            )
+            return
+        await self._persist_tokens(tokens)
+        flow.tokens = tokens
 
     async def disconnect(self) -> None:
         await self._ensure_tokens_loaded()
         if self._tokens is not None and self._tokens.refresh_token:
-            # Best-effort revoke — delete local creds regardless.
             async with aiohttp.ClientSession(
                 timeout=aiohttp.ClientTimeout(total=10),
             ) as session:
                 await revoke_google_token(self._tokens.refresh_token, session)
         await self._store.delete()
         self._tokens = None
-        self._tokens_loaded = True  # stays loaded (just empty)
+        self._tokens_loaded = True
 
     async def health_check(self, timeout_s: float = 5.0) -> tuple[bool, str]:
         await self._ensure_tokens_loaded()
         if self._tokens is None:
             return False, "not connected"
         try:
-            events = await self._authed_get(
+            data = await self._authed_get(
                 f"{CALENDAR_API_BASE}/calendars/primary",
                 timeout_s=timeout_s,
             )
@@ -170,10 +207,10 @@ class GoogleCalendarIntegration(IntegrationBackend):
             return False, f"{type(e).__name__}: {e}"[:120]
         except DeviceCodeError as e:
             return False, f"auth: {e.description[:120]}"
-        cal_id = events.get("id") if isinstance(events, dict) else None
+        cal_id = data.get("id") if isinstance(data, dict) else None
         return True, f"connected to {cal_id or 'primary calendar'}"
 
-    # ── Calendar-specific public API used by the tool wrappers ──
+    # ── Calendar API used by tools ──────────────────────────────
 
     async def list_events(
         self,
@@ -181,13 +218,6 @@ class GoogleCalendarIntegration(IntegrationBackend):
         time_max: Optional[datetime] = None,
         max_results: int = 10,
     ) -> list[dict[str, Any]]:
-        """List events on the user's primary calendar between
-        `time_min` and `time_max`.  Defaults to "from now, no upper
-        bound, 10 results."
-
-        Returns a normalized list of event dicts:
-          {id, summary, location, start_iso, end_iso, all_day, attendees, hangout_link}
-        """
         params = {
             "singleEvents": "true",
             "orderBy": "startTime",
@@ -213,7 +243,6 @@ class GoogleCalendarIntegration(IntegrationBackend):
         location: Optional[str] = None,
         description: Optional[str] = None,
     ) -> dict[str, Any]:
-        """Create an event on the primary calendar."""
         body = {
             "summary": summary,
             "start": {"dateTime": start.astimezone(timezone.utc).isoformat()},
@@ -229,8 +258,6 @@ class GoogleCalendarIntegration(IntegrationBackend):
         return self._normalize_event(raw)
 
     async def cancel_event(self, event_id: str) -> bool:
-        """Delete an event from the primary calendar.  Returns True
-        on success."""
         try:
             await self._authed_delete(
                 f"{CALENDAR_API_BASE}/calendars/primary/events/{event_id}",
@@ -242,21 +269,11 @@ class GoogleCalendarIntegration(IntegrationBackend):
 
     # ── Internals ───────────────────────────────────────────────
 
-    async def _run_flow(self, flow: "_DeviceFlow") -> None:
-        """Background coroutine: poll until tokens or terminal error,
-        then persist tokens to the store."""
-        try:
-            async with make_google_client(flow.cfg) as client:
-                tokens = await client.poll_until_done(flow.challenge)
-            await self._persist_tokens(tokens)
-            flow.tokens = tokens
-        except DeviceCodeError as e:
-            flow.error = e
-        except Exception as e:  # noqa: BLE001
-            flow.error = DeviceCodeError(
-                code="poll_failed",
-                description=f"{type(e).__name__}: {e}"[:120],
-            )
+    def _find_flow_by_state(self, state: str) -> Optional["_AuthFlow"]:
+        for flow in self._flows.values():
+            if flow.state == state:
+                return flow
+        return None
 
     async def _persist_tokens(self, tokens: OAuthTokens) -> None:
         await self._store.save({"tokens": tokens.to_dict()})
@@ -273,7 +290,7 @@ class GoogleCalendarIntegration(IntegrationBackend):
             except (KeyError, ValueError, TypeError) as e:
                 logger.warning(
                     "Stored Google Calendar tokens malformed (%s) — "
-                    "treating as disconnected.  User should reconnect.",
+                    "treating as disconnected.",
                     e,
                 )
                 self._tokens = None
@@ -282,21 +299,19 @@ class GoogleCalendarIntegration(IntegrationBackend):
         self._tokens_loaded = True
 
     async def _get_access_token(self) -> str:
-        """Return a valid access token, refreshing if necessary."""
         await self._ensure_tokens_loaded()
         if self._tokens is None:
             raise DeviceCodeError(
-                code="not_connected",
-                description="Google Calendar is not connected.  Visit Tab5 "
-                "Settings → Integrations → Connect Google.",
+                "not_connected",
+                "Google Calendar is not connected.  Tap Settings → "
+                "Integrations → Connect Google on the Tab5.",
             )
         if not self._tokens.is_expired():
             return self._tokens.access_token
-        # Refresh.
         if not self._tokens.refresh_token:
             raise DeviceCodeError(
-                code="needs_reauth",
-                description="No refresh token — please reconnect Google.",
+                "needs_reauth",
+                "No refresh token — please reconnect Google.",
             )
         cfg = GoogleOAuthConfig.from_env(scopes=self._tokens.scopes or self._SCOPES)
         async with make_google_client(cfg) as client:
@@ -319,7 +334,6 @@ class GoogleCalendarIntegration(IntegrationBackend):
                 headers={"Authorization": f"Bearer {token}"},
             ) as resp:
                 if resp.status == 401:
-                    # Token rejected — try one refresh, then retry once.
                     await self._force_refresh()
                     token = await self._get_access_token()
                     async with session.get(
@@ -357,18 +371,12 @@ class GoogleCalendarIntegration(IntegrationBackend):
                 resp.raise_for_status()
 
     async def _force_refresh(self) -> None:
-        """Force a refresh even if our cached `expires_at` says it's
-        still good.  Used when the API returned 401 unexpectedly."""
         if self._tokens is None or not self._tokens.refresh_token:
             return
-        # Set expiry to a past time so the next `_get_access_token`
-        # call triggers refresh.
         self._tokens.expires_at = int(time.time()) - 1
 
     @staticmethod
     def _normalize_event(raw: dict) -> dict[str, Any]:
-        """Reduce Google's verbose event payload to what voice + chat
-        UIs actually need."""
         start = raw.get("start", {})
         end = raw.get("end", {})
         all_day = "date" in start and "dateTime" not in start
@@ -388,46 +396,26 @@ class GoogleCalendarIntegration(IntegrationBackend):
         }
 
 
-class _DeviceFlow:
-    """Internal: in-flight device-code flow state."""
+class _AuthFlow:
+    """Internal: in-flight auth-code flow state."""
 
-    __slots__ = ("request_id", "cfg", "challenge", "tokens", "error", "poll_task")
+    __slots__ = (
+        "request_id", "state", "code_verifier", "cfg",
+        "expires_at", "tokens", "error",
+    )
 
-    def __init__(self, *, request_id: str, cfg: GoogleOAuthConfig) -> None:
+    def __init__(
+        self,
+        *,
+        request_id: str,
+        state: str,
+        code_verifier: str,
+        cfg: GoogleOAuthConfig,
+    ) -> None:
         self.request_id = request_id
+        self.state = state
+        self.code_verifier = code_verifier
         self.cfg = cfg
-        self.challenge: Optional[Any] = None  # DeviceCodeChallenge
+        self.expires_at = time.time() + 600
         self.tokens: Optional[OAuthTokens] = None
         self.error: Optional[DeviceCodeError] = None
-        self.poll_task: Optional[asyncio.Task] = None
-
-    async def start(self):  # noqa: ANN201
-        """Kick off the device-code endpoint call.  Returns the
-        challenge that becomes the `verification_url` + `user_code`
-        Tab5 will render."""
-        async with make_google_client(self.cfg) as client:
-            return await client.start()
-
-
-def helpful_relative_time(target: datetime, now: Optional[datetime] = None) -> str:
-    """"in 2 hours" / "yesterday" / "next Tuesday at 9am" — used by the
-    tool wrappers to phrase replies naturally for TTS.
-
-    Kept small + deterministic; for richer phrasing the LLM can
-    rewrite the tool result before speaking."""
-    now = now or datetime.now(timezone.utc)
-    target = target.astimezone(timezone.utc)
-    delta = target - now
-    if delta < timedelta(0):
-        delta = -delta
-        direction = "ago"
-    else:
-        direction = "from now"
-    secs = int(delta.total_seconds())
-    if secs < 60:
-        return f"{secs} seconds {direction}"
-    if secs < 3600:
-        return f"{secs // 60} minutes {direction}"
-    if secs < 86400:
-        return f"{secs // 3600} hours {direction}"
-    return f"{secs // 86400} days {direction}"

--- a/dragon_voice/tools/integrations/oauth.py
+++ b/dragon_voice/tools/integrations/oauth.py
@@ -1,28 +1,39 @@
-"""OAuth 2.0 Device Authorization Grant (RFC 8628) client (#341).
+"""OAuth 2.0 helpers for TinkerBox integrations (#341).
 
-Dragon runs headless — there's no browser, no local web server with a
-redirect URI for the standard OAuth code flow.  The device
-authorization grant is designed exactly for this case:
+Two flows supported:
 
-  1. Client (Dragon) hits the provider's device-code endpoint, gets
-     back a `device_code`, a `user_code`, and a `verification_url`.
-  2. Dragon shows the user the URL + code (Tab5 renders as QR).
-  3. User completes the OAuth dance on their phone.
-  4. Dragon polls the token endpoint with `device_code` until the
-     provider returns access + refresh tokens.
+* **Authorization Code with PKCE** (RFC 7636) — used for Google
+  Calendar / Gmail / most modern providers.  Dragon hosts a public
+  ``/api/v1/oauth/callback`` route (reached via the existing ngrok
+  tunnel) so the user can complete consent on their phone browser.
+  No client-secret required for PKCE, but Google's web-app client
+  ships with one — we include it when present.
 
-Supported by Google, Spotify, GitHub, and many others.
+* **Device Authorization Grant** (RFC 8628) — used by providers that
+  support it without scope restrictions (some Spotify scopes, etc.).
+  Dragon polls the token endpoint; user enters a code on their phone.
+  KEPT for future integrations that prefer it.
 
-This module is provider-agnostic — provider-specific bits
-(client_id, scopes, endpoint URLs) are passed in.  See
-``google/auth.py`` for the Google-specific wrapper.
+Both flows produce the same ``OAuthTokens`` dataclass.
+
+### Why we pivoted from device-code to auth-code for Google
+
+Google's device-code flow restricts the allowed scopes to a small set
+(email/profile/openid/Drive/Photos/YouTube).  Calendar + Gmail are NOT
+in that list — Google forces these scopes through the
+authorization-code flow.  See:
+https://developers.google.com/identity/protocols/oauth2/limited-input-device#allowedscopes
 """
 
 from __future__ import annotations
 
 import asyncio
+import base64
+import hashlib
 import logging
+import secrets
 import time
+import urllib.parse
 from dataclasses import dataclass
 from typing import Optional
 
@@ -32,11 +43,9 @@ logger = logging.getLogger(__name__)
 
 
 class DeviceCodeError(Exception):
-    """Raised when the device-code flow fails terminally.
-
-    Distinct from `aiohttp.ClientError` so callers can catch only the
-    flow-specific errors (`expired_token`, `access_denied`, etc.).
-    """
+    """Raised when an OAuth flow fails terminally.  Name kept for
+    backward compat with the existing API + tests; covers both
+    device-code and auth-code failures."""
 
     def __init__(self, code: str, description: str) -> None:
         self.code = code
@@ -44,48 +53,26 @@ class DeviceCodeError(Exception):
         super().__init__(f"{code}: {description}")
 
 
-@dataclass
-class DeviceCodeChallenge:
-    """The triple returned by the device-code endpoint.
-
-    All fields per RFC 8628 §3.2.  `interval` is the recommended poll
-    interval (seconds); providers can ask the client to back off by
-    returning `slow_down` from the token endpoint, but we honor the
-    initial `interval` unless slow_down arrives.
-    """
-
-    device_code: str
-    user_code: str
-    verification_url: str
-    expires_in: int
-    interval: int = 5
-    # Some providers (Google) also return verification_url_complete
-    # which embeds the user_code as a query param — convenient for QR.
-    verification_url_complete: Optional[str] = None
+# ─── Tokens ────────────────────────────────────────────────────────
 
 
 @dataclass
 class OAuthTokens:
-    """Token bundle returned by the token endpoint.
+    """Provider-agnostic token bundle.
 
-    `expires_at` is an absolute unix timestamp so refresh logic doesn't
-    need to track issue time separately.  `refresh_token` may be None
-    if the provider doesn't issue one (rare for device flow).  `scopes`
-    is the granted scope set returned by the provider — may differ from
-    requested if the user denied some scopes.
-    """
+    `expires_at` is an absolute unix timestamp.  `refresh_token` may
+    be None when the provider doesn't issue one or when a refresh
+    response omitted it (callers preserve the prior value in that
+    case)."""
 
     access_token: str
     refresh_token: Optional[str]
     token_type: str
-    expires_at: int  # absolute unix timestamp
+    expires_at: int
     scopes: list[str]
     extra: dict = None  # type: ignore[assignment]
 
     def is_expired(self, skew_s: int = 60) -> bool:
-        """Treat the token as expired `skew_s` seconds before its
-        actual expiry to avoid in-flight 401s during a refresh window.
-        """
         return time.time() + skew_s >= self.expires_at
 
     def to_dict(self) -> dict:
@@ -110,13 +97,278 @@ class OAuthTokens:
         )
 
 
+def _tokens_from_response(data: dict) -> OAuthTokens:
+    expires_in = int(data.get("expires_in", 3600))
+    scope_str = data.get("scope", "")
+    scopes = scope_str.split() if scope_str else []
+    return OAuthTokens(
+        access_token=data["access_token"],
+        refresh_token=data.get("refresh_token"),
+        token_type=data.get("token_type", "Bearer"),
+        expires_at=int(time.time()) + expires_in,
+        scopes=scopes,
+        extra={
+            k: v for k, v in data.items()
+            if k not in {
+                "access_token", "refresh_token", "token_type",
+                "expires_in", "scope",
+            }
+        },
+    )
+
+
+# ─── PKCE helpers (RFC 7636) ──────────────────────────────────────
+
+
+def _pkce_pair() -> tuple[str, str]:
+    """Generate a (code_verifier, code_challenge) pair.
+
+    code_verifier:  43-128 char [A-Za-z0-9-._~] random string.
+    code_challenge: BASE64URL-NOPAD(SHA256(code_verifier)).
+    """
+    verifier = secrets.token_urlsafe(64)  # ~86 chars after urlsafe
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+# ─── Authorization Code with PKCE ─────────────────────────────────
+
+
+@dataclass
+class AuthCodeChallenge:
+    """What `OAuthAuthCodeClient.start` returns.
+
+    Tab5 displays a QR with `authorization_url`; user opens it on
+    their phone, signs in + consents; Google redirects to our
+    ngrok-tunneled callback URL; the callback handler calls
+    `OAuthAuthCodeClient.exchange_code(state, code)` to mint tokens.
+    """
+
+    authorization_url: str
+    state: str
+    code_verifier: str
+    expires_in: int = 600  # PKCE state TTL; we expire after 10 min
+
+
+class OAuthAuthCodeClient:
+    """Authorization Code flow with PKCE.
+
+    One instance per provider.  Holds the in-flight PKCE state
+    (`state` → `code_verifier`) so the callback can find it.
+
+    Typical use:
+
+        client = OAuthAuthCodeClient(
+            client_id=..., client_secret=..., scope=...,
+            auth_url="https://accounts.google.com/o/oauth2/v2/auth",
+            token_url="https://oauth2.googleapis.com/token",
+            redirect_uri="https://tinkerclaw-voice.ngrok.dev/api/v1/oauth/callback",
+        )
+        chal = await client.start(extra_params={"access_type": "offline", "prompt": "consent"})
+        # ... Tab5 shows QR, user authorizes ...
+        # callback receives ?code=...&state=...
+        tokens = await client.exchange_code(state=..., code=...)
+    """
+
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        scope: str,
+        auth_url: str,
+        token_url: str,
+        redirect_uri: str,
+        client_secret: Optional[str] = None,
+        session: Optional[aiohttp.ClientSession] = None,
+    ) -> None:
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._scope = scope
+        self._auth_url = auth_url
+        self._token_url = token_url
+        self._redirect_uri = redirect_uri
+        self._session = session
+        self._owns_session = session is None
+        # state -> {code_verifier, expires_at, future, completed}
+        self._pending: dict[str, dict] = {}
+
+    async def __aenter__(self) -> "OAuthAuthCodeClient":
+        if self._session is None:
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=30),
+            )
+            self._owns_session = True
+        return self
+
+    async def __aexit__(self, *exc_info) -> None:  # noqa: ANN001
+        if self._owns_session and self._session is not None and not self._session.closed:
+            await self._session.close()
+
+    def start(self, extra_params: Optional[dict] = None) -> AuthCodeChallenge:
+        """Generate PKCE pair + return the authorization URL.
+
+        Doesn't hit the network — just builds the URL.  Caller passes
+        provider-specific extras (e.g. Google needs
+        `access_type=offline` + `prompt=consent` to mint a
+        refresh_token on the first turn).
+        """
+        verifier, challenge = _pkce_pair()
+        state = secrets.token_urlsafe(24)
+        params = {
+            "client_id": self._client_id,
+            "redirect_uri": self._redirect_uri,
+            "response_type": "code",
+            "scope": self._scope,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": state,
+        }
+        if extra_params:
+            params.update(extra_params)
+        url = f"{self._auth_url}?{urllib.parse.urlencode(params)}"
+        self._pending[state] = {
+            "code_verifier": verifier,
+            "expires_at": time.time() + 600,
+            "future": asyncio.get_event_loop().create_future(),
+        }
+        return AuthCodeChallenge(
+            authorization_url=url,
+            state=state,
+            code_verifier=verifier,
+        )
+
+    def resolve_callback(self, state: str, code: Optional[str], error: Optional[str]) -> None:
+        """Called from the HTTP callback handler.  Wakes the
+        `wait_for_callback` future."""
+        entry = self._pending.get(state)
+        if entry is None:
+            logger.warning("OAuth callback for unknown state %r — ignoring", state[:12])
+            return
+        future = entry["future"]
+        if future.done():
+            return
+        if error:
+            future.set_exception(DeviceCodeError(code=error, description=error))
+        else:
+            future.set_result(code)
+
+    async def wait_for_callback(self, state: str, timeout_s: int = 600) -> str:
+        """Block until the callback completes the flow for this state.
+
+        Returns the auth code on success; raises DeviceCodeError on
+        provider-side denial or timeout.
+        """
+        entry = self._pending.get(state)
+        if entry is None:
+            raise DeviceCodeError("unknown_state", "no pending flow for state")
+        try:
+            code = await asyncio.wait_for(entry["future"], timeout=timeout_s)
+            return code
+        except asyncio.TimeoutError:
+            raise DeviceCodeError(
+                "expired_token",
+                "user did not complete authorization in time",
+            ) from None
+        finally:
+            # GC the entry — only one shot per state.
+            self._pending.pop(state, None)
+
+    async def exchange_code(self, state: str, code: str) -> OAuthTokens:
+        """Exchange the auth code + PKCE verifier for tokens.
+
+        The state was looked up to find the verifier; the
+        `wait_for_callback` future has already been resolved (and
+        the entry removed) — so we capture the verifier BEFORE
+        calling resolve_callback or use the explicit verifier the
+        caller passes.  In practice this method is called from inside
+        ``GoogleCalendarIntegration._handle_callback`` which has both.
+        """
+        assert self._session is not None, "Use 'async with OAuthAuthCodeClient(...)'"
+        # Caller is expected to pass the verifier directly (we no
+        # longer have the state entry once wait_for_callback returned)
+        # — so this method actually doesn't need state.  But we keep
+        # the parameter for API symmetry; callers can pass any value.
+        del state
+        return await self._exchange(code)
+
+    async def _exchange(self, code: str, code_verifier: str | None = None) -> OAuthTokens:
+        """Used internally by exchange_code_with_verifier."""
+        assert self._session is not None
+        payload = {
+            "client_id": self._client_id,
+            "code": code,
+            "grant_type": "authorization_code",
+            "redirect_uri": self._redirect_uri,
+        }
+        if code_verifier:
+            payload["code_verifier"] = code_verifier
+        if self._client_secret:
+            payload["client_secret"] = self._client_secret
+        async with self._session.post(self._token_url, data=payload) as resp:
+            data = await resp.json()
+            if resp.status != 200:
+                raise DeviceCodeError(
+                    code=data.get("error", "exchange_failed"),
+                    description=data.get(
+                        "error_description", "Code exchange rejected by provider",
+                    ),
+                )
+        return _tokens_from_response(data)
+
+    async def exchange_code_with_verifier(
+        self, code: str, code_verifier: str,
+    ) -> OAuthTokens:
+        """The canonical exchange call — pass verifier explicitly."""
+        assert self._session is not None
+        return await self._exchange(code, code_verifier=code_verifier)
+
+    async def refresh(self, refresh_token: str) -> OAuthTokens:
+        """Exchange a refresh token for a new access token."""
+        assert self._session is not None
+        payload = {
+            "client_id": self._client_id,
+            "refresh_token": refresh_token,
+            "grant_type": "refresh_token",
+        }
+        if self._client_secret:
+            payload["client_secret"] = self._client_secret
+        async with self._session.post(self._token_url, data=payload) as resp:
+            data = await resp.json()
+            if resp.status != 200:
+                raise DeviceCodeError(
+                    code=data.get("error", "refresh_failed"),
+                    description=data.get(
+                        "error_description", "Refresh token rejected"
+                    ),
+                )
+        tokens = _tokens_from_response(data)
+        if not tokens.refresh_token:
+            tokens.refresh_token = refresh_token
+        return tokens
+
+
+# ─── Device Authorization Grant (kept for non-Google providers) ───
+
+
+@dataclass
+class DeviceCodeChallenge:
+    """Returned by the device-code endpoint (RFC 8628 §3.2)."""
+
+    device_code: str
+    user_code: str
+    verification_url: str
+    expires_in: int
+    interval: int = 5
+    verification_url_complete: Optional[str] = None
+
+
 class OAuthDeviceCodeClient:
     """Provider-agnostic device-code OAuth client.
 
-    One instance per provider (Google, Spotify, etc.) — the
-    `client_id`, `scope`, `device_code_url`, and `token_url` are
-    provider-specific.  `client_secret` is optional (Google's device
-    flow uses a client secret, Spotify's doesn't).
+    Kept for providers that allow Calendar/Gmail-equivalent scopes
+    through device-code (some Spotify scopes, etc.).  See
+    `OAuthAuthCodeClient` for Google.
     """
 
     def __init__(
@@ -150,13 +402,7 @@ class OAuthDeviceCodeClient:
             await self._session.close()
 
     async def start(self) -> DeviceCodeChallenge:
-        """POST to the device-code endpoint, return the challenge.
-
-        Raises DeviceCodeError when the provider returns a non-2xx
-        response with a structured error body (rare at this stage —
-        usually only happens if the `client_id` is invalid).
-        """
-        assert self._session is not None, "Use 'async with OAuthDeviceCodeClient(...)'"
+        assert self._session is not None
         payload = {"client_id": self._client_id, "scope": self._scope}
         async with self._session.post(self._device_code_url, data=payload) as resp:
             data = await resp.json()
@@ -177,18 +423,7 @@ class OAuthDeviceCodeClient:
         )
 
     async def poll_once(self, device_code: str) -> Optional[OAuthTokens]:
-        """One poll of the token endpoint.
-
-        Returns:
-            * `OAuthTokens` — flow completed, user authorized.
-            * `None` — still pending (RFC 8628 `authorization_pending`
-              or `slow_down`).  Caller should sleep and try again.
-
-        Raises:
-            DeviceCodeError — terminal failure (`expired_token`,
-            `access_denied`, etc.).  Caller stops polling.
-        """
-        assert self._session is not None, "Use 'async with OAuthDeviceCodeClient(...)'"
+        assert self._session is not None
         payload = {
             "client_id": self._client_id,
             "device_code": device_code,
@@ -196,14 +431,12 @@ class OAuthDeviceCodeClient:
         }
         if self._client_secret:
             payload["client_secret"] = self._client_secret
-
         async with self._session.post(self._token_url, data=payload) as resp:
             data = await resp.json()
             if resp.status == 200:
-                return self._tokens_from_response(data)
+                return _tokens_from_response(data)
             err = data.get("error", "")
             if err in ("authorization_pending", "slow_down"):
-                # Not done yet.
                 return None
             raise DeviceCodeError(
                 code=err or "unknown_error",
@@ -217,12 +450,6 @@ class OAuthDeviceCodeClient:
         challenge: DeviceCodeChallenge,
         cancel_event: Optional[asyncio.Event] = None,
     ) -> OAuthTokens:
-        """Convenience: poll on `challenge.interval` until terminal.
-
-        Honors `expires_in` from the challenge — raises
-        ``DeviceCodeError("expired_token", ...)`` when the device-code
-        TTL is up.  Cancel via `cancel_event` (Tab5 closing the modal).
-        """
         deadline = time.time() + challenge.expires_in
         interval = challenge.interval
         while True:
@@ -236,23 +463,16 @@ class OAuthDeviceCodeClient:
                 tokens = await self.poll_once(challenge.device_code)
             except DeviceCodeError as e:
                 if e.code == "slow_down":
-                    # Provider asked us to back off; bump interval.
                     interval += 5
                     await asyncio.sleep(interval)
                     continue
-                # Anything else is terminal.
                 raise
             if tokens is not None:
                 return tokens
             await asyncio.sleep(interval)
 
     async def refresh(self, refresh_token: str) -> OAuthTokens:
-        """Exchange a refresh token for a new access token.
-
-        Raises DeviceCodeError on terminal failure (refresh token
-        revoked / expired — user has to reconnect).
-        """
-        assert self._session is not None, "Use 'async with OAuthDeviceCodeClient(...)'"
+        assert self._session is not None
         payload = {
             "client_id": self._client_id,
             "refresh_token": refresh_token,
@@ -260,7 +480,6 @@ class OAuthDeviceCodeClient:
         }
         if self._client_secret:
             payload["client_secret"] = self._client_secret
-
         async with self._session.post(self._token_url, data=payload) as resp:
             data = await resp.json()
             if resp.status != 200:
@@ -270,29 +489,7 @@ class OAuthDeviceCodeClient:
                         "error_description", "Refresh token rejected"
                     ),
                 )
-        # Refresh responses may omit `refresh_token` — providers expect
-        # the client to reuse the old one.
-        tokens = self._tokens_from_response(data)
+        tokens = _tokens_from_response(data)
         if not tokens.refresh_token:
             tokens.refresh_token = refresh_token
         return tokens
-
-    @staticmethod
-    def _tokens_from_response(data: dict) -> OAuthTokens:
-        expires_in = int(data.get("expires_in", 3600))
-        scope_str = data.get("scope", "")
-        scopes = scope_str.split() if scope_str else []
-        return OAuthTokens(
-            access_token=data["access_token"],
-            refresh_token=data.get("refresh_token"),
-            token_type=data.get("token_type", "Bearer"),
-            expires_at=int(time.time()) + expires_in,
-            scopes=scopes,
-            extra={
-                k: v for k, v in data.items()
-                if k not in {
-                    "access_token", "refresh_token", "token_type",
-                    "expires_in", "scope",
-                }
-            },
-        )

--- a/tests/test_google_calendar_integration.py
+++ b/tests/test_google_calendar_integration.py
@@ -1,14 +1,14 @@
-"""#341 / #342 — Google Calendar integration tests.
+"""#341 / #342 / #346 — Google Calendar integration tests (auth-code shape).
 
 Stubs the Google OAuth + Calendar API via aiohttp session mocks.
 Asserts:
+  * `auth_kind` is `oauth-authcode` (post-pivot)
   * `is_connected` is False initially, True after token persist
-  * `start_connect` returns a verification_url + user_code from the
-    mocked device-code endpoint
-  * `list_events` builds the right URL + params, normalizes payload
-  * `create_event` + `cancel_event` round-trip
-  * `disconnect` calls revoke + deletes creds
-  * Expired access token triggers refresh-on-401
+  * `start_connect` builds a PKCE authorization_url + tracks the flow
+  * `handle_callback` resolves matching state, persists tokens
+  * `poll_status` reports the flow state correctly
+  * `list_events` / `create_event` / `disconnect` round-trip
+  * Expired access token triggers refresh-on-401 via the auth-code client
 """
 
 from __future__ import annotations
@@ -23,7 +23,7 @@ from dragon_voice.tools.integrations.credentials import CredentialStore
 from dragon_voice.tools.integrations.google.calendar import (
     GoogleCalendarIntegration,
 )
-from dragon_voice.tools.integrations.oauth import OAuthTokens
+from dragon_voice.tools.integrations.oauth import DeviceCodeError, OAuthTokens
 
 
 @pytest.fixture(autouse=True)
@@ -32,11 +32,16 @@ def _redirect_cred_store(tmp_path, monkeypatch):
     monkeypatch.setenv("TINKERCLAW_INTEGRATIONS_DIR", str(tmp_path))
 
 
+@pytest.fixture(autouse=True)
+def _oauth_env(monkeypatch):
+    """Default Google OAuth client env so start_connect can build a URL."""
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "test-cid")
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "test-csec")
+
+
 @pytest.fixture
 def integration(tmp_path):
     integ = GoogleCalendarIntegration()
-    # Replace the store with an explicit tmp_path-backed one to make
-    # the redirect deterministic even if env-var lookup races.
     integ._store = CredentialStore("google-calendar", base_dir=tmp_path)
     return integ
 
@@ -66,6 +71,13 @@ def _make_mock_response(json_data, status=200):
     return cm
 
 
+# ── shape + lifecycle ───────────────────────────────────────────────
+
+
+def test_auth_kind_is_oauth_authcode(integration):
+    assert integration.auth_kind == "oauth-authcode"
+
+
 @pytest.mark.asyncio
 async def test_initial_state_is_disconnected(integration):
     assert await integration.is_connected() is False
@@ -78,9 +90,18 @@ async def test_is_connected_true_after_persist(integration, valid_tokens):
 
 
 @pytest.mark.asyncio
+async def test_health_check_returns_false_when_disconnected(integration):
+    ok, detail = await integration.health_check()
+    assert ok is False
+    assert "not connected" in detail.lower()
+
+
+# ── start_connect / poll_status / handle_callback ───────────────────
+
+
+@pytest.mark.asyncio
 async def test_start_connect_requires_oauth_env(integration, monkeypatch):
-    """No GOOGLE_OAUTH_CLIENT_ID → raises a structured error so the
-    REST layer can surface a 503 + actionable message."""
+    """No GOOGLE_OAUTH_CLIENT_ID → raises so the REST layer returns 503."""
     monkeypatch.delenv("GOOGLE_OAUTH_CLIENT_ID", raising=False)
     from dragon_voice.tools.integrations.google.auth import (
         GoogleOAuthNotConfiguredError,
@@ -90,16 +111,142 @@ async def test_start_connect_requires_oauth_env(integration, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_health_check_returns_false_when_disconnected(integration):
-    ok, detail = await integration.health_check()
-    assert ok is False
-    assert "not connected" in detail.lower()
+async def test_start_connect_returns_pkce_authorization_url(integration):
+    chal = await integration.start_connect()
+    assert chal.request_id
+    assert chal.verification_url.startswith(
+        "https://accounts.google.com/o/oauth2/v2/auth?",
+    )
+    assert "code_challenge=" in chal.verification_url
+    assert "code_challenge_method=S256" in chal.verification_url
+    # Google needs offline + consent to mint a refresh_token.
+    assert "access_type=offline" in chal.verification_url
+    assert "prompt=consent" in chal.verification_url
+    # Auth-code flow has no user_code (only device-code does).
+    assert chal.user_code is None
+
+
+@pytest.mark.asyncio
+async def test_start_connect_tracks_flow_by_request_id_and_state(integration):
+    chal = await integration.start_connect()
+    flow = integration._flows[chal.request_id]
+    assert flow.state  # populated
+    assert flow.code_verifier  # populated
+    # _find_flow_by_state agrees.
+    assert integration._find_flow_by_state(flow.state) is flow
+
+
+@pytest.mark.asyncio
+async def test_find_flow_by_state_returns_none_for_unknown_state(integration):
+    await integration.start_connect()
+    assert integration._find_flow_by_state("never-issued") is None
+
+
+@pytest.mark.asyncio
+async def test_poll_status_reports_connecting_then_connected(
+    integration, valid_tokens,
+):
+    chal = await integration.start_connect()
+    status = await integration.poll_status(chal.request_id)
+    assert status.state == "connecting"
+
+    # Simulate the callback resolving the flow.
+    flow = integration._flows[chal.request_id]
+    flow.tokens = valid_tokens
+
+    status = await integration.poll_status(chal.request_id)
+    assert status.state == "connected"
+
+
+@pytest.mark.asyncio
+async def test_poll_status_unknown_request_id_is_error(integration):
+    status = await integration.poll_status("never-issued")
+    assert status.state == "error"
+    assert "unknown" in (status.error or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_handle_callback_unknown_state_is_noop(integration):
+    # Must not raise; must not persist anything.
+    await integration.handle_callback(state="never-issued", code="x", error=None)
+    assert await integration.is_connected() is False
+
+
+@pytest.mark.asyncio
+async def test_handle_callback_with_error_sets_flow_error(integration):
+    chal = await integration.start_connect()
+    flow = integration._flows[chal.request_id]
+    await integration.handle_callback(
+        state=flow.state, code=None, error="access_denied",
+    )
+    assert flow.error is not None
+    assert flow.error.code == "access_denied"
+
+    status = await integration.poll_status(chal.request_id)
+    assert status.state == "error"
+
+
+@pytest.mark.asyncio
+async def test_handle_callback_success_exchanges_and_persists(
+    integration, valid_tokens,
+):
+    chal = await integration.start_connect()
+    flow = integration._flows[chal.request_id]
+
+    fake_client = MagicMock()
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+    fake_client.exchange_code_with_verifier = AsyncMock(return_value=valid_tokens)
+
+    with patch(
+        "dragon_voice.tools.integrations.google.calendar.make_google_client",
+        return_value=fake_client,
+    ):
+        await integration.handle_callback(
+            state=flow.state, code="AUTH-CODE-1", error=None,
+        )
+
+    fake_client.exchange_code_with_verifier.assert_awaited_once_with(
+        code="AUTH-CODE-1", code_verifier=flow.code_verifier,
+    )
+    assert flow.tokens is valid_tokens
+    assert await integration.is_connected() is True
+
+    status = await integration.poll_status(chal.request_id)
+    assert status.state == "connected"
+
+
+@pytest.mark.asyncio
+async def test_handle_callback_exchange_failure_sets_flow_error(integration):
+    chal = await integration.start_connect()
+    flow = integration._flows[chal.request_id]
+
+    fake_client = MagicMock()
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+    fake_client.exchange_code_with_verifier = AsyncMock(
+        side_effect=DeviceCodeError("invalid_grant", "code reused"),
+    )
+
+    with patch(
+        "dragon_voice.tools.integrations.google.calendar.make_google_client",
+        return_value=fake_client,
+    ):
+        await integration.handle_callback(
+            state=flow.state, code="AUTH-CODE-1", error=None,
+        )
+
+    assert flow.tokens is None
+    assert flow.error is not None
+    assert flow.error.code == "invalid_grant"
+
+
+# ── Calendar API (unchanged by the auth-code pivot) ────────────────
 
 
 @pytest.mark.asyncio
 async def test_list_events_returns_normalized_shape(integration, valid_tokens):
-    """The Calendar API returns verbose payloads — we normalize down
-    to {id, summary, location, start_iso, end_iso, all_day, ...}."""
+    """The Calendar API returns verbose payloads — we normalize down."""
     await integration._persist_tokens(valid_tokens)
 
     fake_session = MagicMock()
@@ -166,7 +313,6 @@ async def test_create_event_posts_with_auth_header(integration, valid_tokens):
 
     assert ev["id"] == "evt-new"
     assert ev["summary"] == "Lunch"
-    # Verify the POST was authed.
     call_kwargs = fake_session.post.call_args.kwargs
     assert call_kwargs["headers"]["Authorization"] == "Bearer AT-fresh"
 
@@ -176,7 +322,6 @@ async def test_disconnect_clears_creds(integration, valid_tokens):
     await integration._persist_tokens(valid_tokens)
     assert await integration.is_connected()
 
-    # Mock the revoke endpoint as a no-op success.
     fake_session = MagicMock()
     fake_session.closed = False
     fake_session.__aenter__ = AsyncMock(return_value=fake_session)
@@ -194,21 +339,17 @@ async def test_disconnect_clears_creds(integration, valid_tokens):
 
 
 @pytest.mark.asyncio
-async def test_expired_token_triggers_refresh(integration, monkeypatch):
-    """When the cached `expires_at` is past, `_get_access_token` must
-    refresh via the OAuth client before returning the new access token."""
+async def test_expired_token_triggers_refresh_via_authcode_client(integration):
+    """When `expires_at` is past, `_get_access_token` refreshes via the
+    auth-code client and persists the new tokens."""
     expired = OAuthTokens(
         access_token="AT-OLD",
         refresh_token="RT-1",
         token_type="Bearer",
-        expires_at=int(time.time()) - 10,  # already expired
+        expires_at=int(time.time()) - 10,
         scopes=["https://www.googleapis.com/auth/calendar.readonly"],
     )
     await integration._persist_tokens(expired)
-
-    # Mock GoogleOAuthConfig.from_env to skip env-var check.
-    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "cid")
-    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "csec")
 
     new_tokens = OAuthTokens(
         access_token="AT-NEW",
@@ -218,11 +359,10 @@ async def test_expired_token_triggers_refresh(integration, monkeypatch):
         scopes=["https://www.googleapis.com/auth/calendar.readonly"],
     )
 
-    refresh_mock = AsyncMock(return_value=new_tokens)
     fake_client = MagicMock()
     fake_client.__aenter__ = AsyncMock(return_value=fake_client)
     fake_client.__aexit__ = AsyncMock(return_value=None)
-    fake_client.refresh = refresh_mock
+    fake_client.refresh = AsyncMock(return_value=new_tokens)
 
     with patch(
         "dragon_voice.tools.integrations.google.calendar.make_google_client",
@@ -231,4 +371,4 @@ async def test_expired_token_triggers_refresh(integration, monkeypatch):
         token = await integration._get_access_token()
 
     assert token == "AT-NEW"
-    refresh_mock.assert_awaited_once_with("RT-1")
+    fake_client.refresh.assert_awaited_once_with("RT-1")

--- a/tests/test_integrations_init.py
+++ b/tests/test_integrations_init.py
@@ -1,0 +1,87 @@
+"""#341 / #348 — `dragon_voice/lifecycle/integrations_init.py`.
+
+Verifies the tool-registration wiring for TinkerBox-native
+integrations.  Mirrors the failure-isolation pattern of
+`test_notes_db_async.py` — the init step must register the calendar
+tools when possible AND swallow import errors at WARNING so a broken
+optional integration doesn't take down boot.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from dragon_voice.lifecycle.integrations_init import init_integration_tools
+
+
+class _FakeRegistry:
+    """Records registrations + lets tests assert by tool name."""
+
+    def __init__(self) -> None:
+        self.registered: list[object] = []
+
+    def register(self, tool) -> None:  # noqa: ANN001
+        self.registered.append(tool)
+
+    @property
+    def names(self) -> list[str]:
+        return [getattr(t, "name", repr(t)) for t in self.registered]
+
+
+@pytest.mark.asyncio
+async def test_registers_all_four_calendar_tools_on_clean_registry():
+    server = MagicMock()
+    server._tool_registry = _FakeRegistry()
+
+    await init_integration_tools(server)
+
+    names = server._tool_registry.names
+    assert "calendar_today" in names
+    assert "calendar_week" in names
+    assert "calendar_create" in names
+    assert "calendar_cancel" in names
+
+
+@pytest.mark.asyncio
+async def test_no_tool_registry_is_silent_noop():
+    """If the registry didn't initialize (e.g. agentic init failed) the
+    function must return cleanly — boot continues without tools."""
+    server = MagicMock()
+    server._tool_registry = None
+    # Must not raise.
+    await init_integration_tools(server)
+
+
+@pytest.mark.asyncio
+async def test_calendar_module_import_failure_is_swallowed(monkeypatch, caplog):
+    """Simulate the google_calendar_tool module being missing — boot
+    must continue, with a single WARNING.  Confirms the try/except
+    failure-isolation invariant lives at the right boundary."""
+    # Drop the module from cache so the next import sees our stub.
+    monkeypatch.delitem(
+        sys.modules, "dragon_voice.tools.google_calendar_tool", raising=False,
+    )
+
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __import__
+
+    def _raising_import(name, *args, **kwargs):
+        if name == "dragon_voice.tools.google_calendar_tool":
+            raise ImportError("simulated: calendar tool unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", _raising_import)
+
+    server = MagicMock()
+    server._tool_registry = _FakeRegistry()
+    with caplog.at_level("WARNING"):
+        await init_integration_tools(server)
+
+    # No tools registered, no exception escaped.
+    assert server._tool_registry.registered == []
+    assert any(
+        "Google Calendar tools not available" in rec.message
+        for rec in caplog.records
+    )

--- a/tests/test_integrations_registry.py
+++ b/tests/test_integrations_registry.py
@@ -62,7 +62,7 @@ def test_create_integration_returns_instance():
     assert isinstance(integ, IntegrationBackend)
     assert integ.name == "google-calendar"
     assert integ.display_name == "Google Calendar"
-    assert integ.auth_kind == "oauth-device"
+    assert integ.auth_kind == "oauth-authcode"
 
 
 def test_reset_clears_then_restores_from_snapshot():

--- a/tests/test_oauth_auth_code.py
+++ b/tests/test_oauth_auth_code.py
@@ -1,0 +1,259 @@
+"""#341 / #345 — OAuth Authorization-Code-with-PKCE client.
+
+Pairs with `test_oauth_device_code.py` (the device-code path is kept
+for non-Google providers).  This file covers the new auth-code client
+that Google Calendar + Gmail use.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import time
+import urllib.parse
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.tools.integrations.oauth import (
+    AuthCodeChallenge,
+    DeviceCodeError,
+    OAuthAuthCodeClient,
+    OAuthTokens,
+    _pkce_pair,
+)
+
+
+@pytest.fixture
+def fake_session():
+    """aiohttp ClientSession stand-in — records POSTs + returns pre-canned responses."""
+    session = MagicMock()
+    session.closed = False
+    return session
+
+
+def _mock_response(json_data: dict, status: int = 200):
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=MagicMock(
+        status=status,
+        json=AsyncMock(return_value=json_data),
+    ))
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return cm
+
+
+def _make_client(session) -> OAuthAuthCodeClient:
+    return OAuthAuthCodeClient(
+        client_id="cid",
+        client_secret="csec",
+        scope="scope-x scope-y",
+        auth_url="https://accounts.example.com/auth",
+        token_url="https://oauth.example.com/token",
+        redirect_uri="https://callback.example.com/cb",
+        session=session,
+    )
+
+
+# ── _pkce_pair ──────────────────────────────────────────────────────
+
+
+def test_pkce_pair_verifier_meets_rfc_7636_length():
+    verifier, _challenge = _pkce_pair()
+    # RFC 7636 §4.1: verifier is 43–128 chars in [A-Za-z0-9-._~].
+    assert 43 <= len(verifier) <= 128
+    allowed = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+    assert set(verifier).issubset(allowed)
+
+
+def test_pkce_pair_challenge_is_sha256_of_verifier():
+    verifier, challenge = _pkce_pair()
+    expected = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode("ascii")).digest(),
+    ).rstrip(b"=").decode("ascii")
+    assert challenge == expected
+
+
+def test_pkce_pair_yields_unique_values():
+    pairs = [_pkce_pair() for _ in range(5)]
+    verifiers = {v for v, _ in pairs}
+    assert len(verifiers) == 5
+
+
+# ── start() ─────────────────────────────────────────────────────────
+
+
+def test_start_returns_authorization_url_with_pkce_and_state(fake_session):
+    client = _make_client(fake_session)
+    chal = client.start()
+    assert isinstance(chal, AuthCodeChallenge)
+
+    parsed = urllib.parse.urlparse(chal.authorization_url)
+    params = dict(urllib.parse.parse_qsl(parsed.query))
+    assert params["client_id"] == "cid"
+    assert params["redirect_uri"] == "https://callback.example.com/cb"
+    assert params["response_type"] == "code"
+    assert params["scope"] == "scope-x scope-y"
+    assert params["code_challenge_method"] == "S256"
+    assert params["state"] == chal.state
+    # The challenge in the URL is BASE64URL(SHA256(verifier)).
+    expected = base64.urlsafe_b64encode(
+        hashlib.sha256(chal.code_verifier.encode("ascii")).digest(),
+    ).rstrip(b"=").decode("ascii")
+    assert params["code_challenge"] == expected
+
+
+def test_start_applies_provider_extras(fake_session):
+    client = _make_client(fake_session)
+    chal = client.start(extra_params={
+        "access_type": "offline",
+        "prompt": "consent",
+    })
+    parsed = urllib.parse.urlparse(chal.authorization_url)
+    params = dict(urllib.parse.parse_qsl(parsed.query))
+    assert params["access_type"] == "offline"
+    assert params["prompt"] == "consent"
+
+
+def test_start_registers_pending_state_with_verifier(fake_session):
+    client = _make_client(fake_session)
+    chal = client.start()
+    entry = client._pending[chal.state]
+    assert entry["code_verifier"] == chal.code_verifier
+    assert entry["future"] is not None
+
+
+# ── resolve_callback + wait_for_callback ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_wait_for_callback_returns_code_after_resolve(fake_session):
+    client = _make_client(fake_session)
+    chal = client.start()
+
+    async def _resolver():
+        await asyncio.sleep(0)  # let the waiter park
+        client.resolve_callback(state=chal.state, code="AUTH-CODE-1", error=None)
+
+    code, _ = await asyncio.gather(
+        client.wait_for_callback(chal.state, timeout_s=5),
+        _resolver(),
+    )
+    assert code == "AUTH-CODE-1"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_callback_raises_on_provider_error(fake_session):
+    client = _make_client(fake_session)
+    chal = client.start()
+
+    async def _resolver():
+        await asyncio.sleep(0)
+        client.resolve_callback(state=chal.state, code=None, error="access_denied")
+
+    with pytest.raises(DeviceCodeError) as excinfo:
+        await asyncio.gather(
+            client.wait_for_callback(chal.state, timeout_s=5),
+            _resolver(),
+        )
+    assert excinfo.value.code == "access_denied"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_callback_times_out_as_expired_token(fake_session):
+    client = _make_client(fake_session)
+    chal = client.start()
+    with pytest.raises(DeviceCodeError) as excinfo:
+        # Tiny timeout — the resolver never runs.
+        await client.wait_for_callback(chal.state, timeout_s=0)
+    assert excinfo.value.code == "expired_token"
+
+
+def test_resolve_callback_unknown_state_does_not_raise(fake_session):
+    """Stale/forged states should log a warning, not crash the callback."""
+    client = _make_client(fake_session)
+    client.resolve_callback(state="never-issued", code="x", error=None)
+    # Test passes if the call returned cleanly.
+
+
+def test_wait_for_callback_unknown_state_raises_immediately(fake_session):
+    client = _make_client(fake_session)
+    with pytest.raises(DeviceCodeError) as excinfo:
+        # No coroutine awaited — the raise is synchronous.
+        asyncio.get_event_loop().run_until_complete(
+            client.wait_for_callback("never-issued", timeout_s=1),
+        )
+    assert excinfo.value.code == "unknown_state"
+
+
+# ── exchange_code_with_verifier ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_with_verifier_posts_pkce_payload(fake_session):
+    fake_session.post = MagicMock(return_value=_mock_response({
+        "access_token": "AT-1",
+        "refresh_token": "RT-1",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "scope": "scope-a scope-b",
+    }))
+    client = _make_client(fake_session)
+    tokens = await client.exchange_code_with_verifier(
+        code="AUTH-CODE-1", code_verifier="VERIFIER-X",
+    )
+    assert isinstance(tokens, OAuthTokens)
+    assert tokens.access_token == "AT-1"
+    assert tokens.refresh_token == "RT-1"
+    assert tokens.scopes == ["scope-a", "scope-b"]
+
+    payload = fake_session.post.call_args.kwargs["data"]
+    assert payload["grant_type"] == "authorization_code"
+    assert payload["code"] == "AUTH-CODE-1"
+    assert payload["code_verifier"] == "VERIFIER-X"
+    assert payload["client_id"] == "cid"
+    assert payload["client_secret"] == "csec"
+    assert payload["redirect_uri"] == "https://callback.example.com/cb"
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_raises_on_provider_400(fake_session):
+    fake_session.post = MagicMock(return_value=_mock_response(
+        {"error": "invalid_grant", "error_description": "code reused"},
+        status=400,
+    ))
+    client = _make_client(fake_session)
+    with pytest.raises(DeviceCodeError) as excinfo:
+        await client.exchange_code_with_verifier(code="x", code_verifier="v")
+    assert excinfo.value.code == "invalid_grant"
+
+
+# ── refresh ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_refresh_returns_new_access_token(fake_session):
+    fake_session.post = MagicMock(return_value=_mock_response({
+        "access_token": "AT-2",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "scope": "scope-a",
+    }))
+    client = _make_client(fake_session)
+    t0 = time.time()
+    new_tokens = await client.refresh("RT-OLD")
+    assert new_tokens.access_token == "AT-2"
+    assert new_tokens.expires_at >= t0 + 3500
+    # Server omitted refresh_token → preserve the prior one.
+    assert new_tokens.refresh_token == "RT-OLD"
+
+
+@pytest.mark.asyncio
+async def test_refresh_raises_on_provider_rejection(fake_session):
+    fake_session.post = MagicMock(return_value=_mock_response(
+        {"error": "invalid_grant"}, status=400,
+    ))
+    client = _make_client(fake_session)
+    with pytest.raises(DeviceCodeError) as excinfo:
+        await client.refresh("RT-DEAD")
+    assert excinfo.value.code == "invalid_grant"


### PR DESCRIPTION
## Summary

- Pivot Google OAuth from device-code to authorization-code-with-PKCE.  Google's device-code allow-scope list excludes Calendar + Gmail, so Phase 1 of #341 wouldn't actually work as planned.
- Add `OAuthAuthCodeClient` (PKCE S256 + state) alongside the existing `OAuthDeviceCodeClient` — the device-code client stays for non-Google providers.
- Public `GET /api/v1/oauth/callback` (bearer-bypass; the PKCE `state` parameter authenticates) renders a small dark-themed HTML success/failure page on the user's phone browser.  Tab5 polls the status endpoint independently.
- Wire the 4 calendar tools (`calendar_today`, `_week`, `_create`, `_cancel`) into the tool registry via `lifecycle/integrations_init.py` so the LLM can call them in any vmode.

Closes #345.  Refs #341.

## Live verification (Dragon)

```
$ curl -H "Authorization: Bearer ***" http://localhost:3502/api/v1/integrations/google-calendar/test
{ "ok": true, "detail": "connected to team@yallax.tech", "name": "google-calendar" }

$ curl -X POST -H "Authorization: Bearer ***" http://localhost:3502/api/v1/tools/calendar_week/execute -d '{"max_results":5}'
{ "tool": "calendar_week", "result": { "count": 17, "events": [ ... ] }, "execution_ms": 467 }
```

Credentials persisted at `/home/radxa/tinkerclaw/integrations/google-calendar.json` (mode 0o600).  The default `~/.tinkerclaw/integrations/` is read-only on Dragon under the `tinkerclaw-voice.service` `ProtectHome=read-only` + `ReadWritePaths` hardening — pointed at a writable sibling via the `TINKERCLAW_INTEGRATIONS_DIR` env override.

## Test plan

- [x] Ruff narrow gate (`F821,F722,F811,F823,B006,B904,E722,B007,RUF006`) passes against the touched files.
- [x] `tests/test_auth_middleware.py` — 6/6 passing (touched `middleware/auth.py` for the callback bypass).
- [x] Live end-to-end auth flow on Dragon: connect → Google consent → callback → token persist → `calendar_today` + `calendar_week` against `team@yallax.tech`.
- [ ] Follow-up: rewrite `tests/test_oauth_device_code.py` + `tests/test_google_calendar_integration.py` for the auth-code shape, add `test_integrations_init.py` for the tool-registration wiring.  Tracked separately so this PR stays scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)