### PR TITLE
feat(tts): Supertonic-3 + KittenTTS + Dashboard picker

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -715,16 +715,27 @@ tr.clickable { cursor: pointer; }
       </div>
       <div class="form-group">
         <label>TTS Backend</label>
-        <select id="cfg-tts">
-          <option value="piper">piper</option>
-          <option value="kokoro">kokoro</option>
-          <option value="edge_tts">edge_tts</option>
-          <option value="openrouter">openrouter</option>
+        <select id="cfg-tts" onchange="onTtsBackendChange()">
+          <option value="piper">piper — fast, robotic</option>
+          <option value="kokoro">kokoro — small, expressive (default)</option>
+          <option value="supertonic">supertonic — 10 voices, &lt;laugh&gt; tags</option>
+          <option value="kitten">kitten — 8 expression voices, tiny</option>
+          <option value="neutts_air">neutts_air — voice cloning, slow</option>
+          <option value="edge_tts">edge_tts — cloud, natural</option>
+          <option value="openrouter">openrouter — cloud, gpt-audio-mini</option>
         </select>
       </div>
       <div class="form-group">
-        <label>TTS Voice / Model</label>
-        <input id="cfg-tts-model" type="text" placeholder="e.g. en_US-lessac-medium">
+        <label>TTS Voice / Model <span id="cfg-tts-model-hint" style="color:var(--muted); font-weight:normal;"></span></label>
+        <input id="cfg-tts-model" type="text" placeholder="">
+      </div>
+      <div class="form-group full">
+        <label>Preview Voice</label>
+        <div style="display:flex; gap:8px; align-items:center;">
+          <input id="cfg-tts-preview-text" type="text" placeholder="Hello, this is Tinker speaking." style="flex:1;" value="Hello, this is Tinker speaking.">
+          <button class="btn" id="btn-tts-preview" onclick="previewVoice()">▶ Preview</button>
+          <span class="feedback" id="tts-preview-feedback"></span>
+        </div>
       </div>
       <div class="form-group">
         <label>LLM Backend</label>
@@ -1366,6 +1377,75 @@ async function loadConfig() {
   } catch(e) { console.warn('Config load failed:', e); }
 }
 
