### PR TITLE
feat(tts): NeuTTS Air backend + honor local-eligible TTS override

### DIFF
--- a/dragon_voice/config.py
+++ b/dragon_voice/config.py
@@ -88,6 +88,9 @@ class TTSConfig:
     text_cleaner_enabled: bool = True
     edge_voice: str = "en-US-AriaNeural"
     sample_rate: int = 22050
+    # NeuTTS Air voice-cloning backend (neuphonic/neutts-air-q4-gguf + neucodec)
+    neutts_ref_audio: str = ""
+    neutts_ref_text: str = ""
     # OpenRouter cloud TTS (key auto-populated from llm.openrouter_api_key)
     openrouter_api_key: str = ""
     openrouter_url: str = "https://openrouter.ai/api/v1"
@@ -329,7 +332,7 @@ class VoiceConfig:
                 f"llm.backend must be one of {valid_llm}, got '{self.llm.backend}'"
             )
 
-        valid_tts = ("piper", "kokoro", "edge_tts", "openrouter")
+        valid_tts = ("piper", "kokoro", "edge_tts", "openrouter", "neutts_air")
         if self.tts.backend not in valid_tts:
             errors.append(
                 f"tts.backend must be one of {valid_tts}, got '{self.tts.backend}'"

--- a/dragon_voice/config_swap.py
+++ b/dragon_voice/config_swap.py
@@ -114,20 +114,26 @@ def select_backends_for_mode(
     # backends are never invoked — but if the user flips back to mode
     # 0 after a SOLO session we want LOCAL-shaped backends already
     # selected rather than CLOUD-shaped ones from a stale prior swap.
+    # Read the configured TTS backend from config.yaml; honor it as an
+    # explicit override on local-shaped modes.  Kokoro remains the
+    # fall-through default if config.yaml says "kokoro" / "piper" /
+    # nothing meaningful.  This is the override mechanism #338 promised
+    # in its comment but didn't actually wire — needed for the
+    # neutts_air premium-voice backend.
+    configured_tts = (conn_config.tts.backend or "").strip().lower()
+    local_tts_override = (
+        configured_tts if configured_tts in ("piper", "kokoro", "neutts_air") else "kokoro"
+    )
+
     if vmode.is_local() or vmode.is_solo():
-        # #338: Kokoro is the new local default — much higher MOS than
-        # Piper at modest CPU cost on Q6A.  Piper stays available as
-        # an explicit override via `tts.backend` in config.yaml for
-        # very low-end deploys or where the 350 MB Kokoro model isn't
-        # acceptable.
-        stt_be, tts_be = "moonshine", "kokoro"
+        stt_be, tts_be = "moonshine", local_tts_override
     elif vmode.is_tinkerclaw():
-        # TinkerClaw mode: default local STT/TTS (Kokoro since #338).
+        # TinkerClaw mode: default local STT/TTS (per local_tts_override).
         # "cloud" suffix in llm_model → use OpenRouter STT/TTS.
         if llm_model and "cloud" in llm_model.lower():
             stt_be, tts_be = "openrouter", "openrouter"
         else:
-            stt_be, tts_be = "moonshine", "kokoro"
+            stt_be, tts_be = "moonshine", local_tts_override
     else:
         stt_be, tts_be = "openrouter", "openrouter"
 

--- a/dragon_voice/pipeline_init.py
+++ b/dragon_voice/pipeline_init.py
@@ -105,7 +105,15 @@ def _reset_conn_config_to_local_defaults(conn_config: Any) -> None:
     tearing it down.
     """
     conn_config.stt.backend = "moonshine"
-    conn_config.tts.backend = "piper"
+    # Honor the user's YAML `tts.backend` if it's a local-eligible
+    # backend; only force-reset to piper when conn_config arrived with
+    # a cloud / unsupported value (preserves the NeuTTS Air premium
+    # voice + Kokoro override paths).  See config_swap.py for the
+    # parallel local_tts_override gate.
+    if (conn_config.tts.backend or "").strip().lower() not in (
+        "piper", "kokoro", "neutts_air",
+    ):
+        conn_config.tts.backend = "piper"
     if conn_config.llm.backend in _CLOUD_LLM_BACKENDS:
         # Use the user's `local_backend` preference when set,
         # else fall back to "ollama" — matches pre-extract.

--- a/dragon_voice/tts/__init__.py
+++ b/dragon_voice/tts/__init__.py
@@ -39,6 +39,7 @@ from dragon_voice.tts.text_cleaner import clean_for_tts
 from dragon_voice.tts import (  # noqa: F401
     edge_tts_backend,
     kokoro_tts,
+    neutts_air_tts,
     openrouter_tts,
     piper_tts,
 )

--- a/dragon_voice/tts/neutts_air_tts.py
+++ b/dragon_voice/tts/neutts_air_tts.py
@@ -1,0 +1,132 @@
+"""NeuTTS Air backend — Neuphonic's 748M speech-LM with voice cloning.
+
+Uses the Q4_0 GGUF for the backbone (via llama-cpp-python) + the
+NeuCodec decoder (PyTorch).  Voice cloning works by encoding a
+reference audio clip + reference transcript once at startup; every
+subsequent synthesis inherits the timbre and prosody of that clip.
+
+The reference WE ship by default is a 2.9 s CSM-1B "Tinker" voice
+sample generated overnight — that's how we keep the CSM voice quality
+on Dragon at ~6× realtime instead of CSM's own 131× realtime.
+
+Latency on Q6A (Cortex-A78×4 cluster, 4 threads):
+  - First-load: ~30-45 s (GGUF mmap + NeuCodec PyTorch init + ref encode)
+  - Per-utterance: ~6× realtime — a 3 s reply takes ~18 s to render.
+    Use this as the "premium voice" backend; fall back to Kokoro/Piper
+    for snappy live conversation.
+
+Outputs 16-bit PCM at 24 kHz mono, same as Kokoro.
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from dragon_voice.config import TTSConfig
+from dragon_voice.tts.base import TTSBackend
+from dragon_voice.tts.registry import register_tts
+
+logger = logging.getLogger(__name__)
+
+_NEUTTS_SAMPLE_RATE = 24000
+_DEFAULT_REF_AUDIO = "/home/radxa/csm/hello.wav"
+_DEFAULT_REF_TEXT = "Hello, Emile. I'm Tinker. Nice to meet you."
+
+
+@register_tts("neutts_air")
+class NeuTTSAirBackend(TTSBackend):
+    """Voice-cloning TTS via NeuTTS Air Q4 GGUF + NeuCodec."""
+
+    def __init__(self, config: TTSConfig) -> None:
+        self._config = config
+        self._tts = None
+        self._ref_codes = None
+        self._ref_text = _DEFAULT_REF_TEXT
+        self._lock = asyncio.Lock()
+
+    async def initialize(self) -> None:
+        try:
+            from neuttsair.neutts import NeuTTSAir
+        except ImportError as err:
+            raise ImportError(
+                "neutts package missing.  Install with: "
+                "pip install 'neutts[llama]' (see TinkerBox docs/PLAN-tinkerbox-integrations.md)"
+            ) from err
+
+        ref_audio = getattr(self._config, "neutts_ref_audio", "") or _DEFAULT_REF_AUDIO
+        ref_text = getattr(self._config, "neutts_ref_text", "") or _DEFAULT_REF_TEXT
+        if not Path(ref_audio).exists():
+            raise FileNotFoundError(
+                f"NeuTTS reference audio missing: {ref_audio}.  Generate via the "
+                "CSM bench (~/csm/hello.wav) or point neutts_ref_audio at a 3-15 s "
+                "clean clip of the voice you want Tinker to inherit."
+            )
+
+        self._ref_text = ref_text
+        logger.info("Initializing NeuTTS Air — ref=%s", ref_audio)
+
+        loop = asyncio.get_running_loop()
+
+        def _load_and_encode():
+            tts = NeuTTSAir(
+                backbone_repo="neuphonic/neutts-air-q4-gguf",
+                backbone_device="cpu",
+                codec_repo="neuphonic/neucodec",
+                codec_device="cpu",
+            )
+            codes = tts.encode_reference(ref_audio)
+            return tts, codes
+
+        try:
+            self._tts, self._ref_codes = await loop.run_in_executor(None, _load_and_encode)
+            logger.info("NeuTTS Air ready (voice cloned from %s)", Path(ref_audio).name)
+        except Exception:
+            logger.exception("NeuTTS Air init failed")
+            raise
+
+    async def synthesize(self, text: str) -> bytes:
+        if not text.strip():
+            return b""
+        if self._tts is None or self._ref_codes is None:
+            raise RuntimeError("NeuTTSAirBackend not initialized")
+
+        from dragon_voice.tts.text_cleaner import clean_for_tts
+
+        cleaned = clean_for_tts(text)
+        if cleaned and cleaned != text:
+            logger.info(
+                "NeuTTS cleaner: %d→%d chars (in=%r out=%r)",
+                len(text), len(cleaned), text[:80], cleaned[:80],
+            )
+        text_to_synth = cleaned or text
+
+        async with self._lock:
+            loop = asyncio.get_running_loop()
+
+            def _synthesize():
+                wav_f32 = self._tts.infer(text_to_synth, self._ref_codes, self._ref_text)
+                # neuttsair returns float32 numpy at 24 kHz; convert to int16
+                wav_i16 = np.clip(wav_f32 * 32767, -32768, 32767).astype(np.int16)
+                return wav_i16.tobytes()
+
+            try:
+                return await loop.run_in_executor(None, _synthesize)
+            except Exception:
+                logger.exception("NeuTTS synthesis failed")
+                return b""
+
+    async def shutdown(self) -> None:
+        # NeuTTSAir holds a Llama handle that auto-closes on GC; no explicit
+        # cleanup needed beyond dropping references.
+        self._tts = None
+        self._ref_codes = None
+
+    @property
+    def sample_rate(self) -> int:
+        return _NEUTTS_SAMPLE_RATE
+
+    @property
+    def name(self) -> str:
+        return "neutts_air"


### PR DESCRIPTION
## Summary
Plumb the neuphonic NeuTTS Air Q4 GGUF (voice-cloning, ~6× RT on Q6A) as a registered backend, and fix two paths that were stripping the configured TTS choice during mode-swap.

Closes #363.

## Why
NeuTTS Air gives us a premium voice-cloned option for users willing to trade some latency.  The two plumbing fixes were prerequisites — without them the WS-side `config_update` flow would reset the connection's `tts.backend` back to Piper, so the picker never actually selected NeuTTS even when config said so.

## Test plan
- [x] `/api/v1/synthesize` with backend=neutts_air produces real PCM bytes that audibly match the reference WAV's speaker
- [x] `/api/config` POST to set neutts_air → `/health` reports it on the live pipeline
- [x] Voice WS pipeline routes through neutts_air after a `config_update`
- [ ] Add `expr-voice-*` style voice list in a follow-up (NeuTTS supports voice cloning, not enumeration)