### PR TITLE
feat(integrations): Phase 2 — Gmail (multi-account)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,4 +140,6 @@ jobs:
             tests/test_integrations_registry.py \
             tests/test_integrations_credentials.py \
             tests/test_oauth_device_code.py \
+            tests/test_oauth_auth_code.py \
+            tests/test_integrations_init.py \
             tests/test_google_calendar_integration.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,4 +142,5 @@ jobs:
             tests/test_oauth_device_code.py \
             tests/test_oauth_auth_code.py \
             tests/test_integrations_init.py \
-            tests/test_google_calendar_integration.py
+            tests/test_google_calendar_integration.py \
+            tests/test_gmail_integration.py

--- a/dragon_voice/api/integrations.py
+++ b/dragon_voice/api/integrations.py
@@ -16,7 +16,7 @@ status — Tab5 turns them into modal text.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from aiohttp import web
 
@@ -33,6 +33,27 @@ from dragon_voice.tools.integrations.registry import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _callback_html(message: str, success: bool) -> web.Response:
+    """Minimal HTML page rendered after Google's OAuth callback."""
+    color = "#0bf08c" if success else "#ff6b6b"
+    title = "Connected" if success else "Connection failed"
+    html = f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{title} — TinkerClaw</title>
+<style>
+  body {{ background:#0a0a0a; color:#e0e0e0; font-family:system-ui;
+         display:flex; align-items:center; justify-content:center;
+         min-height:100vh; margin:0; padding:32px; box-sizing:border-box; }}
+  .card {{ max-width:420px; padding:32px; border-radius:16px;
+          background:#141414; border:1px solid #2a2a2a; text-align:center; }}
+  h1 {{ color:{color}; margin:0 0 16px; font-size:22px; }}
+  p {{ margin:0; line-height:1.5; }}
+</style></head>
+<body><div class="card"><h1>{title}</h1><p>{message}</p></div></body></html>"""
+    return web.Response(text=html, content_type="text/html", charset="utf-8")
 
 
 class IntegrationRoutes:
@@ -72,6 +93,13 @@ class IntegrationRoutes:
             "/api/v1/integrations/{name}/test",
             self.test,
         )
+        # OAuth callback — public route (bearer-auth bypassed by the
+        # middleware's PUBLIC_PREFIXES list; the auth happens via the
+        # PKCE state parameter which only the originating Dragon
+        # process can decrypt).  Google posts the user here after
+        # consent.  Walks every registered integration to find the one
+        # holding this state.
+        app.router.add_get("/api/v1/oauth/callback", self.oauth_callback)
 
     # ── handlers ────────────────────────────────────────────────
 
@@ -169,3 +197,56 @@ class IntegrationRoutes:
             "detail": detail,
             "name": name,
         })
+
+    async def oauth_callback(self, request: web.Request) -> web.Response:
+        """Public OAuth redirect target.
+
+        Google sends the user here after consent:
+        ``?code=...&state=...`` on success or ``?error=...&state=...``
+        on denial.  We walk every instantiated integration looking for
+        one that recognizes the state, then hand the code off.
+
+        Responds with a tiny HTML page so the user's phone shows a
+        success/error message.  Tab5 has its own polling loop and
+        flips the modal independently.
+        """
+        params = request.query
+        state = params.get("state", "")
+        code = params.get("code")
+        error = params.get("error")
+
+        if not state:
+            return _callback_html(
+                "Missing state parameter — link may be malformed.", success=False,
+            )
+
+        # Find the integration holding this state.
+        matched: Optional[IntegrationBackend] = None
+        for integ in self._instances.values():
+            handler = getattr(integ, "handle_callback", None)
+            if handler is None:
+                continue
+            try:
+                flow = integ._find_flow_by_state(state)  # type: ignore[attr-defined]
+            except AttributeError:
+                flow = None
+            if flow is not None:
+                matched = integ
+                break
+        if matched is None:
+            return _callback_html(
+                "This authorization link has already been used or has expired.",
+                success=False,
+            )
+
+        await matched.handle_callback(state=state, code=code, error=error)  # type: ignore[attr-defined]
+        if error:
+            return _callback_html(
+                f"Google reported an error: {error}.  Go back to the Tab5 "
+                f"and try again.",
+                success=False,
+            )
+        return _callback_html(
+            "Connected ✓  You can close this tab and return to your Tab5.",
+            success=True,
+        )

--- a/dragon_voice/api/integrations.py
+++ b/dragon_voice/api/integrations.py
@@ -1,21 +1,26 @@
-"""REST API routes for integrations (#341 / #342).
+"""REST API routes for integrations (#341 / #342 / #347).
 
 Tab5's Settings → Integrations surface calls these:
 
-  * GET  /api/v1/integrations                     — list + connection state
-  * POST /api/v1/integrations/{name}/connect      — start auth flow
-  * GET  /api/v1/integrations/{name}/status/{request_id}  — poll flow
-  * POST /api/v1/integrations/{name}/disconnect   — revoke + delete
-  * GET  /api/v1/integrations/{name}/test         — smoke test
+  * GET    /api/v1/integrations                          — list + connected accounts
+  * POST   /api/v1/integrations/{name}/connect           — start auth flow
+  * GET    /api/v1/integrations/{name}/status/{request_id}  — poll flow
+  * POST   /api/v1/integrations/{name}/disconnect        — disconnect ALL accounts
+  * DELETE /api/v1/integrations/{name}/accounts/{account_id}  — disconnect one (#347)
+  * PATCH  /api/v1/integrations/{name}/accounts/{account_id}  — set default (#347)
+  * GET    /api/v1/integrations/{name}/test              — smoke test default account
+  * GET    /api/v1/integrations/{name}/accounts/{account_id}/test  — per-account smoke test
 
-All routes require bearer auth (the standard middleware covers it; no
-extra check here).  Errors are surfaced as JSON with a sensible HTTP
-status — Tab5 turns them into modal text.
+OAuth callback:
+  * GET    /api/v1/oauth/callback  — Google redirect target (public)
+
+All non-callback routes require bearer auth.
 """
 
 from __future__ import annotations
 
 import logging
+from dataclasses import asdict
 from typing import Any, Optional
 
 from aiohttp import web
@@ -61,7 +66,6 @@ class IntegrationRoutes:
     in-flight auth flows survive across requests."""
 
     def __init__(self) -> None:
-        # name -> backend instance (per-process singleton)
         self._instances: dict[str, IntegrationBackend] = {}
 
     def _get(self, name: str) -> IntegrationBackend:
@@ -73,42 +77,46 @@ class IntegrationRoutes:
         return self._instances[key]
 
     def register(self, app: web.Application) -> None:
+        app.router.add_get("/api/v1/integrations", self.list_all)
+        app.router.add_post(
+            "/api/v1/integrations/{name}/connect", self.connect,
+        )
         app.router.add_get(
-            "/api/v1/integrations",
-            self.list_all,
+            "/api/v1/integrations/{name}/status/{request_id}", self.status,
         )
         app.router.add_post(
-            "/api/v1/integrations/{name}/connect",
-            self.connect,
+            "/api/v1/integrations/{name}/disconnect", self.disconnect_all,
         )
         app.router.add_get(
-            "/api/v1/integrations/{name}/status/{request_id}",
-            self.status,
+            "/api/v1/integrations/{name}/test", self.test,
         )
-        app.router.add_post(
-            "/api/v1/integrations/{name}/disconnect",
-            self.disconnect,
+        # #347 — per-account routes.
+        app.router.add_delete(
+            "/api/v1/integrations/{name}/accounts/{account_id}",
+            self.disconnect_account,
+        )
+        app.router.add_patch(
+            "/api/v1/integrations/{name}/accounts/{account_id}",
+            self.update_account,
         )
         app.router.add_get(
-            "/api/v1/integrations/{name}/test",
-            self.test,
+            "/api/v1/integrations/{name}/accounts/{account_id}/test",
+            self.test_account,
         )
-        # OAuth callback — public route (bearer-auth bypassed by the
-        # middleware's PUBLIC_PREFIXES list; the auth happens via the
-        # PKCE state parameter which only the originating Dragon
-        # process can decrypt).  Google posts the user here after
-        # consent.  Walks every registered integration to find the one
-        # holding this state.
+        # OAuth callback — public (PKCE state authenticates).  See
+        # middleware/auth.py PUBLIC_PREFIXES.  Walks every registered
+        # integration to find the one holding this state.
         app.router.add_get("/api/v1/oauth/callback", self.oauth_callback)
 
     # ── handlers ────────────────────────────────────────────────
 
     async def list_all(self, request: web.Request) -> web.Response:
-        del request  # unused
+        del request
         out: list[dict[str, Any]] = []
         for name in list_integrations():
             integ = self._get(name)
             connected = await integ.is_connected()
+            accounts = await integ.list_accounts()
             state = (
                 IntegrationState.CONNECTED.value
                 if connected else IntegrationState.DISCONNECTED.value
@@ -119,6 +127,8 @@ class IntegrationRoutes:
                 "description": integ.description,
                 "auth_kind": integ.auth_kind,
                 "state": state,
+                "supports_multi_account": integ.supports_multi_account,
+                "accounts": [asdict(a) for a in accounts],
             })
         return web.json_response({"integrations": out})
 
@@ -170,9 +180,11 @@ class IntegrationRoutes:
             "state": status.state,
             "request_id": status.request_id,
             "error": status.error,
+            "account_id": status.account_id,
+            "account_label": status.account_label,
         })
 
-    async def disconnect(self, request: web.Request) -> web.Response:
+    async def disconnect_all(self, request: web.Request) -> web.Response:
         name = request.match_info["name"]
         try:
             integ = self._get(name)
@@ -181,9 +193,56 @@ class IntegrationRoutes:
         try:
             await integ.disconnect()
         except Exception as e:  # noqa: BLE001
-            logger.exception("integration %s disconnect failed", name)
+            logger.exception("integration %s disconnect-all failed", name)
             return json_error(f"Disconnect failed: {e}", 500)
         return web.json_response({"disconnected": True, "name": name})
+
+    async def disconnect_account(self, request: web.Request) -> web.Response:
+        name = request.match_info["name"]
+        account_id = request.match_info["account_id"]
+        try:
+            integ = self._get(name)
+        except KeyError:
+            return json_error(f"Unknown integration '{name}'", 404)
+        if not await integ.is_connected(account_id):
+            return json_error(
+                f"Account '{account_id}' is not connected for '{name}'", 404,
+            )
+        try:
+            await integ.disconnect(account_id=account_id)
+        except Exception as e:  # noqa: BLE001
+            logger.exception(
+                "integration %s disconnect %s failed", name, account_id,
+            )
+            return json_error(f"Disconnect failed: {e}", 500)
+        return web.json_response({
+            "disconnected": True, "name": name, "account_id": account_id,
+        })
+
+    async def update_account(self, request: web.Request) -> web.Response:
+        name = request.match_info["name"]
+        account_id = request.match_info["account_id"]
+        try:
+            integ = self._get(name)
+        except KeyError:
+            return json_error(f"Unknown integration '{name}'", 404)
+        body, err = await parse_json_body(request)
+        if err:
+            return err
+        if body.get("default") is True:
+            try:
+                await integ.set_default_account(account_id)
+            except DeviceCodeError as e:
+                return web.json_response(
+                    {"error": e.code, "message": e.description}, status=404,
+                )
+            return web.json_response({
+                "name": name, "account_id": account_id, "default": True,
+            })
+        return json_error(
+            "PATCH body must contain {\"default\": true} — no other fields supported",
+            400,
+        )
 
     async def test(self, request: web.Request) -> web.Response:
         name = request.match_info["name"]
@@ -192,10 +251,18 @@ class IntegrationRoutes:
         except KeyError:
             return json_error(f"Unknown integration '{name}'", 404)
         ok, detail = await integ.health_check()
+        return web.json_response({"ok": ok, "detail": detail, "name": name})
+
+    async def test_account(self, request: web.Request) -> web.Response:
+        name = request.match_info["name"]
+        account_id = request.match_info["account_id"]
+        try:
+            integ = self._get(name)
+        except KeyError:
+            return json_error(f"Unknown integration '{name}'", 404)
+        ok, detail = await integ.health_check(account_id=account_id)
         return web.json_response({
-            "ok": ok,
-            "detail": detail,
-            "name": name,
+            "ok": ok, "detail": detail, "name": name, "account_id": account_id,
         })
 
     async def oauth_callback(self, request: web.Request) -> web.Response:
@@ -203,12 +270,8 @@ class IntegrationRoutes:
 
         Google sends the user here after consent:
         ``?code=...&state=...`` on success or ``?error=...&state=...``
-        on denial.  We walk every instantiated integration looking for
-        one that recognizes the state, then hand the code off.
-
-        Responds with a tiny HTML page so the user's phone shows a
-        success/error message.  Tab5 has its own polling loop and
-        flips the modal independently.
+        on denial.  Walks every instantiated integration looking for
+        one that recognizes the state, then hands the code off.
         """
         params = request.query
         state = params.get("state", "")
@@ -220,7 +283,6 @@ class IntegrationRoutes:
                 "Missing state parameter — link may be malformed.", success=False,
             )
 
-        # Find the integration holding this state.
         matched: Optional[IntegrationBackend] = None
         for integ in self._instances.values():
             handler = getattr(integ, "handle_callback", None)

--- a/dragon_voice/lifecycle/integrations_init.py
+++ b/dragon_voice/lifecycle/integrations_init.py
@@ -1,12 +1,12 @@
-"""Integrations layer + LLM-callable tools (#341 / #342).
+"""Integrations layer + LLM-callable tools (#341 / #342 / Phase 2).
 
 Registers tool wrappers for TinkerBox-native integrations on the
 existing ``_tool_registry``.  Mirrors ``notes_init.py``'s shape:
 optional dep, layered try/except so a missing integration package
 doesn't block boot.
 
-Today: Google Calendar.  Gmail / Home Assistant / Spotify drop in
-here as they land.
+Today: Google Calendar + Gmail.  Home Assistant / Spotify / Notion
+drop in here as they land.
 """
 from __future__ import annotations
 
@@ -44,3 +44,20 @@ async def init_integration_tools(server: Any) -> None:
         logger.info("Google Calendar tools registered (4)")
     except Exception as e:
         logger.warning("Google Calendar tools not available: %s", e)
+
+    try:
+        from dragon_voice.tools.gmail_tool import (
+            GmailArchiveTool,
+            GmailReadTool,
+            GmailSearchTool,
+            GmailSendTool,
+            GmailUnreadTool,
+        )
+        server._tool_registry.register(GmailUnreadTool())
+        server._tool_registry.register(GmailSearchTool())
+        server._tool_registry.register(GmailReadTool())
+        server._tool_registry.register(GmailSendTool())
+        server._tool_registry.register(GmailArchiveTool())
+        logger.info("Gmail tools registered (5)")
+    except Exception as e:
+        logger.warning("Gmail tools not available: %s", e)

--- a/dragon_voice/lifecycle/integrations_init.py
+++ b/dragon_voice/lifecycle/integrations_init.py
@@ -1,0 +1,46 @@
+"""Integrations layer + LLM-callable tools (#341 / #342).
+
+Registers tool wrappers for TinkerBox-native integrations on the
+existing ``_tool_registry``.  Mirrors ``notes_init.py``'s shape:
+optional dep, layered try/except so a missing integration package
+doesn't block boot.
+
+Today: Google Calendar.  Gmail / Home Assistant / Spotify drop in
+here as they land.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def init_integration_tools(server: Any) -> None:
+    """Register LLM-callable integration tools on ``server._tool_registry``.
+
+    Run AFTER ``init_agentic_modules`` (depends on the registry).
+    The integration *backend* itself is instantiated lazily by each
+    tool via ``_shared_integration()`` so REST connect/disconnect
+    routes and tool calls share a single in-process instance.
+
+    Failure isolation: each integration block is wrapped independently
+    so a broken Google import doesn't block Home Assistant tools.
+    """
+    if not server._tool_registry:
+        return
+
+    try:
+        from dragon_voice.tools.google_calendar_tool import (
+            CalendarCancelTool,
+            CalendarCreateTool,
+            CalendarTodayTool,
+            CalendarWeekTool,
+        )
+        server._tool_registry.register(CalendarTodayTool())
+        server._tool_registry.register(CalendarWeekTool())
+        server._tool_registry.register(CalendarCreateTool())
+        server._tool_registry.register(CalendarCancelTool())
+        logger.info("Google Calendar tools registered (4)")
+    except Exception as e:
+        logger.warning("Google Calendar tools not available: %s", e)

--- a/dragon_voice/lifecycle/startup.py
+++ b/dragon_voice/lifecycle/startup.py
@@ -153,6 +153,15 @@ async def run_startup(server: Any, app: web.Application) -> None:
     from dragon_voice.lifecycle.notes_init import init_notes_module
     await init_notes_module(server, app)
 
+    # #341: TinkerBox-native integration tools (Google Calendar
+    # today, plus Gmail / Home Assistant / Spotify as they land).
+    # Backend instances are created lazily by each tool so REST
+    # connect routes and tool calls share state.
+    from dragon_voice.lifecycle.integrations_init import (
+        init_integration_tools,
+    )
+    await init_integration_tools(server)
+
     # SOLID-audit follow-up: MCP server bridges extracted to
     # lifecycle/mcp_init.py.
     from dragon_voice.lifecycle.mcp_init import init_mcp_bridges

--- a/dragon_voice/middleware/auth.py
+++ b/dragon_voice/middleware/auth.py
@@ -31,6 +31,12 @@ PUBLIC_PREFIXES: tuple[str, ...] = (
     # under /api/v1/* which still gates auth.
     "/call",
     "/static/",
+    # #341 Phase 1: OAuth callback target.  Google redirects the
+    # user's phone browser here after consent — the browser has no
+    # bearer token, but the PKCE `state` parameter is what
+    # authenticates the request (Dragon process holds the only copy
+    # of the matching code_verifier).
+    "/api/v1/oauth/callback",
 )
 
 

--- a/dragon_voice/tools/gmail_tool.py
+++ b/dragon_voice/tools/gmail_tool.py
@@ -1,0 +1,301 @@
+"""Voice-callable tools for Gmail (#341 / Phase 2).
+
+Thin `Tool` wrappers around `GmailIntegration` so the LLM in any vmode
+can drive Gmail via the existing ToolRegistry mechanism.
+
+Tools (all accept optional `account` for multi-account routing):
+  * ``gmail_unread``  — list unread messages
+  * ``gmail_search``  — list messages matching a query
+  * ``gmail_read``    — fetch full body of one message
+  * ``gmail_send``    — compose + send
+  * ``gmail_archive`` — remove INBOX label (== archive)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from dragon_voice.tools.base import Tool
+from dragon_voice.tools.integrations.google.gmail import GmailIntegration
+from dragon_voice.tools.integrations.oauth import DeviceCodeError
+
+logger = logging.getLogger(__name__)
+
+
+_shared_instance: Optional[GmailIntegration] = None
+
+
+def _shared_integration() -> GmailIntegration:
+    """Process-wide singleton — same pattern as the Calendar tool."""
+    global _shared_instance
+    if _shared_instance is None:
+        _shared_instance = GmailIntegration()
+    return _shared_instance
+
+
+def _not_connected(action: str) -> dict[str, Any]:
+    return {
+        "error": "not_connected",
+        "message": (
+            f"Gmail isn't connected yet, so I can't {action}.  Tap "
+            "Settings → Integrations → Connect Gmail on the Tab5."
+        ),
+    }
+
+
+_ACCOUNT_ARG_SCHEMA = {
+    "type": "string",
+    "description": (
+        "Optional Gmail account id (typically the email).  Omit to use "
+        "the default connected Google account.  Use the user's natural-"
+        "language hint to pick — 'my work email' → the work address; "
+        "'my personal email' → the personal address."
+    ),
+}
+
+
+class GmailUnreadTool(Tool):
+    """List unread messages."""
+
+    priority = 30
+
+    @property
+    def name(self) -> str:
+        return "gmail_unread"
+
+    @property
+    def description(self) -> str:
+        return (
+            "List unread email messages.  Returns the most recent unread "
+            "items (from, subject, snippet, id).  Use when the user asks "
+            "'do I have any new emails', 'any unread', or 'what's in my "
+            "inbox'.  Use `gmail_read` to fetch a specific message's body."
+        )
+
+    @property
+    def parameters_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "max_results": {
+                    "type": "integer",
+                    "description": "Max messages to return (default 10, max 25).",
+                },
+                "account": _ACCOUNT_ARG_SCHEMA,
+            },
+        }
+
+    async def execute(self, args: dict) -> dict:
+        integ = _shared_integration()
+        account = args.get("account")
+        if not await integ.is_connected(account_id=account):
+            return _not_connected("read your inbox")
+        try:
+            messages = await integ.list_messages(
+                query="is:unread",
+                max_results=int(args.get("max_results", 10)),
+                account_id=account,
+            )
+        except DeviceCodeError as e:
+            return {"error": e.code, "message": e.description}
+        return {"count": len(messages), "messages": messages, "account": account}
+
+
+class GmailSearchTool(Tool):
+    """Search messages by Gmail query."""
+
+    @property
+    def name(self) -> str:
+        return "gmail_search"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search Gmail using Gmail's search syntax (e.g. 'from:alice', "
+            "'subject:invoice', 'has:attachment newer_than:7d').  Returns "
+            "matching messages with from/subject/snippet/id.  Use `gmail_read` "
+            "to fetch a specific message's body."
+        )
+
+    @property
+    def parameters_schema(self) -> dict:
+        return {
+            "type": "object",
+            "required": ["query"],
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": (
+                        "Gmail search query (Gmail's standard syntax — "
+                        "'from:X', 'to:X', 'subject:X', 'has:attachment', "
+                        "'newer_than:Nd', etc.)."
+                    ),
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Max messages to return (default 10, max 25).",
+                },
+                "account": _ACCOUNT_ARG_SCHEMA,
+            },
+        }
+
+    async def execute(self, args: dict) -> dict:
+        integ = _shared_integration()
+        account = args.get("account")
+        if not await integ.is_connected(account_id=account):
+            return _not_connected("search your inbox")
+        try:
+            messages = await integ.list_messages(
+                query=args["query"],
+                max_results=int(args.get("max_results", 10)),
+                account_id=account,
+            )
+        except DeviceCodeError as e:
+            return {"error": e.code, "message": e.description}
+        return {
+            "count": len(messages), "messages": messages,
+            "query": args["query"], "account": account,
+        }
+
+
+class GmailReadTool(Tool):
+    """Fetch the body of a single message by id."""
+
+    @property
+    def name(self) -> str:
+        return "gmail_read"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Fetch the full body of a Gmail message by its id.  Use after "
+            "`gmail_unread` or `gmail_search` returned a message you want "
+            "to read aloud or summarise.  Returns from/subject/date/"
+            "body_text (preferred) and body_html (fallback)."
+        )
+
+    @property
+    def parameters_schema(self) -> dict:
+        return {
+            "type": "object",
+            "required": ["message_id"],
+            "properties": {
+                "message_id": {
+                    "type": "string",
+                    "description": "Gmail message id from a previous gmail_unread/gmail_search.",
+                },
+                "account": _ACCOUNT_ARG_SCHEMA,
+            },
+        }
+
+    async def execute(self, args: dict) -> dict:
+        integ = _shared_integration()
+        account = args.get("account")
+        if not await integ.is_connected(account_id=account):
+            return _not_connected("read that email")
+        try:
+            msg = await integ.get_message_body(
+                args["message_id"], account_id=account,
+            )
+        except DeviceCodeError as e:
+            return {"error": e.code, "message": e.description}
+        return msg
+
+
+class GmailSendTool(Tool):
+    """Compose + send."""
+
+    @property
+    def name(self) -> str:
+        return "gmail_send"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Send an email through Gmail.  Confirm to/subject/body content "
+            "with the user BEFORE calling — sent email is not undoable.  "
+            "When replying to a message, pass `in_reply_to` so the reply "
+            "threads correctly in the recipient's inbox."
+        )
+
+    @property
+    def parameters_schema(self) -> dict:
+        return {
+            "type": "object",
+            "required": ["to", "subject", "body"],
+            "properties": {
+                "to": {
+                    "type": "string",
+                    "description": "Recipient email (or comma-separated list).",
+                },
+                "subject": {"type": "string"},
+                "body": {"type": "string", "description": "Plain-text body."},
+                "in_reply_to": {
+                    "type": "string",
+                    "description": "Gmail message_id this is a reply to (optional).",
+                },
+                "cc": {
+                    "type": "string",
+                    "description": "Optional CC (comma-separated for multiple).",
+                },
+                "account": _ACCOUNT_ARG_SCHEMA,
+            },
+        }
+
+    async def execute(self, args: dict) -> dict:
+        integ = _shared_integration()
+        account = args.get("account")
+        if not await integ.is_connected(account_id=account):
+            return _not_connected("send an email")
+        try:
+            return await integ.send_message(
+                to=args["to"], subject=args["subject"], body=args["body"],
+                in_reply_to=args.get("in_reply_to"), cc=args.get("cc"),
+                account_id=account,
+            )
+        except DeviceCodeError as e:
+            return {"error": e.code, "message": e.description}
+
+
+class GmailArchiveTool(Tool):
+    """Archive (remove INBOX label)."""
+
+    @property
+    def name(self) -> str:
+        return "gmail_archive"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Archive a Gmail message — removes the INBOX label so it stops "
+            "showing up in the inbox view.  The message is NOT deleted; "
+            "the user can still find it via search.  Confirm message_id "
+            "with the user before calling."
+        )
+
+    @property
+    def parameters_schema(self) -> dict:
+        return {
+            "type": "object",
+            "required": ["message_id"],
+            "properties": {
+                "message_id": {
+                    "type": "string",
+                    "description": "Gmail message id from a previous gmail_unread/gmail_search.",
+                },
+                "account": _ACCOUNT_ARG_SCHEMA,
+            },
+        }
+
+    async def execute(self, args: dict) -> dict:
+        integ = _shared_integration()
+        account = args.get("account")
+        if not await integ.is_connected(account_id=account):
+            return _not_connected("archive that email")
+        try:
+            return await integ.modify_labels(
+                args["message_id"], remove=["INBOX"], account_id=account,
+            )
+        except DeviceCodeError as e:
+            return {"error": e.code, "message": e.description}

--- a/dragon_voice/tools/google_calendar_tool.py
+++ b/dragon_voice/tools/google_calendar_tool.py
@@ -1,11 +1,14 @@
-"""Voice-callable tools for Google Calendar (#341 / #342).
+"""Voice-callable tools for Google Calendar (#341 / #342 / #347).
 
 Thin `Tool` wrappers around `GoogleCalendarIntegration` so the LLM in
 any vmode can call `calendar_today`, `calendar_week`, `calendar_create`,
 `calendar_cancel` via the existing ToolRegistry mechanism.
 
-Return shape mirrors the rest of `dragon_voice/tools/` — plain dicts
-that the LLM injects back into context.  `error` key absent = success.
+Multi-account (#347): every tool accepts an optional ``account``
+argument.  When omitted the integration's default account is used.
+For multi-account providers the LLM is encouraged to infer the account
+from natural-language context ("what's on my work calendar tomorrow?"
+→ ``{"account": "<work email>"}``).
 """
 
 from __future__ import annotations
@@ -47,6 +50,17 @@ def _not_connected(action: str) -> dict[str, Any]:
     }
 
 
+_ACCOUNT_ARG_SCHEMA = {
+    "type": "string",
+    "description": (
+        "Optional account id (typically the email).  Omit to use the "
+        "default connected Google account.  Use the user's natural-"
+        "language hint to pick the right one — 'my work calendar' → "
+        "the work email; 'my personal calendar' → the personal email."
+    ),
+}
+
+
 class CalendarTodayTool(Tool):
     """List today's events."""
 
@@ -61,7 +75,8 @@ class CalendarTodayTool(Tool):
         return (
             "List today's events from the user's primary Google Calendar.  "
             "Use when the user asks 'what's on my calendar today' or 'what "
-            "do I have going on today'."
+            "do I have going on today'.  Accepts an optional `account` arg "
+            "for users with multiple connected Google accounts."
         )
 
     @property
@@ -73,12 +88,14 @@ class CalendarTodayTool(Tool):
                     "type": "integer",
                     "description": "Max events to return (default 10).",
                 },
+                "account": _ACCOUNT_ARG_SCHEMA,
             },
         }
 
     async def execute(self, args: dict) -> dict:
         integ = _shared_integration()
-        if not await integ.is_connected():
+        account = args.get("account")
+        if not await integ.is_connected(account_id=account):
             return _not_connected("read your calendar")
         now = datetime.now(timezone.utc)
         start = now.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -87,12 +104,14 @@ class CalendarTodayTool(Tool):
             events = await integ.list_events(
                 time_min=start, time_max=end,
                 max_results=int(args.get("max_results", 10)),
+                account_id=account,
             )
         except DeviceCodeError as e:
             return {"error": e.code, "message": e.description}
         return {
             "count": len(events),
             "events": events,
+            "account": account,
         }
 
 
@@ -108,7 +127,8 @@ class CalendarWeekTool(Tool):
         return (
             "List events for the next 7 days from the user's primary Google "
             "Calendar.  Use when the user asks 'what's on this week' or "
-            "'what's coming up'."
+            "'what's coming up'.  Accepts an optional `account` arg for "
+            "users with multiple connected Google accounts."
         )
 
     @property
@@ -120,12 +140,14 @@ class CalendarWeekTool(Tool):
                     "type": "integer",
                     "description": "Max events to return (default 20).",
                 },
