### PR TITLE
feat(integrations): multi-account per provider (work + personal Google)

### DIFF
--- a/dragon_voice/api/integrations.py
+++ b/dragon_voice/api/integrations.py
@@ -1,21 +1,26 @@
-"""REST API routes for integrations (#341 / #342).
+"""REST API routes for integrations (#341 / #342 / #347).
 
 Tab5's Settings → Integrations surface calls these:
 
-  * GET  /api/v1/integrations                     — list + connection state
-  * POST /api/v1/integrations/{name}/connect      — start auth flow
-  * GET  /api/v1/integrations/{name}/status/{request_id}  — poll flow
-  * POST /api/v1/integrations/{name}/disconnect   — revoke + delete
-  * GET  /api/v1/integrations/{name}/test         — smoke test
+  * GET    /api/v1/integrations                          — list + connected accounts
+  * POST   /api/v1/integrations/{name}/connect           — start auth flow
+  * GET    /api/v1/integrations/{name}/status/{request_id}  — poll flow
+  * POST   /api/v1/integrations/{name}/disconnect        — disconnect ALL accounts
+  * DELETE /api/v1/integrations/{name}/accounts/{account_id}  — disconnect one (#347)
+  * PATCH  /api/v1/integrations/{name}/accounts/{account_id}  — set default (#347)
+  * GET    /api/v1/integrations/{name}/test              — smoke test default account
+  * GET    /api/v1/integrations/{name}/accounts/{account_id}/test  — per-account smoke test
 
-All routes require bearer auth (the standard middleware covers it; no
-extra check here).  Errors are surfaced as JSON with a sensible HTTP
-status — Tab5 turns them into modal text.
+OAuth callback:
+  * GET    /api/v1/oauth/callback  — Google redirect target (public)
+
+All non-callback routes require bearer auth.
 """
 
 from __future__ import annotations
 
 import logging
+from dataclasses import asdict
 from typing import Any, Optional
 
 from aiohttp import web
@@ -61,7 +66,6 @@ class IntegrationRoutes:
     in-flight auth flows survive across requests."""
 
     def __init__(self) -> None:
-        # name -> backend instance (per-process singleton)
         self._instances: dict[str, IntegrationBackend] = {}
 
     def _get(self, name: str) -> IntegrationBackend:
@@ -73,42 +77,46 @@ class IntegrationRoutes:
         return self._instances[key]
 
     def register(self, app: web.Application) -> None:
+        app.router.add_get("/api/v1/integrations", self.list_all)
+        app.router.add_post(
+            "/api/v1/integrations/{name}/connect", self.connect,
+        )
         app.router.add_get(
-            "/api/v1/integrations",
-            self.list_all,
+            "/api/v1/integrations/{name}/status/{request_id}", self.status,
         )
         app.router.add_post(
-            "/api/v1/integrations/{name}/connect",
-            self.connect,
+            "/api/v1/integrations/{name}/disconnect", self.disconnect_all,
         )
         app.router.add_get(
-            "/api/v1/integrations/{name}/status/{request_id}",
-            self.status,
+            "/api/v1/integrations/{name}/test", self.test,
         )
-        app.router.add_post(
-            "/api/v1/integrations/{name}/disconnect",
-            self.disconnect,
+        # #347 — per-account routes.
+        app.router.add_delete(
+            "/api/v1/integrations/{name}/accounts/{account_id}",
+            self.disconnect_account,
+        )
+        app.router.add_patch(
+            "/api/v1/integrations/{name}/accounts/{account_id}",
+            self.update_account,
         )
         app.router.add_get(
-            "/api/v1/integrations/{name}/test",
-            self.test,
+            "/api/v1/integrations/{name}/accounts/{account_id}/test",
+            self.test_account,
         )
-        # OAuth callback — public route (bearer-auth bypassed by the
-        # middleware's PUBLIC_PREFIXES list; the auth happens via the
-        # PKCE state parameter which only the originating Dragon
-        # process can decrypt).  Google posts the user here after
-        # consent.  Walks every registered integration to find the one
-        # holding this state.
+        # OAuth callback — public (PKCE state authenticates).  See
+        # middleware/auth.py PUBLIC_PREFIXES.  Walks every registered
+        # integration to find the one holding this state.
         app.router.add_get("/api/v1/oauth/callback", self.oauth_callback)
 
     # ── handlers ────────────────────────────────────────────────
 
     async def list_all(self, request: web.Request) -> web.Response:
-        del request  # unused
+        del request
         out: list[dict[str, Any]] = []
         for name in list_integrations():
             integ = self._get(name)
             connected = await integ.is_connected()
+            accounts = await integ.list_accounts()
             state = (
                 IntegrationState.CONNECTED.value
                 if connected else IntegrationState.DISCONNECTED.value
@@ -119,6 +127,8 @@ class IntegrationRoutes:
                 "description": integ.description,
                 "auth_kind": integ.auth_kind,
                 "state": state,
+                "supports_multi_account": integ.supports_multi_account,
+                "accounts": [asdict(a) for a in accounts],
             })
         return web.json_response({"integrations": out})
 
@@ -170,9 +180,11 @@ class IntegrationRoutes:
             "state": status.state,
             "request_id": status.request_id,
             "error": status.error,
+            "account_id": status.account_id,
+            "account_label": status.account_label,
         })
 
-    async def disconnect(self, request: web.Request) -> web.Response:
+    async def disconnect_all(self, request: web.Request) -> web.Response:
         name = request.match_info["name"]
         try:
             integ = self._get(name)
@@ -181,9 +193,56 @@ class IntegrationRoutes:
         try:
             await integ.disconnect()
         except Exception as e:  # noqa: BLE001
-            logger.exception("integration %s disconnect failed", name)
+            logger.exception("integration %s disconnect-all failed", name)
             return json_error(f"Disconnect failed: {e}", 500)
         return web.json_response({"disconnected": True, "name": name})
+
+    async def disconnect_account(self, request: web.Request) -> web.Response:
+        name = request.match_info["name"]
+        account_id = request.match_info["account_id"]
+        try:
+            integ = self._get(name)
+        except KeyError:
+            return json_error(f"Unknown integration '{name}'", 404)
+        if not await integ.is_connected(account_id):
+            return json_error(
+                f"Account '{account_id}' is not connected for '{name}'", 404,
+            )
+        try:
+            await integ.disconnect(account_id=account_id)
+        except Exception as e:  # noqa: BLE001
+            logger.exception(
+                "integration %s disconnect %s failed", name, account_id,
+            )
+            return json_error(f"Disconnect failed: {e}", 500)
+        return web.json_response({
+            "disconnected": True, "name": name, "account_id": account_id,
+        })
+
+    async def update_account(self, request: web.Request) -> web.Response:
+        name = request.match_info["name"]
+        account_id = request.match_info["account_id"]
+        try:
+            integ = self._get(name)
+        except KeyError:
+            return json_error(f"Unknown integration '{name}'", 404)
+        body, err = await parse_json_body(request)
+        if err:
+            return err
+        if body.get("default") is True:
+            try:
+                await integ.set_default_account(account_id)
+            except DeviceCodeError as e:
+                return web.json_response(
+                    {"error": e.code, "message": e.description}, status=404,
+                )
+            return web.json_response({
+                "name": name, "account_id": account_id, "default": True,
+            })
+        return json_error(
+            "PATCH body must contain {\"default\": true} — no other fields supported",
+            400,
+        )
 
     async def test(self, request: web.Request) -> web.Response:
         name = request.match_info["name"]
@@ -192,10 +251,18 @@ class IntegrationRoutes:
         except KeyError:
             return json_error(f"Unknown integration '{name}'", 404)
         ok, detail = await integ.health_check()
+        return web.json_response({"ok": ok, "detail": detail, "name": name})
+
+    async def test_account(self, request: web.Request) -> web.Response:
+        name = request.match_info["name"]
+        account_id = request.match_info["account_id"]
+        try:
+            integ = self._get(name)
+        except KeyError:
+            return json_error(f"Unknown integration '{name}'", 404)
+        ok, detail = await integ.health_check(account_id=account_id)
         return web.json_response({
-            "ok": ok,
-            "detail": detail,
-            "name": name,
+            "ok": ok, "detail": detail, "name": name, "account_id": account_id,
         })
 
     async def oauth_callback(self, request: web.Request) -> web.Response:
@@ -203,12 +270,8 @@ class IntegrationRoutes:
 
         Google sends the user here after consent:
         ``?code=...&state=...`` on success or ``?error=...&state=...``
-        on denial.  We walk every instantiated integration looking for
-        one that recognizes the state, then hand the code off.
-
-        Responds with a tiny HTML page so the user's phone shows a
-        success/error message.  Tab5 has its own polling loop and
-        flips the modal independently.
+        on denial.  Walks every instantiated integration looking for
+        one that recognizes the state, then hands the code off.
         """
         params = request.query
         state = params.get("state", "")
@@ -220,7 +283,6 @@ class IntegrationRoutes:
                 "Missing state parameter — link may be malformed.", success=False,
             )
 
-        # Find the integration holding this state.
         matched: Optional[IntegrationBackend] = None
         for integ in self._instances.values():
             handler = getattr(integ, "handle_callback", None)

--- a/dragon_voice/tools/google_calendar_tool.py
+++ b/dragon_voice/tools/google_calendar_tool.py
@@ -1,11 +1,14 @@
-"""Voice-callable tools for Google Calendar (#341 / #342).
+"""Voice-callable tools for Google Calendar (#341 / #342 / #347).
 
 Thin `Tool` wrappers around `GoogleCalendarIntegration` so the LLM in
 any vmode can call `calendar_today`, `calendar_week`, `calendar_create`,
 `calendar_cancel` via the existing ToolRegistry mechanism.
 
-Return shape mirrors the rest of `dragon_voice/tools/` — plain dicts
-that the LLM injects back into context.  `error` key absent = success.
+Multi-account (#347): every tool accepts an optional ``account``
+argument.  When omitted the integration's default account is used.
+For multi-account providers the LLM is encouraged to infer the account
+from natural-language context ("what's on my work calendar tomorrow?"
+→ ``{"account": "<work email>"}``).
 """
 
 from __future__ import annotations
@@ -47,6 +50,17 @@ def _not_connected(action: str) -> dict[str, Any]:
     }
 
 
+_ACCOUNT_ARG_SCHEMA = {
+    "type": "string",
+    "description": (
+        "Optional account id (typically the email).  Omit to use the "
+        "default connected Google account.  Use the user's natural-"
+        "language hint to pick the right one — 'my work calendar' → "
+        "the work email; 'my personal calendar' → the personal email."
+    ),
+}
+
+
 class CalendarTodayTool(Tool):
     """List today's events."""
 
@@ -61,7 +75,8 @@ class CalendarTodayTool(Tool):
         return (
             "List today's events from the user's primary Google Calendar.  "
             "Use when the user asks 'what's on my calendar today' or 'what "
-            "do I have going on today'."
+            "do I have going on today'.  Accepts an optional `account` arg "
+            "for users with multiple connected Google accounts."
         )
 
     @property
@@ -73,12 +88,14 @@ class CalendarTodayTool(Tool):
                     "type": "integer",
                     "description": "Max events to return (default 10).",
                 },
+                "account": _ACCOUNT_ARG_SCHEMA,
             },
         }
 
     async def execute(self, args: dict) -> dict:
         integ = _shared_integration()