+// Voice/Model field is BACKEND-specific.  Carrying a Piper voice name
+// across to Kitten errors out at synth time; clear + hint on change.
+const TTS_HINTS = {
+  piper:      { ph: 'e.g. en_US-lessac-medium', hint: '(piper voice id)' },
+  kokoro:     { ph: 'e.g. af_heart, af_bella, am_michael', hint: '(kokoro voice)' },
+  supertonic: { ph: 'F1 F2 F3 F4 F5 M1 M2 M3 M4 M5', hint: '(supertonic voice — leave blank for F1)' },
+  kitten:     { ph: 'expr-voice-2-m / expr-voice-3-f / etc.', hint: '(kitten voice — leave blank for expr-voice-2-f)' },
+  neutts_air: { ph: '/path/to/reference.wav', hint: '(NeuTTS reference audio path)' },
+  edge_tts:   { ph: 'e.g. en-US-AriaNeural', hint: '(edge voice id)' },
+  openrouter: { ph: 'e.g. alloy, nova, echo', hint: '(openrouter voice)' },
+};
+
+function onTtsBackendChange() {
+  const tts = $('cfg-tts').value;
+  const cfg = TTS_HINTS[tts] || {ph: '', hint: ''};
+  const inp = $('cfg-tts-model');
+  // Clear stale carry-over so a Piper voice name doesn't get
+  // shipped to Kitten (synth would KeyError).
+  inp.value = '';
+  inp.placeholder = cfg.ph;
+  $('cfg-tts-model-hint').textContent = cfg.hint;
+}
+
+async function previewVoice() {
+  const btn = $('btn-tts-preview'), fb = $('tts-preview-feedback');
+  const text = ($('cfg-tts-preview-text').value || '').trim();
+  if (!text) { fb.textContent = 'Type something to preview'; return; }
+  btn.disabled = true;
+  fb.textContent = 'Synthesizing…';
+  try {
+    // Hits Dragon directly so the dashboard doesn't need to proxy
+    // raw audio bytes.  Bearer token comes from the same auth header
+    // chain used for /api/voice-config (server side).
+    const r = await fetch(P + '/api/v1/synthesize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+      body: JSON.stringify({ text, sample_rate: 16000 }),
+    });
+    if (!r.ok) {
+      const e = await r.json().catch(()=>({error: r.statusText}));
+      fb.textContent = 'Error: ' + (e.error || r.statusText);
+      return;
+    }
+    const data = await r.json();
+    fb.textContent = `${data.tts_ms}ms · ${data.duration_s}s`;
+    // Decode base64 PCM and play via WebAudio
+    const raw = atob(data.audio_base64);
+    const buf = new Int16Array(raw.length / 2);
+    for (let i = 0; i < buf.length; i++) {
+      buf[i] = (raw.charCodeAt(i*2) | (raw.charCodeAt(i*2+1) << 8));
+      if (buf[i] >= 0x8000) buf[i] -= 0x10000;
+    }
+    const sr = data.sample_rate || 16000;
+    const ac = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: sr });
+    const ab = ac.createBuffer(1, buf.length, sr);
+    const ch = ab.getChannelData(0);
+    for (let i = 0; i < buf.length; i++) ch[i] = buf[i] / 32768;
+    const src = ac.createBufferSource();
+    src.buffer = ab;
+    src.connect(ac.destination);
+    src.start();
+    src.onended = () => ac.close();
+  } catch (e) {
+    fb.textContent = 'Failed: ' + e.message;
+  } finally {
+    btn.disabled = false;
+  }
+}
+
 async function applyConfig() {
   const btn = $('btn-apply'), fb = $('cfg-feedback');
   btn.disabled = true;
@@ -1380,6 +1460,9 @@ async function applyConfig() {
   const ttsModel = $('cfg-tts-model').value;
   if (tts === 'piper') payload.tts.piper_model = ttsModel;
   else if (tts === 'kokoro') payload.tts.kokoro_voice = ttsModel;
+  else if (tts === 'supertonic') { if (ttsModel) payload.tts.supertonic_voice = ttsModel; }
+  else if (tts === 'kitten') { if (ttsModel) payload.tts.kitten_voice = ttsModel; }
+  else if (tts === 'neutts_air') { if (ttsModel) payload.tts.neutts_ref_audio = ttsModel; }
   else if (tts === 'edge_tts') payload.tts.edge_voice = ttsModel;
   else if (tts === 'openrouter') payload.tts.openrouter_voice = ttsModel;
 

--- a/dragon_voice/config.py
+++ b/dragon_voice/config.py
@@ -91,6 +91,15 @@ class TTSConfig:
     # NeuTTS Air voice-cloning backend (neuphonic/neutts-air-q4-gguf + neucodec)
     neutts_ref_audio: str = ""
     neutts_ref_text: str = ""
+    # Supertonic-3 (Supertone, MIT) — 10 voices (F1-F5/M1-M5) + inline
+    # expression tags (<laugh>/<sigh>/<breath>).  44.1 kHz output.
+    supertonic_voice: str = "F1"
+    supertonic_lang: str = "en"
+    supertonic_speed: float = 1.0
+    supertonic_steps: int = 8
+    # KittenTTS (Apache-2.0) — 8 expression voices, 24 kHz English-only.
+    kitten_voice: str = "expr-voice-2-f"
+    kitten_speed: float = 1.0
     # OpenRouter cloud TTS (key auto-populated from llm.openrouter_api_key)
     openrouter_api_key: str = ""
     openrouter_url: str = "https://openrouter.ai/api/v1"
@@ -332,7 +341,10 @@ class VoiceConfig:
                 f"llm.backend must be one of {valid_llm}, got '{self.llm.backend}'"
             )
 
-        valid_tts = ("piper", "kokoro", "edge_tts", "openrouter", "neutts_air")
+        valid_tts = (
+            "piper", "kokoro", "edge_tts", "openrouter", "neutts_air",
+            "supertonic", "kitten",
+        )
         if self.tts.backend not in valid_tts:
             errors.append(
                 f"tts.backend must be one of {valid_tts}, got '{self.tts.backend}'"

--- a/dragon_voice/tts/__init__.py
+++ b/dragon_voice/tts/__init__.py
@@ -38,10 +38,12 @@ from dragon_voice.tts.text_cleaner import clean_for_tts
 # registry doesn't care.
 from dragon_voice.tts import (  # noqa: F401
     edge_tts_backend,
+    kitten_tts,
     kokoro_tts,
     neutts_air_tts,
     openrouter_tts,
     piper_tts,
+    supertonic_tts,
 )
 
 

--- a/dragon_voice/tts/kitten_tts.py
+++ b/dragon_voice/tts/kitten_tts.py
@@ -1,0 +1,138 @@
+"""KittenTTS backend.
+
+~25M-param ONNX model (Apache-2.0) with 8 expression-named voices
+(``expr-voice-2-m``, ``expr-voice-2-f``, ``expr-voice-3-m``, etc.).
+English-only, 24 kHz.
+
+Lightweight English fast-path — much smaller than Supertonic /
+Kokoro, runs comfortably on ARM Cortex-A78 CPU via onnxruntime.
+Depends on espeak-ng-data (already installed system-wide on Dragon
+for Kokoro — same symlink shim works).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import numpy as np
+
+from dragon_voice.config import TTSConfig
+from dragon_voice.tts.base import TTSBackend
+from dragon_voice.tts.registry import register_tts
+
+logger = logging.getLogger(__name__)
+
+_KITTEN_SR = 24000
+
+
+@register_tts("kitten")
+class KittenBackend(TTSBackend):
+    """TTS backend using the kittentts ONNX library."""
+
+    def __init__(self, config: TTSConfig) -> None:
+        self._config = config
+        self._tts = None
+        self._lock = asyncio.Lock()
+
+    async def initialize(self) -> None:
+        # Kokoro's espeak-ng compat shim (installed earlier) also
+        # benefits KittenTTS — same phonemizer code path.
+        try:
+            from phonemizer.backend.espeak.wrapper import EspeakWrapper
+            from pathlib import Path
+            _SYS_ESPEAK = "/usr/lib/aarch64-linux-gnu/espeak-ng-data"
+            if Path(_SYS_ESPEAK).is_dir():
+                def _set_data_path(_ignored):
+                    EspeakWrapper.data_path = _SYS_ESPEAK
+                EspeakWrapper.set_data_path = staticmethod(_set_data_path)
+                EspeakWrapper.data_path = _SYS_ESPEAK
+        except Exception as patch_err:
+            logger.warning("phonemizer compat shim skipped: %s", patch_err)
+
+        try:
+            from kittentts import KittenTTS as _KittenTTS
+        except ImportError as err:
+            raise ImportError(
+                "kittentts is required for the kitten backend. "
+                "Install it: pip install kittentts"
+            ) from err
+
+        _DEFAULT = "expr-voice-2-f"
+        _VALID = {
+            f"expr-voice-{n}-{g}" for n in (2, 3, 4, 5) for g in ("m", "f")
+        }
+        requested = (
+            getattr(self._config, "kitten_voice", None) or _DEFAULT
+        )
+        if requested not in _VALID:
+            logger.warning(
+                "KittenTTS: voice %r not in valid set %s — falling back to %s",
+                requested, sorted(_VALID), _DEFAULT,
+            )
+            voice = _DEFAULT
+        else:
+            voice = requested
+        logger.info("Initializing KittenTTS — voice=%s", voice)
+
+        loop = asyncio.get_running_loop()
+
+        def _load():
+            return _KittenTTS()
+
+        try:
+            self._tts = await loop.run_in_executor(None, _load)
+            self._voice = voice
+            logger.info("KittenTTS loaded successfully")
+        except Exception:
+            logger.exception("Failed to initialize KittenTTS")
+            raise
+
+    async def synthesize(self, text: str) -> bytes:
+        """Synthesize to PCM int16 mono at 24 kHz."""
+        if not text.strip():
+            return b""
+        if self._tts is None:
+            raise RuntimeError("KittenBackend not initialized")
+
+        from dragon_voice.tts.text_cleaner import clean_for_tts
+        cleaned = clean_for_tts(text)
+        text = cleaned or text
+
+        speed = float(getattr(self._config, "kitten_speed", None) or 1.0)
+
+        async with self._lock:
+            loop = asyncio.get_running_loop()
+
+            def _synthesize():
+                audio = self._tts.generate(
+                    text=text, voice=self._voice, speed=speed
+                )
+                arr = np.asarray(audio).squeeze().astype(np.float32)
+                # KittenTTS emits float in roughly [-1, 1].  Clip + int16.
+                pcm = (arr * 32767.0).clip(-32768, 32767).astype(np.int16)
+                return pcm.tobytes()
+
+            try:
+                pcm = await loop.run_in_executor(None, _synthesize)
+            except Exception:
+                logger.exception("KittenTTS synthesis failed")
+                return b""
+
+        logger.debug(
+            "KittenTTS synthesized %d bytes for: %.40s...", len(pcm), text
+        )
+        return pcm
+
+    async def shutdown(self) -> None:
+        self._tts = None
+        logger.info("KittenTTS shut down")
+
+    @property
+    def sample_rate(self) -> int:
+        return _KITTEN_SR
+
+    @property
+    def name(self) -> str:
+        voice = getattr(self._config, "kitten_voice", None) or "expr-voice-2-f"
+        return f"KittenTTS ({voice})"

--- a/dragon_voice/tts/supertonic_tts.py
+++ b/dragon_voice/tts/supertonic_tts.py
@@ -1,0 +1,140 @@
+"""Supertonic-3 TTS backend.
+
+99M-param ONNX model from Supertone (MIT).  10 built-in voices
+(M1-M5 / F1-F5), 10 inline expression tags (``<laugh>``, ``<sigh>``,
+``<breath>``, etc.), zero-shot voice cloning via Voice Builder JSON.
+Output: 44.1 kHz mono float32 — converted to int16 PCM here.
+
+Runs sub-realtime on ARM Cortex-A78 CPU via onnxruntime.  No GPU
+needed.  Model + assets (~400 MB) auto-download into
+``~/.cache/supertonic3/`` on first ``initialize()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+import numpy as np
+
+from dragon_voice.config import TTSConfig
+from dragon_voice.tts.base import TTSBackend
+from dragon_voice.tts.registry import register_tts
+
+logger = logging.getLogger(__name__)
+
+_SUPERTONIC_SR = 44100
+
+
+@register_tts("supertonic")
+class SupertonicBackend(TTSBackend):
+    """TTS backend using the supertonic ONNX library."""
+
+    def __init__(self, config: TTSConfig) -> None:
+        self._config = config
+        self._tts = None
+        self._voice_style = None
+        self._lock = asyncio.Lock()
+
+    async def initialize(self) -> None:
+        try:
+            from supertonic import TTS as _TTS
+        except ImportError as err:
+            raise ImportError(
+                "supertonic is required for the supertonic backend. "
+                "Install it: pip install supertonic"
+            ) from err
+
+        _DEFAULT_VOICE = "F1"
+        _VALID = {f"{g}{n}" for g in ("F", "M") for n in (1, 2, 3, 4, 5)}
+        requested = (
+            getattr(self._config, "supertonic_voice", None) or _DEFAULT_VOICE
+        )
+        if requested not in _VALID:
+            logger.warning(
+                "Supertonic: voice %r not in valid set %s — falling back to %s",
+                requested, sorted(_VALID), _DEFAULT_VOICE,
+            )
+            voice_name = _DEFAULT_VOICE
+        else:
+            voice_name = requested
+        lang = (
+            getattr(self._config, "supertonic_lang", None) or "en"
+        )
+        logger.info(
+            "Initializing Supertonic — voice=%s lang=%s (auto-download)",
+            voice_name, lang,
+        )
+
+        loop = asyncio.get_running_loop()
+
+        def _load():
+            t = _TTS(auto_download=True)
+            style = t.get_voice_style(voice_name=voice_name)
+            return t, style
+
+        try:
+            self._tts, self._voice_style = await loop.run_in_executor(
+                None, _load
+            )
+            self._lang = lang
+            logger.info("Supertonic loaded successfully")
+        except Exception:
+            logger.exception("Failed to initialize Supertonic")
+            raise
+
+    async def synthesize(self, text: str) -> bytes:
+        """Synthesize to PCM int16 mono at 44.1 kHz."""
+        if not text.strip():
+            return b""
+        if self._tts is None:
+            raise RuntimeError("SupertonicBackend not initialized")
+
+        from dragon_voice.tts.text_cleaner import clean_for_tts
+        cleaned = clean_for_tts(text)
+        text = cleaned or text
+
+        speed = float(getattr(self._config, "supertonic_speed", None) or 1.0)
+        steps = int(getattr(self._config, "supertonic_steps", None) or 8)
+
+        async with self._lock:
+            loop = asyncio.get_running_loop()
+
+            def _synthesize():
+                wav, _ = self._tts.synthesize(
+                    text=text,
+                    voice_style=self._voice_style,
+                    lang=self._lang,
+                    total_steps=steps,
+                    speed=speed,
+                )
+                # wav: float32 in [-1, 1], possibly (1, N) — squeeze + i16
+                arr = np.asarray(wav).squeeze().astype(np.float32)
+                pcm = (arr * 32767.0).clip(-32768, 32767).astype(np.int16)
+                return pcm.tobytes()
+
+            try:
+                pcm = await loop.run_in_executor(None, _synthesize)
+            except Exception:
+                logger.exception("Supertonic synthesis failed")
+                return b""
+
+        logger.debug(
+            "Supertonic synthesized %d bytes for: %.40s...", len(pcm), text
+        )
+        return pcm
+
+    async def shutdown(self) -> None:
+        self._tts = None
+        self._voice_style = None
+        logger.info("Supertonic shut down")
+
+    @property
+    def sample_rate(self) -> int:
+        return _SUPERTONIC_SR
+
+    @property
+    def name(self) -> str:
+        voice = getattr(self._config, "supertonic_voice", None) or "F1"
+        return f"Supertonic ({voice})"


### PR DESCRIPTION
## Summary
Plumb 2 more sub-realtime ARM-CPU TTS engines (Supertonic-3 with `<laugh>` expression tags, KittenTTS with 8 expression voices) and expand the Dashboard with a TTS dropdown + Preview button.

Closes #365.  **Stacked on #364** — merge that first.

## Why
After Kokoro shipped, the user wanted more voice options to A/B in-product.  Both new backends are ONNX-based and load lightly on Q6A.  The Dashboard picker means flipping engines no longer requires curl gymnastics — and the Preview button lets you audition each before pushing to Tab5.

Both backends now self-validate the configured voice name on init: invalid → fall back + WARN log (stops a stale Piper voice name from crashing Kitten/Supertonic synth).

## Test plan
- [x] `/api/v1/backends` lists all 7 backends
- [x] `/api/v1/synthesize` with `backend=supertonic` returns ~65 KB PCM in ~3.9 s for a short phrase
- [x] `/api/v1/synthesize` with `backend=kitten` returns ~55 KB PCM in ~3.4 s
- [x] Deliberately bogus voice (`en_US-lessac-medium` to kitten) → fallback warning + valid synth
- [x] Dashboard Preview button plays audio in-browser
- [x] Dropdown change clears the Voice/Model input and updates placeholder