+                "account": _ACCOUNT_ARG_SCHEMA,
             },
         }
 
     async def execute(self, args: dict) -> dict:
         integ = _shared_integration()
-        if not await integ.is_connected():
+        account = args.get("account")
+        if not await integ.is_connected(account_id=account):
             return _not_connected("read your calendar")
         now = datetime.now(timezone.utc)
         end = now + timedelta(days=7)
@@ -133,10 +155,11 @@ class CalendarWeekTool(Tool):
             events = await integ.list_events(
                 time_min=now, time_max=end,
                 max_results=int(args.get("max_results", 20)),
+                account_id=account,
             )
         except DeviceCodeError as e:
             return {"error": e.code, "message": e.description}
-        return {"count": len(events), "events": events}
+        return {"count": len(events), "events": events, "account": account}
 
 
 class CalendarCreateTool(Tool):
@@ -153,7 +176,9 @@ class CalendarCreateTool(Tool):
             "when the user explicitly asks to schedule / add / book a "
             "calendar event.  Confirm details with the user BEFORE calling; "
             "calendar writes are not undoable by voice except via "
-            "calendar_cancel."
+            "calendar_cancel.  Accepts an optional `account` arg for users "
+            "with multiple connected Google accounts — ask the user which "
+            "calendar to use if it's not obvious."
         )
 
     @property
@@ -182,12 +207,14 @@ class CalendarCreateTool(Tool):
                     "type": "string",
                     "description": "Optional longer description.",
                 },
+                "account": _ACCOUNT_ARG_SCHEMA,
             },
         }
 
     async def execute(self, args: dict) -> dict:
         integ = _shared_integration()
-        if not await integ.is_connected():
+        account = args.get("account")
+        if not await integ.is_connected(account_id=account):
             return _not_connected("create an event")
         try:
             start = datetime.fromisoformat(args["start_iso"])
@@ -201,10 +228,11 @@ class CalendarCreateTool(Tool):
                 end=end,
                 location=args.get("location"),
                 description=args.get("description"),
+                account_id=account,
             )
         except DeviceCodeError as e:
             return {"error": e.code, "message": e.description}
-        return {"event": ev, "created": True}
+        return {"event": ev, "created": True, "account": account}
 
 
 class CalendarCancelTool(Tool):
@@ -220,7 +248,9 @@ class CalendarCancelTool(Tool):
             "Delete an event from the user's primary Google Calendar.  Use "
             "when the user explicitly asks to cancel / delete / remove an "
             "event.  Confirm the event id (from a previous calendar_today "
-            "or calendar_week result) with the user before calling."
+            "or calendar_week result) with the user before calling.  "
+            "Accepts an optional `account` arg — match the account from "
+            "the event you're cancelling."
         )
 
     @property
@@ -233,14 +263,18 @@ class CalendarCancelTool(Tool):
                     "type": "string",
                     "description": "Event id from a previous calendar_today or calendar_week result.",
                 },
+                "account": _ACCOUNT_ARG_SCHEMA,
             },
         }
 
     async def execute(self, args: dict) -> dict:
         integ = _shared_integration()
-        if not await integ.is_connected():
+        account = args.get("account")
+        if not await integ.is_connected(account_id=account):
             return _not_connected("cancel an event")
-        ok = await integ.cancel_event(args["event_id"])
+        ok = await integ.cancel_event(args["event_id"], account_id=account)
         if not ok:
             return {"error": "cancel_failed", "event_id": args["event_id"]}
-        return {"cancelled": True, "event_id": args["event_id"]}
+        return {
+            "cancelled": True, "event_id": args["event_id"], "account": account,
+        }

--- a/dragon_voice/tools/integrations/base.py
+++ b/dragon_voice/tools/integrations/base.py
@@ -1,4 +1,4 @@
-"""IntegrationBackend ABC + lifecycle types (#341 / #342).
+"""IntegrationBackend ABC + lifecycle types (#341 / #347).
 
 Every TinkerBox integration (Google Calendar, Gmail, Home Assistant,
 Spotify, ...) implements this interface.  The methods are deliberately
@@ -7,10 +7,15 @@ narrow:
   * `display_name`, `description` — UI metadata for Tab5 Settings.
   * `auth_kind` — drives the Tab5 connect-modal shape.
   * `start_connect` — initiates the auth flow, returns the challenge
-    the user needs to complete on their phone (device-code) or the
-    fields they need to fill (static-token).
+    the user needs to complete on their phone (auth-code / device-code)
+    or the fields they need to fill (static-token).
   * `poll_status` — Tab5 polls until `connected: true` or expiry.
-  * `disconnect` — revoke + delete tokens.
+  * `list_accounts` — enumerate connected accounts under this provider.
+    Single-account providers (Home Assistant) return at most one;
+    multi-account providers (Google, Spotify, Notion) return any
+    number.
+  * `disconnect` — revoke + delete tokens for one account (or all when
+    account_id omitted).
   * `health_check` — smoke test; the REST `/test` endpoint calls this.
 
 State persistence lives in `CredentialStore` (see credentials.py); the
@@ -20,7 +25,7 @@ backend owns the schema of what gets stored.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Literal, Optional
 
@@ -36,13 +41,40 @@ class IntegrationState(str, Enum):
 
 
 @dataclass
+class AccountInfo:
+    """One connected account under a multi-account integration.
+
+    * ``account_id`` — stable handle the integration uses to address
+      this account (Google: email; Spotify: user id; HA: host).  Tab5
+      shows it on the connected-account chip; tools take it as an
+      argument when the user wants to target a specific account.
+    * ``display_label`` — human-readable name (often the same as
+      account_id for email-shaped ids).
+    * ``default`` — exactly one account per integration may be the
+      default.  Tools fall back to it when no account is specified.
+    * ``scopes`` — granted OAuth scopes (informational; helps Tab5
+      explain capability gaps).
+    * ``connected_at`` — unix timestamp of first successful auth.
+    """
+
+    account_id: str
+    display_label: str
+    default: bool = False
+    scopes: list[str] = field(default_factory=list)
+    connected_at: Optional[int] = None
+
+
+@dataclass
 class ConnectChallenge:
     """Returned by `start_connect` — what Tab5 should show the user.
 
-    For OAuth device-code:
-      * `verification_url` — what the QR code encodes (with `user_code`
-        embedded as a query param so the phone autofills it).
-      * `user_code` — the human-readable fallback ("ABC-123").
+    For OAuth (device-code AND authorization-code-with-PKCE):
+      * `verification_url` — what the QR code encodes.  For device-code
+        flows the `user_code` is embedded as a query param; for
+        auth-code flows the URL is the full Google auth URL with
+        `code_challenge`+`state`.
+      * `user_code` — human-readable fallback for device-code flows.
+        ``None`` for auth-code flows.
       * `expires_in_s` — countdown for the modal.
       * `interval_s` — how often Tab5 should poll the status endpoint.
       * `request_id` — opaque server-side handle.  Tab5 echoes this
@@ -51,11 +83,9 @@ class ConnectChallenge:
     For static-token:
       * `prompt_fields` — list of field names Tab5 should render as
         text inputs (e.g. `["base_url", "long_lived_token"]`).
-      * `verification_url` / `user_code` / `expires_in_s` / `interval_s`
-        all unset.
     """
 
-    kind: Literal["oauth-device", "static-token", "none"]
+    kind: Literal["oauth-device", "oauth-authcode", "static-token", "none"]
     request_id: str
     verification_url: Optional[str] = None
     user_code: Optional[str] = None
@@ -68,20 +98,30 @@ class ConnectChallenge:
 class ConnectionStatus:
     """Returned by `poll_status` — Tab5 keeps polling until terminal.
 
-    * `state` — `connecting` while OAuth flow is mid-flight, `connected`
-      on success, `error` on a non-recoverable failure, `expired` when
-      the device-code timed out (Tab5 should close the modal).
-    * `error` — human-readable string when `state` is `error` or
-      `expired`.  Tab5 surfaces this in the modal.
+    * `state` — `connecting` while flow is mid-flight, `connected` on
+      success, `error` on a non-recoverable failure, `expired` when
+      the flow timed out.
+    * `error` — human-readable string when `state` is `error`/`expired`.
+    * `account_id` — populated when `state == "connected"` so Tab5
+      knows which account just landed.  ``None`` mid-flight.
+    * `account_label` — human-readable name (email) for the new account.
     """
 
     state: Literal["connecting", "connected", "error", "expired"]
     request_id: str
     error: Optional[str] = None
+    account_id: Optional[str] = None
+    account_label: Optional[str] = None
 
 
 class IntegrationBackend(ABC):
-    """Interface every integration implements."""
+    """Interface every integration implements.
+
+    Default semantics for the account_id parameter on methods that
+    take it:  ``None`` means *the default account* if one is set,
+    otherwise fall back to whatever single-account behaviour made
+    sense pre-#347.  Single-account providers can ignore the parameter.
+    """
 
     @property
     @abstractmethod
@@ -96,10 +136,7 @@ class IntegrationBackend(ABC):
     @property
     @abstractmethod
     def display_name(self) -> str:
-        """User-facing name shown in Tab5 Settings.
-
-        Examples: ``"Google Calendar"``, ``"Gmail"``, ``"Home Assistant"``.
-        """
+        """User-facing name shown in Tab5 Settings."""
         ...
 
     @property
@@ -110,54 +147,87 @@ class IntegrationBackend(ABC):
 
     @property
     @abstractmethod
-    def auth_kind(self) -> Literal["oauth-device", "static-token", "none"]:
+    def auth_kind(self) -> Literal["oauth-device", "oauth-authcode", "static-token", "none"]:
         """Drives the Tab5 connect-modal shape."""
         ...
 
+    @property
+    def supports_multi_account(self) -> bool:
+        """True when the integration can hold more than one connected
+        account (Google, Spotify, Notion).  Default False — Home
+        Assistant and static-token integrations override to True only
+        if they actually multiplex."""
+        return False
+
     @abstractmethod
-    async def is_connected(self) -> bool:
-        """True when credentials exist + are usable.  No network call
-        — read-only.  For network reachability use `health_check`."""
+    async def is_connected(self, account_id: Optional[str] = None) -> bool:
+        """True when credentials exist + are usable.
+
+        When ``account_id`` is None: True if ANY account is connected.
+        When provided: True only if that specific account is connected.
+        No network call — read-only.
+        """
+        ...
+
+    @abstractmethod
+    async def list_accounts(self) -> list[AccountInfo]:
+        """Return all currently-connected accounts under this provider.
+
+        Empty list when nothing is connected.  Order is stable but
+        otherwise unspecified.  Exactly one entry has ``default=True``
+        when any are connected.
+        """
         ...
 
     @abstractmethod
     async def start_connect(self, params: Optional[dict] = None) -> ConnectChallenge:
         """Initiate the auth flow.
 
-        Args:
-            params: For ``static-token`` integrations Tab5 posts the
-                completed field values here (e.g. ``{"base_url": "...",
-                "long_lived_token": "..."}``).  For OAuth device-code
-                it's typically unused.
+        For multi-account providers, the result account_id isn't known
+        until after the callback resolves and we hit ``userinfo``.
+        Tab5 just receives a ``request_id`` here and polls.
         """
         ...
 
     @abstractmethod
     async def poll_status(self, request_id: str) -> ConnectionStatus:
         """Tab5 polls every few seconds while the user completes the
-        OAuth flow on their phone.  Returns terminal state when done.
-        """
+        flow on their phone.  Returns terminal state when done."""
         ...
 
     @abstractmethod
-    async def disconnect(self) -> None:
+    async def disconnect(self, account_id: Optional[str] = None) -> None:
         """Revoke + delete stored credentials.
 
-        Best-effort: if the provider's revoke endpoint fails (network
-        down, token already invalid), still delete the local creds —
-        the user explicitly asked to disconnect.
+        When ``account_id`` is None: disconnect ALL accounts.  When
+        provided: disconnect just that one (other accounts remain
+        connected; the default is reassigned if the disconnected one
+        was the default).
+
+        Best-effort: if the provider's revoke endpoint fails, still
+        delete the local creds — the user explicitly asked to
+        disconnect.
         """
         ...
 
     @abstractmethod
-    async def health_check(self, timeout_s: float = 5.0) -> tuple[bool, str]:
+    async def health_check(
+        self,
+        account_id: Optional[str] = None,
+        timeout_s: float = 5.0,
+    ) -> tuple[bool, str]:
         """Cheap reachability probe.
 
-        Returns ``(ok, detail)``.  REST ``GET /api/v1/integrations/{name}/test``
-        calls this.  `ok=False` with a short detail when the provider
-        is unreachable or our credentials are stale.
+        When ``account_id`` is None: probe the default account.
+        Returns ``(ok, detail)``.
         """
         ...
+
+    async def set_default_account(self, account_id: str) -> None:  # noqa: ARG002
+        """Optional — multi-account providers override to mark an
+        account as the default.  Single-account providers leave the
+        default (no-op)."""
+        return None
 
     async def shutdown(self) -> None:
         """Release any held connections (HTTP sessions, etc.)  Default

