### PR TITLE
fix(tts): Kokoro espeak-ng compat shim

### DIFF
--- a/dragon_voice/tts/kokoro_tts.py
+++ b/dragon_voice/tts/kokoro_tts.py
@@ -31,6 +31,29 @@ class KokoroBackend(TTSBackend):
 
     async def initialize(self) -> None:
         """Load the Kokoro model."""
+        # Compat shim for kokoro-onnx 0.5.0 + phonemizer-fork ≥ 3.3:
+        # (a) restore the static `EspeakWrapper.set_data_path` method
+        #     (became a `data_path` property in 3.3).
+        # (b) IGNORE whatever path kokoro hands us — it comes from
+        #     `espeakng_loader.get_data_path()` which is baked in at
+        #     wheel-build time and points at the CI runner's tmpdir
+        #     (`/home/runner/work/espeakng-loader/…`).  Force the
+        #     system espeak-ng-data dir, which DOES exist.
+        try:
+            from phonemizer.backend.espeak.wrapper import EspeakWrapper
+            _SYS_ESPEAK_DATA = "/usr/lib/aarch64-linux-gnu/espeak-ng-data"
+            if Path(_SYS_ESPEAK_DATA).is_dir():
+                def _set_data_path(_ignored):
+                    EspeakWrapper.data_path = _SYS_ESPEAK_DATA
+                EspeakWrapper.set_data_path = staticmethod(_set_data_path)
+                EspeakWrapper.data_path = _SYS_ESPEAK_DATA
+            elif not hasattr(EspeakWrapper, "set_data_path"):
+                def _set_data_path(path):
+                    EspeakWrapper.data_path = path
+                EspeakWrapper.set_data_path = staticmethod(_set_data_path)
+        except Exception as patch_err:
+            logger.warning("phonemizer compat shim skipped: %s", patch_err)
+
         try:
             import kokoro_onnx
         except ImportError as err:


### PR DESCRIPTION
## Summary
Restore the missing `EspeakWrapper.set_data_path` static method (removed in phonemizer-fork 3.3) and pin the data path to Dragon's system espeak-ng-data dir so kokoro can't fall through to `libespeak-ng.so`'s baked-in CI runner path.

Closes #355.

## Why
Kokoro abort-killed the voice service mid-synthesize with `Error processing file '/home/runner/work/espeakng-loader/...': No such file or directory.`  Two compounding issues: (1) `kokoro-onnx` 0.5.0 calls `EspeakWrapper.set_data_path(p)` which doesn't exist in `phonemizer-fork >= 3.3`; (2) the bundled `libespeak-ng.so` has the CI build path hardcoded as its default, and falls back to it when not explicitly overridden.

## Test plan
- [x] Service stays up across a full Tab5 voice turn (verified live on Dragon)
- [x] `/health` reports `tts.name = "Kokoro (af_heart)"`, `ok: true`
- [x] No SIGKILL / phontab errors in journalctl
- [ ] Pin upstream kokoro-onnx version / file espeakng-loader issue (follow-up)