### PR TITLE
fix(pipeline): flip _pooled_* after pool registration

### DIFF
--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -1604,6 +1604,19 @@ class VoicePipeline:
                 if pool is not None:
                     for t in init_tasks:
                         pool[t.key] = t.instance
+                # Flip `_pooled_*` once registered — otherwise the
+                # NEXT swap (which sees `old_is_pooled=False`) would
+                # shut down a backend the pool still references, and
+                # the third swap back to it would return a
+                # shut-down instance with `_tts is None`.  Mirrors
+                # the initial-init logic at lines 312-321.
+                for t in init_tasks:
+                    if t.kind == "stt":
+                        self._pooled_stt = True
+                    elif t.kind == "tts":
+                        self._pooled_tts = True
+                    elif t.kind == "llm":
+                        self._pooled_llm = True
                 logger.info("Backend swap complete")
 
             # Audit B6 (#154): when swapping INTO a cloud STT mode,


### PR DESCRIPTION
## Summary
After `pipeline.swap_backends()` registers a freshly-built backend in the pool, also set `self._pooled_*` to `True` — without it the next swap shuts down a pool-shared instance, and the swap after that returns a shut-down zombie that errors with `not initialized` on synth.

Closes #357.

## Why
`swap_one_backend` decides whether to shut down the OLD backend based on `old_is_pooled`.  The bug left that flag stale after pool registration, so the OLD backend got torn down even though the pool still referenced it.  Mirrors the initial-init logic already in place at `pipeline.py:312-321`.

## Test plan
- [x] Live 4-step swap chain `kokoro→supertonic→kokoro→supertonic` runs clean (no "not initialized")
- [x] Per-swap log sequence verified: `Initializing X` → `loaded successfully` → `Backend swap complete`
- [ ] Regression test for the 4-step chain in `tests/test_backend_pool.py` (follow-up)