--- a/dragon_voice/tools/integrations/credentials.py
+++ b/dragon_voice/tools/integrations/credentials.py
@@ -1,15 +1,26 @@
-"""Per-integration credential storage (#341).
+"""Per-integration credential storage (#341 / #347).
 
-Each integration owns a small JSON file under
-``~/.tinkerclaw/integrations/{name}.json`` (mode ``0o600``).  Schema is
-opaque to this layer — the integration backend defines what gets
-stored (OAuth tokens + expiry + refresh, or a static long-lived
+Each integration owns a **directory** of small JSON cred files under
+``{base}/{provider}/{account_id}.json`` (mode ``0o600``).  This lets a
+single provider hold multiple connected accounts (e.g. work + personal
+Gmail).  ``account_id`` is whatever the provider considers a stable
+user handle — for Google integrations it's the verified email; for
+Spotify it's the user's id; for Home Assistant it's the host string.
+
+Schema is opaque to this layer — the integration backend defines what
+gets stored (OAuth tokens + expiry + refresh, or a static long-lived
 token, etc.).
 
 Atomic write: writes to ``{name}.json.tmp`` then ``os.replace`` so a
 crash mid-write doesn't corrupt the cred file.  Read returns ``None``
 when the file is missing OR malformed — caller treats that as "not
 connected" and prompts the user to reconnect.
+
+Backward compat: pre-#347 builds stored a single file per provider at
+``{base}/{provider}.json``.  ``ProviderCredentialDir.migrate_legacy``
+moves that to ``{base}/{provider}/_legacy.json`` (the account_id is
+filled in by the integration on first successful health-check via
+userinfo lookup) so existing connections survive an upgrade.
 """
 
 from __future__ import annotations
@@ -18,6 +29,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import stat
 from pathlib import Path
 from typing import Any, Optional
@@ -25,8 +37,22 @@ from typing import Any, Optional
 logger = logging.getLogger(__name__)
 
 # Default location.  Override via TINKERCLAW_INTEGRATIONS_DIR env var
-# (used by tests to redirect to a temp dir).
+# (used by tests + on Dragon to redirect away from ~/.tinkerclaw/ which
+# is OpenClaw's config dir AND read-only under systemd hardening).
 _DEFAULT_DIR = Path.home() / ".tinkerclaw" / "integrations"
+
+# Sentinel used by the legacy-migration shim.  A real account_id is
+# filled in once the integration can look it up (e.g. Google userinfo
+# returns the verified email).
+LEGACY_ACCOUNT_ID = "_legacy"
+
+# Reserved account_id values that aren't real accounts.  Listed so the
+# REST list_accounts surface can hide them.
+_RESERVED_ACCOUNT_IDS = frozenset({LEGACY_ACCOUNT_ID})
+
+# Filesystem-safe account_id pattern.  Emails fit; arbitrary user
+# input is sanitised by `sanitise_account_id` below.
+_ALLOWED_ACCOUNT_ID = re.compile(r"^[A-Za-z0-9._@+\-]+$")
 
 
 def _resolve_dir() -> Path:
@@ -36,30 +62,58 @@ def _resolve_dir() -> Path:
     return _DEFAULT_DIR
 
 
-class CredentialStore:
-    """Per-integration cred file at ``{base}/{name}.json``.
+def sanitise_account_id(raw: str) -> str:
+    """Turn an arbitrary id into a filesystem-safe slug.
 
-    Thread-safe via a per-instance asyncio.Lock — writes are serialized
+    Keeps the email-ish characters (alnum, dot, at, plus, dash,
+    underscore) and replaces anything else with ``-``.  Empty after
+    sanitisation → raises ValueError because that's a programming
+    error, not an integration concern.
+    """
+    cleaned = re.sub(r"[^A-Za-z0-9._@+\-]+", "-", raw.strip())
+    cleaned = cleaned.strip("-._")
+    if not cleaned:
+        raise ValueError(f"account_id sanitises to empty: {raw!r}")
+    return cleaned
+
+
+class CredentialStore:
+    """Per-(provider, account) cred file at ``{base}/{provider}/{account_id}.json``.
+
+    Thread-safe via a per-instance asyncio.Lock — writes are serialised
     but reads run unlocked (file-level atomic).  Cross-process safety
     is not a goal: a single dragon_voice process owns its creds.
+
+    Construction:
+
+        store = CredentialStore("google-calendar", account_id="me@example.com")
+        await store.save({"tokens": {...}})
+        data = await store.load()
     """
 
-    def __init__(self, name: str, base_dir: Optional[Path] = None) -> None:
-        self._name = name
-        self._dir = base_dir if base_dir is not None else _resolve_dir()
-        self._path = self._dir / f"{name}.json"
+    def __init__(
+        self,
+        provider: str,
+        account_id: str = LEGACY_ACCOUNT_ID,
+        base_dir: Optional[Path] = None,
+    ) -> None:
+        self._provider = provider
+        self._account_id = sanitise_account_id(account_id) if account_id != LEGACY_ACCOUNT_ID else account_id
+        base = base_dir if base_dir is not None else _resolve_dir()
+        self._dir = base / provider
+        self._path = self._dir / f"{self._account_id}.json"
         self._lock = asyncio.Lock()
 
     @property
     def path(self) -> Path:
         return self._path
 
-    async def load(self) -> Optional[dict[str, Any]]:
-        """Read credentials.  Returns None on missing OR malformed file.
+    @property
+    def account_id(self) -> str:
+        return self._account_id
 
-        Malformed-file path also logs a warning so an operator sees the
-        corruption rather than silently treating it as "disconnected".
-        """
+    async def load(self) -> Optional[dict[str, Any]]:
+        """Read credentials.  Returns None on missing OR malformed file."""
         if not self._path.exists():
             return None
         try:
@@ -84,32 +138,29 @@ class CredentialStore:
             return None
 
     async def save(self, data: dict[str, Any]) -> None:
-        """Atomic write + chmod 0o600.
-
-        Creates the parent dir if missing.  Raises OSError on
-        underlying filesystem failure — caller decides whether that's
-        fatal (probably yes; if we can't persist creds the user has to
-        reconnect every restart).
-        """
+        """Atomic write + chmod 0o600."""
         async with self._lock:
             await asyncio.to_thread(self._save_sync, data)
 
     def _save_sync(self, data: dict[str, Any]) -> None:
         self._dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-        # Make sure the directory itself isn't world-readable.
         try:
             os.chmod(self._dir, 0o700)
+        except OSError:
+            pass
+        # Also tighten the integrations root so a sibling provider
+        # can't be world-readable.
+        try:
+            os.chmod(self._dir.parent, 0o700)
         except OSError:
             pass
         tmp = self._path.with_suffix(self._path.suffix + ".tmp")
         with tmp.open("w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, sort_keys=True)
-        # Mode 0o600 — owner-only read+write.
         os.chmod(tmp, stat.S_IRUSR | stat.S_IWUSR)
         os.replace(tmp, self._path)
 
     async def delete(self) -> None:
-        """Remove the credential file.  No-op if already missing."""
         async with self._lock:
             try:
                 self._path.unlink(missing_ok=True)
@@ -118,3 +169,107 @@ class CredentialStore:
 
     async def exists(self) -> bool:
         return self._path.exists()
+
+    async def rename_to(self, new_account_id: str) -> None:
+        """Move this store's file to a different account_id.
+
+        Used by the legacy-migration shim once the real account_id is
+        known (e.g. Google userinfo returned the email).  Atomic via
+        ``os.replace``.  Silently no-op when the source doesn't exist.
+        """
+        async with self._lock:
+            if not self._path.exists():
+                return
+            new_account = sanitise_account_id(new_account_id)
+            new_path = self._dir / f"{new_account}.json"
+            if new_path == self._path:
+                return
+            os.replace(self._path, new_path)
+            self._account_id = new_account
+            self._path = new_path
+
+
+class ProviderCredentialDir:
+    """List + manage all accounts under a single provider.
+
+    Each integration backend holds one of these to enumerate the
+    accounts it currently owns and to perform per-provider operations
+    (legacy migration, bulk-disconnect, etc.).
+    """
+
+    def __init__(self, provider: str, base_dir: Optional[Path] = None) -> None:
+        self._provider = provider
+        base = base_dir if base_dir is not None else _resolve_dir()
+        self._dir = base / provider
+        self._base = base
+
+    @property
+    def provider(self) -> str:
+        return self._provider
+
+    @property
+    def path(self) -> Path:
+        return self._dir
+
+    def list_accounts(self, include_reserved: bool = False) -> list[str]:
+        """Return all account_ids that have a cred file on disk.
+
+        Empty list when the provider dir doesn't exist or is empty.
+        ``_legacy`` is hidden by default — callers that need to act
+        on it (the migration shim) pass include_reserved=True.
+        """
+        if not self._dir.is_dir():
+            return []
+        accounts = []
+        for entry in self._dir.iterdir():
+            if not entry.is_file() or entry.suffix != ".json":
+                continue
+            if entry.name.endswith(".tmp"):
+                continue
+            account = entry.stem
+            if not include_reserved and account in _RESERVED_ACCOUNT_IDS:
+                continue
+            accounts.append(account)
+        return sorted(accounts)
+
+    def store_for(self, account_id: str) -> CredentialStore:
+        """Build a CredentialStore for one account under this provider."""
+        return CredentialStore(self._provider, account_id, base_dir=self._base)
+
+    def migrate_legacy(self) -> Optional[CredentialStore]:
+        """Look for a pre-#347 flat ``{base}/{provider}.json`` file and
+        move it to ``{base}/{provider}/_legacy.json`` so the integration
+        keeps loading after the upgrade.
+
+        Returns the CredentialStore pointing at the migrated file when
+        a migration happened, None otherwise.  Idempotent — calling
+        twice is safe.
+        """
+        legacy_flat = self._base / f"{self._provider}.json"
+        if not legacy_flat.exists():
+            return None
+        target = self.store_for(LEGACY_ACCOUNT_ID)
+        if target.path.exists():
+            # Already migrated; just remove the stale flat file.
+            try:
+                legacy_flat.unlink()
+            except OSError as e:
+                logger.warning("Failed to delete stale flat %s: %s", legacy_flat, e)
+            return target
+        self._dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.replace(legacy_flat, target.path)
+        logger.info(
+            "Migrated legacy single-account creds for %s to %s — "
+            "the integration will fold this into a per-account slot "
+            "the next time it confirms the account identity.",
+            self._provider, target.path,
+        )
+        return target
+
+
+__all__ = [
+    "LEGACY_ACCOUNT_ID",
+    "CredentialStore",
+    "ProviderCredentialDir",
+    "sanitise_account_id",
+]

--- a/dragon_voice/tools/integrations/google/auth.py
+++ b/dragon_voice/tools/integrations/google/auth.py
@@ -1,26 +1,21 @@
-"""Google OAuth (device-code grant) — shared by Calendar + Gmail.
+"""Google OAuth helpers — shared by Calendar + Gmail.
 
-Single Google OAuth client_id covers all Google services we use.  The
-flow uses the device authorization grant per RFC 8628; Google's
-endpoints:
-  * device-code:  https://oauth2.googleapis.com/device/code
-  * token:        https://oauth2.googleapis.com/token
+Pivoted from device-code to **authorization-code-with-PKCE** because
+Google's device-code allowed-scope list excludes Calendar + Gmail.
+See ``../oauth.py`` module docstring for the explanation.
 
-The client_id (and optional client_secret) come from environment:
-  * GOOGLE_OAUTH_CLIENT_ID — required for `start_connect` to work.
-    Created by the user at https://console.cloud.google.com/ →
-    APIs & Services → Credentials → Create OAuth client ID → "TVs and
-    Limited Input devices" application type.
-  * GOOGLE_OAUTH_CLIENT_SECRET — required when the OAuth client was
-    issued one (Google's "TVs and Limited Input" type ships with both
-    a client_id AND client_secret).  Optional otherwise.
+Single Google Web-application OAuth client (created in Google Cloud
+Console) is reused across all Google integrations.  The redirect URI
+must match what's registered in the Console:
+``https://tinkerclaw-voice.ngrok.dev/api/v1/oauth/callback``
+(reachable from any device via the existing TinkerClaw ngrok tunnel).
 
-When the env vars are missing, `start_connect` raises a structured
-error so the Tab5 UI can surface a "Set up Google OAuth first"
-explainer instead of failing silently.
+Env vars expected on Dragon:
 
-This module is intentionally not an `IntegrationBackend` itself — it's
-a shared auth helper that Calendar + Gmail backends compose.
+* ``GOOGLE_OAUTH_CLIENT_ID`` — required
+* ``GOOGLE_OAUTH_CLIENT_SECRET`` — required for web-application client
+* ``GOOGLE_OAUTH_REDIRECT_URI`` — optional override; defaults to the
+  ngrok URL.
 """
 
 from __future__ import annotations
@@ -32,20 +27,26 @@ from typing import Optional
 
 from dragon_voice.tools.integrations.oauth import (
     DeviceCodeError,
-    OAuthDeviceCodeClient,
+    OAuthAuthCodeClient,
     OAuthTokens,
 )
 
 logger = logging.getLogger(__name__)
 
-# Google OAuth endpoints — per Google's official documentation for the
-# OAuth 2.0 Device Authorization Grant.
-GOOGLE_DEVICE_CODE_URL = "https://oauth2.googleapis.com/device/code"
+# Endpoints.
+GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
 GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke"
 
-# Scopes are space-separated when sent to Google.  The Calendar +
-# Gmail backends each declare what they need; auth.py just collects.
+# Default redirect — ngrok tunnel that the existing tinkerclaw-ngrok
+# service maintains pointing at Dragon's port 3502.  Operator can
+# override via env var if running on a different network setup.
+DEFAULT_REDIRECT_URI = (
+    "https://tinkerclaw-voice.ngrok.dev/api/v1/oauth/callback"
+)
+
+# Scopes used by Calendar + Gmail.  Each integration only requests
+# what it needs; this module just collects the constants.
 SCOPE_CALENDAR_READ = "https://www.googleapis.com/auth/calendar.readonly"
 SCOPE_CALENDAR_EVENTS = "https://www.googleapis.com/auth/calendar.events"
 SCOPE_GMAIL_READ = "https://www.googleapis.com/auth/gmail.readonly"
@@ -53,36 +54,46 @@ SCOPE_GMAIL_MODIFY = "https://www.googleapis.com/auth/gmail.modify"
 SCOPE_GMAIL_SEND = "https://www.googleapis.com/auth/gmail.send"
 
 
+class GoogleOAuthNotConfiguredError(DeviceCodeError):
+    """Raised when env vars are missing.  Inherits DeviceCodeError so
+    REST handlers render a consistent error shape across all OAuth
+    failures."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(code="oauth_not_configured", description=message)
+
+
 @dataclass
 class GoogleOAuthConfig:
-    """Provider-level OAuth config + scope union.
-
-    `scopes` defaults to read-only Calendar — explicit at construction
-    so a single Google credential file can grow scopes incrementally
-    (Calendar first; then Gmail later expands the set).
-    """
+    """Provider-level OAuth config + scope union."""
 
     client_id: str
-    client_secret: Optional[str] = None
+    client_secret: Optional[str]
+    redirect_uri: str
     scopes: list[str] = field(default_factory=lambda: [SCOPE_CALENDAR_READ])
 
     @classmethod
     def from_env(cls, scopes: Optional[list[str]] = None) -> "GoogleOAuthConfig":
         client_id = os.environ.get("GOOGLE_OAUTH_CLIENT_ID", "").strip()
+        client_secret = os.environ.get(
+            "GOOGLE_OAUTH_CLIENT_SECRET", ""
+        ).strip() or None
+        redirect_uri = (
+            os.environ.get("GOOGLE_OAUTH_REDIRECT_URI", "").strip()
+            or DEFAULT_REDIRECT_URI
+        )
         if not client_id:
             raise GoogleOAuthNotConfiguredError(
-                "GOOGLE_OAUTH_CLIENT_ID env var is not set.  Create an "
-                "OAuth client at https://console.cloud.google.com/ "
-                '(application type "TVs and Limited Input devices") and '
-                "set GOOGLE_OAUTH_CLIENT_ID + GOOGLE_OAUTH_CLIENT_SECRET "
-                "in Dragon's environment."
+                "GOOGLE_OAUTH_CLIENT_ID is not set.  Create a Web-application "
+                "OAuth client at https://console.cloud.google.com/apis/credentials "
+                "(redirect URI: " + redirect_uri + ") then set "
+                "GOOGLE_OAUTH_CLIENT_ID + GOOGLE_OAUTH_CLIENT_SECRET in Dragon's "
+                "environment and restart tinkerclaw-voice."
             )
-        client_secret = (
-            os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET", "").strip() or None
-        )
         return cls(
             client_id=client_id,
             client_secret=client_secret,
+            redirect_uri=redirect_uri,
             scopes=list(scopes) if scopes is not None else [SCOPE_CALENDAR_READ],
         )
 
@@ -90,34 +101,23 @@ class GoogleOAuthConfig:
         return " ".join(self.scopes)
 
 
-class GoogleOAuthNotConfiguredError(DeviceCodeError):
-    """Raised when GOOGLE_OAUTH_CLIENT_ID is missing.
-
-    Inherits DeviceCodeError so the REST layer can render the same
-    error shape for "no client_id set" vs "user denied authorization".
-    """
-
-    def __init__(self, message: str) -> None:
-        super().__init__(code="oauth_not_configured", description=message)
-
-
-def make_google_client(config: GoogleOAuthConfig) -> OAuthDeviceCodeClient:
-    """Build a Google-specific OAuthDeviceCodeClient."""
-    return OAuthDeviceCodeClient(
+def make_google_client(config: GoogleOAuthConfig) -> OAuthAuthCodeClient:
+    """Build a Google-flavored authorization-code-with-PKCE client."""
+    return OAuthAuthCodeClient(
         client_id=config.client_id,
         client_secret=config.client_secret,
         scope=config.scope_string(),
-        device_code_url=GOOGLE_DEVICE_CODE_URL,
+        auth_url=GOOGLE_AUTH_URL,
         token_url=GOOGLE_TOKEN_URL,
+        redirect_uri=config.redirect_uri,
     )
 
 
 async def revoke_google_token(token: str, session) -> bool:  # noqa: ANN001
     """POST to Google's revoke endpoint.  Returns True on 200.
 
-    Per Google: revoking the refresh token invalidates BOTH the refresh
-    token AND any access tokens minted from it — call this with the
-    refresh_token when disconnecting.
+    Per Google: revoking the refresh token invalidates both the refresh
+    token AND any active access tokens minted from it.
     """
     try:
         async with session.post(
@@ -129,21 +129,19 @@ async def revoke_google_token(token: str, session) -> bool:  # noqa: ANN001
         return False
 
 
-# Re-export OAuthTokens here so Calendar + Gmail can import a single
-# Google-flavored auth module without poking into the generic oauth
-# module.
 __all__ = [
+    "DEFAULT_REDIRECT_URI",
+    "GOOGLE_AUTH_URL",
+    "GOOGLE_REVOKE_URL",
+    "GOOGLE_TOKEN_URL",
     "GoogleOAuthConfig",
     "GoogleOAuthNotConfiguredError",
     "OAuthTokens",
+    "SCOPE_CALENDAR_EVENTS",
+    "SCOPE_CALENDAR_READ",
+    "SCOPE_GMAIL_MODIFY",
+    "SCOPE_GMAIL_READ",
+    "SCOPE_GMAIL_SEND",
     "make_google_client",
     "revoke_google_token",
-    "SCOPE_CALENDAR_READ",
-    "SCOPE_CALENDAR_EVENTS",
-    "SCOPE_GMAIL_READ",
-    "SCOPE_GMAIL_MODIFY",
-    "SCOPE_GMAIL_SEND",
-    "GOOGLE_DEVICE_CODE_URL",
-    "GOOGLE_TOKEN_URL",
-    "GOOGLE_REVOKE_URL",
 ]

--- a/dragon_voice/tools/integrations/google/auth.py
+++ b/dragon_voice/tools/integrations/google/auth.py
@@ -16,10 +16,17 @@ Env vars expected on Dragon:
 * ``GOOGLE_OAUTH_CLIENT_SECRET`` — required for web-application client
 * ``GOOGLE_OAUTH_REDIRECT_URI`` — optional override; defaults to the
   ngrok URL.
+
+Multi-account support (#347): every Google integration also requests
+``openid email`` so the token-exchange response includes an ``id_token``
+JWT whose `email` claim becomes the account_id.  See
+``extract_account_id_from_tokens``.
 """
 
 from __future__ import annotations
 
+import base64
+import json
 import logging
 import os
 from dataclasses import dataclass, field
@@ -37,6 +44,7 @@ logger = logging.getLogger(__name__)
 GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
 GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke"
+GOOGLE_USERINFO_URL = "https://openidconnect.googleapis.com/v1/userinfo"
 
 # Default redirect — ngrok tunnel that the existing tinkerclaw-ngrok
 # service maintains pointing at Dragon's port 3502.  Operator can
@@ -45,8 +53,12 @@ DEFAULT_REDIRECT_URI = (
     "https://tinkerclaw-voice.ngrok.dev/api/v1/oauth/callback"
 )
 
-# Scopes used by Calendar + Gmail.  Each integration only requests
-# what it needs; this module just collects the constants.
+# Identity scopes — added to every Google flow so we can extract the
+# account email from the id_token without a second round trip.
+SCOPE_OPENID = "openid"
+SCOPE_EMAIL = "email"
+
+# Per-integration scopes.
 SCOPE_CALENDAR_READ = "https://www.googleapis.com/auth/calendar.readonly"
 SCOPE_CALENDAR_EVENTS = "https://www.googleapis.com/auth/calendar.events"
 SCOPE_GMAIL_READ = "https://www.googleapis.com/auth/gmail.readonly"
@@ -76,7 +88,7 @@ class GoogleOAuthConfig:
     def from_env(cls, scopes: Optional[list[str]] = None) -> "GoogleOAuthConfig":
         client_id = os.environ.get("GOOGLE_OAUTH_CLIENT_ID", "").strip()
         client_secret = os.environ.get(
-            "GOOGLE_OAUTH_CLIENT_SECRET", ""
+            "GOOGLE_OAUTH_CLIENT_SECRET", "",
         ).strip() or None
         redirect_uri = (
             os.environ.get("GOOGLE_OAUTH_REDIRECT_URI", "").strip()
@@ -88,13 +100,19 @@ class GoogleOAuthConfig:
                 "OAuth client at https://console.cloud.google.com/apis/credentials "
                 "(redirect URI: " + redirect_uri + ") then set "
                 "GOOGLE_OAUTH_CLIENT_ID + GOOGLE_OAUTH_CLIENT_SECRET in Dragon's "
-                "environment and restart tinkerclaw-voice."
+                "environment and restart tinkerclaw-voice.",
             )
+        merged_scopes = list(scopes) if scopes is not None else [SCOPE_CALENDAR_READ]
+        # Always include identity scopes so we can extract the account
+        # email from the id_token after exchange.
+        for s in (SCOPE_OPENID, SCOPE_EMAIL):
+            if s not in merged_scopes:
+                merged_scopes.append(s)
         return cls(
             client_id=client_id,
             client_secret=client_secret,
             redirect_uri=redirect_uri,
-            scopes=list(scopes) if scopes is not None else [SCOPE_CALENDAR_READ],
+            scopes=merged_scopes,
         )
 
     def scope_string(self) -> str:
@@ -111,6 +129,70 @@ def make_google_client(config: GoogleOAuthConfig) -> OAuthAuthCodeClient:
         token_url=GOOGLE_TOKEN_URL,
         redirect_uri=config.redirect_uri,
     )
+
+
+def extract_account_id_from_tokens(tokens: OAuthTokens) -> Optional[str]:
+    """Decode the id_token JWT and return the `email` claim.
+
+    The id_token comes back from Google's token endpoint when the
+    request included `openid email` in the scope set.  We don't verify
+    the signature — the token was just delivered over TLS straight
+    from Google's `oauth2.googleapis.com`, so payload trust is
+    transitive.  Returns None when:
+
+      * the response had no id_token (caller should fall back to the
+        userinfo endpoint or use a placeholder account_id)
+      * the JWT is malformed
+      * the email_verified claim is False (we won't use unverified
+        emails as account_ids — they could collide between accounts)
+    """
+    id_token = (tokens.extra or {}).get("id_token") if tokens.extra else None
+    if not id_token or not isinstance(id_token, str):
+        return None
+    parts = id_token.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        # base64url-decode the payload — JWT bodies are url-safe b64
+        # without padding.
+        payload_raw = parts[1]
+        # Re-pad for base64.urlsafe_b64decode.
+        payload_raw += "=" * (-len(payload_raw) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_raw))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    email = payload.get("email")
+    if not email or payload.get("email_verified") is False:
+        return None
+    return str(email).lower()
+
+
+async def fetch_google_email(access_token: str, session) -> Optional[str]:  # noqa: ANN001
+    """Fallback: hit the userinfo endpoint when id_token wasn't present.
+
+    Returns the verified email or None on any failure (caller treats
+    None as "use a placeholder account_id").
+    """
+    try:
+        async with session.get(
+            GOOGLE_USERINFO_URL,
+            headers={"Authorization": f"Bearer {access_token}"},
+        ) as resp:
+            if resp.status != 200:
+                logger.warning(
+                    "Google userinfo returned %s — token may lack "
+                    "openid/email scope.  Falling back to placeholder.",
+                    resp.status,
+                )
+                return None
+            data = await resp.json()
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Google userinfo unreachable: %s", e)
+        return None
+    email = data.get("email")
+    if not email or data.get("email_verified") is False:
+        return None
+    return str(email).lower()
 
 
 async def revoke_google_token(token: str, session) -> bool:  # noqa: ANN001
@@ -134,14 +216,19 @@ __all__ = [
     "GOOGLE_AUTH_URL",
     "GOOGLE_REVOKE_URL",
     "GOOGLE_TOKEN_URL",
+    "GOOGLE_USERINFO_URL",
     "GoogleOAuthConfig",
     "GoogleOAuthNotConfiguredError",
     "OAuthTokens",
     "SCOPE_CALENDAR_EVENTS",
     "SCOPE_CALENDAR_READ",
+    "SCOPE_EMAIL",
     "SCOPE_GMAIL_MODIFY",
     "SCOPE_GMAIL_READ",
     "SCOPE_GMAIL_SEND",
+    "SCOPE_OPENID",
+    "extract_account_id_from_tokens",
+    "fetch_google_email",
     "make_google_client",
     "revoke_google_token",
 ]

--- a/dragon_voice/tools/integrations/google/calendar.py
+++ b/dragon_voice/tools/integrations/google/calendar.py
@@ -1,10 +1,10 @@
-"""Google Calendar integration — auth-code-with-PKCE flow (#342).
+"""Google Calendar integration — auth-code-with-PKCE flow + multi-account (#347).
 
-OAuth state machine:
+OAuth state machine (per-account):
 
   start_connect()
     → creates AuthCodeChallenge (PKCE pair + state)
-    → stashes verifier + asyncio.Future in `self._flows[state]`
+    → stashes verifier + asyncio.Future in `self._flows[request_id]`
     → returns ConnectChallenge with the authorization_url
        (Tab5 shows QR + plain link)
 
@@ -13,10 +13,18 @@ OAuth state machine:
   Google redirects to /api/v1/oauth/callback?code=…&state=…
     → IntegrationRoutes.oauth_callback handler calls
        integration.handle_callback(state, code, error)
-    → we exchange code+verifier for tokens, persist, mark future done
+    → we exchange code+verifier for tokens, decode id_token to find
+       the verified email (= account_id), persist under that key,
+       mark default if it's the first account
 
   Tab5 polls /api/v1/integrations/google-calendar/status/{request_id}
-    → poll_status() reads the flow's future state, returns connected/expired/error
+    → poll_status() reads the flow's future state, returns
+       connected/expired/error AND echoes the new account_id+label
+       once known so Tab5 can update its UI immediately.
+
+Per-account state:
+  self._accounts: dict[account_id, OAuthTokens]
+  self._default_account_id: Optional[str]
 """
 
 from __future__ import annotations
@@ -31,16 +39,23 @@ from typing import Any, Literal, Optional
 import aiohttp
 
 from dragon_voice.tools.integrations.base import (
+    AccountInfo,
     ConnectChallenge,
     ConnectionStatus,
     IntegrationBackend,
 )
-from dragon_voice.tools.integrations.credentials import CredentialStore
+from dragon_voice.tools.integrations.credentials import (
+    LEGACY_ACCOUNT_ID,
+    CredentialStore,
+    ProviderCredentialDir,
+)
 from dragon_voice.tools.integrations.google.auth import (
     GoogleOAuthConfig,
     OAuthTokens,
     SCOPE_CALENDAR_EVENTS,
     SCOPE_CALENDAR_READ,
+    extract_account_id_from_tokens,
+    fetch_google_email,
     make_google_client,
     revoke_google_token,
 )
@@ -50,27 +65,30 @@ from dragon_voice.tools.integrations.registry import register_integration
 logger = logging.getLogger(__name__)
 
 CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3"
+PROVIDER_NAME = "google-calendar"
 
 
-@register_integration("google-calendar")
+@register_integration(PROVIDER_NAME)
 class GoogleCalendarIntegration(IntegrationBackend):
-    """Google Calendar read + write via Calendar API v3."""
+    """Google Calendar read + write via Calendar API v3 — multi-account."""
 
     _SCOPES = [SCOPE_CALENDAR_READ, SCOPE_CALENDAR_EVENTS]
 
     def __init__(self) -> None:
-        self._store = CredentialStore("google-calendar")
-        # request_id → in-flight flow.  Survives across REST calls so
-        # Tab5 polling sees terminal state.
+        self._provider_dir = ProviderCredentialDir(PROVIDER_NAME)
+        # request_id → in-flight flow.  Survives across REST calls.
         self._flows: dict[str, "_AuthFlow"] = {}
-        self._tokens: Optional[OAuthTokens] = None
-        self._tokens_loaded = False
+        # account_id → OAuthTokens (lazy-loaded on first access).
+        self._accounts: dict[str, OAuthTokens] = {}
+        self._default_account_id: Optional[str] = None
+        self._loaded = False
+        self._load_lock = asyncio.Lock()
 
     # ── IntegrationBackend interface ────────────────────────────
 
     @property
     def name(self) -> str:
-        return "google-calendar"
+        return PROVIDER_NAME
 
     @property
     def display_name(self) -> str:
@@ -84,26 +102,40 @@ class GoogleCalendarIntegration(IntegrationBackend):
     def auth_kind(self) -> Literal["oauth-device", "oauth-authcode", "static-token", "none"]:  # type: ignore[override]
         return "oauth-authcode"
 
-    async def is_connected(self) -> bool:
-        await self._ensure_tokens_loaded()
-        return self._tokens is not None
+    @property
+    def supports_multi_account(self) -> bool:
+        return True
+
+    async def is_connected(self, account_id: Optional[str] = None) -> bool:
+        await self._ensure_loaded()
+        if account_id is None:
+            return bool(self._accounts)
+        return account_id in self._accounts
+
+    async def list_accounts(self) -> list[AccountInfo]:
+        await self._ensure_loaded()
+        out: list[AccountInfo] = []
+        for aid, tokens in self._accounts.items():
+            out.append(AccountInfo(
+                account_id=aid,
+                display_label=_label_for_account_id(aid),
+                default=(aid == self._default_account_id),
+                scopes=list(tokens.scopes or []),
+                connected_at=(tokens.extra or {}).get("connected_at"),
+            ))
+        out.sort(key=lambda a: (not a.default, a.account_id))
+        return out
 
     async def start_connect(self, params: Optional[dict] = None) -> ConnectChallenge:
         del params  # unused for auth-code flow
         cfg = GoogleOAuthConfig.from_env(scopes=self._SCOPES)
         request_id = uuid.uuid4().hex
-        # Build the auth URL.  Google needs access_type=offline +
-        # prompt=consent to mint a refresh_token on the first turn.
         client = make_google_client(cfg)
         chal = client.start(extra_params={
             "access_type": "offline",
             "prompt": "consent",
             "include_granted_scopes": "true",
         })
-        # `client.start` adds the entry to client._pending[state]
-        # already, but we don't own that lifecycle — Dragon process
-        # holds the entry until the callback resolves it.  We DO need
-        # our own flow record so poll_status finds it.
         flow = _AuthFlow(
             request_id=request_id,
             state=chal.state,
@@ -113,10 +145,10 @@ class GoogleCalendarIntegration(IntegrationBackend):
         self._flows[request_id] = flow
 
         return ConnectChallenge(
-            kind="oauth-device",  # Tab5 modal reuses the QR/code UX shape
+            kind="oauth-authcode",
             request_id=request_id,
             verification_url=chal.authorization_url,
-            user_code=None,  # auth-code flow doesn't have one
+            user_code=None,
             expires_in_s=600,
             interval_s=2,
         )
@@ -127,8 +159,12 @@ class GoogleCalendarIntegration(IntegrationBackend):
             return ConnectionStatus(
                 state="error", request_id=request_id, error="unknown request_id",
             )
-        if flow.tokens is not None:
-            return ConnectionStatus(state="connected", request_id=request_id)
+        if flow.tokens is not None and flow.account_id is not None:
+            return ConnectionStatus(
+                state="connected", request_id=request_id,
+                account_id=flow.account_id,
+                account_label=_label_for_account_id(flow.account_id),
+            )
         if flow.error is not None:
             state_label = "expired" if flow.error.code == "expired_token" else "error"
             return ConnectionStatus(
@@ -150,9 +186,11 @@ class GoogleCalendarIntegration(IntegrationBackend):
     ) -> None:
         """Called by the /api/v1/oauth/callback route handler.
 
-        Looks up the flow by `state`, exchanges code+verifier for
-        tokens, persists.  Best-effort: any exception becomes
-        `flow.error` so the next poll_status returns it.
+        After exchange, decodes the id_token to find the verified
+        email and persists tokens under that account_id.  If id_token
+        is absent, falls back to the userinfo endpoint.  If both fail,
+        persists under a placeholder account_id ("pending-<request_id>")
+        which the user can disconnect later.
         """
         flow = self._find_flow_by_state(state)
         if flow is None:
@@ -180,35 +218,95 @@ class GoogleCalendarIntegration(IntegrationBackend):
                 description=f"{type(e).__name__}: {e}"[:120],
             )
             return
-        await self._persist_tokens(tokens)
+
+        account_id = await self._resolve_account_id(tokens)
+        await self._ensure_loaded()
+        is_first = not self._accounts
+        # Stamp metadata on the token bundle so list_accounts can show
+        # connected_at + we can flag the default.
+        if tokens.extra is None:
+            tokens.extra = {}
+        tokens.extra.setdefault("connected_at", int(time.time()))
+        if is_first:
+            tokens.extra["default"] = True
+
+        await self._persist_account(account_id, tokens)
+        self._accounts[account_id] = tokens
+        if is_first or self._default_account_id is None:
+            self._default_account_id = account_id
+
+        flow.account_id = account_id
         flow.tokens = tokens
 
-    async def disconnect(self) -> None:
-        await self._ensure_tokens_loaded()
-        if self._tokens is not None and self._tokens.refresh_token:
-            async with aiohttp.ClientSession(
-                timeout=aiohttp.ClientTimeout(total=10),
-            ) as session:
-                await revoke_google_token(self._tokens.refresh_token, session)
-        await self._store.delete()
-        self._tokens = None
-        self._tokens_loaded = True
+    async def disconnect(self, account_id: Optional[str] = None) -> None:
+        """Disconnect one account (or all when account_id is None)."""
+        await self._ensure_loaded()
+        targets = [account_id] if account_id is not None else list(self._accounts.keys())
+        if not targets:
+            return
+        for aid in targets:
+            tokens = self._accounts.get(aid)
+            if tokens is not None and tokens.refresh_token:
+                async with aiohttp.ClientSession(
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as session:
+                    await revoke_google_token(tokens.refresh_token, session)
+            store = self._provider_dir.store_for(aid)
+            await store.delete()
+            self._accounts.pop(aid, None)
+        # Reassign default if we dropped it.
+        if self._default_account_id not in self._accounts:
+            self._default_account_id = next(iter(self._accounts), None)
+            if self._default_account_id is not None:
+                # Persist the new default flag.
+                tokens = self._accounts[self._default_account_id]
+                if tokens.extra is None:
+                    tokens.extra = {}
+                tokens.extra["default"] = True
+                await self._persist_account(self._default_account_id, tokens)
 
-    async def health_check(self, timeout_s: float = 5.0) -> tuple[bool, str]:
-        await self._ensure_tokens_loaded()
-        if self._tokens is None:
+    async def set_default_account(self, account_id: str) -> None:
+        await self._ensure_loaded()
+        if account_id not in self._accounts:
+            raise DeviceCodeError(
+                "unknown_account", f"no connected account with id {account_id!r}",
+            )
+        old_default = self._default_account_id
+        self._default_account_id = account_id
+        # Re-persist both files so the default flag is up to date.
+        if old_default and old_default != account_id and old_default in self._accounts:
+            old_tokens = self._accounts[old_default]
+            if old_tokens.extra is None:
+                old_tokens.extra = {}
+            old_tokens.extra["default"] = False
+            await self._persist_account(old_default, old_tokens)
+        new_tokens = self._accounts[account_id]
+        if new_tokens.extra is None:
+            new_tokens.extra = {}
+        new_tokens.extra["default"] = True
+        await self._persist_account(account_id, new_tokens)
+
+    async def health_check(
+        self,
+        account_id: Optional[str] = None,
+        timeout_s: float = 5.0,
+    ) -> tuple[bool, str]:
+        await self._ensure_loaded()
+        target = self._resolve_target_account(account_id)
+        if target is None:
             return False, "not connected"
         try:
             data = await self._authed_get(
                 f"{CALENDAR_API_BASE}/calendars/primary",
                 timeout_s=timeout_s,
+                account_id=target,
             )
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:
             return False, f"{type(e).__name__}: {e}"[:120]
         except DeviceCodeError as e:
             return False, f"auth: {e.description[:120]}"
         cal_id = data.get("id") if isinstance(data, dict) else None
-        return True, f"connected to {cal_id or 'primary calendar'}"
+        return True, f"connected to {cal_id or 'primary calendar'} as {_label_for_account_id(target)}"
 
     # ── Calendar API used by tools ──────────────────────────────
 
@@ -217,6 +315,7 @@ class GoogleCalendarIntegration(IntegrationBackend):
         time_min: Optional[datetime] = None,
         time_max: Optional[datetime] = None,
         max_results: int = 10,
+        account_id: Optional[str] = None,
     ) -> list[dict[str, Any]]:
         params = {
             "singleEvents": "true",
@@ -231,9 +330,13 @@ class GoogleCalendarIntegration(IntegrationBackend):
             params["timeMax"] = time_max.astimezone(timezone.utc).isoformat()
         raw = await self._authed_get(
             f"{CALENDAR_API_BASE}/calendars/primary/events", params=params,
+            account_id=account_id,
         )
         items = raw.get("items", []) if isinstance(raw, dict) else []
-        return [self._normalize_event(it) for it in items]
+        target = self._resolve_target_account(account_id)
+        return [
+            dict(self._normalize_event(it), account=target) for it in items
+        ]
 
     async def create_event(
         self,
@@ -242,6 +345,7 @@ class GoogleCalendarIntegration(IntegrationBackend):
         end: datetime,
         location: Optional[str] = None,
         description: Optional[str] = None,
+        account_id: Optional[str] = None,
     ) -> dict[str, Any]:
         body = {
             "summary": summary,
@@ -254,13 +358,18 @@ class GoogleCalendarIntegration(IntegrationBackend):
             body["description"] = description
         raw = await self._authed_post(
             f"{CALENDAR_API_BASE}/calendars/primary/events", body=body,
+            account_id=account_id,
         )
-        return self._normalize_event(raw)
+        target = self._resolve_target_account(account_id)
+        return dict(self._normalize_event(raw), account=target)
 
-    async def cancel_event(self, event_id: str) -> bool:
+    async def cancel_event(
+        self, event_id: str, account_id: Optional[str] = None,
+    ) -> bool:
         try:
             await self._authed_delete(
                 f"{CALENDAR_API_BASE}/calendars/primary/events/{event_id}",
+                account_id=account_id,
             )
         except aiohttp.ClientResponseError as e:
             logger.warning("cancel_event %s failed: %s", event_id, e)
@@ -275,48 +384,109 @@ class GoogleCalendarIntegration(IntegrationBackend):
                 return flow
         return None
 
-    async def _persist_tokens(self, tokens: OAuthTokens) -> None:
-        await self._store.save({"tokens": tokens.to_dict()})
-        self._tokens = tokens
-        self._tokens_loaded = True
+    def _resolve_target_account(self, account_id: Optional[str]) -> Optional[str]:
+        if account_id is not None:
+            return account_id if account_id in self._accounts else None
+        return self._default_account_id
 
-    async def _ensure_tokens_loaded(self) -> None:
-        if self._tokens_loaded:
+    async def _resolve_account_id(self, tokens: OAuthTokens) -> str:
+        """Find the verified-email account_id for a freshly-issued
+        token bundle.
+
+        Tries id_token first (zero extra requests), then userinfo, then
+        falls back to a placeholder so the connect flow can still
+        complete and the user can clean up via disconnect+reconnect.
+        """
+        from_jwt = extract_account_id_from_tokens(tokens)
+        if from_jwt:
+            return from_jwt
+        try:
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=8),
+            ) as session:
+                email = await fetch_google_email(tokens.access_token, session)
+                if email:
+                    return email
+        except Exception:  # noqa: BLE001
+            logger.warning("fetch_google_email raised", exc_info=True)
+        placeholder = f"pending-{uuid.uuid4().hex[:8]}"
+        logger.warning(
+            "Could not determine account_id from id_token or userinfo — "
+            "stored under placeholder %s.  User should disconnect + reconnect "
+            "after granting openid+email scope.",
+            placeholder,
+        )
+        return placeholder
+
+    async def _persist_account(self, account_id: str, tokens: OAuthTokens) -> None:
+        store = self._provider_dir.store_for(account_id)
+        await store.save({"tokens": tokens.to_dict()})
+
+    async def _ensure_loaded(self) -> None:
+        if self._loaded:
             return
-        data = await self._store.load()
-        if data and "tokens" in data:
+        async with self._load_lock:
+            if self._loaded:
+                return
+            await self._load_from_disk()
+            self._loaded = True
+
+    async def _load_from_disk(self) -> None:
+        # Pre-#347 layout migration: flat {provider}.json → {provider}/_legacy.json
+        self._provider_dir.migrate_legacy()
+        accounts: dict[str, OAuthTokens] = {}
+        default: Optional[str] = None
+        for aid in self._provider_dir.list_accounts(include_reserved=True):
+            store = self._provider_dir.store_for(aid)
+            data = await store.load()
+            if not data or "tokens" not in data:
+                continue
             try:
-                self._tokens = OAuthTokens.from_dict(data["tokens"])
+                tokens = OAuthTokens.from_dict(data["tokens"])
             except (KeyError, ValueError, TypeError) as e:
                 logger.warning(
-                    "Stored Google Calendar tokens malformed (%s) — "
-                    "treating as disconnected.",
-                    e,
+                    "Stored Google Calendar tokens for %s malformed (%s) — "
+                    "skipping.", aid, e,
                 )
-                self._tokens = None
-        else:
-            self._tokens = None
-        self._tokens_loaded = True
+                continue
+            accounts[aid] = tokens
+            if (tokens.extra or {}).get("default"):
+                default = aid
+        if default is None and accounts:
+            # No explicit default → first account wins.
+            default = next(iter(accounts))
+        self._accounts = accounts
+        self._default_account_id = default
 
-    async def _get_access_token(self) -> str:
-        await self._ensure_tokens_loaded()
-        if self._tokens is None:
+    async def _get_access_token(self, account_id: Optional[str] = None) -> str:
+        await self._ensure_loaded()
+        target = self._resolve_target_account(account_id)
+        if target is None:
             raise DeviceCodeError(
                 "not_connected",
                 "Google Calendar is not connected.  Tap Settings → "
                 "Integrations → Connect Google on the Tab5.",
             )
-        if not self._tokens.is_expired():
-            return self._tokens.access_token
-        if not self._tokens.refresh_token:
+        tokens = self._accounts[target]
+        if not tokens.is_expired():
+            return tokens.access_token
+        if not tokens.refresh_token:
             raise DeviceCodeError(
                 "needs_reauth",
-                "No refresh token — please reconnect Google.",
+                f"No refresh token for {_label_for_account_id(target)} — "
+                "please reconnect this Google account.",
             )
-        cfg = GoogleOAuthConfig.from_env(scopes=self._tokens.scopes or self._SCOPES)
+        cfg = GoogleOAuthConfig.from_env(scopes=tokens.scopes or self._SCOPES)
         async with make_google_client(cfg) as client:
-            new_tokens = await client.refresh(self._tokens.refresh_token)
-        await self._persist_tokens(new_tokens)
+            new_tokens = await client.refresh(tokens.refresh_token)
+        # Preserve metadata (default flag, connected_at).
+        if new_tokens.extra is None:
+            new_tokens.extra = {}
+        if tokens.extra:
+            for k, v in tokens.extra.items():
+                new_tokens.extra.setdefault(k, v)
+        await self._persist_account(target, new_tokens)
+        self._accounts[target] = new_tokens
         return new_tokens.access_token
 
     async def _authed_get(
@@ -324,8 +494,10 @@ class GoogleCalendarIntegration(IntegrationBackend):
         url: str,
         params: Optional[dict] = None,
         timeout_s: float = 15.0,
+        account_id: Optional[str] = None,
     ) -> Any:
-        token = await self._get_access_token()
+        token = await self._get_access_token(account_id)
+        target = self._resolve_target_account(account_id)
         timeout = aiohttp.ClientTimeout(total=timeout_s)
         async with aiohttp.ClientSession(timeout=timeout) as session:
             async with session.get(
@@ -334,8 +506,8 @@ class GoogleCalendarIntegration(IntegrationBackend):
                 headers={"Authorization": f"Bearer {token}"},
             ) as resp:
                 if resp.status == 401:
-                    await self._force_refresh()
-                    token = await self._get_access_token()
+                    await self._force_refresh(target)
+                    token = await self._get_access_token(account_id)
                     async with session.get(
                         url,
                         params=params,
@@ -346,8 +518,10 @@ class GoogleCalendarIntegration(IntegrationBackend):
                 resp.raise_for_status()
                 return await resp.json()
 
-    async def _authed_post(self, url: str, body: dict) -> Any:
-        token = await self._get_access_token()
+    async def _authed_post(
+        self, url: str, body: dict, account_id: Optional[str] = None,
+    ) -> Any:
+        token = await self._get_access_token(account_id)
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=15),
         ) as session:
@@ -359,8 +533,8 @@ class GoogleCalendarIntegration(IntegrationBackend):
                 resp.raise_for_status()
                 return await resp.json()
 
-    async def _authed_delete(self, url: str) -> None:
-        token = await self._get_access_token()
+    async def _authed_delete(self, url: str, account_id: Optional[str] = None) -> None:
+        token = await self._get_access_token(account_id)
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=15),
         ) as session:
@@ -370,10 +544,13 @@ class GoogleCalendarIntegration(IntegrationBackend):
             ) as resp:
                 resp.raise_for_status()
 
-    async def _force_refresh(self) -> None:
-        if self._tokens is None or not self._tokens.refresh_token:
+    async def _force_refresh(self, account_id: Optional[str]) -> None:
+        if account_id is None or account_id not in self._accounts:
             return
-        self._tokens.expires_at = int(time.time()) - 1
+        tokens = self._accounts[account_id]
+        if not tokens.refresh_token:
+            return
+        tokens.expires_at = int(time.time()) - 1
 
     @staticmethod
     def _normalize_event(raw: dict) -> dict[str, Any]:
@@ -396,12 +573,25 @@ class GoogleCalendarIntegration(IntegrationBackend):
         }
 
 
+def _label_for_account_id(account_id: str) -> str:
+    """Human-readable name for the account chip.
+
+    `_legacy` and `pending-*` get friendlier labels so the user knows
+    to reconnect.  Real email-shaped ids pass through unchanged.
+    """
+    if account_id == LEGACY_ACCOUNT_ID:
+        return "Legacy connection (reconnect to identify)"
+    if account_id.startswith("pending-"):
+        return f"Unidentified Google account ({account_id})"
+    return account_id
+
+
 class _AuthFlow:
     """Internal: in-flight auth-code flow state."""
 
     __slots__ = (
         "request_id", "state", "code_verifier", "cfg",
-        "expires_at", "tokens", "error",
+        "expires_at", "tokens", "error", "account_id",
     )
 
     def __init__(
@@ -419,3 +609,4 @@ class _AuthFlow:
         self.expires_at = time.time() + 600
         self.tokens: Optional[OAuthTokens] = None
         self.error: Optional[DeviceCodeError] = None
+        self.account_id: Optional[str] = None

--- a/dragon_voice/tools/integrations/google/calendar.py
+++ b/dragon_voice/tools/integrations/google/calendar.py
@@ -1,17 +1,22 @@
-"""Google Calendar integration — first proof-of-concept (#341 / #342).
+"""Google Calendar integration — auth-code-with-PKCE flow (#342).
 
-Implements `IntegrationBackend` using the shared Google device-code
-auth (`google/auth.py`) and the Calendar v3 REST API.
+OAuth state machine:
 
-Public methods used by tools:
-  * `list_events(time_min, time_max, max_results)` → list[dict]
-  * `create_event(...)` → dict
-  * `cancel_event(event_id)` → bool
+  start_connect()
+    → creates AuthCodeChallenge (PKCE pair + state)
+    → stashes verifier + asyncio.Future in `self._flows[state]`
+    → returns ConnectChallenge with the authorization_url
+       (Tab5 shows QR + plain link)
 
-OAuth state lives in `~/.tinkerclaw/integrations/google-calendar.json`
-managed by the shared `CredentialStore`.  The cred file holds the
-OAuthTokens dict + the active OAuth config snapshot (so we know which
-scopes were granted).
+  user opens auth URL on phone, signs in, grants scopes
+
+  Google redirects to /api/v1/oauth/callback?code=…&state=…
+    → IntegrationRoutes.oauth_callback handler calls
+       integration.handle_callback(state, code, error)
+    → we exchange code+verifier for tokens, persist, mark future done
+
+  Tab5 polls /api/v1/integrations/google-calendar/status/{request_id}
+    → poll_status() reads the flow's future state, returns connected/expired/error
 """
 
 from __future__ import annotations
@@ -33,7 +38,6 @@ from dragon_voice.tools.integrations.base import (
 from dragon_voice.tools.integrations.credentials import CredentialStore
 from dragon_voice.tools.integrations.google.auth import (
     GoogleOAuthConfig,
-    GoogleOAuthNotConfiguredError,
     OAuthTokens,
     SCOPE_CALENDAR_EVENTS,
     SCOPE_CALENDAR_READ,
@@ -52,25 +56,15 @@ CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3"
 class GoogleCalendarIntegration(IntegrationBackend):
     """Google Calendar read + write via Calendar API v3."""
 
-    # Scopes we request when initiating connect.  Read + write events
-    # on the user's primary calendar — both fit in a single consent
-    # screen so the device-flow UX stays one-step.
     _SCOPES = [SCOPE_CALENDAR_READ, SCOPE_CALENDAR_EVENTS]
 
     def __init__(self) -> None:
         self._store = CredentialStore("google-calendar")
-        # In-flight device-code flows, keyed by request_id.  A flow
-        # lives in this dict from `start_connect` to either successful
-        # `poll_status` (terminal `connected`) or expiry/cancellation.
-        self._flows: dict[str, _DeviceFlow] = {}
-        # Lazily-loaded token cache; written through to `_store` on
-        # every refresh.  None means "not loaded yet" — load on first
-        # use.
+        # request_id → in-flight flow.  Survives across REST calls so
+        # Tab5 polling sees terminal state.
+        self._flows: dict[str, "_AuthFlow"] = {}
         self._tokens: Optional[OAuthTokens] = None
         self._tokens_loaded = False
-        # Background flow tasks — keep handles so we don't drop them
-        # (RUF006 lint catches asyncio-dangling-task).
-        self._tasks: set[asyncio.Task] = set()
 
     # ── IntegrationBackend interface ────────────────────────────
 
@@ -87,82 +81,125 @@ class GoogleCalendarIntegration(IntegrationBackend):
         return "Read and create events on your primary Google Calendar."
 
     @property
-    def auth_kind(self) -> Literal["oauth-device", "static-token", "none"]:
-        return "oauth-device"
+    def auth_kind(self) -> Literal["oauth-device", "oauth-authcode", "static-token", "none"]:  # type: ignore[override]
+        return "oauth-authcode"
 
     async def is_connected(self) -> bool:
         await self._ensure_tokens_loaded()
         return self._tokens is not None
 
     async def start_connect(self, params: Optional[dict] = None) -> ConnectChallenge:
-        del params  # unused for OAuth device flow
-        try:
-            cfg = GoogleOAuthConfig.from_env(scopes=self._SCOPES)
-        except GoogleOAuthNotConfiguredError:
-            raise
-
+        del params  # unused for auth-code flow
+        cfg = GoogleOAuthConfig.from_env(scopes=self._SCOPES)
         request_id = uuid.uuid4().hex
-        flow = _DeviceFlow(request_id=request_id, cfg=cfg)
+        # Build the auth URL.  Google needs access_type=offline +
+        # prompt=consent to mint a refresh_token on the first turn.
+        client = make_google_client(cfg)
+        chal = client.start(extra_params={
+            "access_type": "offline",
+            "prompt": "consent",
+            "include_granted_scopes": "true",
+        })
+        # `client.start` adds the entry to client._pending[state]
+        # already, but we don't own that lifecycle — Dragon process
+        # holds the entry until the callback resolves it.  We DO need
+        # our own flow record so poll_status finds it.
+        flow = _AuthFlow(
+            request_id=request_id,
+            state=chal.state,
+            code_verifier=chal.code_verifier,
+            cfg=cfg,
+        )
         self._flows[request_id] = flow
 
-        # Kick off the device-code flow.  `start` returns the
-        # challenge synchronously; `poll_until_done` runs in a
-        # background task and parks the result on the flow object so
-        # `poll_status` can read it without re-issuing requests.
-        flow.challenge = await flow.start()
-        flow.poll_task = asyncio.create_task(self._run_flow(flow))
-        self._tasks.add(flow.poll_task)
-        flow.poll_task.add_done_callback(self._tasks.discard)
-
         return ConnectChallenge(
-            kind="oauth-device",
+            kind="oauth-device",  # Tab5 modal reuses the QR/code UX shape
             request_id=request_id,
-            verification_url=(
-                flow.challenge.verification_url_complete
-                or flow.challenge.verification_url
-            ),
-            user_code=flow.challenge.user_code,
-            expires_in_s=flow.challenge.expires_in,
-            interval_s=flow.challenge.interval,
+            verification_url=chal.authorization_url,
+            user_code=None,  # auth-code flow doesn't have one
+            expires_in_s=600,
+            interval_s=2,
         )
 
     async def poll_status(self, request_id: str) -> ConnectionStatus:
         flow = self._flows.get(request_id)
         if flow is None:
             return ConnectionStatus(
-                state="error",
-                request_id=request_id,
-                error="unknown request_id",
+                state="error", request_id=request_id, error="unknown request_id",
             )
         if flow.tokens is not None:
             return ConnectionStatus(state="connected", request_id=request_id)
         if flow.error is not None:
-            state = "expired" if flow.error.code == "expired_token" else "error"
+            state_label = "expired" if flow.error.code == "expired_token" else "error"
             return ConnectionStatus(
-                state=state,  # type: ignore[arg-type]
+                state=state_label,  # type: ignore[arg-type]
                 request_id=request_id,
                 error=flow.error.description,
             )
+        if time.time() > flow.expires_at:
+            flow.error = DeviceCodeError(
+                "expired_token", "user did not complete authorization in time",
+            )
+            return ConnectionStatus(
+                state="expired", request_id=request_id, error=flow.error.description,
+            )
         return ConnectionStatus(state="connecting", request_id=request_id)
+
+    async def handle_callback(
+        self, state: str, code: Optional[str], error: Optional[str],
+    ) -> None:
+        """Called by the /api/v1/oauth/callback route handler.
+
+        Looks up the flow by `state`, exchanges code+verifier for
+        tokens, persists.  Best-effort: any exception becomes
+        `flow.error` so the next poll_status returns it.
+        """
+        flow = self._find_flow_by_state(state)
+        if flow is None:
+            logger.warning("OAuth callback for unknown state %r", state[:12])
+            return
+        if error:
+            flow.error = DeviceCodeError(code=error, description=error)
+            return
+        if not code:
+            flow.error = DeviceCodeError(
+                "missing_code", "callback missing both code and error",
+            )
+            return
+        try:
+            async with make_google_client(flow.cfg) as client:
+                tokens = await client.exchange_code_with_verifier(
+                    code=code, code_verifier=flow.code_verifier,
+                )
+        except DeviceCodeError as e:
+            flow.error = e
+            return
+        except Exception as e:  # noqa: BLE001
+            flow.error = DeviceCodeError(
+                code="exchange_failed",
+                description=f"{type(e).__name__}: {e}"[:120],
+            )
+            return
+        await self._persist_tokens(tokens)
+        flow.tokens = tokens
 
     async def disconnect(self) -> None:
         await self._ensure_tokens_loaded()
         if self._tokens is not None and self._tokens.refresh_token:
-            # Best-effort revoke — delete local creds regardless.
             async with aiohttp.ClientSession(
                 timeout=aiohttp.ClientTimeout(total=10),
             ) as session:
                 await revoke_google_token(self._tokens.refresh_token, session)
         await self._store.delete()
         self._tokens = None
-        self._tokens_loaded = True  # stays loaded (just empty)
+        self._tokens_loaded = True
 
     async def health_check(self, timeout_s: float = 5.0) -> tuple[bool, str]:
         await self._ensure_tokens_loaded()
         if self._tokens is None:
             return False, "not connected"
         try:
-            events = await self._authed_get(
+            data = await self._authed_get(
                 f"{CALENDAR_API_BASE}/calendars/primary",
                 timeout_s=timeout_s,
             )
@@ -170,10 +207,10 @@ class GoogleCalendarIntegration(IntegrationBackend):
             return False, f"{type(e).__name__}: {e}"[:120]
         except DeviceCodeError as e:
             return False, f"auth: {e.description[:120]}"
-        cal_id = events.get("id") if isinstance(events, dict) else None
+        cal_id = data.get("id") if isinstance(data, dict) else None
         return True, f"connected to {cal_id or 'primary calendar'}"
 
-    # ── Calendar-specific public API used by the tool wrappers ──
+    # ── Calendar API used by tools ──────────────────────────────
 
     async def list_events(
         self,
@@ -181,13 +218,6 @@ class GoogleCalendarIntegration(IntegrationBackend):
         time_max: Optional[datetime] = None,
         max_results: int = 10,
     ) -> list[dict[str, Any]]:
-        """List events on the user's primary calendar between
-        `time_min` and `time_max`.  Defaults to "from now, no upper
-        bound, 10 results."
-
-        Returns a normalized list of event dicts:
-          {id, summary, location, start_iso, end_iso, all_day, attendees, hangout_link}
-        """
         params = {
             "singleEvents": "true",
             "orderBy": "startTime",
@@ -213,7 +243,6 @@ class GoogleCalendarIntegration(IntegrationBackend):
         location: Optional[str] = None,
         description: Optional[str] = None,
     ) -> dict[str, Any]:
-        """Create an event on the primary calendar."""
         body = {
             "summary": summary,
             "start": {"dateTime": start.astimezone(timezone.utc).isoformat()},
@@ -229,8 +258,6 @@ class GoogleCalendarIntegration(IntegrationBackend):
         return self._normalize_event(raw)
 
     async def cancel_event(self, event_id: str) -> bool:
-        """Delete an event from the primary calendar.  Returns True
-        on success."""
         try:
             await self._authed_delete(
                 f"{CALENDAR_API_BASE}/calendars/primary/events/{event_id}",
@@ -242,21 +269,11 @@ class GoogleCalendarIntegration(IntegrationBackend):
 
     # ── Internals ───────────────────────────────────────────────
 
-    async def _run_flow(self, flow: "_DeviceFlow") -> None:
-        """Background coroutine: poll until tokens or terminal error,
-        then persist tokens to the store."""
-        try:
-            async with make_google_client(flow.cfg) as client:
-                tokens = await client.poll_until_done(flow.challenge)
-            await self._persist_tokens(tokens)
-            flow.tokens = tokens
-        except DeviceCodeError as e:
-            flow.error = e
-        except Exception as e:  # noqa: BLE001
-            flow.error = DeviceCodeError(
-                code="poll_failed",
-                description=f"{type(e).__name__}: {e}"[:120],
-            )
+    def _find_flow_by_state(self, state: str) -> Optional["_AuthFlow"]:
+        for flow in self._flows.values():
+            if flow.state == state:
+                return flow
+        return None
 
     async def _persist_tokens(self, tokens: OAuthTokens) -> None:
         await self._store.save({"tokens": tokens.to_dict()})
@@ -273,7 +290,7 @@ class GoogleCalendarIntegration(IntegrationBackend):
             except (KeyError, ValueError, TypeError) as e:
                 logger.warning(
                     "Stored Google Calendar tokens malformed (%s) — "
-                    "treating as disconnected.  User should reconnect.",
+                    "treating as disconnected.",
                     e,
                 )
                 self._tokens = None
@@ -282,21 +299,19 @@ class GoogleCalendarIntegration(IntegrationBackend):
         self._tokens_loaded = True
 
     async def _get_access_token(self) -> str:
-        """Return a valid access token, refreshing if necessary."""
         await self._ensure_tokens_loaded()
         if self._tokens is None:
             raise DeviceCodeError(
-                code="not_connected",
-                description="Google Calendar is not connected.  Visit Tab5 "
-                "Settings → Integrations → Connect Google.",
+                "not_connected",
+                "Google Calendar is not connected.  Tap Settings → "
+                "Integrations → Connect Google on the Tab5.",
             )
         if not self._tokens.is_expired():
             return self._tokens.access_token
-        # Refresh.
         if not self._tokens.refresh_token:
             raise DeviceCodeError(
-                code="needs_reauth",
-                description="No refresh token — please reconnect Google.",
+                "needs_reauth",
+                "No refresh token — please reconnect Google.",
             )
         cfg = GoogleOAuthConfig.from_env(scopes=self._tokens.scopes or self._SCOPES)
         async with make_google_client(cfg) as client:
@@ -319,7 +334,6 @@ class GoogleCalendarIntegration(IntegrationBackend):
                 headers={"Authorization": f"Bearer {token}"},
             ) as resp:
                 if resp.status == 401:
-                    # Token rejected — try one refresh, then retry once.
                     await self._force_refresh()
                     token = await self._get_access_token()
                     async with session.get(
@@ -357,18 +371,12 @@ class GoogleCalendarIntegration(IntegrationBackend):
                 resp.raise_for_status()
 
     async def _force_refresh(self) -> None:
-        """Force a refresh even if our cached `expires_at` says it's
-        still good.  Used when the API returned 401 unexpectedly."""
         if self._tokens is None or not self._tokens.refresh_token:
             return
-        # Set expiry to a past time so the next `_get_access_token`
-        # call triggers refresh.
         self._tokens.expires_at = int(time.time()) - 1
 
     @staticmethod
     def _normalize_event(raw: dict) -> dict[str, Any]:
-        """Reduce Google's verbose event payload to what voice + chat
-        UIs actually need."""
         start = raw.get("start", {})
         end = raw.get("end", {})
         all_day = "date" in start and "dateTime" not in start
@@ -388,46 +396,26 @@ class GoogleCalendarIntegration(IntegrationBackend):
         }
 
 
-class _DeviceFlow:
-    """Internal: in-flight device-code flow state."""
+class _AuthFlow:
+    """Internal: in-flight auth-code flow state."""
 
-    __slots__ = ("request_id", "cfg", "challenge", "tokens", "error", "poll_task")
+    __slots__ = (
+        "request_id", "state", "code_verifier", "cfg",
+        "expires_at", "tokens", "error",
+    )
 
-    def __init__(self, *, request_id: str, cfg: GoogleOAuthConfig) -> None:
+    def __init__(
+        self,
+        *,
+        request_id: str,
+        state: str,
+        code_verifier: str,
+        cfg: GoogleOAuthConfig,
+    ) -> None:
         self.request_id = request_id
+        self.state = state
+        self.code_verifier = code_verifier
         self.cfg = cfg
-        self.challenge: Optional[Any] = None  # DeviceCodeChallenge
+        self.expires_at = time.time() + 600
         self.tokens: Optional[OAuthTokens] = None
         self.error: Optional[DeviceCodeError] = None
-        self.poll_task: Optional[asyncio.Task] = None
-
-    async def start(self):  # noqa: ANN201
-        """Kick off the device-code endpoint call.  Returns the
-        challenge that becomes the `verification_url` + `user_code`
-        Tab5 will render."""
-        async with make_google_client(self.cfg) as client:
-            return await client.start()
-
-
-def helpful_relative_time(target: datetime, now: Optional[datetime] = None) -> str:
-    """"in 2 hours" / "yesterday" / "next Tuesday at 9am" — used by the
-    tool wrappers to phrase replies naturally for TTS.
-
-    Kept small + deterministic; for richer phrasing the LLM can
-    rewrite the tool result before speaking."""
-    now = now or datetime.now(timezone.utc)
-    target = target.astimezone(timezone.utc)
-    delta = target - now
-    if delta < timedelta(0):
-        delta = -delta
-        direction = "ago"
-    else:
-        direction = "from now"
-    secs = int(delta.total_seconds())
-    if secs < 60:
-        return f"{secs} seconds {direction}"
-    if secs < 3600:
-        return f"{secs // 60} minutes {direction}"
-    if secs < 86400:
-        return f"{secs // 3600} hours {direction}"
-    return f"{secs // 86400} days {direction}"

--- a/dragon_voice/tools/integrations/google/gmail.py
+++ b/dragon_voice/tools/integrations/google/gmail.py
@@ -1,0 +1,682 @@
+"""Gmail integration — auth-code-with-PKCE + multi-account (#341 / #347 / Phase 2).
+
+Mirrors ``GoogleCalendarIntegration``'s shape (same OAuth flow, same
+multi-account state machine), but talks to Gmail API v1 instead of
+Calendar v3.  Each Google account that connects Gmail gets its own
+token bundle at ``{integrations_dir}/gmail/{email}.json`` — sibling
+to ``{integrations_dir}/google-calendar/{email}.json``.
+
+Common use cases the LLM should be able to drive:
+  * "What unread emails do I have?"     → list_messages(query="is:unread")
+  * "Read me the one from X"            → get_message_body(message_id)
+  * "Reply: yes, sounds good"           → send_message(in_reply_to=...)
+  * "Archive that"                      → modify_labels(remove=["INBOX"])
+  * "Search for emails about Y"         → list_messages(query="Y")
+
+Scopes used:
+  * ``gmail.readonly`` — list + read messages
+  * ``gmail.modify``   — label changes (archive, mark read, star)
+  * ``gmail.send``     — send/reply
+
+Plus the always-on ``openid email`` so we can extract account_id from
+the id_token.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+import time
+import uuid
+from email.message import EmailMessage
+from typing import Any, Literal, Optional
+
+import aiohttp
+
+from dragon_voice.tools.integrations.base import (
+    AccountInfo,
+    ConnectChallenge,
+    ConnectionStatus,
+    IntegrationBackend,
+)
+from dragon_voice.tools.integrations.credentials import ProviderCredentialDir
+from dragon_voice.tools.integrations.google.auth import (
+    GoogleOAuthConfig,
+    OAuthTokens,
+    SCOPE_GMAIL_MODIFY,
+    SCOPE_GMAIL_READ,
+    SCOPE_GMAIL_SEND,
+    extract_account_id_from_tokens,
+    fetch_google_email,
+    make_google_client,
+    revoke_google_token,
+)
+from dragon_voice.tools.integrations.oauth import DeviceCodeError
+from dragon_voice.tools.integrations.registry import register_integration
+
+logger = logging.getLogger(__name__)
+
+GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1/users/me"
+PROVIDER_NAME = "gmail"
+
+
+@register_integration(PROVIDER_NAME)
+class GmailIntegration(IntegrationBackend):
+    """Gmail read + send + label-modify via Gmail API v1."""
+
+    _SCOPES = [SCOPE_GMAIL_READ, SCOPE_GMAIL_MODIFY, SCOPE_GMAIL_SEND]
+
+    def __init__(self) -> None:
+        self._provider_dir = ProviderCredentialDir(PROVIDER_NAME)
+        self._flows: dict[str, "_AuthFlow"] = {}
+        self._accounts: dict[str, OAuthTokens] = {}
+        self._default_account_id: Optional[str] = None
+        self._loaded = False
+        self._load_lock = asyncio.Lock()
+
+    # ── IntegrationBackend interface ────────────────────────────
+
+    @property
+    def name(self) -> str:
+        return PROVIDER_NAME
+
+    @property
+    def display_name(self) -> str:
+        return "Gmail"
+
+    @property
+    def description(self) -> str:
+        return "Read, search, and send email through your Google account."
+
+    @property
+    def auth_kind(self) -> Literal["oauth-device", "oauth-authcode", "static-token", "none"]:  # type: ignore[override]
+        return "oauth-authcode"
+
+    @property
+    def supports_multi_account(self) -> bool:
+        return True
+
+    async def is_connected(self, account_id: Optional[str] = None) -> bool:
+        await self._ensure_loaded()
+        if account_id is None:
+            return bool(self._accounts)
+        return account_id in self._accounts
+
+    async def list_accounts(self) -> list[AccountInfo]:
+        await self._ensure_loaded()
+        out: list[AccountInfo] = []
+        for aid, tokens in self._accounts.items():
+            out.append(AccountInfo(
+                account_id=aid,
+                display_label=aid,
+                default=(aid == self._default_account_id),
+                scopes=list(tokens.scopes or []),
+                connected_at=(tokens.extra or {}).get("connected_at"),
+            ))
+        out.sort(key=lambda a: (not a.default, a.account_id))
+        return out
+
+    async def start_connect(self, params: Optional[dict] = None) -> ConnectChallenge:
+        del params
+        cfg = GoogleOAuthConfig.from_env(scopes=self._SCOPES)
+        request_id = uuid.uuid4().hex
+        client = make_google_client(cfg)
+        chal = client.start(extra_params={
+            "access_type": "offline",
+            "prompt": "consent",
+            "include_granted_scopes": "true",
+        })
+        flow = _AuthFlow(
+            request_id=request_id,
+            state=chal.state,
+            code_verifier=chal.code_verifier,
+            cfg=cfg,
+        )
+        self._flows[request_id] = flow
+        return ConnectChallenge(
+            kind="oauth-authcode",
+            request_id=request_id,
+            verification_url=chal.authorization_url,
+            user_code=None,
+            expires_in_s=600,
+            interval_s=2,
+        )
+
+    async def poll_status(self, request_id: str) -> ConnectionStatus:
+        flow = self._flows.get(request_id)
+        if flow is None:
+            return ConnectionStatus(
+                state="error", request_id=request_id, error="unknown request_id",
+            )
+        if flow.tokens is not None and flow.account_id is not None:
+            return ConnectionStatus(
+                state="connected", request_id=request_id,
+                account_id=flow.account_id, account_label=flow.account_id,
+            )
+        if flow.error is not None:
+            state_label = "expired" if flow.error.code == "expired_token" else "error"
+            return ConnectionStatus(
+                state=state_label,  # type: ignore[arg-type]
+                request_id=request_id,
+                error=flow.error.description,
+            )
+        if time.time() > flow.expires_at:
+            flow.error = DeviceCodeError(
+                "expired_token", "user did not complete authorization in time",
+            )
+            return ConnectionStatus(
+                state="expired", request_id=request_id, error=flow.error.description,
+            )
+        return ConnectionStatus(state="connecting", request_id=request_id)
+
+    async def handle_callback(
+        self, state: str, code: Optional[str], error: Optional[str],
+    ) -> None:
+        flow = self._find_flow_by_state(state)
+        if flow is None:
+            logger.warning("Gmail OAuth callback for unknown state %r", state[:12])
+            return
+        if error:
+            flow.error = DeviceCodeError(code=error, description=error)
+            return
+        if not code:
+            flow.error = DeviceCodeError(
+                "missing_code", "callback missing both code and error",
+            )
+            return
+        try:
+            async with make_google_client(flow.cfg) as client:
+                tokens = await client.exchange_code_with_verifier(
+                    code=code, code_verifier=flow.code_verifier,
+                )
+        except DeviceCodeError as e:
+            flow.error = e
+            return
+        except Exception as e:  # noqa: BLE001
+            flow.error = DeviceCodeError(
+                code="exchange_failed",
+                description=f"{type(e).__name__}: {e}"[:120],
+            )
+            return
+
+        account_id = await self._resolve_account_id(tokens)
+        await self._ensure_loaded()
+        is_first = not self._accounts
+        if tokens.extra is None:
+            tokens.extra = {}
+        tokens.extra.setdefault("connected_at", int(time.time()))
+        if is_first:
+            tokens.extra["default"] = True
+
+        await self._persist_account(account_id, tokens)
+        self._accounts[account_id] = tokens
+        if is_first or self._default_account_id is None:
+            self._default_account_id = account_id
+
+        flow.account_id = account_id
+        flow.tokens = tokens
+
+    async def disconnect(self, account_id: Optional[str] = None) -> None:
+        await self._ensure_loaded()
+        targets = [account_id] if account_id is not None else list(self._accounts.keys())
+        if not targets:
+            return
+        for aid in targets:
+            tokens = self._accounts.get(aid)
+            if tokens is not None and tokens.refresh_token:
+                async with aiohttp.ClientSession(
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as session:
+                    await revoke_google_token(tokens.refresh_token, session)
+            store = self._provider_dir.store_for(aid)
+            await store.delete()
+            self._accounts.pop(aid, None)
+        if self._default_account_id not in self._accounts:
+            self._default_account_id = next(iter(self._accounts), None)
+            if self._default_account_id is not None:
+                tokens = self._accounts[self._default_account_id]
+                if tokens.extra is None:
+                    tokens.extra = {}
+                tokens.extra["default"] = True
+                await self._persist_account(self._default_account_id, tokens)
+
+    async def set_default_account(self, account_id: str) -> None:
+        await self._ensure_loaded()
+        if account_id not in self._accounts:
+            raise DeviceCodeError(
+                "unknown_account", f"no connected Gmail account {account_id!r}",
+            )
+        old_default = self._default_account_id
+        self._default_account_id = account_id
+        if old_default and old_default != account_id and old_default in self._accounts:
+            old_tokens = self._accounts[old_default]
+            if old_tokens.extra is None:
+                old_tokens.extra = {}
+            old_tokens.extra["default"] = False
+            await self._persist_account(old_default, old_tokens)
+        new_tokens = self._accounts[account_id]
+        if new_tokens.extra is None:
+            new_tokens.extra = {}
+        new_tokens.extra["default"] = True
+        await self._persist_account(account_id, new_tokens)
+
+    async def health_check(
+        self,
+        account_id: Optional[str] = None,
+        timeout_s: float = 5.0,
+    ) -> tuple[bool, str]:
+        await self._ensure_loaded()
+        target = self._resolve_target_account(account_id)
+        if target is None:
+            return False, "not connected"
+        try:
+            data = await self._authed_get(
+                f"{GMAIL_API_BASE}/profile",
+                timeout_s=timeout_s, account_id=target,
+            )
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            return False, f"{type(e).__name__}: {e}"[:120]
+        except DeviceCodeError as e:
+            return False, f"auth: {e.description[:120]}"
+        email = data.get("emailAddress") if isinstance(data, dict) else None
+        total = data.get("messagesTotal") if isinstance(data, dict) else None
+        return True, f"connected to {email or target} ({total or '?'} total messages)"
+
+    # ── Gmail API used by tools ─────────────────────────────────
+
+    async def list_messages(
+        self,
+        query: Optional[str] = None,
+        label_ids: Optional[list[str]] = None,
+        max_results: int = 10,
+        account_id: Optional[str] = None,
+    ) -> list[dict[str, Any]]:
+        """List messages matching ``query`` / ``label_ids``.
+
+        Returns a list of summaries (id, snippet, from, subject, date,
+        unread bool, labels).  Two round trips: one to enumerate ids,
+        one batched-format=metadata pull per id.  Hard-capped at 25
+        ids per call to keep latency sane.
+        """
+        params = {"maxResults": str(min(max_results, 25))}
+        if query:
+            params["q"] = query
+        if label_ids:
+            for lid in label_ids:
+                params.setdefault("labelIds", []).append(lid)  # type: ignore[union-attr]
+        raw = await self._authed_get(
+            f"{GMAIL_API_BASE}/messages", params=params, account_id=account_id,
+        )
+        ids = [m["id"] for m in (raw.get("messages") or []) if "id" in m]
+        target = self._resolve_target_account(account_id)
+        if not ids:
+            return []
+        # Fan-out the metadata fetches concurrently.
+        summaries = await asyncio.gather(*[
+            self._fetch_message_metadata(mid, account_id=account_id) for mid in ids
+        ], return_exceptions=True)
+        out = []
+        for mid, summary in zip(ids, summaries):
+            if isinstance(summary, Exception):
+                logger.warning("Failed to fetch metadata for %s: %s", mid, summary)
+                continue
+            out.append(dict(summary, account=target))
+        return out
+
+    async def get_message_body(
+        self, message_id: str, account_id: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Fetch and decode the message body (text/plain preferred).
+
+        Returns ``{id, from, subject, date, body_text, body_html, snippet}``.
+        ``body_text`` is the decoded text/plain part if present, else
+        the HTML stripped to plain (lossy — Gmail's HTML is verbose).
+        """
+        raw = await self._authed_get(
+            f"{GMAIL_API_BASE}/messages/{message_id}",
+            params={"format": "full"},
+            account_id=account_id,
+        )
+        headers = _extract_headers(raw)
+        body_text, body_html = _extract_body(raw)
+        target = self._resolve_target_account(account_id)
+        return {
+            "id": message_id,
+            "from": headers.get("From"),
+            "to": headers.get("To"),
+            "subject": headers.get("Subject", "(no subject)"),
+            "date": headers.get("Date"),
+            "snippet": raw.get("snippet", ""),
+            "body_text": body_text,
+            "body_html": body_html,
+            "labels": raw.get("labelIds", []),
+            "account": target,
+        }
+
+    async def send_message(
+        self,
+        to: str,
+        subject: str,
+        body: str,
+        in_reply_to: Optional[str] = None,
+        cc: Optional[str] = None,
+        account_id: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Compose + send.
+
+        When ``in_reply_to`` is the Gmail-internal message_id of the
+        original, we look up its RFC 2822 Message-Id + thread-id so the
+        reply threads correctly in the recipient's inbox.
+        """
+        msg = EmailMessage()
+        msg["To"] = to
+        if cc:
+            msg["Cc"] = cc
+        msg["Subject"] = subject
+        msg.set_content(body)
+
+        thread_id: Optional[str] = None
+        if in_reply_to:
+            try:
+                original = await self._authed_get(
+                    f"{GMAIL_API_BASE}/messages/{in_reply_to}",
+                    params={"format": "metadata", "metadataHeaders": "Message-Id"},
+                    account_id=account_id,
+                )
+                rfc_msg_id = _extract_headers(original).get("Message-Id")
+                if rfc_msg_id:
+                    msg["In-Reply-To"] = rfc_msg_id
+                    msg["References"] = rfc_msg_id
+                thread_id = original.get("threadId")
+            except Exception as e:  # noqa: BLE001
+                logger.warning("Failed to load in_reply_to %s: %s", in_reply_to, e)
+
+        raw_bytes = msg.as_bytes()
+        raw_b64 = base64.urlsafe_b64encode(raw_bytes).rstrip(b"=").decode("ascii")
+        body_payload: dict[str, Any] = {"raw": raw_b64}
+        if thread_id:
+            body_payload["threadId"] = thread_id
+        resp = await self._authed_post(
+            f"{GMAIL_API_BASE}/messages/send", body=body_payload,
+            account_id=account_id,
+        )
+        target = self._resolve_target_account(account_id)
+        return {
+            "sent": True,
+            "id": resp.get("id"),
+            "thread_id": resp.get("threadId"),
+            "labels": resp.get("labelIds", []),
+            "account": target,
+        }
+
+    async def modify_labels(
+        self,
+        message_id: str,
+        add: Optional[list[str]] = None,
+        remove: Optional[list[str]] = None,
+        account_id: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Add or remove labels on a message.
+
+        Common patterns:
+          * Archive: ``remove=["INBOX"]``
+          * Mark as read: ``remove=["UNREAD"]``
+          * Star: ``add=["STARRED"]``
+        """
+        body: dict[str, Any] = {}
+        if add:
+            body["addLabelIds"] = add
+        if remove:
+            body["removeLabelIds"] = remove
+        if not body:
+            return {"modified": False, "id": message_id, "reason": "no labels supplied"}
+        resp = await self._authed_post(
+            f"{GMAIL_API_BASE}/messages/{message_id}/modify",
+            body=body, account_id=account_id,
+        )
+        target = self._resolve_target_account(account_id)
+        return {
+            "modified": True,
+            "id": resp.get("id", message_id),
+            "labels": resp.get("labelIds", []),
+            "account": target,
+        }
+
+    # ── Internals (mirror GoogleCalendarIntegration) ────────────
+
+    def _find_flow_by_state(self, state: str) -> Optional["_AuthFlow"]:
+        for flow in self._flows.values():
+            if flow.state == state:
+                return flow
+        return None
+
+    def _resolve_target_account(self, account_id: Optional[str]) -> Optional[str]:
+        if account_id is not None:
+            return account_id if account_id in self._accounts else None
+        return self._default_account_id
+
+    async def _resolve_account_id(self, tokens: OAuthTokens) -> str:
+        from_jwt = extract_account_id_from_tokens(tokens)
+        if from_jwt:
+            return from_jwt
+        try:
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=8),
+            ) as session:
+                email = await fetch_google_email(tokens.access_token, session)
+                if email:
+                    return email
+        except Exception:  # noqa: BLE001
+            logger.warning("Gmail fetch_google_email raised", exc_info=True)
+        placeholder = f"pending-{uuid.uuid4().hex[:8]}"
+        logger.warning(
+            "Could not determine Gmail account_id — stored under %s.  User "
+            "should disconnect + reconnect after granting openid+email.",
+            placeholder,
+        )
+        return placeholder
+
+    async def _persist_account(self, account_id: str, tokens: OAuthTokens) -> None:
+        store = self._provider_dir.store_for(account_id)
+        await store.save({"tokens": tokens.to_dict()})
+
+    async def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        async with self._load_lock:
+            if self._loaded:
+                return
+            await self._load_from_disk()
+            self._loaded = True
+
+    async def _load_from_disk(self) -> None:
+        self._provider_dir.migrate_legacy()
+        accounts: dict[str, OAuthTokens] = {}
+        default: Optional[str] = None
+        for aid in self._provider_dir.list_accounts(include_reserved=True):
+            store = self._provider_dir.store_for(aid)
+            data = await store.load()
+            if not data or "tokens" not in data:
+                continue
+            try:
+                tokens = OAuthTokens.from_dict(data["tokens"])
+            except (KeyError, ValueError, TypeError) as e:
+                logger.warning("Gmail tokens for %s malformed (%s) — skipping.", aid, e)
+                continue
+            accounts[aid] = tokens
+            if (tokens.extra or {}).get("default"):
+                default = aid
+        if default is None and accounts:
+            default = next(iter(accounts))
+        self._accounts = accounts
+        self._default_account_id = default
+
+    async def _get_access_token(self, account_id: Optional[str] = None) -> str:
+        await self._ensure_loaded()
+        target = self._resolve_target_account(account_id)
+        if target is None:
+            raise DeviceCodeError(
+                "not_connected",
+                "Gmail is not connected.  Tap Settings → Integrations → "
+                "Connect Gmail on the Tab5.",
+            )
+        tokens = self._accounts[target]
+        if not tokens.is_expired():
+            return tokens.access_token
+        if not tokens.refresh_token:
+            raise DeviceCodeError(
+                "needs_reauth",
+                f"No refresh token for {target} — please reconnect this account.",
+            )
+        cfg = GoogleOAuthConfig.from_env(scopes=tokens.scopes or self._SCOPES)
+        async with make_google_client(cfg) as client:
+            new_tokens = await client.refresh(tokens.refresh_token)
+        if new_tokens.extra is None:
+            new_tokens.extra = {}
+        if tokens.extra:
+            for k, v in tokens.extra.items():
+                new_tokens.extra.setdefault(k, v)
+        await self._persist_account(target, new_tokens)
+        self._accounts[target] = new_tokens
+        return new_tokens.access_token
+
+    async def _authed_get(
+        self,
+        url: str,
+        params: Optional[dict] = None,
+        timeout_s: float = 15.0,
+        account_id: Optional[str] = None,
+    ) -> Any:
+        token = await self._get_access_token(account_id)
+        target = self._resolve_target_account(account_id)
+        timeout = aiohttp.ClientTimeout(total=timeout_s)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(
+                url, params=params,
+                headers={"Authorization": f"Bearer {token}"},
+            ) as resp:
+                if resp.status == 401:
+                    await self._force_refresh(target)
+                    token = await self._get_access_token(account_id)
+                    async with session.get(
+                        url, params=params,
+                        headers={"Authorization": f"Bearer {token}"},
+                    ) as resp2:
+                        resp2.raise_for_status()
+                        return await resp2.json()
+                resp.raise_for_status()
+                return await resp.json()
+
+    async def _authed_post(
+        self, url: str, body: dict, account_id: Optional[str] = None,
+    ) -> Any:
+        token = await self._get_access_token(account_id)
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=15),
+        ) as session:
+            async with session.post(
+                url, json=body,
+                headers={"Authorization": f"Bearer {token}"},
+            ) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+
+    async def _force_refresh(self, account_id: Optional[str]) -> None:
+        if account_id is None or account_id not in self._accounts:
+            return
+        tokens = self._accounts[account_id]
+        if not tokens.refresh_token:
+            return
+        tokens.expires_at = int(time.time()) - 1
+
+    async def _fetch_message_metadata(
+        self, message_id: str, account_id: Optional[str] = None,
+    ) -> dict[str, Any]:
+        raw = await self._authed_get(
+            f"{GMAIL_API_BASE}/messages/{message_id}",
+            params={
+                "format": "metadata",
+                "metadataHeaders": ["Subject", "From", "Date"],
+            },
+            account_id=account_id,
+        )
+        headers = _extract_headers(raw)
+        return {
+            "id": message_id,
+            "snippet": raw.get("snippet", ""),
+            "from": headers.get("From"),
+            "subject": headers.get("Subject", "(no subject)"),
+            "date": headers.get("Date"),
+            "labels": raw.get("labelIds", []),
+            "unread": "UNREAD" in (raw.get("labelIds") or []),
+        }
+
+
+def _extract_headers(raw: dict) -> dict[str, str]:
+    """Convert Gmail's [{name,value}] header list to a flat dict."""
+    out: dict[str, str] = {}
+    payload = raw.get("payload") or {}
+    for h in payload.get("headers") or []:
+        name = h.get("name")
+        value = h.get("value")
+        if name and value:
+            out[name] = value
+    return out
+
+
+def _extract_body(raw: dict) -> tuple[Optional[str], Optional[str]]:
+    """Walk a Gmail message payload tree, return (text, html) bodies.
+
+    Bodies are base64url-encoded in ``payload.body.data`` (when the
+    message is single-part) or under ``payload.parts[i].body.data``
+    (multipart).  Either or both may be missing.
+    """
+    payload = raw.get("payload") or {}
+    text: Optional[str] = None
+    html: Optional[str] = None
+
+    def _walk(part: dict) -> None:
+        nonlocal text, html
+        mime = part.get("mimeType", "")
+        body = part.get("body") or {}
+        data = body.get("data")
+        if data:
+            try:
+                # Gmail uses url-safe base64 without padding.
+                padded = data + "=" * (-len(data) % 4)
+                decoded = base64.urlsafe_b64decode(padded).decode(
+                    "utf-8", errors="replace",
+                )
+            except (ValueError, TypeError):
+                decoded = None
+            if decoded:
+                if mime == "text/plain" and text is None:
+                    text = decoded
+                elif mime == "text/html" and html is None:
+                    html = decoded
+        for sub in part.get("parts") or []:
+            _walk(sub)
+
+    _walk(payload)
+    return text, html
+
+
+class _AuthFlow:
+    __slots__ = (
+        "request_id", "state", "code_verifier", "cfg",
+        "expires_at", "tokens", "error", "account_id",
+    )
+
+    def __init__(
+        self, *,
+        request_id: str, state: str, code_verifier: str, cfg: GoogleOAuthConfig,
+    ) -> None:
+        self.request_id = request_id
+        self.state = state
+        self.code_verifier = code_verifier
+        self.cfg = cfg
+        self.expires_at = time.time() + 600
+        self.tokens: Optional[OAuthTokens] = None
+        self.error: Optional[DeviceCodeError] = None
+        self.account_id: Optional[str] = None

--- a/dragon_voice/tools/integrations/oauth.py
+++ b/dragon_voice/tools/integrations/oauth.py
@@ -1,28 +1,39 @@
-"""OAuth 2.0 Device Authorization Grant (RFC 8628) client (#341).
+"""OAuth 2.0 helpers for TinkerBox integrations (#341).
 
-Dragon runs headless — there's no browser, no local web server with a
-redirect URI for the standard OAuth code flow.  The device
-authorization grant is designed exactly for this case:
+Two flows supported:
 
-  1. Client (Dragon) hits the provider's device-code endpoint, gets
-     back a `device_code`, a `user_code`, and a `verification_url`.
-  2. Dragon shows the user the URL + code (Tab5 renders as QR).
-  3. User completes the OAuth dance on their phone.
-  4. Dragon polls the token endpoint with `device_code` until the
-     provider returns access + refresh tokens.
+* **Authorization Code with PKCE** (RFC 7636) — used for Google
+  Calendar / Gmail / most modern providers.  Dragon hosts a public
+  ``/api/v1/oauth/callback`` route (reached via the existing ngrok
+  tunnel) so the user can complete consent on their phone browser.
+  No client-secret required for PKCE, but Google's web-app client
+  ships with one — we include it when present.
 
-Supported by Google, Spotify, GitHub, and many others.
+* **Device Authorization Grant** (RFC 8628) — used by providers that
+  support it without scope restrictions (some Spotify scopes, etc.).
+  Dragon polls the token endpoint; user enters a code on their phone.
+  KEPT for future integrations that prefer it.
 
-This module is provider-agnostic — provider-specific bits
-(client_id, scopes, endpoint URLs) are passed in.  See
-``google/auth.py`` for the Google-specific wrapper.
+Both flows produce the same ``OAuthTokens`` dataclass.
+
+### Why we pivoted from device-code to auth-code for Google
+
+Google's device-code flow restricts the allowed scopes to a small set
+(email/profile/openid/Drive/Photos/YouTube).  Calendar + Gmail are NOT
+in that list — Google forces these scopes through the
+authorization-code flow.  See:
+https://developers.google.com/identity/protocols/oauth2/limited-input-device#allowedscopes
 """
 
 from __future__ import annotations
 
 import asyncio
+import base64
+import hashlib
 import logging
+import secrets
 import time
+import urllib.parse
 from dataclasses import dataclass
 from typing import Optional
 
@@ -32,11 +43,9 @@ logger = logging.getLogger(__name__)
 
 
 class DeviceCodeError(Exception):
-    """Raised when the device-code flow fails terminally.
-
-    Distinct from `aiohttp.ClientError` so callers can catch only the
-    flow-specific errors (`expired_token`, `access_denied`, etc.).
-    """
+    """Raised when an OAuth flow fails terminally.  Name kept for
+    backward compat with the existing API + tests; covers both
+    device-code and auth-code failures."""
 
     def __init__(self, code: str, description: str) -> None:
         self.code = code
@@ -44,48 +53,26 @@ class DeviceCodeError(Exception):
         super().__init__(f"{code}: {description}")
 
 
-@dataclass
-class DeviceCodeChallenge:
-    """The triple returned by the device-code endpoint.
-
-    All fields per RFC 8628 §3.2.  `interval` is the recommended poll
-    interval (seconds); providers can ask the client to back off by
-    returning `slow_down` from the token endpoint, but we honor the
-    initial `interval` unless slow_down arrives.
-    """
-
-    device_code: str
-    user_code: str
-    verification_url: str
-    expires_in: int
-    interval: int = 5
-    # Some providers (Google) also return verification_url_complete
-    # which embeds the user_code as a query param — convenient for QR.
-    verification_url_complete: Optional[str] = None
+# ─── Tokens ────────────────────────────────────────────────────────
 
 
 @dataclass
 class OAuthTokens:
-    """Token bundle returned by the token endpoint.
+    """Provider-agnostic token bundle.
 
-    `expires_at` is an absolute unix timestamp so refresh logic doesn't
-    need to track issue time separately.  `refresh_token` may be None
-    if the provider doesn't issue one (rare for device flow).  `scopes`
-    is the granted scope set returned by the provider — may differ from
-    requested if the user denied some scopes.
-    """
+    `expires_at` is an absolute unix timestamp.  `refresh_token` may
+    be None when the provider doesn't issue one or when a refresh
+    response omitted it (callers preserve the prior value in that
+    case)."""
 
     access_token: str
     refresh_token: Optional[str]
     token_type: str
-    expires_at: int  # absolute unix timestamp
+    expires_at: int
     scopes: list[str]
     extra: dict = None  # type: ignore[assignment]
 
     def is_expired(self, skew_s: int = 60) -> bool:
-        """Treat the token as expired `skew_s` seconds before its
-        actual expiry to avoid in-flight 401s during a refresh window.
-        """
         return time.time() + skew_s >= self.expires_at
 
     def to_dict(self) -> dict:
@@ -110,13 +97,278 @@ class OAuthTokens:
         )
 
 
+def _tokens_from_response(data: dict) -> OAuthTokens:
+    expires_in = int(data.get("expires_in", 3600))
+    scope_str = data.get("scope", "")
+    scopes = scope_str.split() if scope_str else []
+    return OAuthTokens(
+        access_token=data["access_token"],
+        refresh_token=data.get("refresh_token"),
+        token_type=data.get("token_type", "Bearer"),
+        expires_at=int(time.time()) + expires_in,
+        scopes=scopes,
+        extra={
+            k: v for k, v in data.items()
+            if k not in {
+                "access_token", "refresh_token", "token_type",
+                "expires_in", "scope",
+            }
+        },
+    )
+
+
+# ─── PKCE helpers (RFC 7636) ──────────────────────────────────────
+
+
+def _pkce_pair() -> tuple[str, str]:
+    """Generate a (code_verifier, code_challenge) pair.
+
+    code_verifier:  43-128 char [A-Za-z0-9-._~] random string.
+    code_challenge: BASE64URL-NOPAD(SHA256(code_verifier)).
+    """
+    verifier = secrets.token_urlsafe(64)  # ~86 chars after urlsafe
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+# ─── Authorization Code with PKCE ─────────────────────────────────
+
+
+@dataclass
+class AuthCodeChallenge:
+    """What `OAuthAuthCodeClient.start` returns.
+
+    Tab5 displays a QR with `authorization_url`; user opens it on
+    their phone, signs in + consents; Google redirects to our
+    ngrok-tunneled callback URL; the callback handler calls
+    `OAuthAuthCodeClient.exchange_code(state, code)` to mint tokens.
+    """
+
+    authorization_url: str
+    state: str
+    code_verifier: str
+    expires_in: int = 600  # PKCE state TTL; we expire after 10 min
+
+
+class OAuthAuthCodeClient:
+    """Authorization Code flow with PKCE.
+
+    One instance per provider.  Holds the in-flight PKCE state
+    (`state` → `code_verifier`) so the callback can find it.
+
+    Typical use:
+
+        client = OAuthAuthCodeClient(
+            client_id=..., client_secret=..., scope=...,
+            auth_url="https://accounts.google.com/o/oauth2/v2/auth",
+            token_url="https://oauth2.googleapis.com/token",
+            redirect_uri="https://tinkerclaw-voice.ngrok.dev/api/v1/oauth/callback",
+        )
+        chal = await client.start(extra_params={"access_type": "offline", "prompt": "consent"})
+        # ... Tab5 shows QR, user authorizes ...
+        # callback receives ?code=...&state=...
+        tokens = await client.exchange_code(state=..., code=...)
+    """
+
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        scope: str,
+        auth_url: str,
+        token_url: str,
+        redirect_uri: str,
+        client_secret: Optional[str] = None,
+        session: Optional[aiohttp.ClientSession] = None,
+    ) -> None:
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._scope = scope
+        self._auth_url = auth_url
+        self._token_url = token_url
+        self._redirect_uri = redirect_uri
+        self._session = session
+        self._owns_session = session is None
+        # state -> {code_verifier, expires_at, future, completed}
+        self._pending: dict[str, dict] = {}
+
+    async def __aenter__(self) -> "OAuthAuthCodeClient":
+        if self._session is None:
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=30),
+            )
+            self._owns_session = True
+        return self
+
+    async def __aexit__(self, *exc_info) -> None:  # noqa: ANN001
+        if self._owns_session and self._session is not None and not self._session.closed:
+            await self._session.close()
+
+    def start(self, extra_params: Optional[dict] = None) -> AuthCodeChallenge:
+        """Generate PKCE pair + return the authorization URL.
+
+        Doesn't hit the network — just builds the URL.  Caller passes
+        provider-specific extras (e.g. Google needs
+        `access_type=offline` + `prompt=consent` to mint a
+        refresh_token on the first turn).
+        """
+        verifier, challenge = _pkce_pair()
+        state = secrets.token_urlsafe(24)
+        params = {
+            "client_id": self._client_id,
+            "redirect_uri": self._redirect_uri,
+            "response_type": "code",
+            "scope": self._scope,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": state,
+        }
+        if extra_params:
+            params.update(extra_params)
+        url = f"{self._auth_url}?{urllib.parse.urlencode(params)}"
+        self._pending[state] = {
+            "code_verifier": verifier,
+            "expires_at": time.time() + 600,
+            "future": asyncio.get_event_loop().create_future(),
+        }
+        return AuthCodeChallenge(
+            authorization_url=url,
+            state=state,
+            code_verifier=verifier,
+        )
+
+    def resolve_callback(self, state: str, code: Optional[str], error: Optional[str]) -> None:
+        """Called from the HTTP callback handler.  Wakes the
+        `wait_for_callback` future."""
+        entry = self._pending.get(state)
+        if entry is None:
+            logger.warning("OAuth callback for unknown state %r — ignoring", state[:12])
+            return
+        future = entry["future"]
+        if future.done():
+            return
+        if error:
+            future.set_exception(DeviceCodeError(code=error, description=error))
+        else:
+            future.set_result(code)
+
+    async def wait_for_callback(self, state: str, timeout_s: int = 600) -> str:
+        """Block until the callback completes the flow for this state.
+
+        Returns the auth code on success; raises DeviceCodeError on
+        provider-side denial or timeout.
+        """
+        entry = self._pending.get(state)
+        if entry is None:
+            raise DeviceCodeError("unknown_state", "no pending flow for state")
+        try:
+            code = await asyncio.wait_for(entry["future"], timeout=timeout_s)
+            return code
+        except asyncio.TimeoutError:
+            raise DeviceCodeError(
+                "expired_token",
+                "user did not complete authorization in time",
+            ) from None
+        finally:
+            # GC the entry — only one shot per state.
+            self._pending.pop(state, None)
+
+    async def exchange_code(self, state: str, code: str) -> OAuthTokens:
+        """Exchange the auth code + PKCE verifier for tokens.
+
+        The state was looked up to find the verifier; the
+        `wait_for_callback` future has already been resolved (and
+        the entry removed) — so we capture the verifier BEFORE
+        calling resolve_callback or use the explicit verifier the
+        caller passes.  In practice this method is called from inside
+        ``GoogleCalendarIntegration._handle_callback`` which has both.
+        """
+        assert self._session is not None, "Use 'async with OAuthAuthCodeClient(...)'"
+        # Caller is expected to pass the verifier directly (we no
+        # longer have the state entry once wait_for_callback returned)
+        # — so this method actually doesn't need state.  But we keep
+        # the parameter for API symmetry; callers can pass any value.
+        del state
+        return await self._exchange(code)
+
+    async def _exchange(self, code: str, code_verifier: str | None = None) -> OAuthTokens:
+        """Used internally by exchange_code_with_verifier."""
+        assert self._session is not None
+        payload = {
+            "client_id": self._client_id,
+            "code": code,
+            "grant_type": "authorization_code",
+            "redirect_uri": self._redirect_uri,
+        }
+        if code_verifier:
+            payload["code_verifier"] = code_verifier
+        if self._client_secret:
+            payload["client_secret"] = self._client_secret
+        async with self._session.post(self._token_url, data=payload) as resp:
+            data = await resp.json()
+            if resp.status != 200:
+                raise DeviceCodeError(
+                    code=data.get("error", "exchange_failed"),
+                    description=data.get(
+                        "error_description", "Code exchange rejected by provider",
+                    ),
+                )
+        return _tokens_from_response(data)
+
+    async def exchange_code_with_verifier(
+        self, code: str, code_verifier: str,
+    ) -> OAuthTokens:
+        """The canonical exchange call — pass verifier explicitly."""
+        assert self._session is not None
+        return await self._exchange(code, code_verifier=code_verifier)
+
+    async def refresh(self, refresh_token: str) -> OAuthTokens:
+        """Exchange a refresh token for a new access token."""
+        assert self._session is not None
+        payload = {
+            "client_id": self._client_id,
+            "refresh_token": refresh_token,
+            "grant_type": "refresh_token",
+        }
+        if self._client_secret:
+            payload["client_secret"] = self._client_secret
+        async with self._session.post(self._token_url, data=payload) as resp:
+            data = await resp.json()
+            if resp.status != 200:
+                raise DeviceCodeError(
+                    code=data.get("error", "refresh_failed"),
+                    description=data.get(
+                        "error_description", "Refresh token rejected"
+                    ),
+                )
+        tokens = _tokens_from_response(data)
+        if not tokens.refresh_token:
+            tokens.refresh_token = refresh_token
+        return tokens
+
+
+# ─── Device Authorization Grant (kept for non-Google providers) ───
+
+
+@dataclass
+class DeviceCodeChallenge:
+    """Returned by the device-code endpoint (RFC 8628 §3.2)."""
+
+    device_code: str
+    user_code: str
+    verification_url: str
+    expires_in: int
+    interval: int = 5
+    verification_url_complete: Optional[str] = None
+
+
 class OAuthDeviceCodeClient:
     """Provider-agnostic device-code OAuth client.
 
-    One instance per provider (Google, Spotify, etc.) — the
-    `client_id`, `scope`, `device_code_url`, and `token_url` are
-    provider-specific.  `client_secret` is optional (Google's device
-    flow uses a client secret, Spotify's doesn't).
+    Kept for providers that allow Calendar/Gmail-equivalent scopes
+    through device-code (some Spotify scopes, etc.).  See
+    `OAuthAuthCodeClient` for Google.
     """
 
     def __init__(
@@ -150,13 +402,7 @@ class OAuthDeviceCodeClient:
             await self._session.close()
 
     async def start(self) -> DeviceCodeChallenge:
-        """POST to the device-code endpoint, return the challenge.
-
-        Raises DeviceCodeError when the provider returns a non-2xx
-        response with a structured error body (rare at this stage —
-        usually only happens if the `client_id` is invalid).
-        """
-        assert self._session is not None, "Use 'async with OAuthDeviceCodeClient(...)'"
+        assert self._session is not None
         payload = {"client_id": self._client_id, "scope": self._scope}
         async with self._session.post(self._device_code_url, data=payload) as resp:
             data = await resp.json()
@@ -177,18 +423,7 @@ class OAuthDeviceCodeClient:
         )
 
     async def poll_once(self, device_code: str) -> Optional[OAuthTokens]:
-        """One poll of the token endpoint.
-
-        Returns:
-            * `OAuthTokens` — flow completed, user authorized.
-            * `None` — still pending (RFC 8628 `authorization_pending`
-              or `slow_down`).  Caller should sleep and try again.
-
-        Raises:
-            DeviceCodeError — terminal failure (`expired_token`,
-            `access_denied`, etc.).  Caller stops polling.
-        """
-        assert self._session is not None, "Use 'async with OAuthDeviceCodeClient(...)'"
+        assert self._session is not None
         payload = {
             "client_id": self._client_id,
             "device_code": device_code,
@@ -196,14 +431,12 @@ class OAuthDeviceCodeClient:
         }
         if self._client_secret:
             payload["client_secret"] = self._client_secret
-
         async with self._session.post(self._token_url, data=payload) as resp:
             data = await resp.json()
             if resp.status == 200:
-                return self._tokens_from_response(data)
+                return _tokens_from_response(data)
             err = data.get("error", "")
             if err in ("authorization_pending", "slow_down"):
-                # Not done yet.
                 return None
             raise DeviceCodeError(
                 code=err or "unknown_error",
@@ -217,12 +450,6 @@ class OAuthDeviceCodeClient:
         challenge: DeviceCodeChallenge,
         cancel_event: Optional[asyncio.Event] = None,
     ) -> OAuthTokens:
-        """Convenience: poll on `challenge.interval` until terminal.
-
-        Honors `expires_in` from the challenge — raises
-        ``DeviceCodeError("expired_token", ...)`` when the device-code
-        TTL is up.  Cancel via `cancel_event` (Tab5 closing the modal).
-        """
         deadline = time.time() + challenge.expires_in
         interval = challenge.interval
         while True:
@@ -236,23 +463,16 @@ class OAuthDeviceCodeClient:
                 tokens = await self.poll_once(challenge.device_code)
             except DeviceCodeError as e:
                 if e.code == "slow_down":
-                    # Provider asked us to back off; bump interval.
                     interval += 5
                     await asyncio.sleep(interval)
                     continue
-                # Anything else is terminal.
                 raise
             if tokens is not None:
                 return tokens
             await asyncio.sleep(interval)
 
     async def refresh(self, refresh_token: str) -> OAuthTokens:
-        """Exchange a refresh token for a new access token.
-
-        Raises DeviceCodeError on terminal failure (refresh token
-        revoked / expired — user has to reconnect).
-        """
-        assert self._session is not None, "Use 'async with OAuthDeviceCodeClient(...)'"
+        assert self._session is not None
         payload = {
             "client_id": self._client_id,
             "refresh_token": refresh_token,
@@ -260,7 +480,6 @@ class OAuthDeviceCodeClient:
         }
         if self._client_secret:
             payload["client_secret"] = self._client_secret
-
         async with self._session.post(self._token_url, data=payload) as resp:
             data = await resp.json()
             if resp.status != 200:
@@ -270,29 +489,7 @@ class OAuthDeviceCodeClient:
                         "error_description", "Refresh token rejected"
                     ),
                 )
-        # Refresh responses may omit `refresh_token` — providers expect
-        # the client to reuse the old one.
-        tokens = self._tokens_from_response(data)
+        tokens = _tokens_from_response(data)
         if not tokens.refresh_token:
             tokens.refresh_token = refresh_token
         return tokens
-
-    @staticmethod
-    def _tokens_from_response(data: dict) -> OAuthTokens:
-        expires_in = int(data.get("expires_in", 3600))
-        scope_str = data.get("scope", "")
-        scopes = scope_str.split() if scope_str else []
-        return OAuthTokens(
-            access_token=data["access_token"],
-            refresh_token=data.get("refresh_token"),
-            token_type=data.get("token_type", "Bearer"),
-            expires_at=int(time.time()) + expires_in,
-            scopes=scopes,
-            extra={
-                k: v for k, v in data.items()
-                if k not in {
-                    "access_token", "refresh_token", "token_type",
-                    "expires_in", "scope",
-                }
-            },
-        )

--- a/tests/test_gmail_integration.py
+++ b/tests/test_gmail_integration.py
@@ -1,0 +1,442 @@
+"""#341 / Phase 2 — Gmail integration tests (multi-account, auth-code).
+
+Stubs the Google OAuth + Gmail API via aiohttp session mocks.  Covers
+the shape (multi-account, auth-code), list_messages + get_message_body
++ send_message + modify_labels round-trips, and account routing.
+
+Mirrors test_google_calendar_integration.py — same patterns, same
+fixtures, different API surface.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dragon_voice.tools.integrations.credentials import ProviderCredentialDir
+from dragon_voice.tools.integrations.google.gmail import (
+    PROVIDER_NAME,
+    GmailIntegration,
+)
+from dragon_voice.tools.integrations.oauth import DeviceCodeError, OAuthTokens
+
+
+@pytest.fixture(autouse=True)
+def _redirect_cred_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("TINKERCLAW_INTEGRATIONS_DIR", str(tmp_path))
+
+
+@pytest.fixture(autouse=True)
+def _oauth_env(monkeypatch):
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "test-cid")
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "test-csec")
+
+
+@pytest.fixture
+def integration(tmp_path):
+    integ = GmailIntegration()
+    integ._provider_dir = ProviderCredentialDir(PROVIDER_NAME, base_dir=tmp_path)
+    return integ
+
+
+def _tokens(access="AT-1", refresh="RT-1", id_email=None):
+    extra = {}
+    if id_email:
+        payload = {
+            "email": id_email, "email_verified": True, "sub": "1234567890",
+        }
+        body_b64 = base64.urlsafe_b64encode(
+            json.dumps(payload).encode("ascii"),
+        ).rstrip(b"=").decode("ascii")
+        extra["id_token"] = f"header.{body_b64}.signature"
+    return OAuthTokens(
+        access_token=access,
+        refresh_token=refresh,
+        token_type="Bearer",
+        expires_at=int(time.time()) + 3600,
+        scopes=[
+            "https://www.googleapis.com/auth/gmail.readonly",
+            "https://www.googleapis.com/auth/gmail.modify",
+            "https://www.googleapis.com/auth/gmail.send",
+            "openid", "email",
+        ],
+        extra=extra,
+    )
+
+
+def _resp(json_data, status=200):
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=MagicMock(
+        status=status,
+        json=AsyncMock(return_value=json_data),
+        raise_for_status=MagicMock(),
+    ))
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return cm
+
+
+async def _persist(integ, account_id, tokens, default=False):
+    await integ._ensure_loaded()
+    if tokens.extra is None:
+        tokens.extra = {}
+    tokens.extra["default"] = default
+    await integ._persist_account(account_id, tokens)
+    integ._accounts[account_id] = tokens
+    if default or integ._default_account_id is None:
+        integ._default_account_id = account_id
+
+
+# ── shape ───────────────────────────────────────────────────────────
+
+
+def test_provider_metadata(integration):
+    assert integration.name == "gmail"
+    assert integration.display_name == "Gmail"
+    assert integration.auth_kind == "oauth-authcode"
+    assert integration.supports_multi_account is True
+
+
+# ── lifecycle ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_disconnected_initially(integration):
+    assert await integration.is_connected() is False
+    assert await integration.list_accounts() == []
+
+
+@pytest.mark.asyncio
+async def test_start_connect_returns_pkce_url(integration):
+    chal = await integration.start_connect()
+    assert chal.kind == "oauth-authcode"
+    # All three gmail scopes plus openid+email.
+    assert "gmail.readonly" in chal.verification_url
+    assert "gmail.modify" in chal.verification_url
+    assert "gmail.send" in chal.verification_url
+    assert "openid" in chal.verification_url
+
+
+@pytest.mark.asyncio
+async def test_handle_callback_uses_id_token_email(integration):
+    chal = await integration.start_connect()
+    flow = integration._flows[chal.request_id]
+    tokens = _tokens(id_email="me@example.com")
+
+    fake_client = MagicMock()
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+    fake_client.exchange_code_with_verifier = AsyncMock(return_value=tokens)
+
+    with patch(
+        "dragon_voice.tools.integrations.google.gmail.make_google_client",
+        return_value=fake_client,
+    ):
+        await integration.handle_callback(
+            state=flow.state, code="AUTH-1", error=None,
+        )
+
+    accounts = await integration.list_accounts()
+    assert [a.account_id for a in accounts] == ["me@example.com"]
+    assert accounts[0].default is True
+
+
+# ── list_messages ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_messages_fans_out_metadata(integration):
+    await _persist(integration, "me@example.com", _tokens(), default=True)
+
+    fake_session = MagicMock()
+    fake_session.closed = False
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=None)
+
+    # First call: list endpoint returns 2 ids.  Then 2 metadata fetches.
+    responses = [
+        _resp({"messages": [{"id": "m1"}, {"id": "m2"}]}),
+        _resp({
+            "id": "m1", "snippet": "first",
+            "labelIds": ["INBOX", "UNREAD"],
+            "payload": {"headers": [
+                {"name": "From", "value": "alice@example.com"},
+                {"name": "Subject", "value": "hi"},
+                {"name": "Date", "value": "Sat, 17 May 2026 10:00:00 +0000"},
+            ]},
+        }),
+        _resp({
+            "id": "m2", "snippet": "second",
+            "labelIds": ["INBOX"],
+            "payload": {"headers": [
+                {"name": "From", "value": "bob@example.com"},
+                {"name": "Subject", "value": "follow-up"},
+                {"name": "Date", "value": "Sat, 17 May 2026 11:00:00 +0000"},
+            ]},
+        }),
+    ]
+    fake_session.get = MagicMock(side_effect=responses)
+
+    with patch(
+        "dragon_voice.tools.integrations.google.gmail.aiohttp.ClientSession",
+        return_value=fake_session,
+    ):
+        messages = await integration.list_messages(query="is:unread")
+
+    assert len(messages) == 2
+    by_id = {m["id"]: m for m in messages}
+    assert by_id["m1"]["from"] == "alice@example.com"
+    assert by_id["m1"]["subject"] == "hi"
+    assert by_id["m1"]["unread"] is True
+    assert by_id["m2"]["unread"] is False
+    assert by_id["m1"]["account"] == "me@example.com"
+
+
+@pytest.mark.asyncio
+async def test_list_messages_empty_when_no_matches(integration):
+    await _persist(integration, "me@example.com", _tokens(), default=True)
+
+    fake_session = MagicMock()
+    fake_session.closed = False
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=None)
+    fake_session.get = MagicMock(return_value=_resp({}))
+
+    with patch(
+        "dragon_voice.tools.integrations.google.gmail.aiohttp.ClientSession",
+        return_value=fake_session,
+    ):
+        messages = await integration.list_messages(query="from:nobody")
+
+    assert messages == []
+
+
+# ── get_message_body ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_message_body_extracts_text_plain(integration):
+    await _persist(integration, "me@example.com", _tokens(), default=True)
+
+    plain_body = base64.urlsafe_b64encode(b"Hello world.\n").rstrip(b"=").decode("ascii")
+    fake_session = MagicMock()
+    fake_session.closed = False
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=None)
+    fake_session.get = MagicMock(return_value=_resp({
+        "id": "m1", "snippet": "Hello world.",
+        "labelIds": ["INBOX"],
+        "payload": {
+            "headers": [
+                {"name": "From", "value": "alice@example.com"},
+                {"name": "Subject", "value": "Hi"},
+                {"name": "Date", "value": "Sat, 17 May 2026 10:00:00 +0000"},
+            ],
+            "mimeType": "multipart/alternative",
+            "parts": [
+                {"mimeType": "text/plain", "body": {"data": plain_body}},
+                {"mimeType": "text/html", "body": {"data": ""}},
+            ],
+        },
+    }))
+
+    with patch(
+        "dragon_voice.tools.integrations.google.gmail.aiohttp.ClientSession",
+        return_value=fake_session,
+    ):
+        msg = await integration.get_message_body("m1")
+
+    assert msg["body_text"] == "Hello world.\n"
+    assert msg["from"] == "alice@example.com"
+    assert msg["subject"] == "Hi"
+    assert msg["account"] == "me@example.com"
+
+
+@pytest.mark.asyncio
+async def test_get_message_body_handles_single_part(integration):
+    """Single-part messages have body.data directly under payload."""
+    await _persist(integration, "me@example.com", _tokens(), default=True)
+
+    plain_body = base64.urlsafe_b64encode(b"single part text").rstrip(b"=").decode("ascii")
+    fake_session = MagicMock()
+    fake_session.closed = False
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=None)
+    fake_session.get = MagicMock(return_value=_resp({
+        "id": "m1", "snippet": "single part text",
+        "labelIds": ["INBOX"],
+        "payload": {
+            "headers": [
+                {"name": "From", "value": "alice@example.com"},
+                {"name": "Subject", "value": "Single"},
+            ],
+            "mimeType": "text/plain",
+            "body": {"data": plain_body},
+        },
+    }))
+
+    with patch(
+        "dragon_voice.tools.integrations.google.gmail.aiohttp.ClientSession",
+        return_value=fake_session,
+    ):
+        msg = await integration.get_message_body("m1")
+
+    assert msg["body_text"] == "single part text"
+
+
+# ── send_message ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_message_posts_base64url_raw(integration):
+    await _persist(integration, "me@example.com", _tokens(), default=True)
+
+    fake_session = MagicMock()
+    fake_session.closed = False
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=None)
+    fake_session.post = MagicMock(return_value=_resp({
+        "id": "sent-id", "threadId": "thread-id", "labelIds": ["SENT"],
+    }))
+
+    with patch(
+        "dragon_voice.tools.integrations.google.gmail.aiohttp.ClientSession",
+        return_value=fake_session,
+    ):
+        resp = await integration.send_message(
+            to="alice@example.com",
+            subject="Hello",
+            body="Greetings from Tab5.",
+        )
+
+    assert resp["sent"] is True
+    assert resp["id"] == "sent-id"
+    assert resp["thread_id"] == "thread-id"
+    # Verify the POST contained the RFC 822 raw payload.
+    payload = fake_session.post.call_args.kwargs["json"]
+    assert "raw" in payload
+    decoded = base64.urlsafe_b64decode(payload["raw"] + "==").decode("utf-8", errors="replace")
+    assert "To: alice@example.com" in decoded
+    assert "Subject: Hello" in decoded
+    assert "Greetings from Tab5." in decoded
+
+
+@pytest.mark.asyncio
+async def test_send_message_in_reply_to_threads_correctly(integration):
+    await _persist(integration, "me@example.com", _tokens(), default=True)
+
+    fake_session = MagicMock()
+    fake_session.closed = False
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=None)
+    # First GET fetches the original (Message-Id header + threadId),
+    # then POST sends the reply.
+    fake_session.get = MagicMock(return_value=_resp({
+        "id": "orig", "threadId": "T-99",
+        "payload": {"headers": [
+            {"name": "Message-Id", "value": "<orig@example.com>"},
+        ]},
+    }))
+    fake_session.post = MagicMock(return_value=_resp({
+        "id": "reply-id", "threadId": "T-99",
+    }))
+
+    with patch(
+        "dragon_voice.tools.integrations.google.gmail.aiohttp.ClientSession",
+        return_value=fake_session,
+    ):
+        resp = await integration.send_message(
+            to="alice@example.com",
+            subject="Re: Hi",
+            body="yes",
+            in_reply_to="orig",
+        )
+
+    assert resp["thread_id"] == "T-99"
+    payload = fake_session.post.call_args.kwargs["json"]
+    assert payload.get("threadId") == "T-99"
+    decoded = base64.urlsafe_b64decode(payload["raw"] + "==").decode("utf-8", errors="replace")
+    assert "In-Reply-To: <orig@example.com>" in decoded
+
+
+# ── modify_labels (archive etc.) ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_modify_labels_archive(integration):
+    await _persist(integration, "me@example.com", _tokens(), default=True)
+
+    fake_session = MagicMock()
+    fake_session.closed = False
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=None)
+    fake_session.post = MagicMock(return_value=_resp({
+        "id": "m1", "labelIds": ["UNREAD"],
+    }))
+
+    with patch(
+        "dragon_voice.tools.integrations.google.gmail.aiohttp.ClientSession",
+        return_value=fake_session,
+    ):
+        resp = await integration.modify_labels("m1", remove=["INBOX"])
+
+    assert resp["modified"] is True
+    assert "INBOX" not in resp["labels"]
+    body = fake_session.post.call_args.kwargs["json"]
+    assert body == {"removeLabelIds": ["INBOX"]}
+
+
+@pytest.mark.asyncio
+async def test_modify_labels_noop_when_nothing_supplied(integration):
+    await _persist(integration, "me@example.com", _tokens(), default=True)
+    resp = await integration.modify_labels("m1")
+    assert resp["modified"] is False
+
+
+# ── multi-account routing ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_messages_routes_to_explicit_account(integration):
+    await _persist(integration, "first@example.com", _tokens(access="AT-FIRST"), default=True)
+    await _persist(integration, "second@example.com", _tokens(access="AT-SECOND"))
+
+    fake_session = MagicMock()
+    fake_session.closed = False
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=None)
+    fake_session.get = MagicMock(return_value=_resp({}))
+
+    with patch(
+        "dragon_voice.tools.integrations.google.gmail.aiohttp.ClientSession",
+        return_value=fake_session,
+    ):
+        await integration.list_messages(
+            query="is:unread", account_id="second@example.com",
+        )
+
+    headers = fake_session.get.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer AT-SECOND"
+
+
+@pytest.mark.asyncio
+async def test_disconnect_one_account_leaves_others(integration):
+    await _persist(integration, "first@example.com", _tokens(refresh=None), default=True)
+    await _persist(integration, "second@example.com", _tokens(refresh=None))
+
+    await integration.disconnect(account_id="first@example.com")
+
+    accounts = await integration.list_accounts()
+    assert [a.account_id for a in accounts] == ["second@example.com"]
+    assert accounts[0].default is True
+
+
+@pytest.mark.asyncio
+async def test_set_default_account_unknown_raises(integration):
+    await _persist(integration, "first@example.com", _tokens(), default=True)
+    with pytest.raises(DeviceCodeError) as excinfo:
+        await integration.set_default_account("ghost@example.com")
+    assert excinfo.value.code == "unknown_account"