-        if not await integ.is_connected():
+        account = args.get("account")
+        if not await integ.is_connected(account_id=account):
             return _not_connected("read your calendar")
         now = datetime.now(timezone.utc)
         start = now.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -87,12 +104,14 @@ class CalendarTodayTool(Tool):
             events = await integ.list_events(
                 time_min=start, time_max=end,
                 max_results=int(args.get("max_results", 10)),
+                account_id=account,
             )
         except DeviceCodeError as e:
             return {"error": e.code, "message": e.description}
         return {
             "count": len(events),
             "events": events,
+            "account": account,
         }
 
 
@@ -108,7 +127,8 @@ class CalendarWeekTool(Tool):
         return (
             "List events for the next 7 days from the user's primary Google "
             "Calendar.  Use when the user asks 'what's on this week' or "
-            "'what's coming up'."
+            "'what's coming up'.  Accepts an optional `account` arg for "
+            "users with multiple connected Google accounts."
         )
 
     @property
@@ -120,12 +140,14 @@ class CalendarWeekTool(Tool):
                     "type": "integer",
                     "description": "Max events to return (default 20).",
                 },
+                "account": _ACCOUNT_ARG_SCHEMA,
             },
         }
 
     async def execute(self, args: dict) -> dict:
         integ = _shared_integration()
-        if not await integ.is_connected():
+        account = args.get("account")
+        if not await integ.is_connected(account_id=account):
             return _not_connected("read your calendar")
         now = datetime.now(timezone.utc)
         end = now + timedelta(days=7)
@@ -133,10 +155,11 @@ class CalendarWeekTool(Tool):
             events = await integ.list_events(
                 time_min=now, time_max=end,
                 max_results=int(args.get("max_results", 20)),
+                account_id=account,
             )
         except DeviceCodeError as e:
             return {"error": e.code, "message": e.description}
-        return {"count": len(events), "events": events}
+        return {"count": len(events), "events": events, "account": account}
 
 
 class CalendarCreateTool(Tool):
@@ -153,7 +176,9 @@ class CalendarCreateTool(Tool):
             "when the user explicitly asks to schedule / add / book a "
             "calendar event.  Confirm details with the user BEFORE calling; "
             "calendar writes are not undoable by voice except via "
-            "calendar_cancel."
+            "calendar_cancel.  Accepts an optional `account` arg for users "
+            "with multiple connected Google accounts — ask the user which "
+            "calendar to use if it's not obvious."
         )
 
     @property
@@ -182,12 +207,14 @@ class CalendarCreateTool(Tool):
                     "type": "string",
                     "description": "Optional longer description.",
                 },
+                "account": _ACCOUNT_ARG_SCHEMA,
             },
         }
 
     async def execute(self, args: dict) -> dict:
         integ = _shared_integration()
-        if not await integ.is_connected():
+        account = args.get("account")
+        if not await integ.is_connected(account_id=account):
             return _not_connected("create an event")
         try:
             start = datetime.fromisoformat(args["start_iso"])
@@ -201,10 +228,11 @@ class CalendarCreateTool(Tool):
                 end=end,
                 location=args.get("location"),
                 description=args.get("description"),
+                account_id=account,
             )
         except DeviceCodeError as e:
             return {"error": e.code, "message": e.description}
-        return {"event": ev, "created": True}
+        return {"event": ev, "created": True, "account": account}
 
 
 class CalendarCancelTool(Tool):
@@ -220,7 +248,9 @@ class CalendarCancelTool(Tool):
             "Delete an event from the user's primary Google Calendar.  Use "
             "when the user explicitly asks to cancel / delete / remove an "
             "event.  Confirm the event id (from a previous calendar_today "
-            "or calendar_week result) with the user before calling."
+            "or calendar_week result) with the user before calling.  "
+            "Accepts an optional `account` arg — match the account from "
+            "the event you're cancelling."
         )
 
     @property
@@ -233,14 +263,18 @@ class CalendarCancelTool(Tool):
                     "type": "string",
                     "description": "Event id from a previous calendar_today or calendar_week result.",
                 },
+                "account": _ACCOUNT_ARG_SCHEMA,
             },
         }
 
     async def execute(self, args: dict) -> dict:
         integ = _shared_integration()
-        if not await integ.is_connected():
+        account = args.get("account")
+        if not await integ.is_connected(account_id=account):
             return _not_connected("cancel an event")
-        ok = await integ.cancel_event(args["event_id"])
+        ok = await integ.cancel_event(args["event_id"], account_id=account)
         if not ok:
             return {"error": "cancel_failed", "event_id": args["event_id"]}
-        return {"cancelled": True, "event_id": args["event_id"]}
+        return {
+            "cancelled": True, "event_id": args["event_id"], "account": account,
+        }

--- a/dragon_voice/tools/integrations/base.py
+++ b/dragon_voice/tools/integrations/base.py
@@ -1,4 +1,4 @@
-"""IntegrationBackend ABC + lifecycle types (#341 / #342).
+"""IntegrationBackend ABC + lifecycle types (#341 / #347).
 
 Every TinkerBox integration (Google Calendar, Gmail, Home Assistant,
 Spotify, ...) implements this interface.  The methods are deliberately
@@ -7,10 +7,15 @@ narrow:
   * `display_name`, `description` — UI metadata for Tab5 Settings.
   * `auth_kind` — drives the Tab5 connect-modal shape.
   * `start_connect` — initiates the auth flow, returns the challenge
-    the user needs to complete on their phone (device-code) or the
-    fields they need to fill (static-token).
+    the user needs to complete on their phone (auth-code / device-code)
+    or the fields they need to fill (static-token).
   * `poll_status` — Tab5 polls until `connected: true` or expiry.
-  * `disconnect` — revoke + delete tokens.
+  * `list_accounts` — enumerate connected accounts under this provider.
+    Single-account providers (Home Assistant) return at most one;
+    multi-account providers (Google, Spotify, Notion) return any
+    number.
+  * `disconnect` — revoke + delete tokens for one account (or all when
+    account_id omitted).
   * `health_check` — smoke test; the REST `/test` endpoint calls this.
 
 State persistence lives in `CredentialStore` (see credentials.py); the
@@ -20,7 +25,7 @@ backend owns the schema of what gets stored.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Literal, Optional
 
@@ -36,13 +41,40 @@ class IntegrationState(str, Enum):
 
 
 @dataclass
+class AccountInfo:
+    """One connected account under a multi-account integration.
+
+    * ``account_id`` — stable handle the integration uses to address
+      this account (Google: email; Spotify: user id; HA: host).  Tab5
+      shows it on the connected-account chip; tools take it as an
+      argument when the user wants to target a specific account.
+    * ``display_label`` — human-readable name (often the same as
+      account_id for email-shaped ids).
+    * ``default`` — exactly one account per integration may be the
+      default.  Tools fall back to it when no account is specified.
+    * ``scopes`` — granted OAuth scopes (informational; helps Tab5
+      explain capability gaps).
+    * ``connected_at`` — unix timestamp of first successful auth.
+    """
+
+    account_id: str
+    display_label: str
+    default: bool = False
+    scopes: list[str] = field(default_factory=list)
+    connected_at: Optional[int] = None
+
+
+@dataclass
 class ConnectChallenge:
     """Returned by `start_connect` — what Tab5 should show the user.
 
-    For OAuth device-code:
-      * `verification_url` — what the QR code encodes (with `user_code`
-        embedded as a query param so the phone autofills it).
-      * `user_code` — the human-readable fallback ("ABC-123").
+    For OAuth (device-code AND authorization-code-with-PKCE):
+      * `verification_url` — what the QR code encodes.  For device-code
+        flows the `user_code` is embedded as a query param; for
+        auth-code flows the URL is the full Google auth URL with
+        `code_challenge`+`state`.
+      * `user_code` — human-readable fallback for device-code flows.
+        ``None`` for auth-code flows.
       * `expires_in_s` — countdown for the modal.
       * `interval_s` — how often Tab5 should poll the status endpoint.
       * `request_id` — opaque server-side handle.  Tab5 echoes this
@@ -51,11 +83,9 @@ class ConnectChallenge:
     For static-token:
       * `prompt_fields` — list of field names Tab5 should render as
         text inputs (e.g. `["base_url", "long_lived_token"]`).
-      * `verification_url` / `user_code` / `expires_in_s` / `interval_s`
-        all unset.
     """
 
-    kind: Literal["oauth-device", "static-token", "none"]
+    kind: Literal["oauth-device", "oauth-authcode", "static-token", "none"]
     request_id: str
     verification_url: Optional[str] = None
     user_code: Optional[str] = None
@@ -68,20 +98,30 @@ class ConnectChallenge:
 class ConnectionStatus:
     """Returned by `poll_status` — Tab5 keeps polling until terminal.
 
-    * `state` — `connecting` while OAuth flow is mid-flight, `connected`
-      on success, `error` on a non-recoverable failure, `expired` when
-      the device-code timed out (Tab5 should close the modal).
-    * `error` — human-readable string when `state` is `error` or
-      `expired`.  Tab5 surfaces this in the modal.
+    * `state` — `connecting` while flow is mid-flight, `connected` on
+      success, `error` on a non-recoverable failure, `expired` when
+      the flow timed out.
+    * `error` — human-readable string when `state` is `error`/`expired`.
+    * `account_id` — populated when `state == "connected"` so Tab5
+      knows which account just landed.  ``None`` mid-flight.
+    * `account_label` — human-readable name (email) for the new account.
     """
 
     state: Literal["connecting", "connected", "error", "expired"]
     request_id: str
     error: Optional[str] = None
+    account_id: Optional[str] = None
+    account_label: Optional[str] = None
 
 
 class IntegrationBackend(ABC):
-    """Interface every integration implements."""
+    """Interface every integration implements.
+
+    Default semantics for the account_id parameter on methods that
+    take it:  ``None`` means *the default account* if one is set,
+    otherwise fall back to whatever single-account behaviour made
+    sense pre-#347.  Single-account providers can ignore the parameter.
+    """
 
     @property
     @abstractmethod
@@ -96,10 +136,7 @@ class IntegrationBackend(ABC):
     @property
     @abstractmethod
     def display_name(self) -> str:
-        """User-facing name shown in Tab5 Settings.
-
-        Examples: ``"Google Calendar"``, ``"Gmail"``, ``"Home Assistant"``.
-        """
+        """User-facing name shown in Tab5 Settings."""
         ...
 
     @property
@@ -110,54 +147,87 @@ class IntegrationBackend(ABC):
 
     @property
     @abstractmethod
-    def auth_kind(self) -> Literal["oauth-device", "static-token", "none"]:
+    def auth_kind(self) -> Literal["oauth-device", "oauth-authcode", "static-token", "none"]:
         """Drives the Tab5 connect-modal shape."""
         ...
 
+    @property
+    def supports_multi_account(self) -> bool:
+        """True when the integration can hold more than one connected
+        account (Google, Spotify, Notion).  Default False — Home
+        Assistant and static-token integrations override to True only
+        if they actually multiplex."""
+        return False
+
     @abstractmethod
-    async def is_connected(self) -> bool:
-        """True when credentials exist + are usable.  No network call
-        — read-only.  For network reachability use `health_check`."""
+    async def is_connected(self, account_id: Optional[str] = None) -> bool:
+        """True when credentials exist + are usable.
+
+        When ``account_id`` is None: True if ANY account is connected.
+        When provided: True only if that specific account is connected.
+        No network call — read-only.
+        """
+        ...
+
+    @abstractmethod
+    async def list_accounts(self) -> list[AccountInfo]:
+        """Return all currently-connected accounts under this provider.
+
+        Empty list when nothing is connected.  Order is stable but
+        otherwise unspecified.  Exactly one entry has ``default=True``
+        when any are connected.
+        """
         ...
 
     @abstractmethod
     async def start_connect(self, params: Optional[dict] = None) -> ConnectChallenge:
         """Initiate the auth flow.
 
-        Args:
-            params: For ``static-token`` integrations Tab5 posts the
-                completed field values here (e.g. ``{"base_url": "...",
-                "long_lived_token": "..."}``).  For OAuth device-code
-                it's typically unused.
+        For multi-account providers, the result account_id isn't known
+        until after the callback resolves and we hit ``userinfo``.
+        Tab5 just receives a ``request_id`` here and polls.
         """
         ...
 
     @abstractmethod
     async def poll_status(self, request_id: str) -> ConnectionStatus:
         """Tab5 polls every few seconds while the user completes the
-        OAuth flow on their phone.  Returns terminal state when done.
-        """
+        flow on their phone.  Returns terminal state when done."""
         ...
 
     @abstractmethod
-    async def disconnect(self) -> None:
+    async def disconnect(self, account_id: Optional[str] = None) -> None:
         """Revoke + delete stored credentials.
 
-        Best-effort: if the provider's revoke endpoint fails (network
-        down, token already invalid), still delete the local creds —
-        the user explicitly asked to disconnect.
+        When ``account_id`` is None: disconnect ALL accounts.  When
+        provided: disconnect just that one (other accounts remain
+        connected; the default is reassigned if the disconnected one
+        was the default).
+
+        Best-effort: if the provider's revoke endpoint fails, still
+        delete the local creds — the user explicitly asked to
+        disconnect.
         """
         ...
 
     @abstractmethod
-    async def health_check(self, timeout_s: float = 5.0) -> tuple[bool, str]:
+    async def health_check(
+        self,
+        account_id: Optional[str] = None,
+        timeout_s: float = 5.0,
+    ) -> tuple[bool, str]:
         """Cheap reachability probe.
 
