### PR TITLE
feat(stt): route /api/v1/transcribe to a dedicated backend

### DIFF
--- a/dragon_voice/api/synthesize.py
+++ b/dragon_voice/api/synthesize.py
@@ -1,6 +1,7 @@
 """TTS synthesis and STT transcription API routes."""
 
 import base64
+import copy
 import json
 import logging
 import time
@@ -29,11 +30,29 @@ class SynthesizeRoutes:
         app.router.add_get("/api/ota/firmware.bin", self.ota_firmware)
 
     async def _ensure_stt(self) -> STTBackend | None:
+        """Build the STT backend used for /api/v1/transcribe.
+
+        When `stt.transcribe_backend` is set in config, we build a
+        DEDICATED backend (typically whisper.cpp) for batched WAV
+        uploads — independent of the voice-pipeline's `stt.backend`
+        (typically Moonshine, tuned for short streaming turns).
+        This is what makes long-form dictation work without stalling
+        the streaming model.
+        """
         if self._stt:
             return self._stt
-        self._stt = create_stt(self._config.stt)
+        cfg = self._config.stt
+        if cfg.transcribe_backend:
+            override = copy.deepcopy(cfg)
+            override.backend = cfg.transcribe_backend
+            if cfg.transcribe_model:
+                override.model = cfg.transcribe_model
+            stt_cfg = override
+        else:
+            stt_cfg = cfg
+        self._stt = create_stt(stt_cfg)
         await self._stt.initialize()
-        logger.info("STT initialized for API: %s", self._stt.name)
+        logger.info("Transcribe STT initialized: %s", self._stt.name)
         return self._stt
 
     async def _ensure_tts(self) -> TTSBackend | None:

--- a/dragon_voice/config.py
+++ b/dragon_voice/config.py
@@ -71,6 +71,13 @@ class STTConfig:
     # OpenRouter cloud STT (key auto-populated from llm.openrouter_api_key)
     openrouter_api_key: str = ""
     openrouter_url: str = "https://openrouter.ai/api/v1"
+    # Dedicated backend for the REST `/api/v1/transcribe` endpoint
+    # (long-form dictation).  When set, the transcribe endpoint uses
+    # this instead of `backend` — keeps Moonshine's low-latency
+    # streaming model on the voice WS pipeline while routing
+    # batched WAV uploads to a long-form-friendly Whisper model.
+    transcribe_backend: str = ""
+    transcribe_model: str = ""
 
 
 @dataclass
@@ -321,6 +328,11 @@ class VoiceConfig:
         if self.stt.backend not in valid_stt:
             errors.append(
                 f"stt.backend must be one of {valid_stt}, got '{self.stt.backend}'"
+            )
+        if self.stt.transcribe_backend and self.stt.transcribe_backend not in valid_stt:
+            errors.append(
+                f"stt.transcribe_backend must be one of {valid_stt} (or empty), "
+                f"got '{self.stt.transcribe_backend}'"
             )
 
         valid_llm = ("ollama", "openrouter", "lmstudio", "npu_genie", "tinkerclaw", "dual", "router")


### PR DESCRIPTION
## Summary
Add `stt.transcribe_backend` + `stt.transcribe_model` config fields.  When set, `/api/v1/transcribe` builds a separate STT instance from those overrides — the voice WS pipeline keeps Moonshine, the REST transcribe endpoint can use whisper.cpp for long-form audio.

Closes #359.

## Why
Moonshine's streaming model is tuned for short, low-latency voice-assistant turns.  Multi-minute meeting WAVs stall it.  Whisper.cpp has internal VAD chunking and handles long-form cleanly.  This change lets both worlds coexist.

## Test plan
- [x] `POST /api/v1/transcribe` returns 200 with whisper-source transcript when `transcribe_backend: whisper_cpp` set
- [x] Voice WS pipeline still uses Moonshine (no change)
- [x] Log line `Transcribe STT initialized: whisper.cpp (base.en)` confirms separate instance
- [ ] Unit test for the override deep-copy logic (follow-up)