--- a/tests/test_google_calendar_integration.py
+++ b/tests/test_google_calendar_integration.py
@@ -1,14 +1,14 @@
-"""#341 / #342 — Google Calendar integration tests.
+"""#341 / #342 / #346 — Google Calendar integration tests (auth-code shape).
 
 Stubs the Google OAuth + Calendar API via aiohttp session mocks.
 Asserts:
+  * `auth_kind` is `oauth-authcode` (post-pivot)
   * `is_connected` is False initially, True after token persist
-  * `start_connect` returns a verification_url + user_code from the
-    mocked device-code endpoint
-  * `list_events` builds the right URL + params, normalizes payload
-  * `create_event` + `cancel_event` round-trip
-  * `disconnect` calls revoke + deletes creds
-  * Expired access token triggers refresh-on-401
+  * `start_connect` builds a PKCE authorization_url + tracks the flow
+  * `handle_callback` resolves matching state, persists tokens
+  * `poll_status` reports the flow state correctly
+  * `list_events` / `create_event` / `disconnect` round-trip
+  * Expired access token triggers refresh-on-401 via the auth-code client
 """
 
 from __future__ import annotations
@@ -23,7 +23,7 @@ from dragon_voice.tools.integrations.credentials import CredentialStore
 from dragon_voice.tools.integrations.google.calendar import (
     GoogleCalendarIntegration,
 )
-from dragon_voice.tools.integrations.oauth import OAuthTokens
+from dragon_voice.tools.integrations.oauth import DeviceCodeError, OAuthTokens
 
 
 @pytest.fixture(autouse=True)
@@ -32,11 +32,16 @@ def _redirect_cred_store(tmp_path, monkeypatch):
     monkeypatch.setenv("TINKERCLAW_INTEGRATIONS_DIR", str(tmp_path))
 
 
+@pytest.fixture(autouse=True)
+def _oauth_env(monkeypatch):
+    """Default Google OAuth client env so start_connect can build a URL."""
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "test-cid")
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "test-csec")
+
+
 @pytest.fixture
 def integration(tmp_path):
     integ = GoogleCalendarIntegration()
-    # Replace the store with an explicit tmp_path-backed one to make
-    # the redirect deterministic even if env-var lookup races.
     integ._store = CredentialStore("google-calendar", base_dir=tmp_path)
     return integ
 
@@ -66,6 +71,13 @@ def _make_mock_response(json_data, status=200):
     return cm
 
 
+# ── shape + lifecycle ───────────────────────────────────────────────
+
+
+def test_auth_kind_is_oauth_authcode(integration):
+    assert integration.auth_kind == "oauth-authcode"
+
+
 @pytest.mark.asyncio
 async def test_initial_state_is_disconnected(integration):
     assert await integration.is_connected() is False
@@ -78,9 +90,18 @@ async def test_is_connected_true_after_persist(integration, valid_tokens):
 
 
 @pytest.mark.asyncio
+async def test_health_check_returns_false_when_disconnected(integration):
+    ok, detail = await integration.health_check()
+    assert ok is False
+    assert "not connected" in detail.lower()
+
+
+# ── start_connect / poll_status / handle_callback ───────────────────
+
+
+@pytest.mark.asyncio
 async def test_start_connect_requires_oauth_env(integration, monkeypatch):
-    """No GOOGLE_OAUTH_CLIENT_ID → raises a structured error so the
-    REST layer can surface a 503 + actionable message."""
+    """No GOOGLE_OAUTH_CLIENT_ID → raises so the REST layer returns 503."""
     monkeypatch.delenv("GOOGLE_OAUTH_CLIENT_ID", raising=False)
     from dragon_voice.tools.integrations.google.auth import (
         GoogleOAuthNotConfiguredError,
@@ -90,16 +111,142 @@ async def test_start_connect_requires_oauth_env(integration, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_health_check_returns_false_when_disconnected(integration):
-    ok, detail = await integration.health_check()
-    assert ok is False
-    assert "not connected" in detail.lower()
+async def test_start_connect_returns_pkce_authorization_url(integration):
+    chal = await integration.start_connect()
+    assert chal.request_id
+    assert chal.verification_url.startswith(
+        "https://accounts.google.com/o/oauth2/v2/auth?",
+    )
+    assert "code_challenge=" in chal.verification_url
+    assert "code_challenge_method=S256" in chal.verification_url
+    # Google needs offline + consent to mint a refresh_token.
+    assert "access_type=offline" in chal.verification_url
+    assert "prompt=consent" in chal.verification_url
+    # Auth-code flow has no user_code (only device-code does).
+    assert chal.user_code is None
+
+
+@pytest.mark.asyncio
+async def test_start_connect_tracks_flow_by_request_id_and_state(integration):
+    chal = await integration.start_connect()
+    flow = integration._flows[chal.request_id]
+    assert flow.state  # populated
+    assert flow.code_verifier  # populated
+    # _find_flow_by_state agrees.
+    assert integration._find_flow_by_state(flow.state) is flow
+
+
+@pytest.mark.asyncio
+async def test_find_flow_by_state_returns_none_for_unknown_state(integration):
+    await integration.start_connect()
+    assert integration._find_flow_by_state("never-issued") is None
+
+
+@pytest.mark.asyncio
+async def test_poll_status_reports_connecting_then_connected(
+    integration, valid_tokens,
+):
+    chal = await integration.start_connect()
+    status = await integration.poll_status(chal.request_id)
+    assert status.state == "connecting"
+
+    # Simulate the callback resolving the flow.
+    flow = integration._flows[chal.request_id]
+    flow.tokens = valid_tokens
+
+    status = await integration.poll_status(chal.request_id)
+    assert status.state == "connected"
+
+
+@pytest.mark.asyncio
+async def test_poll_status_unknown_request_id_is_error(integration):
+    status = await integration.poll_status("never-issued")
+    assert status.state == "error"
+    assert "unknown" in (status.error or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_handle_callback_unknown_state_is_noop(integration):
+    # Must not raise; must not persist anything.
+    await integration.handle_callback(state="never-issued", code="x", error=None)
+    assert await integration.is_connected() is False
+
+
+@pytest.mark.asyncio
+async def test_handle_callback_with_error_sets_flow_error(integration):
+    chal = await integration.start_connect()
+    flow = integration._flows[chal.request_id]
+    await integration.handle_callback(
+        state=flow.state, code=None, error="access_denied",
+    )
+    assert flow.error is not None
+    assert flow.error.code == "access_denied"
+
+    status = await integration.poll_status(chal.request_id)
+    assert status.state == "error"
+
+
+@pytest.mark.asyncio
+async def test_handle_callback_success_exchanges_and_persists(
+    integration, valid_tokens,
+):
+    chal = await integration.start_connect()
+    flow = integration._flows[chal.request_id]
+
+    fake_client = MagicMock()
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+    fake_client.exchange_code_with_verifier = AsyncMock(return_value=valid_tokens)
+
+    with patch(
+        "dragon_voice.tools.integrations.google.calendar.make_google_client",
+        return_value=fake_client,
+    ):
+        await integration.handle_callback(
+            state=flow.state, code="AUTH-CODE-1", error=None,
+        )
+
+    fake_client.exchange_code_with_verifier.assert_awaited_once_with(
+        code="AUTH-CODE-1", code_verifier=flow.code_verifier,
+    )
+    assert flow.tokens is valid_tokens
+    assert await integration.is_connected() is True
+
+    status = await integration.poll_status(chal.request_id)
+    assert status.state == "connected"
+
+
+@pytest.mark.asyncio
+async def test_handle_callback_exchange_failure_sets_flow_error(integration):
+    chal = await integration.start_connect()
+    flow = integration._flows[chal.request_id]
+
+    fake_client = MagicMock()
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+    fake_client.exchange_code_with_verifier = AsyncMock(
+        side_effect=DeviceCodeError("invalid_grant", "code reused"),
+    )
+
+    with patch(
+        "dragon_voice.tools.integrations.google.calendar.make_google_client",
+        return_value=fake_client,
+    ):
+        await integration.handle_callback(
+            state=flow.state, code="AUTH-CODE-1", error=None,
+        )
+
+    assert flow.tokens is None
+    assert flow.error is not None
+    assert flow.error.code == "invalid_grant"
+
+
+# ── Calendar API (unchanged by the auth-code pivot) ────────────────
 
 
 @pytest.mark.asyncio
 async def test_list_events_returns_normalized_shape(integration, valid_tokens):
-    """The Calendar API returns verbose payloads — we normalize down
-    to {id, summary, location, start_iso, end_iso, all_day, ...}."""
+    """The Calendar API returns verbose payloads — we normalize down."""
     await integration._persist_tokens(valid_tokens)
 
     fake_session = MagicMock()
@@ -166,7 +313,6 @@ async def test_create_event_posts_with_auth_header(integration, valid_tokens):
 
     assert ev["id"] == "evt-new"
     assert ev["summary"] == "Lunch"
-    # Verify the POST was authed.
     call_kwargs = fake_session.post.call_args.kwargs
     assert call_kwargs["headers"]["Authorization"] == "Bearer AT-fresh"
 
@@ -176,7 +322,6 @@ async def test_disconnect_clears_creds(integration, valid_tokens):
     await integration._persist_tokens(valid_tokens)
     assert await integration.is_connected()
 
-    # Mock the revoke endpoint as a no-op success.
     fake_session = MagicMock()
     fake_session.closed = False
     fake_session.__aenter__ = AsyncMock(return_value=fake_session)
@@ -194,21 +339,17 @@ async def test_disconnect_clears_creds(integration, valid_tokens):
 
 
 @pytest.mark.asyncio
-async def test_expired_token_triggers_refresh(integration, monkeypatch):
-    """When the cached `expires_at` is past, `_get_access_token` must
-    refresh via the OAuth client before returning the new access token."""
+async def test_expired_token_triggers_refresh_via_authcode_client(integration):
+    """When `expires_at` is past, `_get_access_token` refreshes via the
+    auth-code client and persists the new tokens."""
     expired = OAuthTokens(
         access_token="AT-OLD",
         refresh_token="RT-1",
         token_type="Bearer",
-        expires_at=int(time.time()) - 10,  # already expired
+        expires_at=int(time.time()) - 10,
         scopes=["https://www.googleapis.com/auth/calendar.readonly"],
     )
     await integration._persist_tokens(expired)
-
-    # Mock GoogleOAuthConfig.from_env to skip env-var check.
-    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "cid")
-    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "csec")
 
     new_tokens = OAuthTokens(
         access_token="AT-NEW",
@@ -218,11 +359,10 @@ async def test_expired_token_triggers_refresh(integration, monkeypatch):
         scopes=["https://www.googleapis.com/auth/calendar.readonly"],
     )
 
-    refresh_mock = AsyncMock(return_value=new_tokens)
     fake_client = MagicMock()
     fake_client.__aenter__ = AsyncMock(return_value=fake_client)
     fake_client.__aexit__ = AsyncMock(return_value=None)
-    fake_client.refresh = refresh_mock
+    fake_client.refresh = AsyncMock(return_value=new_tokens)
 
     with patch(
         "dragon_voice.tools.integrations.google.calendar.make_google_client",
@@ -231,4 +371,4 @@ async def test_expired_token_triggers_refresh(integration, monkeypatch):
         token = await integration._get_access_token()
 
     assert token == "AT-NEW"
-    refresh_mock.assert_awaited_once_with("RT-1")
+    fake_client.refresh.assert_awaited_once_with("RT-1")

--- a/tests/test_google_calendar_integration.py
+++ b/tests/test_google_calendar_integration.py
@@ -1,26 +1,35 @@
-"""#341 / #342 / #346 — Google Calendar integration tests (auth-code shape).
+"""#341 / #342 / #346 / #347 — Google Calendar integration (multi-account).
 
 Stubs the Google OAuth + Calendar API via aiohttp session mocks.
-Asserts:
-  * `auth_kind` is `oauth-authcode` (post-pivot)
-  * `is_connected` is False initially, True after token persist
+Covers:
+  * Multi-account internals (_accounts dict + default_account_id)
+  * `auth_kind` is `oauth-authcode`
   * `start_connect` builds a PKCE authorization_url + tracks the flow
-  * `handle_callback` resolves matching state, persists tokens
-  * `poll_status` reports the flow state correctly
-  * `list_events` / `create_event` / `disconnect` round-trip
-  * Expired access token triggers refresh-on-401 via the auth-code client
+  * `handle_callback` resolves account_id from id_token / userinfo /
+    placeholder, persists tokens under that key
+  * First connect sets default; second connect leaves default alone
+  * `set_default_account` moves the flag
+  * `disconnect(account_id)` and `disconnect()` semantics
+  * `list_events` / `create_event` round-trip with multi-account internals
+  * Legacy single-account file is migrated to `_legacy.json` on first load
 """
 
 from __future__ import annotations
 