-        Returns ``(ok, detail)``.  REST ``GET /api/v1/integrations/{name}/test``
-        calls this.  `ok=False` with a short detail when the provider
-        is unreachable or our credentials are stale.
+        When ``account_id`` is None: probe the default account.
+        Returns ``(ok, detail)``.
         """
         ...
+
+    async def set_default_account(self, account_id: str) -> None:  # noqa: ARG002
+        """Optional — multi-account providers override to mark an
+        account as the default.  Single-account providers leave the
+        default (no-op)."""
+        return None
 
     async def shutdown(self) -> None:
         """Release any held connections (HTTP sessions, etc.)  Default

--- a/dragon_voice/tools/integrations/credentials.py
+++ b/dragon_voice/tools/integrations/credentials.py
@@ -1,15 +1,26 @@
-"""Per-integration credential storage (#341).
+"""Per-integration credential storage (#341 / #347).
 
-Each integration owns a small JSON file under
-``~/.tinkerclaw/integrations/{name}.json`` (mode ``0o600``).  Schema is
-opaque to this layer — the integration backend defines what gets
-stored (OAuth tokens + expiry + refresh, or a static long-lived
+Each integration owns a **directory** of small JSON cred files under
+``{base}/{provider}/{account_id}.json`` (mode ``0o600``).  This lets a
+single provider hold multiple connected accounts (e.g. work + personal
+Gmail).  ``account_id`` is whatever the provider considers a stable
+user handle — for Google integrations it's the verified email; for
+Spotify it's the user's id; for Home Assistant it's the host string.
+
+Schema is opaque to this layer — the integration backend defines what
+gets stored (OAuth tokens + expiry + refresh, or a static long-lived
 token, etc.).
 
 Atomic write: writes to ``{name}.json.tmp`` then ``os.replace`` so a
 crash mid-write doesn't corrupt the cred file.  Read returns ``None``
 when the file is missing OR malformed — caller treats that as "not
 connected" and prompts the user to reconnect.
+
+Backward compat: pre-#347 builds stored a single file per provider at
+``{base}/{provider}.json``.  ``ProviderCredentialDir.migrate_legacy``
+moves that to ``{base}/{provider}/_legacy.json`` (the account_id is
+filled in by the integration on first successful health-check via
+userinfo lookup) so existing connections survive an upgrade.
 """
 
 from __future__ import annotations
@@ -18,6 +29,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import stat
 from pathlib import Path
 from typing import Any, Optional
@@ -25,8 +37,22 @@ from typing import Any, Optional
 logger = logging.getLogger(__name__)
 
 # Default location.  Override via TINKERCLAW_INTEGRATIONS_DIR env var
-# (used by tests to redirect to a temp dir).
+# (used by tests + on Dragon to redirect away from ~/.tinkerclaw/ which
+# is OpenClaw's config dir AND read-only under systemd hardening).
 _DEFAULT_DIR = Path.home() / ".tinkerclaw" / "integrations"
+
+# Sentinel used by the legacy-migration shim.  A real account_id is
+# filled in once the integration can look it up (e.g. Google userinfo
+# returns the verified email).
+LEGACY_ACCOUNT_ID = "_legacy"
+
+# Reserved account_id values that aren't real accounts.  Listed so the
+# REST list_accounts surface can hide them.
+_RESERVED_ACCOUNT_IDS = frozenset({LEGACY_ACCOUNT_ID})
+
+# Filesystem-safe account_id pattern.  Emails fit; arbitrary user
+# input is sanitised by `sanitise_account_id` below.
+_ALLOWED_ACCOUNT_ID = re.compile(r"^[A-Za-z0-9._@+\-]+$")
 
 
 def _resolve_dir() -> Path:
@@ -36,30 +62,58 @@ def _resolve_dir() -> Path:
     return _DEFAULT_DIR
 
 
-class CredentialStore:
-    """Per-integration cred file at ``{base}/{name}.json``.
+def sanitise_account_id(raw: str) -> str:
+    """Turn an arbitrary id into a filesystem-safe slug.
 
-    Thread-safe via a per-instance asyncio.Lock — writes are serialized
+    Keeps the email-ish characters (alnum, dot, at, plus, dash,
+    underscore) and replaces anything else with ``-``.  Empty after
+    sanitisation → raises ValueError because that's a programming
+    error, not an integration concern.
+    """
+    cleaned = re.sub(r"[^A-Za-z0-9._@+\-]+", "-", raw.strip())
+    cleaned = cleaned.strip("-._")
+    if not cleaned:
+        raise ValueError(f"account_id sanitises to empty: {raw!r}")
+    return cleaned
+
+
+class CredentialStore:
+    """Per-(provider, account) cred file at ``{base}/{provider}/{account_id}.json``.
+
+    Thread-safe via a per-instance asyncio.Lock — writes are serialised
     but reads run unlocked (file-level atomic).  Cross-process safety
     is not a goal: a single dragon_voice process owns its creds.
+
+    Construction:
+
+        store = CredentialStore("google-calendar", account_id="me@example.com")
+        await store.save({"tokens": {...}})
+        data = await store.load()
     """
 
-    def __init__(self, name: str, base_dir: Optional[Path] = None) -> None:
-        self._name = name
-        self._dir = base_dir if base_dir is not None else _resolve_dir()
-        self._path = self._dir / f"{name}.json"
+    def __init__(
+        self,
+        provider: str,
+        account_id: str = LEGACY_ACCOUNT_ID,
+        base_dir: Optional[Path] = None,
+    ) -> None:
+        self._provider = provider
+        self._account_id = sanitise_account_id(account_id) if account_id != LEGACY_ACCOUNT_ID else account_id
+        base = base_dir if base_dir is not None else _resolve_dir()
+        self._dir = base / provider
+        self._path = self._dir / f"{self._account_id}.json"
         self._lock = asyncio.Lock()
 
     @property
     def path(self) -> Path:
         return self._path
 
-    async def load(self) -> Optional[dict[str, Any]]:
-        """Read credentials.  Returns None on missing OR malformed file.
+    @property
+    def account_id(self) -> str:
+        return self._account_id
 
-        Malformed-file path also logs a warning so an operator sees the
-        corruption rather than silently treating it as "disconnected".
-        """
+    async def load(self) -> Optional[dict[str, Any]]:
+        """Read credentials.  Returns None on missing OR malformed file."""
         if not self._path.exists():
             return None
         try:
@@ -84,32 +138,29 @@ class CredentialStore:
             return None
 
     async def save(self, data: dict[str, Any]) -> None:
-        """Atomic write + chmod 0o600.
-
-        Creates the parent dir if missing.  Raises OSError on
-        underlying filesystem failure — caller decides whether that's
-        fatal (probably yes; if we can't persist creds the user has to
-        reconnect every restart).
-        """
+        """Atomic write + chmod 0o600."""
         async with self._lock:
             await asyncio.to_thread(self._save_sync, data)
 
     def _save_sync(self, data: dict[str, Any]) -> None:
         self._dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-        # Make sure the directory itself isn't world-readable.
         try:
             os.chmod(self._dir, 0o700)
+        except OSError:
+            pass
+        # Also tighten the integrations root so a sibling provider
+        # can't be world-readable.
+        try:
+            os.chmod(self._dir.parent, 0o700)
         except OSError:
             pass
         tmp = self._path.with_suffix(self._path.suffix + ".tmp")
         with tmp.open("w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, sort_keys=True)
-        # Mode 0o600 — owner-only read+write.
         os.chmod(tmp, stat.S_IRUSR | stat.S_IWUSR)
         os.replace(tmp, self._path)
 
     async def delete(self) -> None:
-        """Remove the credential file.  No-op if already missing."""
         async with self._lock:
             try:
                 self._path.unlink(missing_ok=True)
@@ -118,3 +169,107 @@ class CredentialStore:
 
     async def exists(self) -> bool:
         return self._path.exists()
+
+    async def rename_to(self, new_account_id: str) -> None:
+        """Move this store's file to a different account_id.
+
+        Used by the legacy-migration shim once the real account_id is
+        known (e.g. Google userinfo returned the email).  Atomic via
+        ``os.replace``.  Silently no-op when the source doesn't exist.
+        """
+        async with self._lock:
+            if not self._path.exists():
+                return
+            new_account = sanitise_account_id(new_account_id)
+            new_path = self._dir / f"{new_account}.json"
+            if new_path == self._path:
+                return
+            os.replace(self._path, new_path)
+            self._account_id = new_account
+            self._path = new_path
+
+
+class ProviderCredentialDir:
+    """List + manage all accounts under a single provider.
+
+    Each integration backend holds one of these to enumerate the
+    accounts it currently owns and to perform per-provider operations
+    (legacy migration, bulk-disconnect, etc.).
+    """
+
+    def __init__(self, provider: str, base_dir: Optional[Path] = None) -> None:
+        self._provider = provider
+        base = base_dir if base_dir is not None else _resolve_dir()
+        self._dir = base / provider
+        self._base = base
+
+    @property
+    def provider(self) -> str:
+        return self._provider
+
+    @property
+    def path(self) -> Path:
+        return self._dir
+
+    def list_accounts(self, include_reserved: bool = False) -> list[str]:
+        """Return all account_ids that have a cred file on disk.
+
+        Empty list when the provider dir doesn't exist or is empty.
+        ``_legacy`` is hidden by default — callers that need to act
+        on it (the migration shim) pass include_reserved=True.
+        """
+        if not self._dir.is_dir():
+            return []
+        accounts = []
+        for entry in self._dir.iterdir():
+            if not entry.is_file() or entry.suffix != ".json":
+                continue
+            if entry.name.endswith(".tmp"):
+                continue
+            account = entry.stem
+            if not include_reserved and account in _RESERVED_ACCOUNT_IDS:
+                continue
+            accounts.append(account)
+        return sorted(accounts)
+
+    def store_for(self, account_id: str) -> CredentialStore:
+        """Build a CredentialStore for one account under this provider."""
+        return CredentialStore(self._provider, account_id, base_dir=self._base)
+
+    def migrate_legacy(self) -> Optional[CredentialStore]:
+        """Look for a pre-#347 flat ``{base}/{provider}.json`` file and
+        move it to ``{base}/{provider}/_legacy.json`` so the integration
+        keeps loading after the upgrade.
+
+        Returns the CredentialStore pointing at the migrated file when
+        a migration happened, None otherwise.  Idempotent — calling
+        twice is safe.
+        """
+        legacy_flat = self._base / f"{self._provider}.json"
+        if not legacy_flat.exists():
+            return None
+        target = self.store_for(LEGACY_ACCOUNT_ID)
+        if target.path.exists():
+            # Already migrated; just remove the stale flat file.
+            try:
+                legacy_flat.unlink()
+            except OSError as e:
+                logger.warning("Failed to delete stale flat %s: %s", legacy_flat, e)
+            return target
+        self._dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.replace(legacy_flat, target.path)
+        logger.info(
+            "Migrated legacy single-account creds for %s to %s — "
+            "the integration will fold this into a per-account slot "
+            "the next time it confirms the account identity.",
+            self._provider, target.path,
+        )
+        return target
+
+
+__all__ = [
+    "LEGACY_ACCOUNT_ID",
+    "CredentialStore",
+    "ProviderCredentialDir",
+    "sanitise_account_id",
+]

--- a/dragon_voice/tools/integrations/google/auth.py
+++ b/dragon_voice/tools/integrations/google/auth.py
@@ -16,10 +16,17 @@ Env vars expected on Dragon:
 * ``GOOGLE_OAUTH_CLIENT_SECRET`` — required for web-application client
 * ``GOOGLE_OAUTH_REDIRECT_URI`` — optional override; defaults to the
   ngrok URL.
+
+Multi-account support (#347): every Google integration also requests
+``openid email`` so the token-exchange response includes an ``id_token``
+JWT whose `email` claim becomes the account_id.  See
+``extract_account_id_from_tokens``.
 """
 
 from __future__ import annotations
 
+import base64
+import json
 import logging
 import os
 from dataclasses import dataclass, field
@@ -37,6 +44,7 @@ logger = logging.getLogger(__name__)
 GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
 GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke"
+GOOGLE_USERINFO_URL = "https://openidconnect.googleapis.com/v1/userinfo"
 
 # Default redirect — ngrok tunnel that the existing tinkerclaw-ngrok
 # service maintains pointing at Dragon's port 3502.  Operator can
@@ -45,8 +53,12 @@ DEFAULT_REDIRECT_URI = (
     "https://tinkerclaw-voice.ngrok.dev/api/v1/oauth/callback"
 )
 
-# Scopes used by Calendar + Gmail.  Each integration only requests
-# what it needs; this module just collects the constants.
+# Identity scopes — added to every Google flow so we can extract the
+# account email from the id_token without a second round trip.
+SCOPE_OPENID = "openid"
+SCOPE_EMAIL = "email"
+
+# Per-integration scopes.
 SCOPE_CALENDAR_READ = "https://www.googleapis.com/auth/calendar.readonly"
 SCOPE_CALENDAR_EVENTS = "https://www.googleapis.com/auth/calendar.events"
 SCOPE_GMAIL_READ = "https://www.googleapis.com/auth/gmail.readonly"
@@ -76,7 +88,7 @@ class GoogleOAuthConfig:
     def from_env(cls, scopes: Optional[list[str]] = None) -> "GoogleOAuthConfig":
         client_id = os.environ.get("GOOGLE_OAUTH_CLIENT_ID", "").strip()
         client_secret = os.environ.get(
-            "GOOGLE_OAUTH_CLIENT_SECRET", ""
+            "GOOGLE_OAUTH_CLIENT_SECRET", "",
         ).strip() or None
         redirect_uri = (
             os.environ.get("GOOGLE_OAUTH_REDIRECT_URI", "").strip()
@@ -88,13 +100,19 @@ class GoogleOAuthConfig:
                 "OAuth client at https://console.cloud.google.com/apis/credentials "
                 "(redirect URI: " + redirect_uri + ") then set "
                 "GOOGLE_OAUTH_CLIENT_ID + GOOGLE_OAUTH_CLIENT_SECRET in Dragon's "
-                "environment and restart tinkerclaw-voice."
+                "environment and restart tinkerclaw-voice.",
             )
+        merged_scopes = list(scopes) if scopes is not None else [SCOPE_CALENDAR_READ]
+        # Always include identity scopes so we can extract the account
+        # email from the id_token after exchange.
+        for s in (SCOPE_OPENID, SCOPE_EMAIL):
+            if s not in merged_scopes:
+                merged_scopes.append(s)
         return cls(
             client_id=client_id,
             client_secret=client_secret,
             redirect_uri=redirect_uri,
-            scopes=list(scopes) if scopes is not None else [SCOPE_CALENDAR_READ],
+            scopes=merged_scopes,
         )
 
     def scope_string(self) -> str:
@@ -111,6 +129,70 @@ def make_google_client(config: GoogleOAuthConfig) -> OAuthAuthCodeClient:
         token_url=GOOGLE_TOKEN_URL,
         redirect_uri=config.redirect_uri,
     )
+
+
+def extract_account_id_from_tokens(tokens: OAuthTokens) -> Optional[str]:
+    """Decode the id_token JWT and return the `email` claim.
+
+    The id_token comes back from Google's token endpoint when the
+    request included `openid email` in the scope set.  We don't verify
+    the signature — the token was just delivered over TLS straight
+    from Google's `oauth2.googleapis.com`, so payload trust is
+    transitive.  Returns None when:
+
+      * the response had no id_token (caller should fall back to the
+        userinfo endpoint or use a placeholder account_id)
+      * the JWT is malformed
+      * the email_verified claim is False (we won't use unverified
+        emails as account_ids — they could collide between accounts)
+    """
+    id_token = (tokens.extra or {}).get("id_token") if tokens.extra else None
+    if not id_token or not isinstance(id_token, str):
+        return None
+    parts = id_token.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        # base64url-decode the payload — JWT bodies are url-safe b64
+        # without padding.
+        payload_raw = parts[1]
+        # Re-pad for base64.urlsafe_b64decode.
+        payload_raw += "=" * (-len(payload_raw) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_raw))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    email = payload.get("email")
+    if not email or payload.get("email_verified") is False:
+        return None
+    return str(email).lower()
+
+
+async def fetch_google_email(access_token: str, session) -> Optional[str]:  # noqa: ANN001
+    """Fallback: hit the userinfo endpoint when id_token wasn't present.
+
+    Returns the verified email or None on any failure (caller treats
+    None as "use a placeholder account_id").
+    """
+    try:
+        async with session.get(
+            GOOGLE_USERINFO_URL,
+            headers={"Authorization": f"Bearer {access_token}"},
+        ) as resp:
+            if resp.status != 200:
+                logger.warning(
+                    "Google userinfo returned %s — token may lack "
+                    "openid/email scope.  Falling back to placeholder.",
+                    resp.status,
+                )
+                return None
+            data = await resp.json()
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Google userinfo unreachable: %s", e)
+        return None
+    email = data.get("email")
+    if not email or data.get("email_verified") is False:
+        return None
+    return str(email).lower()
 
 
 async def revoke_google_token(token: str, session) -> bool:  # noqa: ANN001
@@ -134,14 +216,19 @@ __all__ = [
     "GOOGLE_AUTH_URL",
     "GOOGLE_REVOKE_URL",
     "GOOGLE_TOKEN_URL",
+    "GOOGLE_USERINFO_URL",
     "GoogleOAuthConfig",
     "GoogleOAuthNotConfiguredError",
     "OAuthTokens",
     "SCOPE_CALENDAR_EVENTS",
     "SCOPE_CALENDAR_READ",
+    "SCOPE_EMAIL",
     "SCOPE_GMAIL_MODIFY",
     "SCOPE_GMAIL_READ",
     "SCOPE_GMAIL_SEND",
+    "SCOPE_OPENID",
+    "extract_account_id_from_tokens",
+    "fetch_google_email",
     "make_google_client",
     "revoke_google_token",
 ]

--- a/dragon_voice/tools/integrations/google/calendar.py
+++ b/dragon_voice/tools/integrations/google/calendar.py
@@ -1,10 +1,10 @@
-"""Google Calendar integration — auth-code-with-PKCE flow (#342).
+"""Google Calendar integration — auth-code-with-PKCE flow + multi-account (#347).
 
-OAuth state machine:
+OAuth state machine (per-account):
 
   start_connect()
     → creates AuthCodeChallenge (PKCE pair + state)
-    → stashes verifier + asyncio.Future in `self._flows[state]`
+    → stashes verifier + asyncio.Future in `self._flows[request_id]`
     → returns ConnectChallenge with the authorization_url
        (Tab5 shows QR + plain link)
 
@@ -13,10 +13,18 @@ OAuth state machine:
   Google redirects to /api/v1/oauth/callback?code=…&state=…
     → IntegrationRoutes.oauth_callback handler calls
        integration.handle_callback(state, code, error)
-    → we exchange code+verifier for tokens, persist, mark future done
+    → we exchange code+verifier for tokens, decode id_token to find
+       the verified email (= account_id), persist under that key,
+       mark default if it's the first account
 
   Tab5 polls /api/v1/integrations/google-calendar/status/{request_id}
-    → poll_status() reads the flow's future state, returns connected/expired/error
+    → poll_status() reads the flow's future state, returns
+       connected/expired/error AND echoes the new account_id+label
+       once known so Tab5 can update its UI immediately.
+
+Per-account state:
+  self._accounts: dict[account_id, OAuthTokens]
+  self._default_account_id: Optional[str]
 """
 
 from __future__ import annotations
@@ -31,16 +39,23 @@ from typing import Any, Literal, Optional
 import aiohttp
 
 from dragon_voice.tools.integrations.base import (
+    AccountInfo,
     ConnectChallenge,
     ConnectionStatus,
     IntegrationBackend,
 )
-from dragon_voice.tools.integrations.credentials import CredentialStore
+from dragon_voice.tools.integrations.credentials import (
+    LEGACY_ACCOUNT_ID,
+    CredentialStore,
+    ProviderCredentialDir,
+)
 from dragon_voice.tools.integrations.google.auth import (
     GoogleOAuthConfig,
     OAuthTokens,
     SCOPE_CALENDAR_EVENTS,
     SCOPE_CALENDAR_READ,
+    extract_account_id_from_tokens,
+    fetch_google_email,
     make_google_client,
     revoke_google_token,
 )
@@ -50,27 +65,30 @@ from dragon_voice.tools.integrations.registry import register_integration
 logger = logging.getLogger(__name__)
 
 CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3"
+PROVIDER_NAME = "google-calendar"
 
 
-@register_integration("google-calendar")
+@register_integration(PROVIDER_NAME)
 class GoogleCalendarIntegration(IntegrationBackend):
-    """Google Calendar read + write via Calendar API v3."""
+    """Google Calendar read + write via Calendar API v3 — multi-account."""
 
     _SCOPES = [SCOPE_CALENDAR_READ, SCOPE_CALENDAR_EVENTS]
 
     def __init__(self) -> None:
-        self._store = CredentialStore("google-calendar")
-        # request_id → in-flight flow.  Survives across REST calls so
-        # Tab5 polling sees terminal state.
+        self._provider_dir = ProviderCredentialDir(PROVIDER_NAME)
+        # request_id → in-flight flow.  Survives across REST calls.
         self._flows: dict[str, "_AuthFlow"] = {}
-        self._tokens: Optional[OAuthTokens] = None
-        self._tokens_loaded = False
+        # account_id → OAuthTokens (lazy-loaded on first access).
+        self._accounts: dict[str, OAuthTokens] = {}
+        self._default_account_id: Optional[str] = None
+        self._loaded = False
+        self._load_lock = asyncio.Lock()
 
     # ── IntegrationBackend interface ────────────────────────────
 
     @property
     def name(self) -> str:
-        return "google-calendar"
+        return PROVIDER_NAME
 
     @property
     def display_name(self) -> str:
@@ -84,26 +102,40 @@ class GoogleCalendarIntegration(IntegrationBackend):
     def auth_kind(self) -> Literal["oauth-device", "oauth-authcode", "static-token", "none"]:  # type: ignore[override]
         return "oauth-authcode"
 
-    async def is_connected(self) -> bool:
-        await self._ensure_tokens_loaded()
-        return self._tokens is not None
+    @property
+    def supports_multi_account(self) -> bool:
+        return True
+
+    async def is_connected(self, account_id: Optional[str] = None) -> bool:
+        await self._ensure_loaded()
+        if account_id is None:
+            return bool(self._accounts)
+        return account_id in self._accounts
+
+    async def list_accounts(self) -> list[AccountInfo]:
+        await self._ensure_loaded()
+        out: list[AccountInfo] = []
+        for aid, tokens in self._accounts.items():
+            out.append(AccountInfo(
+                account_id=aid,
+                display_label=_label_for_account_id(aid),
+                default=(aid == self._default_account_id),
+                scopes=list(tokens.scopes or []),
+                connected_at=(tokens.extra or {}).get("connected_at"),
+            ))
+        out.sort(key=lambda a: (not a.default, a.account_id))
+        return out
 
     async def start_connect(self, params: Optional[dict] = None) -> ConnectChallenge:
         del params  # unused for auth-code flow
         cfg = GoogleOAuthConfig.from_env(scopes=self._SCOPES)
         request_id = uuid.uuid4().hex
-        # Build the auth URL.  Google needs access_type=offline +
-        # prompt=consent to mint a refresh_token on the first turn.
         client = make_google_client(cfg)
         chal = client.start(extra_params={
             "access_type": "offline",
             "prompt": "consent",
             "include_granted_scopes": "true",
         })
-        # `client.start` adds the entry to client._pending[state]
-        # already, but we don't own that lifecycle — Dragon process
-        # holds the entry until the callback resolves it.  We DO need
-        # our own flow record so poll_status finds it.
         flow = _AuthFlow(
             request_id=request_id,
             state=chal.state,
@@ -113,10 +145,10 @@ class GoogleCalendarIntegration(IntegrationBackend):
         self._flows[request_id] = flow
 
         return ConnectChallenge(
-            kind="oauth-device",  # Tab5 modal reuses the QR/code UX shape
+            kind="oauth-authcode",
             request_id=request_id,
             verification_url=chal.authorization_url,
-            user_code=None,  # auth-code flow doesn't have one
+            user_code=None,
             expires_in_s=600,
             interval_s=2,
         )
@@ -127,8 +159,12 @@ class GoogleCalendarIntegration(IntegrationBackend):
             return ConnectionStatus(
                 state="error", request_id=request_id, error="unknown request_id",
             )
-        if flow.tokens is not None:
-            return ConnectionStatus(state="connected", request_id=request_id)
+        if flow.tokens is not None and flow.account_id is not None:
+            return ConnectionStatus(
+                state="connected", request_id=request_id,
+                account_id=flow.account_id,
+                account_label=_label_for_account_id(flow.account_id),
+            )
         if flow.error is not None:
             state_label = "expired" if flow.error.code == "expired_token" else "error"
             return ConnectionStatus(
@@ -150,9 +186,11 @@ class GoogleCalendarIntegration(IntegrationBackend):
     ) -> None:
         """Called by the /api/v1/oauth/callback route handler.
 
-        Looks up the flow by `state`, exchanges code+verifier for
-        tokens, persists.  Best-effort: any exception becomes
-        `flow.error` so the next poll_status returns it.
+        After exchange, decodes the id_token to find the verified
+        email and persists tokens under that account_id.  If id_token
+        is absent, falls back to the userinfo endpoint.  If both fail,
+        persists under a placeholder account_id ("pending-<request_id>")
+        which the user can disconnect later.
         """
         flow = self._find_flow_by_state(state)
         if flow is None:
@@ -180,35 +218,95 @@ class GoogleCalendarIntegration(IntegrationBackend):
                 description=f"{type(e).__name__}: {e}"[:120],
             )
             return
-        await self._persist_tokens(tokens)
+
+        account_id = await self._resolve_account_id(tokens)
+        await self._ensure_loaded()
+        is_first = not self._accounts
+        # Stamp metadata on the token bundle so list_accounts can show
+        # connected_at + we can flag the default.
+        if tokens.extra is None:
+            tokens.extra = {}
+        tokens.extra.setdefault("connected_at", int(time.time()))
+        if is_first:
+            tokens.extra["default"] = True
+
+        await self._persist_account(account_id, tokens)
+        self._accounts[account_id] = tokens
+        if is_first or self._default_account_id is None:
+            self._default_account_id = account_id
+
+        flow.account_id = account_id
         flow.tokens = tokens
 
-    async def disconnect(self) -> None:
-        await self._ensure_tokens_loaded()
-        if self._tokens is not None and self._tokens.refresh_token:
-            async with aiohttp.ClientSession(
-                timeout=aiohttp.ClientTimeout(total=10),
-            ) as session:
-                await revoke_google_token(self._tokens.refresh_token, session)
-        await self._store.delete()
-        self._tokens = None
-        self._tokens_loaded = True
+    async def disconnect(self, account_id: Optional[str] = None) -> None:
+        """Disconnect one account (or all when account_id is None)."""
+        await self._ensure_loaded()
+        targets = [account_id] if account_id is not None else list(self._accounts.keys())
+        if not targets:
+            return
+        for aid in targets:
+            tokens = self._accounts.get(aid)
+            if tokens is not None and tokens.refresh_token:
+                async with aiohttp.ClientSession(
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as session:
+                    await revoke_google_token(tokens.refresh_token, session)
+            store = self._provider_dir.store_for(aid)
+            await store.delete()
+            self._accounts.pop(aid, None)
+        # Reassign default if we dropped it.
+        if self._default_account_id not in self._accounts:
+            self._default_account_id = next(iter(self._accounts), None)
+            if self._default_account_id is not None:
+                # Persist the new default flag.
+                tokens = self._accounts[self._default_account_id]
+                if tokens.extra is None:
+                    tokens.extra = {}
+                tokens.extra["default"] = True
+                await self._persist_account(self._default_account_id, tokens)
 
-    async def health_check(self, timeout_s: float = 5.0) -> tuple[bool, str]:
-        await self._ensure_tokens_loaded()
-        if self._tokens is None:
+    async def set_default_account(self, account_id: str) -> None:
+        await self._ensure_loaded()
+        if account_id not in self._accounts:
+            raise DeviceCodeError(
+                "unknown_account", f"no connected account with id {account_id!r}",
+            )
+        old_default = self._default_account_id
+        self._default_account_id = account_id
+        # Re-persist both files so the default flag is up to date.
+        if old_default and old_default != account_id and old_default in self._accounts:
+            old_tokens = self._accounts[old_default]
+            if old_tokens.extra is None:
+                old_tokens.extra = {}
+            old_tokens.extra["default"] = False
+            await self._persist_account(old_default, old_tokens)
+        new_tokens = self._accounts[account_id]
+        if new_tokens.extra is None:
+            new_tokens.extra = {}
+        new_tokens.extra["default"] = True
+        await self._persist_account(account_id, new_tokens)
+
+    async def health_check(
+        self,
+        account_id: Optional[str] = None,
+        timeout_s: float = 5.0,
+    ) -> tuple[bool, str]:
+        await self._ensure_loaded()
+        target = self._resolve_target_account(account_id)
+        if target is None:
             return False, "not connected"
         try:
             data = await self._authed_get(
                 f"{CALENDAR_API_BASE}/calendars/primary",
                 timeout_s=timeout_s,
+                account_id=target,
             )
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:
             return False, f"{type(e).__name__}: {e}"[:120]
         except DeviceCodeError as e:
             return False, f"auth: {e.description[:120]}"
         cal_id = data.get("id") if isinstance(data, dict) else None
-        return True, f"connected to {cal_id or 'primary calendar'}"
+        return True, f"connected to {cal_id or 'primary calendar'} as {_label_for_account_id(target)}"
 
     # ── Calendar API used by tools ──────────────────────────────
 
@@ -217,6 +315,7 @@ class GoogleCalendarIntegration(IntegrationBackend):
         time_min: Optional[datetime] = None,
         time_max: Optional[datetime] = None,
         max_results: int = 10,
+        account_id: Optional[str] = None,
     ) -> list[dict[str, Any]]:
         params = {
             "singleEvents": "true",
@@ -231,9 +330,13 @@ class GoogleCalendarIntegration(IntegrationBackend):
             params["timeMax"] = time_max.astimezone(timezone.utc).isoformat()
         raw = await self._authed_get(
             f"{CALENDAR_API_BASE}/calendars/primary/events", params=params,
+            account_id=account_id,
         )
         items = raw.get("items", []) if isinstance(raw, dict) else []
-        return [self._normalize_event(it) for it in items]
+        target = self._resolve_target_account(account_id)
+        return [
+            dict(self._normalize_event(it), account=target) for it in items
+        ]
 
     async def create_event(
         self,
@@ -242,6 +345,7 @@ class GoogleCalendarIntegration(IntegrationBackend):
         end: datetime,
         location: Optional[str] = None,
         description: Optional[str] = None,
+        account_id: Optional[str] = None,
     ) -> dict[str, Any]:
         body = {
             "summary": summary,
@@ -254,13 +358,18 @@ class GoogleCalendarIntegration(IntegrationBackend):
             body["description"] = description
         raw = await self._authed_post(
             f"{CALENDAR_API_BASE}/calendars/primary/events", body=body,
+            account_id=account_id,
         )
-        return self._normalize_event(raw)
+        target = self._resolve_target_account(account_id)
+        return dict(self._normalize_event(raw), account=target)
 
-    async def cancel_event(self, event_id: str) -> bool:
+    async def cancel_event(
+        self, event_id: str, account_id: Optional[str] = None,
+    ) -> bool:
         try:
             await self._authed_delete(
                 f"{CALENDAR_API_BASE}/calendars/primary/events/{event_id}",
+                account_id=account_id,
             )
         except aiohttp.ClientResponseError as e:
             logger.warning("cancel_event %s failed: %s", event_id, e)
@@ -275,48 +384,109 @@ class GoogleCalendarIntegration(IntegrationBackend):
                 return flow
         return None
 
-    async def _persist_tokens(self, tokens: OAuthTokens) -> None:
-        await self._store.save({"tokens": tokens.to_dict()})
-        self._tokens = tokens
-        self._tokens_loaded = True
+    def _resolve_target_account(self, account_id: Optional[str]) -> Optional[str]:
+        if account_id is not None:
+            return account_id if account_id in self._accounts else None
+        return self._default_account_id
 
-    async def _ensure_tokens_loaded(self) -> None:
-        if self._tokens_loaded:
+    async def _resolve_account_id(self, tokens: OAuthTokens) -> str:
+        """Find the verified-email account_id for a freshly-issued
+        token bundle.
+
+        Tries id_token first (zero extra requests), then userinfo, then
+        falls back to a placeholder so the connect flow can still
+        complete and the user can clean up via disconnect+reconnect.
+        """
+        from_jwt = extract_account_id_from_tokens(tokens)
+        if from_jwt:
+            return from_jwt
+        try:
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=8),
+            ) as session:
+                email = await fetch_google_email(tokens.access_token, session)
+                if email:
+                    return email
+        except Exception:  # noqa: BLE001
+            logger.warning("fetch_google_email raised", exc_info=True)
+        placeholder = f"pending-{uuid.uuid4().hex[:8]}"
+        logger.warning(
+            "Could not determine account_id from id_token or userinfo — "
+            "stored under placeholder %s.  User should disconnect + reconnect "
+            "after granting openid+email scope.",
+            placeholder,
+        )
+        return placeholder
+
+    async def _persist_account(self, account_id: str, tokens: OAuthTokens) -> None:
+        store = self._provider_dir.store_for(account_id)
+        await store.save({"tokens": tokens.to_dict()})
+
+    async def _ensure_loaded(self) -> None:
+        if self._loaded:
             return
-        data = await self._store.load()
-        if data and "tokens" in data:
+        async with self._load_lock:
+            if self._loaded:
+                return
+            await self._load_from_disk()
+            self._loaded = True
+
+    async def _load_from_disk(self) -> None:
+        # Pre-#347 layout migration: flat {provider}.json → {provider}/_legacy.json
+        self._provider_dir.migrate_legacy()
+        accounts: dict[str, OAuthTokens] = {}
+        default: Optional[str] = None
+        for aid in self._provider_dir.list_accounts(include_reserved=True):
+            store = self._provider_dir.store_for(aid)
+            data = await store.load()
+            if not data or "tokens" not in data:
+                continue
             try:
-                self._tokens = OAuthTokens.from_dict(data["tokens"])
+                tokens = OAuthTokens.from_dict(data["tokens"])
             except (KeyError, ValueError, TypeError) as e:
                 logger.warning(
-                    "Stored Google Calendar tokens malformed (%s) — "
-                    "treating as disconnected.",
-                    e,
+                    "Stored Google Calendar tokens for %s malformed (%s) — "
+                    "skipping.", aid, e,
                 )
-                self._tokens = None
-        else:
-            self._tokens = None
-        self._tokens_loaded = True
+                continue
+            accounts[aid] = tokens
+            if (tokens.extra or {}).get("default"):
+                default = aid
+        if default is None and accounts:
+            # No explicit default → first account wins.
+            default = next(iter(accounts))
+        self._accounts = accounts
+        self._default_account_id = default
 
-    async def _get_access_token(self) -> str:
-        await self._ensure_tokens_loaded()
-        if self._tokens is None:
+    async def _get_access_token(self, account_id: Optional[str] = None) -> str:
+        await self._ensure_loaded()
+        target = self._resolve_target_account(account_id)
+        if target is None:
             raise DeviceCodeError(
                 "not_connected",
                 "Google Calendar is not connected.  Tap Settings → "
                 "Integrations → Connect Google on the Tab5.",
             )
-        if not self._tokens.is_expired():
-            return self._tokens.access_token
-        if not self._tokens.refresh_token:
+        tokens = self._accounts[target]
+        if not tokens.is_expired():
+            return tokens.access_token
+        if not tokens.refresh_token:
             raise DeviceCodeError(
                 "needs_reauth",
-                "No refresh token — please reconnect Google.",
+                f"No refresh token for {_label_for_account_id(target)} — "
+                "please reconnect this Google account.",
             )
-        cfg = GoogleOAuthConfig.from_env(scopes=self._tokens.scopes or self._SCOPES)
+        cfg = GoogleOAuthConfig.from_env(scopes=tokens.scopes or self._SCOPES)
         async with make_google_client(cfg) as client:
-            new_tokens = await client.refresh(self._tokens.refresh_token)
-        await self._persist_tokens(new_tokens)
+            new_tokens = await client.refresh(tokens.refresh_token)
+        # Preserve metadata (default flag, connected_at).
+        if new_tokens.extra is None:
+            new_tokens.extra = {}
+        if tokens.extra:
+            for k, v in tokens.extra.items():
+                new_tokens.extra.setdefault(k, v)
+        await self._persist_account(target, new_tokens)
+        self._accounts[target] = new_tokens
         return new_tokens.access_token
 
     async def _authed_get(
@@ -324,8 +494,10 @@ class GoogleCalendarIntegration(IntegrationBackend):
         url: str,
         params: Optional[dict] = None,
         timeout_s: float = 15.0,
+        account_id: Optional[str] = None,
     ) -> Any:
-        token = await self._get_access_token()
+        token = await self._get_access_token(account_id)
+        target = self._resolve_target_account(account_id)
         timeout = aiohttp.ClientTimeout(total=timeout_s)
         async with aiohttp.ClientSession(timeout=timeout) as session:
             async with session.get(
@@ -334,8 +506,8 @@ class GoogleCalendarIntegration(IntegrationBackend):
                 headers={"Authorization": f"Bearer {token}"},
             ) as resp:
                 if resp.status == 401:
-                    await self._force_refresh()
-                    token = await self._get_access_token()
+                    await self._force_refresh(target)
+                    token = await self._get_access_token(account_id)
                     async with session.get(
                         url,
                         params=params,
@@ -346,8 +518,10 @@ class GoogleCalendarIntegration(IntegrationBackend):
                 resp.raise_for_status()
                 return await resp.json()
 
-    async def _authed_post(self, url: str, body: dict) -> Any:
-        token = await self._get_access_token()
+    async def _authed_post(
+        self, url: str, body: dict, account_id: Optional[str] = None,
+    ) -> Any:
+        token = await self._get_access_token(account_id)
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=15),
         ) as session:
@@ -359,8 +533,8 @@ class GoogleCalendarIntegration(IntegrationBackend):
                 resp.raise_for_status()
                 return await resp.json()
 
-    async def _authed_delete(self, url: str) -> None:
-        token = await self._get_access_token()
+    async def _authed_delete(self, url: str, account_id: Optional[str] = None) -> None:
+        token = await self._get_access_token(account_id)
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=15),
         ) as session:
@@ -370,10 +544,13 @@ class GoogleCalendarIntegration(IntegrationBackend):
             ) as resp:
                 resp.raise_for_status()
 
-    async def _force_refresh(self) -> None:
-        if self._tokens is None or not self._tokens.refresh_token:
+    async def _force_refresh(self, account_id: Optional[str]) -> None:
+        if account_id is None or account_id not in self._accounts:
             return
-        self._tokens.expires_at = int(time.time()) - 1
+        tokens = self._accounts[account_id]
+        if not tokens.refresh_token:
+            return
+        tokens.expires_at = int(time.time()) - 1
 
     @staticmethod
     def _normalize_event(raw: dict) -> dict[str, Any]:
@@ -396,12 +573,25 @@ class GoogleCalendarIntegration(IntegrationBackend):
         }
 
 