+import base64
+import json
 import time
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from dragon_voice.tools.integrations.credentials import CredentialStore
+from dragon_voice.tools.integrations.credentials import (
+    LEGACY_ACCOUNT_ID,
+    ProviderCredentialDir,
+)
 from dragon_voice.tools.integrations.google.calendar import (
+    PROVIDER_NAME,
     GoogleCalendarIntegration,
 )
 from dragon_voice.tools.integrations.oauth import DeviceCodeError, OAuthTokens
@@ -28,13 +37,11 @@ from dragon_voice.tools.integrations.oauth import DeviceCodeError, OAuthTokens
 
 @pytest.fixture(autouse=True)
 def _redirect_cred_store(tmp_path, monkeypatch):
-    """Make all CredentialStore writes land in a per-test tmp dir."""
     monkeypatch.setenv("TINKERCLAW_INTEGRATIONS_DIR", str(tmp_path))
 
 
 @pytest.fixture(autouse=True)
 def _oauth_env(monkeypatch):
-    """Default Google OAuth client env so start_connect can build a URL."""
     monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "test-cid")
     monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "test-csec")
 
@@ -42,21 +49,34 @@ def _oauth_env(monkeypatch):
 @pytest.fixture
 def integration(tmp_path):
     integ = GoogleCalendarIntegration()
-    integ._store = CredentialStore("google-calendar", base_dir=tmp_path)
+    integ._provider_dir = ProviderCredentialDir(PROVIDER_NAME, base_dir=tmp_path)
     return integ
 
 
-@pytest.fixture
-def valid_tokens():
+def _tokens(access="AT-1", refresh="RT-1", scope_overrides=None, id_email=None):
+    """Build OAuthTokens, optionally with an id_token claiming `id_email`."""
+    extra = {}
+    if id_email:
+        payload = {
+            "email": id_email,
+            "email_verified": True,
+            "sub": "1234567890",
+        }
+        body_b64 = base64.urlsafe_b64encode(
+            json.dumps(payload).encode("ascii"),
+        ).rstrip(b"=").decode("ascii")
+        extra["id_token"] = f"header.{body_b64}.signature"
     return OAuthTokens(
-        access_token="AT-fresh",
-        refresh_token="RT-1",
+        access_token=access,
+        refresh_token=refresh,
         token_type="Bearer",
         expires_at=int(time.time()) + 3600,
-        scopes=[
+        scopes=scope_overrides or [
             "https://www.googleapis.com/auth/calendar.readonly",
             "https://www.googleapis.com/auth/calendar.events",
+            "openid", "email",
         ],
+        extra=extra,
     )
 
 
@@ -71,22 +91,36 @@ def _make_mock_response(json_data, status=200):
     return cm
 
 
-# ── shape + lifecycle ───────────────────────────────────────────────
+async def _persist(integ, account_id, tokens, default=False):
+    """Helper to put an account in the integration's state + on disk."""
+    await integ._ensure_loaded()
+    if tokens.extra is None:
+        tokens.extra = {}
+    tokens.extra["default"] = default
+    await integ._persist_account(account_id, tokens)
+    integ._accounts[account_id] = tokens
+    if default or integ._default_account_id is None:
+        integ._default_account_id = account_id
+
+
+# ── shape ───────────────────────────────────────────────────────────
 
 
 def test_auth_kind_is_oauth_authcode(integration):
     assert integration.auth_kind == "oauth-authcode"
 
 
+def test_supports_multi_account(integration):
+    assert integration.supports_multi_account is True
+
+
+# ── lifecycle: empty state ─────────────────────────────────────────
+
+
 @pytest.mark.asyncio
 async def test_initial_state_is_disconnected(integration):
     assert await integration.is_connected() is False
-
-
-@pytest.mark.asyncio
-async def test_is_connected_true_after_persist(integration, valid_tokens):
-    await integration._persist_tokens(valid_tokens)
-    assert await integration.is_connected() is True
+    assert await integration.list_accounts() == []
 
 
 @pytest.mark.asyncio
@@ -96,12 +130,11 @@ async def test_health_check_returns_false_when_disconnected(integration):
     assert "not connected" in detail.lower()
 
 
-# ── start_connect / poll_status / handle_callback ───────────────────
+# ── start_connect ───────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
 async def test_start_connect_requires_oauth_env(integration, monkeypatch):
-    """No GOOGLE_OAUTH_CLIENT_ID → raises so the REST layer returns 503."""
     monkeypatch.delenv("GOOGLE_OAUTH_CLIENT_ID", raising=False)
     from dragon_voice.tools.integrations.google.auth import (
         GoogleOAuthNotConfiguredError,
@@ -113,61 +146,31 @@ async def test_start_connect_requires_oauth_env(integration, monkeypatch):
 @pytest.mark.asyncio
 async def test_start_connect_returns_pkce_authorization_url(integration):
     chal = await integration.start_connect()
+    assert chal.kind == "oauth-authcode"
     assert chal.request_id
     assert chal.verification_url.startswith(
         "https://accounts.google.com/o/oauth2/v2/auth?",
     )
-    assert "code_challenge=" in chal.verification_url
     assert "code_challenge_method=S256" in chal.verification_url
-    # Google needs offline + consent to mint a refresh_token.
     assert "access_type=offline" in chal.verification_url
-    assert "prompt=consent" in chal.verification_url
-    # Auth-code flow has no user_code (only device-code does).
+    # openid + email scopes are auto-included so we can extract account_id.
+    assert "openid" in chal.verification_url
+    assert "email" in chal.verification_url
     assert chal.user_code is None
 
 
 @pytest.mark.asyncio
-async def test_start_connect_tracks_flow_by_request_id_and_state(integration):
+async def test_start_connect_tracks_flow_by_state(integration):
     chal = await integration.start_connect()
     flow = integration._flows[chal.request_id]
-    assert flow.state  # populated
-    assert flow.code_verifier  # populated
-    # _find_flow_by_state agrees.
     assert integration._find_flow_by_state(flow.state) is flow
 
 
-@pytest.mark.asyncio
-async def test_find_flow_by_state_returns_none_for_unknown_state(integration):
-    await integration.start_connect()
-    assert integration._find_flow_by_state("never-issued") is None
-
-
-@pytest.mark.asyncio
-async def test_poll_status_reports_connecting_then_connected(
-    integration, valid_tokens,
-):
-    chal = await integration.start_connect()
-    status = await integration.poll_status(chal.request_id)
-    assert status.state == "connecting"
-
-    # Simulate the callback resolving the flow.
-    flow = integration._flows[chal.request_id]
-    flow.tokens = valid_tokens
-
-    status = await integration.poll_status(chal.request_id)
-    assert status.state == "connected"
-
-
-@pytest.mark.asyncio
-async def test_poll_status_unknown_request_id_is_error(integration):
-    status = await integration.poll_status("never-issued")
-    assert status.state == "error"
-    assert "unknown" in (status.error or "").lower()
+# ── handle_callback paths ──────────────────────────────────────────
 
 
 @pytest.mark.asyncio
 async def test_handle_callback_unknown_state_is_noop(integration):
-    # Must not raise; must not persist anything.
     await integration.handle_callback(state="never-issued", code="x", error=None)
     assert await integration.is_connected() is False
 
@@ -181,73 +184,203 @@ async def test_handle_callback_with_error_sets_flow_error(integration):
     )
     assert flow.error is not None
     assert flow.error.code == "access_denied"
-
     status = await integration.poll_status(chal.request_id)
     assert status.state == "error"
 
 
 @pytest.mark.asyncio
-async def test_handle_callback_success_exchanges_and_persists(
-    integration, valid_tokens,
+async def test_handle_callback_uses_id_token_email_as_account_id(integration):
+    chal = await integration.start_connect()
+    flow = integration._flows[chal.request_id]
+    tokens = _tokens(id_email="me@example.com")
+
+    fake_client = MagicMock()
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+    fake_client.exchange_code_with_verifier = AsyncMock(return_value=tokens)
+
+    with patch(
+        "dragon_voice.tools.integrations.google.calendar.make_google_client",
+        return_value=fake_client,
+    ):
+        await integration.handle_callback(
+            state=flow.state, code="AUTH-1", error=None,
+        )
+
+    accounts = await integration.list_accounts()
+    assert len(accounts) == 1
+    assert accounts[0].account_id == "me@example.com"
+    assert accounts[0].default is True
+    status = await integration.poll_status(chal.request_id)
+    assert status.state == "connected"
+    assert status.account_id == "me@example.com"
+
+
+@pytest.mark.asyncio
+async def test_handle_callback_falls_back_to_userinfo_when_id_token_missing(
+    integration,
 ):
     chal = await integration.start_connect()
     flow = integration._flows[chal.request_id]
+    tokens = _tokens()  # no id_email → no id_token
 
     fake_client = MagicMock()
     fake_client.__aenter__ = AsyncMock(return_value=fake_client)
     fake_client.__aexit__ = AsyncMock(return_value=None)
-    fake_client.exchange_code_with_verifier = AsyncMock(return_value=valid_tokens)
+    fake_client.exchange_code_with_verifier = AsyncMock(return_value=tokens)
 
     with patch(
         "dragon_voice.tools.integrations.google.calendar.make_google_client",
         return_value=fake_client,
+    ), patch(
+        "dragon_voice.tools.integrations.google.calendar.fetch_google_email",
+        new=AsyncMock(return_value="userinfo@example.com"),
     ):
         await integration.handle_callback(
-            state=flow.state, code="AUTH-CODE-1", error=None,
+            state=flow.state, code="AUTH-1", error=None,
         )
 
-    fake_client.exchange_code_with_verifier.assert_awaited_once_with(
-        code="AUTH-CODE-1", code_verifier=flow.code_verifier,
-    )
-    assert flow.tokens is valid_tokens
-    assert await integration.is_connected() is True
-
-    status = await integration.poll_status(chal.request_id)
-    assert status.state == "connected"
+    accounts = await integration.list_accounts()
+    assert [a.account_id for a in accounts] == ["userinfo@example.com"]
 
 
 @pytest.mark.asyncio
-async def test_handle_callback_exchange_failure_sets_flow_error(integration):
+async def test_handle_callback_uses_placeholder_when_both_id_sources_fail(
+    integration,
+):
     chal = await integration.start_connect()
     flow = integration._flows[chal.request_id]
+    tokens = _tokens()
 
     fake_client = MagicMock()
     fake_client.__aenter__ = AsyncMock(return_value=fake_client)
     fake_client.__aexit__ = AsyncMock(return_value=None)
-    fake_client.exchange_code_with_verifier = AsyncMock(
-        side_effect=DeviceCodeError("invalid_grant", "code reused"),
-    )
+    fake_client.exchange_code_with_verifier = AsyncMock(return_value=tokens)
+
+    with patch(
+        "dragon_voice.tools.integrations.google.calendar.make_google_client",
+        return_value=fake_client,
+    ), patch(
+        "dragon_voice.tools.integrations.google.calendar.fetch_google_email",
+        new=AsyncMock(return_value=None),
+    ):
+        await integration.handle_callback(
+            state=flow.state, code="AUTH-1", error=None,
+        )
+
+    accounts = await integration.list_accounts()
+    assert len(accounts) == 1
+    assert accounts[0].account_id.startswith("pending-")
+
+
+@pytest.mark.asyncio
+async def test_second_connect_does_not_unseat_first_default(integration):
+    await _persist(integration, "first@example.com", _tokens(), default=True)
+
+    chal = await integration.start_connect()
+    flow = integration._flows[chal.request_id]
+    second = _tokens(id_email="second@example.com")
+
+    fake_client = MagicMock()
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+    fake_client.exchange_code_with_verifier = AsyncMock(return_value=second)
 
     with patch(
         "dragon_voice.tools.integrations.google.calendar.make_google_client",
         return_value=fake_client,
     ):
         await integration.handle_callback(
-            state=flow.state, code="AUTH-CODE-1", error=None,
+            state=flow.state, code="AUTH-2", error=None,
         )
 
-    assert flow.tokens is None
-    assert flow.error is not None
-    assert flow.error.code == "invalid_grant"
+    accounts = {a.account_id: a for a in await integration.list_accounts()}
+    assert set(accounts.keys()) == {"first@example.com", "second@example.com"}
+    assert accounts["first@example.com"].default is True
+    assert accounts["second@example.com"].default is False
 
 
-# ── Calendar API (unchanged by the auth-code pivot) ────────────────
+# ── set_default_account / disconnect ───────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_list_events_returns_normalized_shape(integration, valid_tokens):
-    """The Calendar API returns verbose payloads — we normalize down."""
-    await integration._persist_tokens(valid_tokens)
+async def test_set_default_account_moves_the_flag(integration, tmp_path):
+    await _persist(integration, "first@example.com", _tokens(), default=True)
+    await _persist(integration, "second@example.com", _tokens())
+
+    await integration.set_default_account("second@example.com")
+
+    # Reload from disk to verify persistence.
+    fresh = GoogleCalendarIntegration()
+    fresh._provider_dir = ProviderCredentialDir(PROVIDER_NAME, base_dir=tmp_path)
+    await fresh._ensure_loaded()
+    accounts = {a.account_id: a for a in await fresh.list_accounts()}
+    assert accounts["second@example.com"].default is True
+    assert accounts["first@example.com"].default is False
+
+
+@pytest.mark.asyncio
+async def test_set_default_account_unknown_raises(integration):
+    await _persist(integration, "first@example.com", _tokens(), default=True)
+    with pytest.raises(DeviceCodeError) as excinfo:
+        await integration.set_default_account("ghost@example.com")
+    assert excinfo.value.code == "unknown_account"
+
+
+@pytest.mark.asyncio
+async def test_disconnect_one_account_leaves_others(integration):
+    await _persist(integration, "first@example.com", _tokens(refresh=None), default=True)
+    await _persist(integration, "second@example.com", _tokens(refresh=None))
+
+    await integration.disconnect(account_id="first@example.com")
+
+    accounts = await integration.list_accounts()
+    assert [a.account_id for a in accounts] == ["second@example.com"]
+    assert accounts[0].default is True
+    assert await integration.is_connected("first@example.com") is False
+    assert await integration.is_connected("second@example.com") is True
+
+
+@pytest.mark.asyncio
+async def test_disconnect_with_no_account_id_clears_all(integration):
+    await _persist(integration, "first@example.com", _tokens(refresh=None), default=True)
+    await _persist(integration, "second@example.com", _tokens(refresh=None))
+
+    await integration.disconnect()
+
+    assert await integration.list_accounts() == []
+    assert await integration.is_connected() is False
+
+
+# ── Legacy migration ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_legacy_flat_file_migrated_on_first_load(tmp_path):
+    """Pre-#347 builds wrote ``{base}/{provider}.json``.  The first load
+    after upgrade must move it to ``{provider}/_legacy.json`` and
+    surface it as the default account."""
+    flat = tmp_path / f"{PROVIDER_NAME}.json"
+    flat.write_text(json.dumps({"tokens": _tokens().to_dict()}))
+
+    integ = GoogleCalendarIntegration()
+    integ._provider_dir = ProviderCredentialDir(PROVIDER_NAME, base_dir=tmp_path)
+    await integ._ensure_loaded()
+
+    accounts = await integ.list_accounts()
+    assert [a.account_id for a in accounts] == [LEGACY_ACCOUNT_ID]
+    assert accounts[0].default is True
+    assert not flat.exists()
+    assert (tmp_path / PROVIDER_NAME / f"{LEGACY_ACCOUNT_ID}.json").exists()
+
+
+# ── Calendar API (multi-account aware) ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_events_routes_to_default_when_account_omitted(integration):
+    await _persist(integration, "first@example.com", _tokens(), default=True)
+    await _persist(integration, "second@example.com", _tokens(access="AT-OTHER"))
 
     fake_session = MagicMock()
     fake_session.closed = False
@@ -255,19 +388,9 @@ async def test_list_events_returns_normalized_shape(integration, valid_tokens):
     fake_session.__aexit__ = AsyncMock(return_value=None)
     fake_session.get = MagicMock(return_value=_make_mock_response({
         "items": [
-            {
-                "id": "evt-1",
-                "summary": "Dentist",
-                "location": "Geneva",
-                "start": {"dateTime": "2026-05-17T14:00:00Z"},
-                "end": {"dateTime": "2026-05-17T15:00:00Z"},
-            },
-            {
-                "id": "evt-2",
-                "summary": "Conference",
-                "start": {"date": "2026-05-18"},
-                "end": {"date": "2026-05-19"},
-            },
+            {"id": "evt-1", "summary": "Dentist",
+             "start": {"dateTime": "2026-05-17T14:00:00Z"},
+             "end": {"dateTime": "2026-05-17T15:00:00Z"}},
         ],
     }))
 
@@ -277,26 +400,43 @@ async def test_list_events_returns_normalized_shape(integration, valid_tokens):
     ):
         events = await integration.list_events()
 
-    assert len(events) == 2
-    assert events[0]["id"] == "evt-1"
-    assert events[0]["summary"] == "Dentist"
-    assert events[0]["location"] == "Geneva"
-    assert events[0]["all_day"] is False
-    assert events[1]["all_day"] is True
-    assert events[1]["start_iso"] == "2026-05-18"
+    assert len(events) == 1
+    assert events[0]["account"] == "first@example.com"
+    headers = fake_session.get.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer AT-1"
 
 
 @pytest.mark.asyncio
-async def test_create_event_posts_with_auth_header(integration, valid_tokens):
-    await integration._persist_tokens(valid_tokens)
+async def test_list_events_with_explicit_account_routes_correctly(integration):
+    await _persist(integration, "first@example.com", _tokens(access="AT-FIRST"), default=True)
+    await _persist(integration, "second@example.com", _tokens(access="AT-SECOND"))
+
+    fake_session = MagicMock()
+    fake_session.closed = False
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=None)
+    fake_session.get = MagicMock(return_value=_make_mock_response({"items": []}))
+
+    with patch(
+        "dragon_voice.tools.integrations.google.calendar.aiohttp.ClientSession",
+        return_value=fake_session,
+    ):
+        await integration.list_events(account_id="second@example.com")
+
+    headers = fake_session.get.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer AT-SECOND"
+
+
+@pytest.mark.asyncio
+async def test_create_event_posts_with_default_account_token(integration):
+    await _persist(integration, "first@example.com", _tokens(), default=True)
 
     fake_session = MagicMock()
     fake_session.closed = False
     fake_session.__aenter__ = AsyncMock(return_value=fake_session)
     fake_session.__aexit__ = AsyncMock(return_value=None)
     fake_session.post = MagicMock(return_value=_make_mock_response({
-        "id": "evt-new",
-        "summary": "Lunch",
+        "id": "evt-new", "summary": "Lunch",
         "start": {"dateTime": "2026-05-17T12:00:00Z"},
         "end": {"dateTime": "2026-05-17T13:00:00Z"},
     }))