+def _label_for_account_id(account_id: str) -> str:
+    """Human-readable name for the account chip.
+
+    `_legacy` and `pending-*` get friendlier labels so the user knows
+    to reconnect.  Real email-shaped ids pass through unchanged.
+    """
+    if account_id == LEGACY_ACCOUNT_ID:
+        return "Legacy connection (reconnect to identify)"
+    if account_id.startswith("pending-"):
+        return f"Unidentified Google account ({account_id})"
+    return account_id
+
+
 class _AuthFlow:
     """Internal: in-flight auth-code flow state."""
 
     __slots__ = (
         "request_id", "state", "code_verifier", "cfg",
-        "expires_at", "tokens", "error",
+        "expires_at", "tokens", "error", "account_id",
     )
 
     def __init__(
@@ -419,3 +609,4 @@ class _AuthFlow:
         self.expires_at = time.time() + 600
         self.tokens: Optional[OAuthTokens] = None
         self.error: Optional[DeviceCodeError] = None
+        self.account_id: Optional[str] = None

--- a/tests/test_google_calendar_integration.py
+++ b/tests/test_google_calendar_integration.py
@@ -1,26 +1,35 @@
-"""#341 / #342 / #346 — Google Calendar integration tests (auth-code shape).
+"""#341 / #342 / #346 / #347 — Google Calendar integration (multi-account).
 
 Stubs the Google OAuth + Calendar API via aiohttp session mocks.
-Asserts:
-  * `auth_kind` is `oauth-authcode` (post-pivot)
-  * `is_connected` is False initially, True after token persist
+Covers:
+  * Multi-account internals (_accounts dict + default_account_id)
+  * `auth_kind` is `oauth-authcode`
   * `start_connect` builds a PKCE authorization_url + tracks the flow
-  * `handle_callback` resolves matching state, persists tokens
-  * `poll_status` reports the flow state correctly
-  * `list_events` / `create_event` / `disconnect` round-trip
-  * Expired access token triggers refresh-on-401 via the auth-code client
+  * `handle_callback` resolves account_id from id_token / userinfo /
+    placeholder, persists tokens under that key
+  * First connect sets default; second connect leaves default alone
+  * `set_default_account` moves the flag
+  * `disconnect(account_id)` and `disconnect()` semantics
+  * `list_events` / `create_event` round-trip with multi-account internals
+  * Legacy single-account file is migrated to `_legacy.json` on first load
 """
 
 from __future__ import annotations
 
+import base64
+import json
 import time
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from dragon_voice.tools.integrations.credentials import CredentialStore
+from dragon_voice.tools.integrations.credentials import (
+    LEGACY_ACCOUNT_ID,
+    ProviderCredentialDir,
+)
 from dragon_voice.tools.integrations.google.calendar import (
+    PROVIDER_NAME,
     GoogleCalendarIntegration,
 )
 from dragon_voice.tools.integrations.oauth import DeviceCodeError, OAuthTokens
@@ -28,13 +37,11 @@ from dragon_voice.tools.integrations.oauth import DeviceCodeError, OAuthTokens
 
 @pytest.fixture(autouse=True)
 def _redirect_cred_store(tmp_path, monkeypatch):
-    """Make all CredentialStore writes land in a per-test tmp dir."""
     monkeypatch.setenv("TINKERCLAW_INTEGRATIONS_DIR", str(tmp_path))
 
 
 @pytest.fixture(autouse=True)
 def _oauth_env(monkeypatch):
-    """Default Google OAuth client env so start_connect can build a URL."""
     monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "test-cid")
     monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "test-csec")
 
@@ -42,21 +49,34 @@ def _oauth_env(monkeypatch):
 @pytest.fixture
 def integration(tmp_path):
     integ = GoogleCalendarIntegration()
-    integ._store = CredentialStore("google-calendar", base_dir=tmp_path)
+    integ._provider_dir = ProviderCredentialDir(PROVIDER_NAME, base_dir=tmp_path)
     return integ
 
 
-@pytest.fixture
-def valid_tokens():
+def _tokens(access="AT-1", refresh="RT-1", scope_overrides=None, id_email=None):
+    """Build OAuthTokens, optionally with an id_token claiming `id_email`."""
+    extra = {}
+    if id_email:
+        payload = {
+            "email": id_email,
+            "email_verified": True,
+            "sub": "1234567890",
+        }
+        body_b64 = base64.urlsafe_b64encode(
+            json.dumps(payload).encode("ascii"),
+        ).rstrip(b"=").decode("ascii")
+        extra["id_token"] = f"header.{body_b64}.signature"
     return OAuthTokens(
-        access_token="AT-fresh",
-        refresh_token="RT-1",
+        access_token=access,
+        refresh_token=refresh,
         token_type="Bearer",
         expires_at=int(time.time()) + 3600,
-        scopes=[
+        scopes=scope_overrides or [
             "https://www.googleapis.com/auth/calendar.readonly",
             "https://www.googleapis.com/auth/calendar.events",
+            "openid", "email",
         ],
+        extra=extra,
     )
 
 
@@ -71,22 +91,36 @@ def _make_mock_response(json_data, status=200):
     return cm
 
 
-# ── shape + lifecycle ───────────────────────────────────────────────
+async def _persist(integ, account_id, tokens, default=False):
+    """Helper to put an account in the integration's state + on disk."""
+    await integ._ensure_loaded()
+    if tokens.extra is None:
+        tokens.extra = {}
+    tokens.extra["default"] = default
+    await integ._persist_account(account_id, tokens)
+    integ._accounts[account_id] = tokens
+    if default or integ._default_account_id is None:
+        integ._default_account_id = account_id
+
+
+# ── shape ───────────────────────────────────────────────────────────
 
 
 def test_auth_kind_is_oauth_authcode(integration):
     assert integration.auth_kind == "oauth-authcode"
 
 
+def test_supports_multi_account(integration):
+    assert integration.supports_multi_account is True
+
+
+# ── lifecycle: empty state ─────────────────────────────────────────
+
+
 @pytest.mark.asyncio
 async def test_initial_state_is_disconnected(integration):
     assert await integration.is_connected() is False
-
-
-@pytest.mark.asyncio
-async def test_is_connected_true_after_persist(integration, valid_tokens):
-    await integration._persist_tokens(valid_tokens)
-    assert await integration.is_connected() is True
+    assert await integration.list_accounts() == []
 
 
 @pytest.mark.asyncio
@@ -96,12 +130,11 @@ async def test_health_check_returns_false_when_disconnected(integration):
     assert "not connected" in detail.lower()
 
 
-# ── start_connect / poll_status / handle_callback ───────────────────
+# ── start_connect ───────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
 async def test_start_connect_requires_oauth_env(integration, monkeypatch):
-    """No GOOGLE_OAUTH_CLIENT_ID → raises so the REST layer returns 503."""
     monkeypatch.delenv("GOOGLE_OAUTH_CLIENT_ID", raising=False)
     from dragon_voice.tools.integrations.google.auth import (
         GoogleOAuthNotConfiguredError,
@@ -113,61 +146,31 @@ async def test_start_connect_requires_oauth_env(integration, monkeypatch):
 @pytest.mark.asyncio
 async def test_start_connect_returns_pkce_authorization_url(integration):
     chal = await integration.start_connect()
+    assert chal.kind == "oauth-authcode"
     assert chal.request_id
     assert chal.verification_url.startswith(
         "https://accounts.google.com/o/oauth2/v2/auth?",
     )
-    assert "code_challenge=" in chal.verification_url
     assert "code_challenge_method=S256" in chal.verification_url
-    # Google needs offline + consent to mint a refresh_token.
     assert "access_type=offline" in chal.verification_url
-    assert "prompt=consent" in chal.verification_url
-    # Auth-code flow has no user_code (only device-code does).
+    # openid + email scopes are auto-included so we can extract account_id.
+    assert "openid" in chal.verification_url
+    assert "email" in chal.verification_url
     assert chal.user_code is None
 
 
 @pytest.mark.asyncio
-async def test_start_connect_tracks_flow_by_request_id_and_state(integration):
+async def test_start_connect_tracks_flow_by_state(integration):
     chal = await integration.start_connect()
     flow = integration._flows[chal.request_id]
-    assert flow.state  # populated
-    assert flow.code_verifier  # populated
-    # _find_flow_by_state agrees.
     assert integration._find_flow_by_state(flow.state) is flow
 
 
-@pytest.mark.asyncio
-async def test_find_flow_by_state_returns_none_for_unknown_state(integration):
-    await integration.start_connect()
-    assert integration._find_flow_by_state("never-issued") is None
-
-
-@pytest.mark.asyncio
-async def test_poll_status_reports_connecting_then_connected(
-    integration, valid_tokens,
-):
-    chal = await integration.start_connect()
-    status = await integration.poll_status(chal.request_id)
-    assert status.state == "connecting"
-
-    # Simulate the callback resolving the flow.
-    flow = integration._flows[chal.request_id]
-    flow.tokens = valid_tokens
-
-    status = await integration.poll_status(chal.request_id)
-    assert status.state == "connected"
-
-
-@pytest.mark.asyncio
-async def test_poll_status_unknown_request_id_is_error(integration):
-    status = await integration.poll_status("never-issued")
-    assert status.state == "error"
-    assert "unknown" in (status.error or "").lower()
+# ── handle_callback paths ──────────────────────────────────────────
 
 
 @pytest.mark.asyncio
 async def test_handle_callback_unknown_state_is_noop(integration):
-    # Must not raise; must not persist anything.
     await integration.handle_callback(state="never-issued", code="x", error=None)
     assert await integration.is_connected() is False
 
@@ -181,73 +184,203 @@ async def test_handle_callback_with_error_sets_flow_error(integration):
     )
     assert flow.error is not None
     assert flow.error.code == "access_denied"
-
     status = await integration.poll_status(chal.request_id)
     assert status.state == "error"
 
 
 @pytest.mark.asyncio
-async def test_handle_callback_success_exchanges_and_persists(
-    integration, valid_tokens,
+async def test_handle_callback_uses_id_token_email_as_account_id(integration):
+    chal = await integration.start_connect()
+    flow = integration._flows[chal.request_id]
+    tokens = _tokens(id_email="me@example.com")
+
+    fake_client = MagicMock()
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+    fake_client.exchange_code_with_verifier = AsyncMock(return_value=tokens)
+
+    with patch(
+        "dragon_voice.tools.integrations.google.calendar.make_google_client",
+        return_value=fake_client,
+    ):
+        await integration.handle_callback(
+            state=flow.state, code="AUTH-1", error=None,
+        )
+
+    accounts = await integration.list_accounts()
+    assert len(accounts) == 1
+    assert accounts[0].account_id == "me@example.com"
+    assert accounts[0].default is True
+    status = await integration.poll_status(chal.request_id)
+    assert status.state == "connected"
+    assert status.account_id == "me@example.com"
+
+
+@pytest.mark.asyncio
+async def test_handle_callback_falls_back_to_userinfo_when_id_token_missing(
+    integration,
 ):
     chal = await integration.start_connect()
     flow = integration._flows[chal.request_id]
+    tokens = _tokens()  # no id_email → no id_token
 
     fake_client = MagicMock()
     fake_client.__aenter__ = AsyncMock(return_value=fake_client)
     fake_client.__aexit__ = AsyncMock(return_value=None)
-    fake_client.exchange_code_with_verifier = AsyncMock(return_value=valid_tokens)
+    fake_client.exchange_code_with_verifier = AsyncMock(return_value=tokens)
 
     with patch(
         "dragon_voice.tools.integrations.google.calendar.make_google_client",
         return_value=fake_client,
+    ), patch(
+        "dragon_voice.tools.integrations.google.calendar.fetch_google_email",
+        new=AsyncMock(return_value="userinfo@example.com"),
     ):
         await integration.handle_callback(
-            state=flow.state, code="AUTH-CODE-1", error=None,
+            state=flow.state, code="AUTH-1", error=None,
         )
 
-    fake_client.exchange_code_with_verifier.assert_awaited_once_with(
-        code="AUTH-CODE-1", code_verifier=flow.code_verifier,
-    )
-    assert flow.tokens is valid_tokens
-    assert await integration.is_connected() is True
-
-    status = await integration.poll_status(chal.request_id)
-    assert status.state == "connected"
+    accounts = await integration.list_accounts()
+    assert [a.account_id for a in accounts] == ["userinfo@example.com"]
 
 
 @pytest.mark.asyncio
-async def test_handle_callback_exchange_failure_sets_flow_error(integration):
+async def test_handle_callback_uses_placeholder_when_both_id_sources_fail(
+    integration,
+):
     chal = await integration.start_connect()
     flow = integration._flows[chal.request_id]
+    tokens = _tokens()
 
     fake_client = MagicMock()
     fake_client.__aenter__ = AsyncMock(return_value=fake_client)
     fake_client.__aexit__ = AsyncMock(return_value=None)
-    fake_client.exchange_code_with_verifier = AsyncMock(
-        side_effect=DeviceCodeError("invalid_grant", "code reused"),
-    )
+    fake_client.exchange_code_with_verifier = AsyncMock(return_value=tokens)
+
+    with patch(
+        "dragon_voice.tools.integrations.google.calendar.make_google_client",
+        return_value=fake_client,
+    ), patch(
+        "dragon_voice.tools.integrations.google.calendar.fetch_google_email",
+        new=AsyncMock(return_value=None),
+    ):
+        await integration.handle_callback(
+            state=flow.state, code="AUTH-1", error=None,
+        )
+
+    accounts = await integration.list_accounts()
+    assert len(accounts) == 1
+    assert accounts[0].account_id.startswith("pending-")
+
+
+@pytest.mark.asyncio
+async def test_second_connect_does_not_unseat_first_default(integration):
+    await _persist(integration, "first@example.com", _tokens(), default=True)
+
+    chal = await integration.start_connect()
+    flow = integration._flows[chal.request_id]
+    second = _tokens(id_email="second@example.com")
+
+    fake_client = MagicMock()
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+    fake_client.exchange_code_with_verifier = AsyncMock(return_value=second)
 
     with patch(
         "dragon_voice.tools.integrations.google.calendar.make_google_client",
         return_value=fake_client,
     ):
         await integration.handle_callback(
-            state=flow.state, code="AUTH-CODE-1", error=None,
+            state=flow.state, code="AUTH-2", error=None,
         )
 
-    assert flow.tokens is None
-    assert flow.error is not None
-    assert flow.error.code == "invalid_grant"
+    accounts = {a.account_id: a for a in await integration.list_accounts()}
+    assert set(accounts.keys()) == {"first@example.com", "second@example.com"}
+    assert accounts["first@example.com"].default is True
+    assert accounts["second@example.com"].default is False
 
 
-# ── Calendar API (unchanged by the auth-code pivot) ────────────────
+# ── set_default_account / disconnect ───────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_list_events_returns_normalized_shape(integration, valid_tokens):
-    """The Calendar API returns verbose payloads — we normalize down."""
-    await integration._persist_tokens(valid_tokens)
+async def test_set_default_account_moves_the_flag(integration, tmp_path):
+    await _persist(integration, "first@example.com", _tokens(), default=True)
+    await _persist(integration, "second@example.com", _tokens())
+
+    await integration.set_default_account("second@example.com")
+
+    # Reload from disk to verify persistence.
+    fresh = GoogleCalendarIntegration()
+    fresh._provider_dir = ProviderCredentialDir(PROVIDER_NAME, base_dir=tmp_path)
+    await fresh._ensure_loaded()
+    accounts = {a.account_id: a for a in await fresh.list_accounts()}
+    assert accounts["second@example.com"].default is True
+    assert accounts["first@example.com"].default is False
+
+
+@pytest.mark.asyncio
+async def test_set_default_account_unknown_raises(integration):
+    await _persist(integration, "first@example.com", _tokens(), default=True)
+    with pytest.raises(DeviceCodeError) as excinfo:
+        await integration.set_default_account("ghost@example.com")
+    assert excinfo.value.code == "unknown_account"
+
+
+@pytest.mark.asyncio
+async def test_disconnect_one_account_leaves_others(integration):
+    await _persist(integration, "first@example.com", _tokens(refresh=None), default=True)
+    await _persist(integration, "second@example.com", _tokens(refresh=None))
+
+    await integration.disconnect(account_id="first@example.com")
+
+    accounts = await integration.list_accounts()
+    assert [a.account_id for a in accounts] == ["second@example.com"]
+    assert accounts[0].default is True
+    assert await integration.is_connected("first@example.com") is False
+    assert await integration.is_connected("second@example.com") is True
+
+
+@pytest.mark.asyncio
+async def test_disconnect_with_no_account_id_clears_all(integration):
+    await _persist(integration, "first@example.com", _tokens(refresh=None), default=True)
+    await _persist(integration, "second@example.com", _tokens(refresh=None))
+
+    await integration.disconnect()
+
+    assert await integration.list_accounts() == []
+    assert await integration.is_connected() is False
+
+
+# ── Legacy migration ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_legacy_flat_file_migrated_on_first_load(tmp_path):
+    """Pre-#347 builds wrote ``{base}/{provider}.json``.  The first load
+    after upgrade must move it to ``{provider}/_legacy.json`` and
+    surface it as the default account."""
+    flat = tmp_path / f"{PROVIDER_NAME}.json"
+    flat.write_text(json.dumps({"tokens": _tokens().to_dict()}))
+
+    integ = GoogleCalendarIntegration()
+    integ._provider_dir = ProviderCredentialDir(PROVIDER_NAME, base_dir=tmp_path)
+    await integ._ensure_loaded()
+
+    accounts = await integ.list_accounts()
+    assert [a.account_id for a in accounts] == [LEGACY_ACCOUNT_ID]
+    assert accounts[0].default is True
+    assert not flat.exists()
+    assert (tmp_path / PROVIDER_NAME / f"{LEGACY_ACCOUNT_ID}.json").exists()
+
+
+# ── Calendar API (multi-account aware) ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_events_routes_to_default_when_account_omitted(integration):
+    await _persist(integration, "first@example.com", _tokens(), default=True)
+    await _persist(integration, "second@example.com", _tokens(access="AT-OTHER"))
 
     fake_session = MagicMock()
     fake_session.closed = False
@@ -255,19 +388,9 @@ async def test_list_events_returns_normalized_shape(integration, valid_tokens):
     fake_session.__aexit__ = AsyncMock(return_value=None)
     fake_session.get = MagicMock(return_value=_make_mock_response({
         "items": [
-            {
-                "id": "evt-1",
-                "summary": "Dentist",
-                "location": "Geneva",
-                "start": {"dateTime": "2026-05-17T14:00:00Z"},
-                "end": {"dateTime": "2026-05-17T15:00:00Z"},
-            },
-            {
-                "id": "evt-2",
-                "summary": "Conference",
-                "start": {"date": "2026-05-18"},
-                "end": {"date": "2026-05-19"},
-            },
+            {"id": "evt-1", "summary": "Dentist",
+             "start": {"dateTime": "2026-05-17T14:00:00Z"},
+             "end": {"dateTime": "2026-05-17T15:00:00Z"}},
         ],
     }))
 
@@ -277,26 +400,43 @@ async def test_list_events_returns_normalized_shape(integration, valid_tokens):
     ):
         events = await integration.list_events()
 
-    assert len(events) == 2
-    assert events[0]["id"] == "evt-1"
-    assert events[0]["summary"] == "Dentist"
-    assert events[0]["location"] == "Geneva"
-    assert events[0]["all_day"] is False
-    assert events[1]["all_day"] is True
-    assert events[1]["start_iso"] == "2026-05-18"
+    assert len(events) == 1
+    assert events[0]["account"] == "first@example.com"
+    headers = fake_session.get.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer AT-1"
 
 
 @pytest.mark.asyncio
-async def test_create_event_posts_with_auth_header(integration, valid_tokens):
-    await integration._persist_tokens(valid_tokens)
+async def test_list_events_with_explicit_account_routes_correctly(integration):
+    await _persist(integration, "first@example.com", _tokens(access="AT-FIRST"), default=True)
+    await _persist(integration, "second@example.com", _tokens(access="AT-SECOND"))
+
+    fake_session = MagicMock()
+    fake_session.closed = False
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=None)
+    fake_session.get = MagicMock(return_value=_make_mock_response({"items": []}))
+
+    with patch(
+        "dragon_voice.tools.integrations.google.calendar.aiohttp.ClientSession",
+        return_value=fake_session,
+    ):
+        await integration.list_events(account_id="second@example.com")
+
+    headers = fake_session.get.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer AT-SECOND"
+
+
+@pytest.mark.asyncio
+async def test_create_event_posts_with_default_account_token(integration):
+    await _persist(integration, "first@example.com", _tokens(), default=True)
 
     fake_session = MagicMock()
     fake_session.closed = False
     fake_session.__aenter__ = AsyncMock(return_value=fake_session)
     fake_session.__aexit__ = AsyncMock(return_value=None)
     fake_session.post = MagicMock(return_value=_make_mock_response({
-        "id": "evt-new",
-        "summary": "Lunch",
+        "id": "evt-new", "summary": "Lunch",
         "start": {"dateTime": "2026-05-17T12:00:00Z"},
         "end": {"dateTime": "2026-05-17T13:00:00Z"},
     }))