@@ -312,52 +452,22 @@ async def test_create_event_posts_with_auth_header(integration, valid_tokens):
         )
 
     assert ev["id"] == "evt-new"
-    assert ev["summary"] == "Lunch"
+    assert ev["account"] == "first@example.com"
     call_kwargs = fake_session.post.call_args.kwargs
-    assert call_kwargs["headers"]["Authorization"] == "Bearer AT-fresh"
+    assert call_kwargs["headers"]["Authorization"] == "Bearer AT-1"
 
 
 @pytest.mark.asyncio
-async def test_disconnect_clears_creds(integration, valid_tokens):
-    await integration._persist_tokens(valid_tokens)
-    assert await integration.is_connected()
+async def test_expired_token_triggers_refresh_per_account(integration):
+    """When the default account's token expires, refresh fires only
+    for that account; the other account's tokens are untouched."""
+    expired_first = _tokens(access="AT-OLD", refresh="RT-1")
+    expired_first.expires_at = int(time.time()) - 10
+    await _persist(integration, "first@example.com", expired_first, default=True)
+    untouched = _tokens(access="AT-OTHER-STILL-GOOD", refresh="RT-OTHER")
+    await _persist(integration, "second@example.com", untouched)
 
-    fake_session = MagicMock()
-    fake_session.closed = False
-    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
-    fake_session.__aexit__ = AsyncMock(return_value=None)
-    fake_session.post = MagicMock(return_value=_make_mock_response({}, status=200))
-
-    with patch(
-        "dragon_voice.tools.integrations.google.calendar.aiohttp.ClientSession",
-        return_value=fake_session,
-    ):
-        await integration.disconnect()
-
-    assert await integration.is_connected() is False
-    assert not await integration._store.exists()
-
-
-@pytest.mark.asyncio
-async def test_expired_token_triggers_refresh_via_authcode_client(integration):
-    """When `expires_at` is past, `_get_access_token` refreshes via the
-    auth-code client and persists the new tokens."""
-    expired = OAuthTokens(
-        access_token="AT-OLD",
-        refresh_token="RT-1",
-        token_type="Bearer",
-        expires_at=int(time.time()) - 10,
-        scopes=["https://www.googleapis.com/auth/calendar.readonly"],
-    )
-    await integration._persist_tokens(expired)
-
-    new_tokens = OAuthTokens(
-        access_token="AT-NEW",
-        refresh_token="RT-1",
-        token_type="Bearer",
-        expires_at=int(time.time()) + 3600,
-        scopes=["https://www.googleapis.com/auth/calendar.readonly"],
-    )
+    new_tokens = _tokens(access="AT-NEW", refresh="RT-1")
 
     fake_client = MagicMock()
     fake_client.__aenter__ = AsyncMock(return_value=fake_client)
@@ -372,3 +482,4 @@ async def test_expired_token_triggers_refresh_via_authcode_client(integration):
 
     assert token == "AT-NEW"
     fake_client.refresh.assert_awaited_once_with("RT-1")
+    assert integration._accounts["second@example.com"].access_token == "AT-OTHER-STILL-GOOD"

--- a/tests/test_integrations_init.py
+++ b/tests/test_integrations_init.py
@@ -1,0 +1,87 @@
+"""#341 / #348 — `dragon_voice/lifecycle/integrations_init.py`.
+
+Verifies the tool-registration wiring for TinkerBox-native
+integrations.  Mirrors the failure-isolation pattern of
+`test_notes_db_async.py` — the init step must register the calendar
+tools when possible AND swallow import errors at WARNING so a broken
+optional integration doesn't take down boot.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from dragon_voice.lifecycle.integrations_init import init_integration_tools
+
+
+class _FakeRegistry:
+    """Records registrations + lets tests assert by tool name."""
+
+    def __init__(self) -> None:
+        self.registered: list[object] = []
+
+    def register(self, tool) -> None:  # noqa: ANN001
+        self.registered.append(tool)
+
+    @property
+    def names(self) -> list[str]:
+        return [getattr(t, "name", repr(t)) for t in self.registered]
+
+
+@pytest.mark.asyncio
+async def test_registers_all_four_calendar_tools_on_clean_registry():
+    server = MagicMock()
+    server._tool_registry = _FakeRegistry()
+
+    await init_integration_tools(server)
+
+    names = server._tool_registry.names
+    assert "calendar_today" in names
+    assert "calendar_week" in names
+    assert "calendar_create" in names
+    assert "calendar_cancel" in names
+
+
+@pytest.mark.asyncio
+async def test_no_tool_registry_is_silent_noop():
+    """If the registry didn't initialize (e.g. agentic init failed) the
+    function must return cleanly — boot continues without tools."""
+    server = MagicMock()
+    server._tool_registry = None
+    # Must not raise.
+    await init_integration_tools(server)
+
+
+@pytest.mark.asyncio
+async def test_calendar_module_import_failure_is_swallowed(monkeypatch, caplog):
+    """Simulate the google_calendar_tool module being missing — boot
+    must continue, with a single WARNING.  Confirms the try/except
+    failure-isolation invariant lives at the right boundary."""
+    # Drop the module from cache so the next import sees our stub.
+    monkeypatch.delitem(
+        sys.modules, "dragon_voice.tools.google_calendar_tool", raising=False,
+    )
+
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __import__
+
+    def _raising_import(name, *args, **kwargs):
+        if name == "dragon_voice.tools.google_calendar_tool":
+            raise ImportError("simulated: calendar tool unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", _raising_import)
+
+    server = MagicMock()
+    server._tool_registry = _FakeRegistry()
+    with caplog.at_level("WARNING"):
+        await init_integration_tools(server)
+
+    # No tools registered, no exception escaped.
+    assert server._tool_registry.registered == []
+    assert any(
+        "Google Calendar tools not available" in rec.message
+        for rec in caplog.records
+    )

--- a/tests/test_integrations_init.py
+++ b/tests/test_integrations_init.py
@@ -32,17 +32,48 @@ class _FakeRegistry:
 
 
 @pytest.mark.asyncio
-async def test_registers_all_four_calendar_tools_on_clean_registry():
+async def test_registers_all_calendar_and_gmail_tools_on_clean_registry():
     server = MagicMock()
     server._tool_registry = _FakeRegistry()
 
     await init_integration_tools(server)
 
     names = server._tool_registry.names
+    # Calendar — 4 tools.
     assert "calendar_today" in names
     assert "calendar_week" in names
     assert "calendar_create" in names
     assert "calendar_cancel" in names
+    # Gmail — 5 tools (Phase 2).
+    assert "gmail_unread" in names
+    assert "gmail_search" in names
+    assert "gmail_read" in names
+    assert "gmail_send" in names
+    assert "gmail_archive" in names
+
+
+@pytest.mark.asyncio
+async def test_gmail_import_failure_does_not_block_calendar(monkeypatch, caplog):
+    """If Gmail's tool module fails to import, Calendar tools still
+    register — each integration block is independently failure-isolated."""
+    monkeypatch.delitem(sys.modules, "dragon_voice.tools.gmail_tool", raising=False)
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __import__
+
+    def _raising_import(name, *args, **kwargs):
+        if name == "dragon_voice.tools.gmail_tool":
+            raise ImportError("simulated: gmail tool unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", _raising_import)
+    server = MagicMock()
+    server._tool_registry = _FakeRegistry()
+    with caplog.at_level("WARNING"):
+        await init_integration_tools(server)
+
+    names = server._tool_registry.names
+    assert "calendar_today" in names  # Calendar still landed.
+    assert "gmail_unread" not in names
+    assert any("Gmail tools not available" in r.message for r in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -56,15 +87,13 @@ async def test_no_tool_registry_is_silent_noop():
 
 
 @pytest.mark.asyncio
-async def test_calendar_module_import_failure_is_swallowed(monkeypatch, caplog):
-    """Simulate the google_calendar_tool module being missing — boot
-    must continue, with a single WARNING.  Confirms the try/except
-    failure-isolation invariant lives at the right boundary."""
-    # Drop the module from cache so the next import sees our stub.
+async def test_calendar_import_failure_does_not_block_gmail(monkeypatch, caplog):
+    """Simulate the google_calendar_tool module being missing.  Boot
+    must continue with a single WARNING AND the Gmail tools still
+    register — each integration block is independently failure-isolated."""
     monkeypatch.delitem(
         sys.modules, "dragon_voice.tools.google_calendar_tool", raising=False,
     )
-
     real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __import__
 
     def _raising_import(name, *args, **kwargs):
@@ -79,8 +108,9 @@ async def test_calendar_module_import_failure_is_swallowed(monkeypatch, caplog):
     with caplog.at_level("WARNING"):
         await init_integration_tools(server)
 
-    # No tools registered, no exception escaped.
-    assert server._tool_registry.registered == []
+    names = server._tool_registry.names
+    assert "calendar_today" not in names
+    assert "gmail_unread" in names  # Gmail still landed.
     assert any(
         "Google Calendar tools not available" in rec.message
         for rec in caplog.records

--- a/tests/test_integrations_registry.py
+++ b/tests/test_integrations_registry.py
@@ -62,7 +62,7 @@ def test_create_integration_returns_instance():
     assert isinstance(integ, IntegrationBackend)
     assert integ.name == "google-calendar"
     assert integ.display_name == "Google Calendar"
-    assert integ.auth_kind == "oauth-device"
+    assert integ.auth_kind == "oauth-authcode"
 
 
 def test_reset_clears_then_restores_from_snapshot():

--- a/tests/test_oauth_auth_code.py
+++ b/tests/test_oauth_auth_code.py
@@ -1,0 +1,259 @@
+"""#341 / #345 — OAuth Authorization-Code-with-PKCE client.
+
+Pairs with `test_oauth_device_code.py` (the device-code path is kept
+for non-Google providers).  This file covers the new auth-code client
+that Google Calendar + Gmail use.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import time
+import urllib.parse
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.tools.integrations.oauth import (
+    AuthCodeChallenge,
+    DeviceCodeError,
+    OAuthAuthCodeClient,
+    OAuthTokens,
+    _pkce_pair,
+)
+
+
+@pytest.fixture
+def fake_session():
+    """aiohttp ClientSession stand-in — records POSTs + returns pre-canned responses."""
+    session = MagicMock()
+    session.closed = False
+    return session
+
+
+def _mock_response(json_data: dict, status: int = 200):
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=MagicMock(
+        status=status,
+        json=AsyncMock(return_value=json_data),
+    ))
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return cm
+
+
+def _make_client(session) -> OAuthAuthCodeClient:
+    return OAuthAuthCodeClient(
+        client_id="cid",
+        client_secret="csec",
+        scope="scope-x scope-y",
+        auth_url="https://accounts.example.com/auth",
+        token_url="https://oauth.example.com/token",
+        redirect_uri="https://callback.example.com/cb",
+        session=session,
+    )
+
+
+# ── _pkce_pair ──────────────────────────────────────────────────────
+
+
+def test_pkce_pair_verifier_meets_rfc_7636_length():
+    verifier, _challenge = _pkce_pair()
+    # RFC 7636 §4.1: verifier is 43–128 chars in [A-Za-z0-9-._~].
+    assert 43 <= len(verifier) <= 128
+    allowed = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+    assert set(verifier).issubset(allowed)
+
+
+def test_pkce_pair_challenge_is_sha256_of_verifier():
+    verifier, challenge = _pkce_pair()
+    expected = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode("ascii")).digest(),
+    ).rstrip(b"=").decode("ascii")
+    assert challenge == expected
+
+
+def test_pkce_pair_yields_unique_values():
+    pairs = [_pkce_pair() for _ in range(5)]
+    verifiers = {v for v, _ in pairs}
+    assert len(verifiers) == 5
+
+
+# ── start() ─────────────────────────────────────────────────────────
+
+
+def test_start_returns_authorization_url_with_pkce_and_state(fake_session):
+    client = _make_client(fake_session)
+    chal = client.start()
+    assert isinstance(chal, AuthCodeChallenge)
+
+    parsed = urllib.parse.urlparse(chal.authorization_url)
+    params = dict(urllib.parse.parse_qsl(parsed.query))
+    assert params["client_id"] == "cid"
+    assert params["redirect_uri"] == "https://callback.example.com/cb"
+    assert params["response_type"] == "code"
+    assert params["scope"] == "scope-x scope-y"
+    assert params["code_challenge_method"] == "S256"
+    assert params["state"] == chal.state
+    # The challenge in the URL is BASE64URL(SHA256(verifier)).
+    expected = base64.urlsafe_b64encode(
+        hashlib.sha256(chal.code_verifier.encode("ascii")).digest(),
+    ).rstrip(b"=").decode("ascii")
+    assert params["code_challenge"] == expected
+
+
+def test_start_applies_provider_extras(fake_session):
+    client = _make_client(fake_session)
+    chal = client.start(extra_params={
+        "access_type": "offline",
+        "prompt": "consent",
+    })
+    parsed = urllib.parse.urlparse(chal.authorization_url)
+    params = dict(urllib.parse.parse_qsl(parsed.query))
+    assert params["access_type"] == "offline"
+    assert params["prompt"] == "consent"
+
+
+def test_start_registers_pending_state_with_verifier(fake_session):
+    client = _make_client(fake_session)
+    chal = client.start()
+    entry = client._pending[chal.state]
+    assert entry["code_verifier"] == chal.code_verifier
+    assert entry["future"] is not None
+
+
+# ── resolve_callback + wait_for_callback ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_wait_for_callback_returns_code_after_resolve(fake_session):
+    client = _make_client(fake_session)
+    chal = client.start()
+
+    async def _resolver():
+        await asyncio.sleep(0)  # let the waiter park
+        client.resolve_callback(state=chal.state, code="AUTH-CODE-1", error=None)
+
+    code, _ = await asyncio.gather(
+        client.wait_for_callback(chal.state, timeout_s=5),
+        _resolver(),
+    )
+    assert code == "AUTH-CODE-1"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_callback_raises_on_provider_error(fake_session):
+    client = _make_client(fake_session)
+    chal = client.start()
+
+    async def _resolver():
+        await asyncio.sleep(0)
+        client.resolve_callback(state=chal.state, code=None, error="access_denied")
+
+    with pytest.raises(DeviceCodeError) as excinfo:
+        await asyncio.gather(
+            client.wait_for_callback(chal.state, timeout_s=5),
+            _resolver(),
+        )
+    assert excinfo.value.code == "access_denied"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_callback_times_out_as_expired_token(fake_session):
+    client = _make_client(fake_session)
+    chal = client.start()
+    with pytest.raises(DeviceCodeError) as excinfo:
+        # Tiny timeout — the resolver never runs.
+        await client.wait_for_callback(chal.state, timeout_s=0)
+    assert excinfo.value.code == "expired_token"
+
+
+def test_resolve_callback_unknown_state_does_not_raise(fake_session):
+    """Stale/forged states should log a warning, not crash the callback."""
+    client = _make_client(fake_session)
+    client.resolve_callback(state="never-issued", code="x", error=None)
+    # Test passes if the call returned cleanly.
+
+
+def test_wait_for_callback_unknown_state_raises_immediately(fake_session):
+    client = _make_client(fake_session)
+    with pytest.raises(DeviceCodeError) as excinfo:
+        # No coroutine awaited — the raise is synchronous.
+        asyncio.get_event_loop().run_until_complete(
+            client.wait_for_callback("never-issued", timeout_s=1),
+        )
+    assert excinfo.value.code == "unknown_state"
+
+
+# ── exchange_code_with_verifier ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_with_verifier_posts_pkce_payload(fake_session):
+    fake_session.post = MagicMock(return_value=_mock_response({
+        "access_token": "AT-1",
+        "refresh_token": "RT-1",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "scope": "scope-a scope-b",
+    }))
+    client = _make_client(fake_session)
+    tokens = await client.exchange_code_with_verifier(
+        code="AUTH-CODE-1", code_verifier="VERIFIER-X",
+    )
+    assert isinstance(tokens, OAuthTokens)
+    assert tokens.access_token == "AT-1"
+    assert tokens.refresh_token == "RT-1"
+    assert tokens.scopes == ["scope-a", "scope-b"]
+
+    payload = fake_session.post.call_args.kwargs["data"]
+    assert payload["grant_type"] == "authorization_code"
+    assert payload["code"] == "AUTH-CODE-1"
+    assert payload["code_verifier"] == "VERIFIER-X"
+    assert payload["client_id"] == "cid"
+    assert payload["client_secret"] == "csec"
+    assert payload["redirect_uri"] == "https://callback.example.com/cb"
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_raises_on_provider_400(fake_session):
+    fake_session.post = MagicMock(return_value=_mock_response(
+        {"error": "invalid_grant", "error_description": "code reused"},
+        status=400,
+    ))
+    client = _make_client(fake_session)
+    with pytest.raises(DeviceCodeError) as excinfo:
+        await client.exchange_code_with_verifier(code="x", code_verifier="v")
+    assert excinfo.value.code == "invalid_grant"
+
+
+# ── refresh ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_refresh_returns_new_access_token(fake_session):
+    fake_session.post = MagicMock(return_value=_mock_response({
+        "access_token": "AT-2",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "scope": "scope-a",
+    }))
+    client = _make_client(fake_session)
+    t0 = time.time()
+    new_tokens = await client.refresh("RT-OLD")
+    assert new_tokens.access_token == "AT-2"
+    assert new_tokens.expires_at >= t0 + 3500
+    # Server omitted refresh_token → preserve the prior one.
+    assert new_tokens.refresh_token == "RT-OLD"
+
+
+@pytest.mark.asyncio
+async def test_refresh_raises_on_provider_rejection(fake_session):
+    fake_session.post = MagicMock(return_value=_mock_response(
+        {"error": "invalid_grant"}, status=400,
+    ))
+    client = _make_client(fake_session)
+    with pytest.raises(DeviceCodeError) as excinfo:
+        await client.refresh("RT-DEAD")
+    assert excinfo.value.code == "invalid_grant"


### PR DESCRIPTION
## Summary

Stacked on #349 (multi-account).  Reuses the Phase 1 OAuth client + the multi-account state machine — just a new scope set + Gmail API v1.

### New LLM-callable tools (all accept optional \`account\`)

| Tool | Purpose |
|---|---|
| \`gmail_unread\` | List unread (from / subject / snippet / id) |
| \`gmail_search\` | Gmail-syntax query (from:X, subject:Y, has:attachment, newer_than:Nd, …) |
| \`gmail_read\` | Fetch full body (text/plain preferred, HTML fallback) |
| \`gmail_send\` | Compose + send.  \`in_reply_to\` threads correctly via Message-Id + threadId lookup |
| \`gmail_archive\` | Remove INBOX label |

### Backend

- Same multi-account pattern as \`GoogleCalendarIntegration\` (\`_accounts: dict[email, OAuthTokens]\` + \`_default_account_id\`).
- Each connected Google account gets its own token bundle at \`{integrations_dir}/gmail/{email}.json\` — sibling to \`{integrations_dir}/google-calendar/{email}.json\`, so the same Google account is consented separately per integration.
- Scopes: \`gmail.readonly + gmail.modify + gmail.send + openid + email\`.
- \`list_messages\` fans out metadata fetches concurrently (asyncio.gather), capped at 25 ids/call.
- \`send_message\` builds an RFC 822 \`EmailMessage\`, base64url-encodes the raw bytes, posts to \`/messages/send\`.
- Refresh-on-401 per account.

## Live verification

```
$ curl -H "Authorization: Bearer ***" http://localhost:3502/api/v1/integrations | jq '.integrations[].name'
"gmail"
"google-calendar"

$ curl -X POST -H "Authorization: Bearer ***" http://localhost:3502/api/v1/integrations/gmail/connect
{
  "kind": "oauth-authcode",
  "request_id": "f84e3b232dd149a1a31e801060ff95a7",
  "verification_url": "https://accounts.google.com/o/oauth2/v2/auth?...scope=gmail.readonly+gmail.modify+gmail.send+openid+email...",
  ...
}
```

Boot log confirms 5 Gmail tools registered alongside the 4 Calendar tools — independent try/except blocks per integration so a broken import on one doesn't block the other.

To actually complete a Gmail connection you'll need to:
1. Open the \`verification_url\` on your phone
2. Sign in to Google + grant the 3 Gmail scopes (consent screen now shows them)
3. Google redirects back to Dragon → callback → tokens saved at \`gmail/{email}.json\`

The Google Cloud OAuth client may need the Gmail scopes added to its consent screen if it was originally scoped only for Calendar — Google will surface a clear error if so.

## Test plan

- [x] Ruff narrow gate (\`F821,F722,F811,F823,B006,B904,E722,B007,RUF006\`) across \`dragon_voice/\` + \`tests/\`.
- [x] 80/80 integration tests passing locally (18 new Gmail tests).
- [x] Live verification on Dragon: integration listed, connect endpoint generates a properly-scoped Google auth URL.
- [ ] End-to-end connect flow — needs user action in browser; do this when convenient.
- [ ] Tab5 UI surface for Gmail rows / per-tool affordances — lorcan35/TinkerTab#571.

refs #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)