@@ -312,52 +452,22 @@ async def test_create_event_posts_with_auth_header(integration, valid_tokens):
         )
 
     assert ev["id"] == "evt-new"
-    assert ev["summary"] == "Lunch"
+    assert ev["account"] == "first@example.com"
     call_kwargs = fake_session.post.call_args.kwargs
-    assert call_kwargs["headers"]["Authorization"] == "Bearer AT-fresh"
+    assert call_kwargs["headers"]["Authorization"] == "Bearer AT-1"
 
 
 @pytest.mark.asyncio
-async def test_disconnect_clears_creds(integration, valid_tokens):
-    await integration._persist_tokens(valid_tokens)
-    assert await integration.is_connected()
+async def test_expired_token_triggers_refresh_per_account(integration):
+    """When the default account's token expires, refresh fires only
+    for that account; the other account's tokens are untouched."""
+    expired_first = _tokens(access="AT-OLD", refresh="RT-1")
+    expired_first.expires_at = int(time.time()) - 10
+    await _persist(integration, "first@example.com", expired_first, default=True)
+    untouched = _tokens(access="AT-OTHER-STILL-GOOD", refresh="RT-OTHER")
+    await _persist(integration, "second@example.com", untouched)
 
-    fake_session = MagicMock()
-    fake_session.closed = False
-    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
-    fake_session.__aexit__ = AsyncMock(return_value=None)
-    fake_session.post = MagicMock(return_value=_make_mock_response({}, status=200))
-
-    with patch(
-        "dragon_voice.tools.integrations.google.calendar.aiohttp.ClientSession",
-        return_value=fake_session,
-    ):
-        await integration.disconnect()
-
-    assert await integration.is_connected() is False
-    assert not await integration._store.exists()
-
-
-@pytest.mark.asyncio
-async def test_expired_token_triggers_refresh_via_authcode_client(integration):
-    """When `expires_at` is past, `_get_access_token` refreshes via the
-    auth-code client and persists the new tokens."""
-    expired = OAuthTokens(
-        access_token="AT-OLD",
-        refresh_token="RT-1",
-        token_type="Bearer",
-        expires_at=int(time.time()) - 10,
-        scopes=["https://www.googleapis.com/auth/calendar.readonly"],
-    )
-    await integration._persist_tokens(expired)
-
-    new_tokens = OAuthTokens(
-        access_token="AT-NEW",
-        refresh_token="RT-1",
-        token_type="Bearer",
-        expires_at=int(time.time()) + 3600,
-        scopes=["https://www.googleapis.com/auth/calendar.readonly"],
-    )
+    new_tokens = _tokens(access="AT-NEW", refresh="RT-1")
 
     fake_client = MagicMock()
     fake_client.__aenter__ = AsyncMock(return_value=fake_client)
@@ -372,3 +482,4 @@ async def test_expired_token_triggers_refresh_via_authcode_client(integration):
 
     assert token == "AT-NEW"
     fake_client.refresh.assert_awaited_once_with("RT-1")
+    assert integration._accounts["second@example.com"].access_token == "AT-OTHER-STILL-GOOD"


### PR DESCRIPTION
## Summary

Stacked on top of #346 (auth-code pivot).  Gmail without multi-account isn't the product, so this lands before Phase 2.

- **Multi-account per provider** — connect work + personal Google to the same `google-calendar` integration; account_id resolved from the id_token email after OAuth exchange (falls back to userinfo, then to a `pending-{uuid}` placeholder when both fail).
- **First-connect-wins default** — subsequent connects don't unseat the existing default.  `PATCH /api/v1/integrations/{name}/accounts/{account_id} {"default": true}` reassigns.
- **Per-account REST surface** while keeping the flat routes for backward compat:
  - `DELETE /accounts/{account_id}` — disconnect one
  - `PATCH /accounts/{account_id}` — set default
  - `GET /accounts/{account_id}/test` — per-account health check
- **Calendar tools accept optional `account` arg** so the LLM can route based on natural-language context (\"what's on my work calendar?\" → the work email).  Omit `account` → default account.
- **Legacy-migration shim**: existing flat `{provider}.json` files auto-move to `{provider}/_legacy.json` on first integration load, surfaced as the default account.  No data loss for live Dragon installs.

Closes #347.

## Live verification

```
# Before deploy: flat google-calendar.json on disk
# After deploy + GET /api/v1/integrations (triggers migration):
{
  \"accounts\": [{
    \"account_id\": \"_legacy\",
    \"display_label\": \"Legacy connection (reconnect to identify)\",
    \"default\": true,
    \"scopes\": [\"https://www.googleapis.com/auth/calendar.readonly\", \"https://www.googleapis.com/auth/calendar.events\"]
  }]
}

# Disk after migration:
/home/radxa/tinkerclaw/integrations/
  google-calendar/
    _legacy.json   (mode 0600)

# calendar_week still works — 17 events tagged \`account: \"_legacy\"\`.
```

To upgrade `_legacy` to a real-named account: disconnect + reconnect (fresh OAuth grants `openid email` so the email gets picked up).  This is one tap on the Tab5 Settings UI once TinkerTab#571 ships.

## Test plan

- [x] Ruff narrow gate (`F821,F722,F811,F823,B006,B904,E722,B007,RUF006`) passes across `dragon_voice/` + `tests/`.
- [x] 70/70 integration tests passing locally (22 new/rewritten covering multi-account paths: id_token vs userinfo vs placeholder, default preservation, set_default_account, per-account + bulk disconnect, legacy migration, per-account read+write routing).
- [x] Live verification on Dragon: existing single-account install auto-migrated; default account preserved; `calendar_week` still serves 17 real events.
- [ ] Tab5 UI surface (lorcan35/TinkerTab#571) — separate repo, tracked there.

## Internals

- `IntegrationBackend` ABC gets `list_accounts`, `supports_multi_account`, optional `account_id` on `is_connected` / `disconnect` / `health_check`, and `set_default_account`.  Single-account backends stay trivial — they ignore `account_id`.
- `GoogleCalendarIntegration` owns `_accounts: dict[account_id, OAuthTokens]` + `_default_account_id`.  Refresh fires per-account.
- `ConnectionStatus` carries `account_id` + `account_label` when state flips to connected so Tab5 updates its UI in one round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)