### PR TITLE
Local-mode capability rework — native llama-server tool-calling (Granite 19/20) + latency fix + suite green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,4 +143,5 @@ jobs:
             tests/test_oauth_auth_code.py \
             tests/test_integrations_init.py \
             tests/test_google_calendar_integration.py \
-            tests/test_gmail_integration.py
+            tests/test_gmail_integration.py \
+            tests/test_tool_openai_schema.py

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -19,6 +19,31 @@ sequentially across the whole file (don't restart per section).
 
 ---
 
+## 2026-05-29 — Test suite: 20 pre-existing failures (config_swap stub, oauth event-loop, live-audit probes)
+
+### OAuth PKCE waiter future bound to a stale/absent event loop
+- **Date:** 2026-05-29
+- **Symptom:** `tests/test_oauth_auth_code.py` start/unknown-state tests PASS in isolation but FAIL in the full suite with `RuntimeError: There is no current event loop in thread 'MainThread'`. 4 failures.
+- **Root Cause:** `oauth.py::OAuthAuthCodeClient.start()` is a *synchronous* URL-builder that eagerly created the waiter future via `asyncio.get_event_loop().create_future()`. Under Python 3.12 `get_event_loop()` with no running loop only warns the first time but RAISES once a prior test has closed/replaced the thread's loop (suite-order pollution). It's also semantically wrong: a future must live on the loop that awaits it, and `wait_for_callback()` can run on a different loop than `start()`.
+- **Fix:** Defer future creation — `start()` stores `"future": None`; `wait_for_callback()` creates it lazily via `asyncio.get_running_loop().create_future()`; `resolve_callback()` buffers the outcome (`pending_code`/`pending_error`) when it fires before the waiter parks, and `wait_for_callback()` honors the buffer immediately. The unknown-state test moved from `get_event_loop().run_until_complete` to `asyncio.run`.
+- **Prevention:** Never call `asyncio.get_event_loop()` in sync code on 3.12+. Create futures on the awaiting loop (`get_running_loop()`), not at registration time.
+
+### config_swap test stub drifted from production
+- **Date:** 2026-05-29
+- **Symptom:** 14 `SelectBackendsTests` fail with `AttributeError: '_StubVoiceCfg' object has no attribute 'tts'` at `config_swap.py:123`.
+- **Root Cause:** `select_backends_for_mode` reads `conn_config.tts.backend` (the #338 neutts_air/kokoro override). Real `VoiceConfig.tts` is a `TTSConfig`, so prod is correct; the hand-rolled `_StubVoiceCfg` only modeled `.llm` and was never updated.
+- **Fix:** Add `_StubTtsCfg(backend="kokoro")` + a `tts` field to the stub.
+- **Prevention:** When a hand-rolled test stub mirrors a production dataclass, construct the real dataclass (or assert the stub covers every attribute the unit reads).
+
+### Live-Dragon audit probes auto-collected as unit tests
+- **Date:** 2026-05-29
+- **Symptom:** 2 `tests/audit/test_d5_d6_ws.py` failures: "async def functions are not natively supported."
+- **Root Cause:** The file is a manual live-Dragon WS probe (its docstring says so) but its `async def test_*` functions got collected by pytest with no `@pytest.mark.asyncio` (repo uses strict pytest-asyncio mode).
+- **Fix:** Module-level `pytestmark = [pytest.mark.asyncio, pytest.mark.skipif(not RUN_LIVE_AUDIT, ...)]` — skip by default, run on opt-in against a live Dragon.
+- **Prevention:** Gate live-service probes behind an opt-in env var; don't let manual scripts masquerade as collectable unit tests.
+
+---
+
 ## 2026-05-15 — Local-mode dictation_summary hangs: Ollama 60-90 s vs ngrok / WS PONG timeout
 
 - **Date:** 2026-05-15

--- a/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
+++ b/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
@@ -147,16 +147,40 @@ contamination (exemplars removed).
 ### Component 3 — Model bake-off behind the harness
 
 With the harness (1) and the hardened path (2) in place, run the candidates and
-pick the **capability knee** (latency recorded but not gating):
+pick the **capability knee** (latency recorded but not gating).
 
-- **LFM2.5-VL-1.6B** — incumbent; does the native tools API lift it past 7/20?
-- **Qwen3-4B-Instruct-2507 @ Q4_K_M** (thinking off) — research-recommended
-  accuracy anchor, lighter quant than the Q8 we benched.
-- **Qwen3.5-4B @ Q4_K_M** — the parked 18/20 leader, now viable since latency
-  is not the gate.
-- **ministral-3:3b** — old default, baseline.
-- *(optional)* **LFM2.5-1.2B-Instruct** — fastest candidate, for the latency
-  data point.
+**Selection constraint (from the 2026-05-27 deep model survey):** because
+Component 2 uses the native OpenAI `tools=[...]` API, the candidate must emit
+tool calls that **round-trip cleanly through llama-server's OpenAI-compatible
+parser**. This is a hard gate equal to GGUF availability. Function-calling
+*specialists* with custom formats (Hammer 2.1, xLAM-2) fail it badly on this
+runtime class (independent eval: Hammer 0/8 on actual calls, xLAM ~15%) even
+though their weights are strong — they would require their bespoke parsers (the
+existing 5-dialect text parser path), not the native API. So the native-path
+bake-off favors **native-OpenAI-schema generalists**:
+
+- **NVIDIA Nemotron-3-Nano-4B @ Q4_K_M** — *new top challenger.* Mar 2026,
+  official NVIDIA GGUF, Mamba-2/Transformer hybrid (linear attention → fast on
+  the CPU-bound Dragon), tool-use as a primary RL target, native OpenAI tools +
+  `finish_reason:"tool_calls"`, reasoning toggleable off for latency. Scored
+  95% on an independent OpenAI-compatible tool-calling eval. `<think>` tokens
+  (12/13) must be stripped.
+- **Qwen3.5-4B @ Q4_K_M** — the parked 18/20 accuracy leader, BFCL-v4 0.503,
+  now viable since latency is not the gate. Use a GGUF post-dating the universal
+  chat-template tool-calling fix.
+- **Qwen3-4B-Instruct-2507 @ Q4_K_M** (thinking off) — accuracy anchor,
+  lighter quant than the Q8 we benched.
+- **IBM Granite 4.0 Micro 3B / Nano-1B (plain transformer)** — cleanest native
+  OpenAI-schema tool-calling, BFCLv3 + IFEval-proven; the safe well-behaved
+  baseline and the tiny option.
+- **MiniCPM5-1B** — *speed wildcard.* Brand new (~late May 2026), official clean
+  GGUF, claims 1B-class agentic-tool SOTA. Emits XML tool calls → needs a
+  `--jinja` template mapping to OpenAI JSON; validate that round-trip before
+  trusting it on the native path.
+- **LFM2.5-VL-1.6B** — incumbent baseline (already measured: prose 7/10 →
+  native 9/10).
+- *(optional)* **LFM2.5-1.2B-Instruct** / **ministral-3:3b** — additional
+  latency/baseline data points.
 
 Make the winner the **committed `config.yaml` default**, reconciling the repo
 with the documented production reality (finding #2).

--- a/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
+++ b/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
@@ -283,6 +283,34 @@ text-only). Next step: swap the `tinkerclaw-llama-server` unit's `--model` to
 the Granite Nano GGUF, set `llm.native_tools: true` in the live config, restart,
 and confirm a real WS voice turn end-to-end.
 
+## Further model survey (2026-05-27, round 2) — challengers + vision question
+
+A second deep survey (≤2B native-tool challengers + sub-4B vision+tools VLMs):
+
+**Tool challengers to Granite Nano-1B (only native-OpenAI/Hermes round-trip models qualify):**
+- **Qwen3.5-2B** (NEW ~Mar 2026) — Hermes `<tool_call>` JSON, thinking off by
+  default, **201 languages**, 256K ctx. The "equal tools + far better
+  multilingual" play. GGUF `unsloth/Qwen3.5-2B-GGUF` Q4_K_M (1.28 GB). Caveat:
+  use a post-template-fix GGUF (a universal Qwen3.5 tool-template bug is fixed).
+- **Qwen3-1.7B** — Hermes JSON, BFCL-v3 56.6 (non-thinking), the "faster than
+  13 s" play. Pin non-thinking + temp 0. Official GGUF.
+- **Qwen3.5-0.8B** — sub-1B speed gamble; accuracy may crack at arg extraction.
+- *Not ready (custom/non-OpenAI tool format → won't round-trip):* LFM2-1.2B-Tool
+  / LFM2.5-1.2B (Pythonic `<|tool_call_start|>`), SmolLM2-1.7B (plain-text tags,
+  BFCL ~27), EXAONE-4.0-1.2B (works only via `--chat-template-file`), Kanana,
+  Falcon3-1B (unverified), StableLM2, Zamba2, Danube3, R1-Distill-1.5B.
+
+**Vision + tools sub-4B (can one model replace text-tool + vision-fallback?):**
+**Conclusion — keep them separate.** No sub-4B VLM is good enough at tool-calling
+to replace a dedicated text tool model. LFM2.5-VL tools are weak (450M variant
+BFCL-v4 ~21, text-only). Most VLMs can't even run vision on mainline llama.cpp
+(MiniCPM-V, Granite-vision, Ovis2, DeepSeek-VL2, PaliGemma2, Phi-3.5-vision all
+unsupported/crash). The only sub-4B VLM with both halves live on stock llama.cpp
+is **Qwen3-VL-2B**, but its 2B tool-calling won't beat Granite Nano and VL chat
+templates are historically fragile for the OpenAI round-trip. **Plan: Granite
+Nano-1B stays the tool/voice brain; keep a VLM as the camera fallback (trial
+Qwen3-VL-2B vs LFM2.5-VL-1.6B only for vision quality, route tools to Granite).**
+
 ## Risks & open questions
 
 - **llama-server native tool-calling fidelity per model.** `--jinja` tool

--- a/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
+++ b/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
@@ -232,6 +232,57 @@ re-validated **through the real deployed code path** (`LMStudioBackend
 native`): **9/10**, matching the raw probe. Latency ~2× (acceptable —
 capability is the gate). Committed: `feat(llm): native tool-calling path`.
 
+## Bake-off results (2026-05-27) — Component 3 run on live hardware
+
+All candidates pulled as Q4_K_M GGUF and run through the native OpenAI
+`tools=[...]` path on Dragon (llama-server, `--jinja`, reasoning disabled,
+`temperature=0`) over the same 10-scenario hard-gauntlet subset. Production
+llama-server was stopped during the run so each candidate had the full CPU.
+
+| Model | Params | Score | Avg latency/turn |
+|-------|--------|-------|------------------|
+| **IBM Granite 4.0 Nano-1B** | **1B** | **10/10** | **13.0 s** |
+| Qwen3.5-4B | 4B | 10/10 | 118.3 s |
+| IBM Granite 4.0 Micro-3B | 3B | 9/10 | 31.4 s |
+| NVIDIA Nemotron-3-Nano-4B | 4B | 9/10 | 117.1 s |
+| LFM2.5-VL-1.6B (incumbent) | 1.6B | 9/10 | ~28 s* |
+| MiniCPM5-1B | 1B | 4/10 | 15.0 s |
+
+\* LFM-VL measured earlier through the deployed `generate_with_tools` path.
+
+### Findings
+
+- **Winner: IBM Granite 4.0 Nano-1B — perfect 10/10 at 13 s/turn.** A 1 B / ~1 GB
+  model matched the 4 B Qwen's perfect score (both red-herrings, OOS, chit-chat,
+  and the complex-arg `gmail_send` with apostrophe handling) at **~9× lower
+  latency than Qwen and ~2× faster than the current LFM-VL incumbent — while
+  also beating LFM-VL on accuracy (10 vs 9).** This breaks the project's
+  founding assumption that sub-4B capability requires high latency; the
+  native-tools path plus a tool-tuned 1 B model gets both.
+- **The 4 B models are ~2 min/turn on the Dragon CPU** regardless of
+  architecture — Nemotron's Mamba-2 hybrid did not help (llama.cpp's ARM Mamba
+  kernels aren't optimized, and reasoning isn't fully suppressible via the
+  template kwargs). 4 B is impractical for voice even under a capability-first
+  priority.
+- **MiniCPM5-1B scored 4/10 — emitted zero native `tool_calls`.** Its XML tool
+  format does not round-trip through llama-server's OpenAI-compatible parser,
+  exactly as the survey warned. It would need a custom parser, not the native
+  path; not worth it given Granite Nano wins outright.
+- The native-tools selection constraint held: every model that emits native
+  OpenAI tool calls (Granite, Qwen, Nemotron, LFM) worked on the path; the one
+  that uses a custom format (MiniCPM5) failed.
+
+### Recommendation
+
+Make **IBM Granite 4.0 Nano-1B (Q4_K_M) the new Local default** with
+`llm.native_tools: true`. It is the capability *and* latency winner, ~1 GB
+resident (leaving ample headroom on the 12 GB Dragon), and uses native
+OpenAI-schema tool calling that the deployed Component 2 path already handles.
+Keep LFM2.5-VL-1.6B available as the vision-capable fallback (Granite is
+text-only). Next step: swap the `tinkerclaw-llama-server` unit's `--model` to
+the Granite Nano GGUF, set `llm.native_tools: true` in the live config, restart,
+and confirm a real WS voice turn end-to-end.
+
 ## Risks & open questions
 
 - **llama-server native tool-calling fidelity per model.** `--jinja` tool

--- a/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
+++ b/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
@@ -311,6 +311,45 @@ templates are historically fragile for the OpenAI round-trip. **Plan: Granite
 Nano-1B stays the tool/voice brain; keep a VLM as the camera fallback (trial
 Qwen3-VL-2B vs LFM2.5-VL-1.6B only for vision quality, route tools to Granite).**
 
+## Round-3 bake-off (2026-05-27) — all challengers + ruled-out, BOTH modes
+
+Tested every candidate in **native** (OpenAI `tools=[...]`) AND **prose**
+(tools in system prompt, parsed by Dragon's deployed 5-dialect parser — the
+production fallback path). Best mode per model bolded. (A 4/10 floor = the model
+emitted no correct tool call; only the 4 no-tool scenarios pass.)
+
+| Model | Params | Native | Prose |
+|-------|--------|--------|-------|
+| **IBM Granite 4.0 Nano-1B** | 1B | **10/10 @ 14s** | 4/10 @ 10s |
+| Qwen3-1.7B | 1.7B | 8/10 @ 13s | **9/10 @ 7.6s** |
+| Qwen3.5-2B | 2B | 8/10 @ 41s | 8/10 @ 24s |
+| LFM2-1.2B-Tool | 1.2B | **8/10 @ 29s** | 6/10 @ 19s |
+| LFM2.5-1.2B-Instruct | 1.2B | **8/10 @ 30s** | 4/10 @ 15s |
+| Qwen3.5-0.8B | 0.8B | 7/10 @ 22s | 5/10 @ 11s |
+| SmolLM2-1.7B | 1.7B | 4/10 @ 10s | **7/10 @ 7.6s** |
+| EXAONE-4.0-1.2B | 1.2B | 4/10 @ 24s | 4/10 @ 26s |
+| DeepSeek-R1-Distill-Qwen-1.5B | 1.5B | 4/10 @ 87s | 4/10 @ 81s |
+| Kanana-nano-2.1B | 2.1B | 4/10 @ 24s | 4/10 @ 15s |
+| Falcon3-1B-Instruct | 1B | 2/10 @ 20s | 4/10 @ 6.5s |
+| StableLM-2-1.6B | 1.6B | 4/10 @ 12s | 4/10 @ 14s |
+| H2O-Danube3-1.8B | 1.8B | — (GGUF gated, not obtainable) | — |
+
+### Findings
+
+- **Granite 4.0 Nano-1B is confirmed the winner — 10/10 @ 14s, reproduced.**
+  Nothing beat it across two rounds and both modes.
+- **Granite's accuracy lives in the native path** (10/10 native vs 4/10 prose).
+  Confirms Component 2 (`native_tools`) is *essential* for the winner, not
+  optional.
+- **Qwen models are the inverse — better via prose.** Qwen3-1.7B: 9/10 prose vs
+  8/10 native; SmolLM2: 7/10 prose vs 4/10 native. The prose-path test earned
+  its keep here.
+- **Qwen3-1.7B (9/10 @ 7.6s prose) is the one real alternative** — one point
+  below Granite but ~2× faster. The speed pick if 14s feels long.
+- **The ruled-out set stayed ruled out.** LFM2-Tool/LFM2.5 reach 8/10 native but
+  slower than Granite; the rest sit at the 4/10 floor (no reliable tool
+  emission). Reasoning models (R1-Distill, EXAONE) are both weak and slow.
+
 ## Risks & open questions
 
 - **llama-server native tool-calling fidelity per model.** `--jinja` tool

--- a/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
+++ b/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
@@ -1,0 +1,210 @@
+# Capability-first Local Mode — Design
+
+**Date:** 2026-05-27
+**Repo:** TinkerBox (Dragon-side; Tab5 is a thin client and is not touched)
+**Status:** Design — pending implementation plan
+
+## Problem
+
+Local mode (`voice_mode=0`, Dragon-hosted LLM via llama-server) is the
+privacy-and-free tier — the product's reason to exist over Cloud. Today it is
+both slow and unreliable:
+
+- **Latency:** ~67 s/turn on the current default (LFM2.5-VL-1.6B Q8_0). Not
+  conversational.
+- **Capability:** the same model scores **7/20 on the hard tool-use gauntlet**
+  (2026-05-17, documented in TinkerBox `CLAUDE.md` → "LFM2.5-VL-1.6B HARD
+  gauntlet"). The documented failure modes are red-herring tool firing, verb
+  confusion, few-shot contamination, and arg-extraction brittleness.
+
+The accuracy leader we already benched — Qwen3.5-4B — scores **18/20
+(effectively 20/20)** but at **~96 s/turn**, and was parked as "too slow for
+real-time voice."
+
+### User intent (captured during brainstorming, 2026-05-27)
+
+The user wants the **best balance point**, explicitly weighted so that
+**capability is the gate and latency is secondary** ("I'd tolerate slowness if
+it were actually reliable at tools/instructions"). The capability bar is **all
+four** of:
+
+1. Right tool + right args, first try (single-shot).
+2. Multi-step agentic chains (call → read result → next call → finish).
+3. Instruction-following / not rambling / not hallucinating tool calls.
+4. Knowing when **not** to call a tool (no spurious fire on chit-chat / Q&A).
+
+### Research finding (2026-05-26)
+
+A deep survey of GitHub / HuggingFace / r/LocalLLaMA for sub-4B models released
+in the prior ~2 weeks (mid-May 2026) found **nothing that beats the
+incumbents**. The May drops (Qwen3.7 Max, DeepSeek-V4, Gemini 3.5 Flash) are
+large or API-only. The strongest sub-4B candidates remain April releases
+(LFM2.5-1.2B-Instruct, Gemma 4 E2B, Granite 4.1 3B) plus the standing
+Qwen3-4B-Instruct-2507 and Qwen3.5-4B. **Conclusion: the lever is not "grab the
+hot new model" — it is fixing how we use the models we already have.**
+
+## Constraints
+
+- **Dragon-only Local-first.** The LLM runs on the Dragon Q6A (ARM64, 12 GB
+  RAM, ~12 TOPS NPU not in the llama.cpp path). Never introduce a
+  workstation-LAN inference dependency as a Local path. (User directive →
+  memory `feedback_dragon_only_local.md`.)
+- **Sub-4B parameters**, served as **GGUF via llama-server** (the
+  LM-Studio-compatible OpenAI API on `localhost:1234`, backend `lmstudio`).
+- **No Tab5 firmware changes.** Tab5 sends `{"type":"text",...}` / mic PCM over
+  the voice WS and renders the reply; all model/tool logic is Dragon-side.
+
+## Current-state findings (code-grounded, 2026-05-27)
+
+1. **Tools are prose-listed, not native.** `LMStudioBackend.generate_stream*`
+   (`dragon_voice/llm/lmstudio_llm.py`) sends only
+   `{model, messages, stream, max_tokens, temperature}`. Tool definitions are
+   injected as a prose `[TOOLS]` block in the system prompt
+   (`dragon_voice/tools/formatter.py::_format_compact` / `_format_full`), and
+   tool calls are recovered by a **5-dialect text parser**
+   (`dragon_voice/tools/parser.py`). There is **no** `tools=[...]`, no
+   `tool_choice`, no schema/grammar constraint. This is the single biggest
+   undone capability lever and it is already listed in `CLAUDE.md` as a
+   "mitigation to try before giving up" — never built.
+
+2. **Config drift.** Committed `dragon_voice/config.yaml` still declares
+   `backend: "ollama"` + `ollama_model: "ministral-3:3b"`, but the documented
+   production decision (CLAUDE.md → "Local-first Inference on Dragon") is
+   `backend: "lmstudio"` (llama-server) + LFM2.5-VL-1.6B. The committed default
+   does not match reality. (NOTE: verify the live Dragon `config.yaml` before
+   assuming either — the on-device file may differ from the repo.)
+
+3. **Dual-model is a dead end here.** The xLAM-picker + ministral-responder
+   pipeline (`dragon_voice/llm/dual.py`, `docs/PLAN-dual-model-pipeline.md`)
+   was post-mortemed: combined resident set ~8.7/11 GB, Ollama LRU eviction
+   ping-pong → 240–300 s timeouts after 2–3 turns. Reusable only on ≥16 GB
+   hardware. Not in scope.
+
+4. **The gauntlets are not committed.** The easy-10 / hard-20 scenario sets
+   exist only as hand-run tables pasted into `CLAUDE.md` / `CHANGELOG.md`.
+   There is no repeatable, scored harness in the tree, so there is no
+   regression net against capability drift.
+
+## Design
+
+Three components, sequenced so every lever's contribution is **measured, not
+guessed**.
+
+### Component 1 — Committed capability gauntlet (the foundation)
+
+A repeatable, scored harness in TinkerBox `tests/` (local-only; it needs a live
+llama-server, so it is **not** added to the CI named-set).
+
+- **Scenario corpus:** the seven axes already in use — happy-path,
+  disambiguation, complex-args, red-herring, out-of-scope, multi-step,
+  chitchat. Each scenario is a dataclass: `utterance`, `expected` (one of:
+  `{"tool": name, "args_contains": {...}}` or `{"no_tool": true}`), and an
+  `axis` tag. Seed it from the documented hard-20 set so today's results are
+  directly comparable.
+- **Execution path:** runs through **Dragon's real `ConversationEngine` tool
+  path** (system prompt build → tool formatting → LLM call → tool-call
+  extraction), against the configured local backend — i.e. it measures the
+  actual product behavior, not a direct llama-server probe. A flag allows a
+  direct-probe mode for fast iteration during development.
+- **Scoring:** per-axis pass/fail + overall, with a `args_contains` partial
+  match for arg extraction. Logs **per-turn latency** alongside each result.
+- **Output:** a markdown report (mirroring the existing CLAUDE.md tables) +
+  a machine-readable JSON, written under a gitignored runs dir.
+- **Why E2E, not direct probe:** the failure modes we care about (few-shot
+  contamination, prose-parser mismatch) are introduced by Dragon's own prompt
+  assembly. A direct llama-server probe would hide exactly the bugs we are
+  hunting.
+
+### Component 2 — Tool-path hardening (the structural fix)
+
+Add llama-server's **native OpenAI `tools=[...]` API** to the local path.
+llama-server with `--jinja` already emits OpenAI-format `tool_calls` in the
+response, so the wire support exists; we are not currently using it.
+
+- **`LMStudioBackend`:** add a generation path that includes `tools=[...]`
+  (built from each registered tool's `parameters_schema`) and
+  `tool_choice="auto"`, and surfaces native `tool_calls` from the streamed
+  response (the `delta.tool_calls` shape) instead of relying on prose markers.
+- **`ConversationEngine`:** when native `tool_calls` are present, consume them
+  directly (name + JSON args already structured). **Keep the existing 5-dialect
+  text parser as a fallback** for backends/models that do not support native
+  tool-calling, so nothing regresses for the prose path.
+- **Sampling + prompt hygiene for tool turns:** `temperature=0` (was 0.1);
+  drop the few-shot exemplars that caused contamination ("buy bread" leaking
+  into the Venmo scenario); rely on `tool_choice="auto"` for the chit-chat /
+  out-of-scope case instead of the synthetic `none()` escape-hatch tool.
+- **Feature flag:** a config key (e.g. `llm.native_tools: true`) gates the new
+  path so the prose path remains the default until the bake-off proves the
+  native path is better. Default off on merge; flipped on by the bake-off
+  result.
+
+This single change targets every documented hard-gauntlet failure class at
+once: arg-extraction brittleness (model fills a JSON schema rather than a prose
+template), malformed/positional args (schema-constrained), red-herring
+over-firing and chit-chat (native `tool_choice="auto"`), and few-shot
+contamination (exemplars removed).
+
+### Component 3 — Model bake-off behind the harness
+
+With the harness (1) and the hardened path (2) in place, run the candidates and
+pick the **capability knee** (latency recorded but not gating):
+
+- **LFM2.5-VL-1.6B** — incumbent; does the native tools API lift it past 7/20?
+- **Qwen3-4B-Instruct-2507 @ Q4_K_M** (thinking off) — research-recommended
+  accuracy anchor, lighter quant than the Q8 we benched.
+- **Qwen3.5-4B @ Q4_K_M** — the parked 18/20 leader, now viable since latency
+  is not the gate.
+- **ministral-3:3b** — old default, baseline.
+- *(optional)* **LFM2.5-1.2B-Instruct** — fastest candidate, for the latency
+  data point.
+
+Make the winner the **committed `config.yaml` default**, reconciling the repo
+with the documented production reality (finding #2).
+
+### Sequence
+
+1. Build the harness (Component 1).
+2. Run it once to capture **today's baseline** (current default, prose path).
+3. Land tool-path hardening (Component 2); re-run to **prove the lift** on the
+   same model.
+4. Run the bake-off (Component 3); commit the winning default.
+
+## Explicitly out of scope
+
+- **Dual-model pipeline** — known RAM dead-end on Q6A (finding #3).
+- **NPU offload** — the ~12 TOPS NPU is not in the llama.cpp path; wait for
+  upstream (Dragon-only constraint). Not this project.
+- **Chasing brand-new models** — research confirmed nothing in the last ~2
+  weeks beats the incumbents (research finding above).
+- **Tab5 firmware changes** — none required.
+- **Speculative decoding (MTP)** — interesting (merged into llama.cpp
+  2026-05-16) and latency-relevant, but latency is secondary here; track as a
+  follow-up, not part of this capability-first project.
+
+## Risks & open questions
+
+- **llama-server native tool-calling fidelity per model.** `--jinja` tool
+  parsing depends on each GGUF carrying a correct chat template with a tool
+  section. Some community quants ship broken templates (the Gemma-4-E2B
+  mradermacher quant already burned us). The harness will catch this per-model;
+  the prose-path fallback is the safety net.
+- **E2E latency of the harness.** 20 scenarios × up to ~3 min E2E per turn on a
+  4B model ≈ an hour per model. Acceptable for an occasional bake-off; the
+  direct-probe mode is the fast inner loop during development.
+- **Multi-step axis is the weakest at sub-4B.** Even Qwen3.5-4B was only
+  spot-checked on multi-step ("picks first reasonable step"). The harness should
+  score multi-step honestly; if no sub-4B model clears it, that is a finding to
+  report, not a failure to hide.
+- **Config-drift verification.** Confirm the live Dragon `config.yaml` before
+  changing the committed default, so we reconcile to the true production state
+  rather than overwriting a hand-tuned on-device file.
+
+## Success criteria
+
+- A committed, repeatable gauntlet that scores all four capability axes + logs
+  latency, runnable against a live Dragon.
+- A measured before/after showing the native-tools path's contribution on a
+  fixed model.
+- A data-driven Local-mode default committed to `config.yaml`, matching the
+  documented production reality, that beats today's 7/20 on the hard gauntlet
+  while keeping latency within the "tolerable, capability-first" envelope.

--- a/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
+++ b/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
@@ -386,6 +386,41 @@ production-grade:** (1) local-mode system prompt that nudges tool use + the
 read-vs-action and remember-vs-recall distinctions; (2) sharper action-tool
 descriptions; (3) consider curating/grouping the tool set for the 1 B model.
 
+## Quant + hardware-speed research (2026-05-27)
+
+Dragon CPU verified: **8-core aarch64, `asimddp` (dotprod), NO `i8mm`, NO `sve`**
+(QCS6490, Hexagon v66/v68-class NPU).
+
+**Optimal quant for this core:**
+- Ship plain **Q4_0** → llama.cpp **runtime-repacks** to `q4_0_4x4` (dotprod) at
+  load (PR #9921; the static `Q4_0_4_4` type was removed in b4282). Gives
+  ~1.2–1.5× tok/s over Q4_K_M on this class of core. Verify `DOTPROD=1` +
+  `AARCH64_REPACK=1` + `q4_0_4x4` repack lines in the startup log.
+- **Q4_K_M** = best quality-per-bit (~5× less perplexity damage than Q4_0).
+- **Q8_0** = near-lossless but ~2× the memory bandwidth → ~half the tok/s.
+- **i-quants (IQ4_NL)** net neutral-to-slower on a slow dotprod core.
+
+**Q8 quant test (live, optimized recipe):** Granite-1B Q8 = **17/20**,
+Qwen3-1.7B Q8 = **15/20** — i.e. **Q8 gave NO tool-accuracy gain** over Q4
+(Granite Q4_K_M was 19/20; the gap is run-variance + the turn-1 cold-start
+artifact) while running ~2× slower. **Conclusion: Q4_K_M is the right production
+quant; Q4_0 is the speed option (~1.3×) if a quick A/B shows the 1B keeps its
+tool accuracy. Q8 is not worth the latency.**
+
+**Making 3-4B usable — verdict: not on this CPU.**
+- **Speculative decoding**: ~no gain on a compute-bound CPU (llama.cpp CPU
+  spec-decode is still a proposal, #21453; voice = open-ended chat = ~50% draft
+  acceptance). MTP is GPU-only numbers + Qwen3.6-only.
+- **Hexagon NPU**: QCS6490 is below the v73 floor that LLM-on-Genie/HTP
+  requires — no LLM-on-NPU path in 2026.
+- Best case for a 4B (Q4_0 + tuned threads) ≈ 70–90 s/turn, still above the
+  ~30-40 s usability bar. **Sub-2B is the only viable real-time path.**
+
+**Recommended llama-server flags for the live 1-2B tool model:**
+`-t 6 -fa on -ctk q8_0 -ctv q8_0 --mlock -c 4096 --cache-reuse 256`
+(pin with `taskset -c 0-5`; benchmark -t 6 vs 7 vs 8 — bandwidth-bound, 6 often
+wins). KV-quant must be symmetric (ctk==ctv) or it falls back to the slow path.
+
 ## Risks & open questions
 
 - **llama-server native tool-calling fidelity per model.** `--jinja` tool

--- a/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
+++ b/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
@@ -481,6 +481,34 @@ learned classifier, 3+ resident models.
   much of it the Google Calendar API call + the post-tool LLM wrap, not routing.
   Tighten tool-exec timeouts; the tiering + cache-reuse address the LLM side.
 
+## Dragon-side performance infra (2026-05-28) — LIVES ON DRAGON, NOT IN REPO
+
+Root cause of slow local inference was a **misbuilt llama.cpp**: the b8696 binary
+had NO dotprod kernels (`system_info`: `NEON=1 ... REPACK=1`, no `DOTPROD=1`)
+because `GGML_NATIVE=ON` doesn't set `__ARM_FEATURE_DOTPROD` on GCC 13 (llama.cpp
+#16237) — despite the QCS6490 having `asimddp`. It ran the generic-NEON matmul
+(2-4× slower). Fixes applied live on Dragon (re-apply if reflashed):
+
+- **Rebuilt** to `/home/radxa/llama.cpp/build_dp/`:
+  `cmake -B build_dp -S . -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8.2-a+dotprod+fp16 -DGGML_CPU_KLEIDIAI=ON -DCMAKE_BUILD_TYPE=Release && cmake --build build_dp -j6 --target llama-server`.
+  New banner: `DOTPROD = 1 | KLEIDIAI = 1 | FP16_VA = 1`. Do NOT add +i8mm/+sve
+  (A78 lacks them → SIGILL).
+- **Both llama-server units repointed** to `build_dp/bin/llama-server`:
+  `tinkerclaw-llama-server` (fast, Granite-1B, :1234) + `tinkerclaw-llama-smart`
+  (Qwen3.5-4B, :1235).
+- Fast unit: `CPUAffinity=4 5 6 7` (the 4 big A78 cores; 0-3 are weak A55),
+  `--threads 4 --threads-batch 4 --ubatch-size 512 --parallel 1 --cache-reuse 256
+  --mlock --jinja`.
+- **`cpu-performance.service`** (new, enabled): pins all cores to the
+  `performance` governor at boot (was `schedutil` idling at 1.65 GHz).
+
+**Measured result:** prefill ~12.8 → ~25 tok/s (~2×), generation ~3 → ~27 tok/s,
+**calendar tool turn ~110 s → 69 s** (clean, returns a real event summary). Both
+tiers benefit. Next levers (not limits): trim the ~2400-token agentic prompt
+(fewer tools / lighter few-shot), `--slot-save-path` to persist the system-prompt
+prefill across restarts, larger ubatch. **DEBUG GOTCHA:** kill stray `llama-bench`
+before trusting any latency number (it saturates the box).
+
 ## Risks & open questions
 
 - **llama-server native tool-calling fidelity per model.** `--jinja` tool

--- a/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
+++ b/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
@@ -536,3 +536,67 @@ before trusting any latency number (it saturates the box).
 - A data-driven Local-mode default committed to `config.yaml`, matching the
   documented production reality, that beats today's 7/20 on the hard gauntlet
   while keeping latency within the "tolerable, capability-first" envelope.
+
+---
+
+## Latency optimization — verified results (2026-05-29)
+
+The capability work (native tool-calling, Granite-1B 19/20) landed first; this
+section records the latency follow-through. Headline: per-turn latency was never
+a hardware floor. Three root causes were found and fixed, with live measurements
+on Dragon (Granite-4.0-Nano-1B Q4_K_M).
+
+### Root cause 1 — the binary lacked DOTPROD kernels
+The deployed `llama-server` was built with `GGML_NATIVE=ON`, which on GCC 13 does
+NOT set `__ARM_FEATURE_DOTPROD` even though the QCS6490 has `asimddp` (llama.cpp
+#16237) — so it ran the generic-NEON matmul, 2-4x slow. Rebuilt to `build_dp`
+with `-DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8.2-a+dotprod+fp16
+-DGGML_CPU_KLEIDIAI=ON` (verify `DOTPROD=1 KLEIDIAI=1` in the banner). Do NOT add
+`+i8mm`/`+sve` (A78 lacks them → SIGILL). Also set the `performance` CPU governor
+(persisted via `cpu-performance.service`).
+
+### Root cause 2 — thermal throttling (no fan)
+Measured: `cpuinfo_max_freq=2.7GHz` but under a big prefill the kernel clamps
+`scaling_max_freq` to 1.32GHz at the 90°C passive trip (zone `power_allocator`,
+trips 90/95/110°C). The Dragon Q6A is passively cooled — no PWM/fan, every hwmon
+is a `*_thermal` sensor. Starting cool (54°C) a short generation ran at full
+2.7GHz and only dipped past ~66°C; the multi-thousand-token prefill pegs all
+cores for minutes → 90°C → half-clock, and heat accumulates across a session
+(why turn 2 was slower than turn 1). Mitigations landed: pin the background smart
+server (:1235) to the cooler A55 little cores (0-3) so it stops stacking heat on
+the big cluster (4-7) the fast path needs; kill stale orphan `dragon_voice`
+processes. **The biggest remaining unlock is a $5 fan** → sustained full clock →
+~2x on the prefill-bound turn. (Raising the 90°C passive trip toward 100°C trades
+silicon longevity for speed — not done without explicit consent.)
+
+### Root cause 3 — the prompt was re-prefilled every turn (cache busted)
+The agentic prompt was ~6431 tokens and llama-server's prompt cache wasn't being
+reused because (a) query-keyed memory facts changed the system message each turn
+and (b) fat re-fetched tool-result history (e.g. 10 emails with snippets ≈ 2900
+tokens) and legacy `<tool>` markers diverged the cached prefix. Fixed in
+`conversation.py` `_process_text_stream_native` (commit `6b0510d`):
+- Build the prompt prefix ONCE; accumulate the current turn's tool round-trip
+  in-memory as proper OpenAI `tool_calls`/`tool` messages (multi-tool chains stay
+  intact under the history cap).
+- `inject_memory=False` on the fast path → byte-stable system message.
+- `drop_tool_history=True` → strip prior turns' tool/`<tool>` messages from the
+  prefill only (DB record untouched for dashboard/audit).
+- `NATIVE_HISTORY_MSGS=6` history cap.
+- `_compact_tool_result` → cap list length + per-string length, drop
+  link/url/snippet fields before a result re-enters context.
+- Spoken-answer guidance (one short sentence, no markdown/links) → ~7x fewer
+  generated tokens, better for TTS.
+
+### Measured before/after (live Dragon, Granite-1B)
+| Turn | Before | After |
+|---|---|---|
+| Calendar (cold) | 62s | 30s |
+| Email (10 results) | 436s | 29s |
+| Warm follow-up (tasks) | — | ~7s |
+
+Decision-call reprocessing dropped from ~550 tokens to ~14-74 (near-total cache
+hit on the static prefix). The remaining per-turn floor is the wrap call
+prefilling the CURRENT tool result (~20-24s for multi-item results — the model
+must read it to summarize); reducible by trimming results harder (trades
+completeness) or by the fan (full clock). Tests:
+`tests/test_native_context_accumulation.py`.

--- a/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
+++ b/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
@@ -181,6 +181,33 @@ with the documented production reality (finding #2).
   2026-05-16) and latency-relevant, but latency is secondary here; track as a
   follow-up, not part of this capability-first project.
 
+## Validation (2026-05-27) — Component 2 proven on live hardware
+
+Before writing the production code, an A/B probe ran against the live
+llama-server (LFM2.5-VL-1.6B Q8, the current Local default, `--jinja` already
+enabled) over a 10-scenario hard-gauntlet subset spanning all four capability
+axes:
+
+| Path | Score | Avg latency |
+|------|-------|-------------|
+| Prose-listed tools (current) | **7/10** | 13.7 s |
+| Native `tools=[...]` API (proposed) | **9/10** | 27.7 s |
+
+The native path fixed exactly the documented prose-path failures: happy-path
+tool selection ("what's on my plate today?" → `calendar_today` not
+`tasks_list`) and complex-arg extraction ("email mom…" → clean
+`gmail_send(to, subject, body)` instead of positional placeholders). The one
+native miss is a 1.6B red-herring over-fire ("these tasks are killing me" →
+`tasks_list`), unmoved by a tool-discipline system-prompt line — a model
+ceiling that the Component 3 bake-off (Qwen3.5-4B scored 3/3 on red-herrings)
+addresses.
+
+The implementation then landed behind `llm.native_tools` (default off) and was
+re-validated **through the real deployed code path** (`LMStudioBackend
+.generate_with_tools` + `ToolRegistry.openai_tools` + `_process_text_stream_
+native`): **9/10**, matching the raw probe. Latency ~2× (acceptable —
+capability is the gate). Committed: `feat(llm): native tool-calling path`.
+
 ## Risks & open questions
 
 - **llama-server native tool-calling fidelity per model.** `--jinja` tool

--- a/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
+++ b/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
@@ -350,6 +350,42 @@ emitted no correct tool call; only the 4 no-tool scenarios pass.)
   slower than Granite; the rest sit at the 4/10 floor (no reliable tool
   emission). Reasoning models (R1-Distill, EXAONE) are both weak and slow.
 
+## Live deployment + real-tools test (2026-05-27)
+
+**Shipped:** `tinkerclaw-llama-server` unit swapped to Granite 4.0 Nano-1B
+(text-only, `--mmproj` dropped; LFM-VL unit backed up at `.lfmvl.bak`).
+`llm.native_tools: true` added to live `config.yaml`; voice server restarted.
+Granite serves on :1234, native tool probe confirmed (`weather → {location:Paris}`).
+**Local mode vision is temporarily unavailable** (Granite is text-only) — wiring
+a dual-server / router fallback for camera turns is the follow-up.
+
+**Real-tools test** — varied phrasings against Granite with the *actual* 27-tool
+Dragon registry (calendar/email/tasks/weather/web/datetime/memory) + native API:
+
+Correct + clean args: "any new emails"→`gmail_unread`, "search inbox for
+invoices"→`gmail_search(subject:invoice)`, "email mom happy birthday…"→
+`gmail_send(to,subject,body)` (clean), "to-do list"→`tasks_list`, "add buy
+groceries"→`tasks_add(title)`, "what time"→`datetime`, "weather in London"→
+`weather(London)`, "18% tip on 64"→`calculator(64*0.18)`, "thanks!"→no tool. (~12/19)
+
+**Misroutes exposed by the 27-tool granularity (not seen on the 9-tool bench):**
+- Defaults to the READ/LIST variant over the ACTION variant: "schedule a
+  dentist…"→`calendar_today` (want `calendar_create`); "cancel my 2pm"→
+  `calendar_today` (want `calendar_cancel`); "mark laundry done"→`tasks_list`
+  (want `tasks_complete`).
+- "did Sarah email me…"→`gmail_unread` (want `gmail_search`).
+- "remember I prefer window seats"→`recall` (want `remember`).
+- "tell me a joke"→`web_search` (should answer directly — chitchat over-fire).
+- First 3 turns timed out = cold-start (first inference ~117 s after load); warm
+  turns 9-18 s.
+
+**Conclusion:** Granite native-tools is solid for the common single-shot cases
+but the large, granular real registry + the terse production system prompt drop
+it below the controlled-bench 10/10. **Tuning needed before this is
+production-grade:** (1) local-mode system prompt that nudges tool use + the
+read-vs-action and remember-vs-recall distinctions; (2) sharper action-tool
+descriptions; (3) consider curating/grouping the tool set for the 1 B model.
+
 ## Risks & open questions
 
 - **llama-server native tool-calling fidelity per model.** `--jinja` tool

--- a/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
+++ b/docs/superpowers/specs/2026-05-27-local-mode-capability-design.md
@@ -421,6 +421,66 @@ tool accuracy. Q8 is not worth the latency.**
 (pin with `taskset -c 0-5`; benchmark -t 6 vs 7 vs 8 — bandwidth-bound, 6 often
 wins). KV-quant must be symmetric (ctk==ctv) or it falls back to the slow path.
 
+## 10x local-capability architecture (2026-05-27 research + plan)
+
+Goal: a Local setup that can "actually do" multi-step/agentic tasks, not just
+route one tool call — accepting "smart" can be slower than real-time. The infra
+mostly already exists (ReAct loop in `conversation.py`, native-tools path,
+`CapabilityAwareRouter` #183 unused, `DualModelBackend` parked, `SchedulerManager`).
+
+**RAM math (the enabler):** STT+TTS+Python ≈ 2.5–3.5 GB; 1B Q4 (~1.4 GB) + 4B Q4
+(Qwen3.5-4B, ~4 GB incl KV) both fit resident in 12 GB with ~2 GB headroom. Only
+one model infers at a time (turns are sequential) → no 8-core oversubscription.
+"Two warm, one inferring."
+
+**The 3 highest-value changes (capability-per-latency):**
+1. **Two warm tiers + grounded escalation.** Fast Granite-1B (real-time, 19/20
+   routing) + warm smart Qwen3.5-4B (18–20/20, drafts/chains). Prefer
+   llama-server router/`--models-preset` (one endpoint, `model:"fast"|"smart"`,
+   both `load-on-startup`, smart `stop-timeout=0`); else two `--port` instances
+   via the existing `DualModelBackend`/fleet plumbing. Escalation: the fast 1B
+   self-escalates via a `<escalate/>` sentinel; an explicit "think hard" voice
+   intent / Tab5 smartness knob forces smart; and the `MAX_TOOL_CALLS` branch
+   re-issues on smart instead of erroring. Raise `MAX_TOOL_CALLS` to 6–8 on the
+   smart tier only (keep 3 on fast).
+2. **`--cache-reuse 256` + prefix-stable context.** Biggest *latency* cut on a
+   prefill-bound CPU: reuse the static system+tools prefix across every
+   tool-loop iteration. Keep the tool block fixed in `context[0]`; move volatile
+   memory/RAG to a later message so the long prefix stays cacheable. VERIFY
+   reuse engages (logs) on Qwen3.5-4B — it's broken for some archs (Gemma-4,
+   Qwen3-Next).
+3. **Async background smart-agent tier.** For "research X and get back to me" /
+   "draft replies to my unread": ack instantly on fast tier, enqueue a
+   `SchedulerManager` job that runs the smart tier (high tool cap + reflection,
+   latency is free), deliver via the existing notification/channel-push. Turns
+   Qwen3.5-4B's ~2 min/turn from a liability into a feature. (Local browsing
+   lives on the parked `feat/browser-agent` branch — natural home here.)
+
+**Agentic-loop guidance:** keep grounded ReAct + parallel tool execution
+(`asyncio.gather` independent calls instead of `tool_calls[0]` one-at-a-time);
+add **CodeAct** for the smart tier later (smolagents: ~30% fewer steps). Do NOT
+add plan-and-execute or reflection to the live voice loop (extra full LLM calls
+you can't afford at ~2 min/turn) — reserve reflection for the async tier.
+NOT worth it: spec-decode/MTP, `--parallel>1` concurrent inference, a separate
+learned classifier, 3+ resident models.
+
+## Production findings during recipe rollout (2026-05-27)
+
+- **Recipe is LIVE + verified:** native path fires; "schedule a dentist
+  appointment" → `calendar_create` w/ clean args (was `calendar_today`).
+- **Concurrency oversubscription:** the WS inference executor (`max_workers=4`)
+  let 4 simultaneous local-LLM turns run on the 8-core CPU → thrash → every turn
+  crawled to the 300 s `sock_read` timeout. **Fix: serialize the local CPU model
+  (effective max_workers=1 for the lmstudio/local backend)** so bursts queue
+  instead of thrashing.
+- **Startup Ollama fallback:** `create_llm()`'s one-shot lmstudio TCP probe fell
+  back to (dead) Ollama at boot when :1234 was momentarily busy. Per-connection
+  re-init used lmstudio correctly, but the global instance shouldn't silently
+  land on a dead backend — harden the probe (retry/backoff) or fail loud.
+- **Tool-execution latency:** a verified `calendar_create` turn took ~120 s —
+  much of it the Google Calendar API call + the post-tool LLM wrap, not routing.
+  Tighten tool-exec timeouts; the tiering + cache-reuse address the LLM side.
+
 ## Risks & open questions
 
 - **llama-server native tool-calling fidelity per model.** `--jinja` tool

--- a/dragon_voice/async_agent.py
+++ b/dragon_voice/async_agent.py
@@ -1,0 +1,169 @@
+"""Async background smart-agent tier (Wave 3 of the 10x local program).
+
+A heavy/agentic request ("research X and get back to me", "go through my unread
+and draft replies") shouldn't block the voice loop for ~2 minutes. Instead the
+fast tier acks instantly and a background task runs the SMART model
+(Qwen3.5-4B on :1235) with the FULL tool set + a higher tool cap, then delivers
+the result to the device via `deliver` (a channel_message the Tab5 notification
+surface renders).
+
+This is deliberately self-contained: it spins up its own LMStudioBackend pointed
+at the smart server so it never contends with or mutates the live fast-path
+ConversationEngine.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Awaitable, Callable
+
+from dragon_voice.config import LLMConfig
+from dragon_voice.llm.lmstudio_llm import LMStudioBackend
+
+logger = logging.getLogger(__name__)
+
+SMART_URL = "http://127.0.0.1:1235/v1"
+MAX_SMART_TOOL_CALLS = 5
+
+# Smart-tier tool allowlist (~8). Kept TIGHT: Qwen3.5-4B on this CPU prefills
+# slowly, and 15 schemas pushed a single step past the 300s read timeout
+# (calls=[] content_len=0). 8 core tools keep a step well under the timeout
+# while still covering research + the common calendar/email/tasks actions.
+_SMART_TOOLS = {
+    "web_search", "calendar_today", "calendar_create",
+    "gmail_unread", "gmail_search", "gmail_send",
+    "tasks_list", "tasks_add",
+}
+
+# Phrases that signal a heavy/deferred agentic task. Cheap heuristic — no extra
+# LLM call. Tuned to be specific so normal single-shot commands ("add milk to my
+# tasks", "what's the weather") stay on the fast tier.
+_BG_TRIGGERS = (
+    "get back to me", "and let me know", "research", "look into", "dig into",
+    "go through my", "draft replies", "draft a reply to my", "take your time",
+    "in the background", "when you get a chance", "when you have time",
+    "figure out", "look through", "go over my", "summarize my",
+)
+
+SMART_SYS = (
+    "You are Tinker's deep-thinking background agent. You have full access to the "
+    "user's calendar, email, tasks, web search, and memory tools. Carry out the "
+    "request thoroughly, using multiple tool calls as needed (read first, then "
+    "act). When done, reply with a short, plain-language summary of what you did "
+    "and what you found — no markdown, 1-3 sentences, suitable to be read aloud."
+)
+
+
+def is_background_request(text: str) -> bool:
+    """True if the text looks like a heavy/deferred agentic task."""
+    t = (text or "").lower()
+    return any(k in t for k in _BG_TRIGGERS)
+
+
+async def run_background_agent(
+    text: str,
+    registry,
+    deliver: Callable[[str], Awaitable[None]],
+) -> None:
+    """Run the smart-tier agentic loop, then `await deliver(summary)`.
+
+    Never raises — failures are reported through `deliver` so the user always
+    hears back.
+    """
+    t0 = time.monotonic()
+    cfg = LLMConfig(
+        backend="lmstudio", local_backend="lmstudio",
+        lmstudio_url=SMART_URL, lmstudio_model="default",
+        native_tools=True, max_tokens=1024,
+    )
+    be = LMStudioBackend(cfg)
+    final = ""
+    tools_used = 0
+    try:
+        await be.initialize()
+        tools = [
+            t for t in registry.openai_tools()
+            if t["function"]["name"] in _SMART_TOOLS
+        ] or registry.openai_tools()
+        messages = [
+            {"role": "system", "content": SMART_SYS},
+            {"role": "user", "content": text},
+        ]
+        for _step in range(MAX_SMART_TOOL_CALLS):
+            res = await be.generate_with_tools(
+                messages, tools, max_tokens=384, disable_thinking=True,
+                timeout_s=900,  # async/background: latency-free, let Qwen finish
+            )
+            calls = res.get("tool_calls") or []
+            logger.info(
+                "bg-agent step %d: calls=%s content_len=%d",
+                _step, [c.get("name") for c in calls],
+                len(res.get("content") or ""),
+            )
+            if not calls:
+                final = (res.get("content") or "").strip()
+                break
+            call = calls[0]
+            name = call["name"]
+            args = dict(call.get("args") or {})
+            tools_used += 1
+            logger.info("bg-agent tool: %s(%s)", name, args)
+            messages.append({
+                "role": "assistant", "content": None,
+                "tool_calls": [{
+                    "id": "c", "type": "function",
+                    "function": {"name": name, "arguments": json.dumps(args)},
+                }],
+            })
+            result = await registry.execute(name, args)
+            messages.append({
+                "role": "tool", "tool_call_id": "c",
+                "content": json.dumps(result.get("result", result))[:1500],
+            })
+        if not final:
+            # Used all tool steps without writing an answer — force a final
+            # no-tool synthesis from what was gathered.
+            messages.append({
+                "role": "user",
+                "content": ("Now stop searching and answer my original request "
+                            "in 1-3 short, plain sentences suitable to be read "
+                            "aloud. Do not call any tool."),
+            })
+            try:
+                res = await be.generate_with_tools(
+                    messages, [], max_tokens=400, disable_thinking=True,
+                    timeout_s=900,
+                )
+                final = (res.get("content") or "").strip()
+            except Exception:  # noqa: BLE001
+                logger.exception("bg-agent synthesis failed")
+            if not final:
+                final = "I gathered the info but couldn't summarize it in time."
+    except Exception as e:  # noqa: BLE001 — must always report back
+        logger.exception("bg-agent failed")
+        final = f"Sorry, that background task hit an error: {e}"
+    finally:
+        try:
+            await be.shutdown()
+        except Exception:  # noqa: BLE001
+            pass
+    logger.info(
+        "bg-agent done (%.0fs, tools=%d): '%s' → '%s'",
+        time.monotonic() - t0, tools_used, text[:50], final[:80],
+    )
+    try:
+        await deliver(final)
+    except Exception:  # noqa: BLE001
+        logger.exception("bg-agent deliver failed")
+
+
+_bg_tasks: set = set()
+
+
+def spawn_background_agent(text, registry, deliver) -> None:
+    """Fire-and-forget the background agent (holds a ref so it isn't GC'd)."""
+    task = asyncio.create_task(run_background_agent(text, registry, deliver))
+    _bg_tasks.add(task)
+    task.add_done_callback(_bg_tasks.discard)

--- a/dragon_voice/config.py
+++ b/dragon_voice/config.py
@@ -134,6 +134,13 @@ class LLMConfig:
     openrouter_url: str = "https://openrouter.ai/api/v1"
     lmstudio_url: str = "http://localhost:1234/v1"
     lmstudio_model: str = "default"
+    # Native tool-calling: pass tools=[...] + tool_choice="auto" to the
+    # llama-server OpenAI API (requires --jinja) and consume structured
+    # tool_calls, instead of prose-listing tools in the system prompt and
+    # parsing markers out of the text. Off by default — the prose path
+    # stays the fallback for backends/models without native tool support.
+    # Live A/B on LFM2.5-VL-1.6B lifted the hard gauntlet 7/10 → 9/10.
+    native_tools: bool = False
     genie_model_dir: str = "/home/radxa/qairt/models/llama32-1b"
     genie_config: str = "htp-model-config-llama32-1b-gqa.json"
     system_prompt: str = (

--- a/dragon_voice/config.yaml
+++ b/dragon_voice/config.yaml
@@ -31,27 +31,31 @@ tts:
   sample_rate: 22050
 
 llm:
-  local_backend: "ollama"  # Stores original local backend for cloud-to-local fallback
-  backend: "ollama"  # ollama, openrouter, lmstudio, npu_genie, tinkerclaw, dual
+  local_backend: "lmstudio"  # original local backend for cloud→local fallback (lmstudio = llama-server)
+  backend: "lmstudio"  # ollama, openrouter, lmstudio, npu_genie, tinkerclaw, dual
+  # ── Local inference ──────────────────────────────────────────────
+  # PRIMARY local path is lmstudio (llama-server) + native tool-calling —
+  # see `native_tools` below.  Ollama is the automatic FALLBACK: create_llm()
+  # TCP-probes lmstudio_url at process start and falls back to ollama for that
+  # session if llama-server isn't reachable.
   # ollama
   ollama_url: "http://localhost:11434"
-  # Default local LLM for voice_mode=0 (Local) and the LLM side of mode 1 (Hybrid).
-  # Selected 2026-04-24 from the 11-model gauntlet audit: ministral-3:3b was the
-  # only tested model that (a) fit inside Tab5's ~30 s WS keepalive ceiling, (b)
-  # fired the calculator tool with the correct answer on a non-memorized number
-  # (456*789=359,784), (c) cleanly stored a fact to the memory DB without leaking
-  # prior-session context, and (d) produced a user-visible reply on 4/5 prompts.
-  # See CLAUDE.md "Local LLM Benchmarks" + LEARNINGS.md 2026-04-24 entry for
-  # the full gauntlet table, the three failure classes (too-small / too-slow /
-  # fluent-hallucinator) we ruled out, and the re-benchmark methodology.
-  ollama_model: "ministral-3:3b"
+  # Ollama fallback model (used only when lmstudio is unreachable).  Matches the
+  # live Dragon as of 2026-05-29.  History: ministral-3:3b was the 2026-04-24
+  # gauntlet winner — see CLAUDE.md "Local LLM Benchmarks" + LEARNINGS.md.
+  ollama_model: "qwen3.5:4b"
   # openrouter
   openrouter_api_key: ""  # reads from OPENROUTER_API_KEY env var if empty
   openrouter_model: "anthropic/claude-3.5-haiku"
   openrouter_url: "https://openrouter.ai/api/v1"
-  # lmstudio
+  # lmstudio (llama-server) — PRIMARY local path.  Serves the loaded GGUF
+  # (Granite 4.0 Nano-1B as of 2026-05-27) on an OpenAI-compatible API.
   lmstudio_url: "http://localhost:1234/v1"
-  lmstudio_model: "default"
+  lmstudio_model: "default"  # llama-server reports its loaded GGUF
+  # Native OpenAI tools=[...] tool-calling on llama-server — the local-mode
+  # capability rework (2026-05-27).  Granite scored 19/20 with this enabled.
+  # Falls back to the prose 5-dialect parser when off / unsupported.
+  native_tools: true
 
   # TinkerClaw agent gateway (optional sidecar)
   tinkerclaw_url: "http://localhost:18789"

--- a/dragon_voice/conversation.py
+++ b/dragon_voice/conversation.py
@@ -20,6 +20,7 @@ from dragon_voice.messages import (
     trim_context_to_budget,
 )
 from dragon_voice.llm import create_llm, LLMBackend
+from dragon_voice.llm.base import SupportsNativeTools
 from dragon_voice.config import LLMConfig
 
 logger = logging.getLogger(__name__)
@@ -412,11 +413,17 @@ class ConversationEngine:
         )
         return response_text
 
-    async def _build_context(self, session_id: str, user_text: str) -> list[dict]:
+    async def _build_context(
+        self, session_id: str, user_text: str, inject_tool_prose: bool = True
+    ) -> list[dict]:
         """Build LLM context with optional memory augmentation and tool descriptions.
 
         After assembling the full context (system prompt + memory + tools + history),
         trims oldest messages to fit within the model's token budget (US-P16).
+
+        `inject_tool_prose=False` skips the prose [TOOLS] block — used by the
+        native tool-calling path, which sends tool schemas via the API
+        `tools=[...]` parameter instead of describing them in the prompt.
         """
         # Mode-aware context depth: local models have tiny context windows,
         # cloud models (128K+) can use much more conversation history.
@@ -439,7 +446,7 @@ class ConversationEngine:
 
         # Inject tool descriptions into system prompt
         # Use compact format for local models to save tokens
-        if self._tool_registry:
+        if self._tool_registry and inject_tool_prose:
             is_local = self._llm_config.backend in ("ollama", "npu_genie", "lmstudio")
             tool_desc = self._tool_registry.format_for_llm(compact=is_local)
             if tool_desc and context and context[0]["role"] == "system":
@@ -485,6 +492,22 @@ class ConversationEngine:
         """
         if not self._llm:
             raise RuntimeError("ConversationEngine not initialized")
+
+        # Native tool-calling path (llm.native_tools + a backend that
+        # supports the OpenAI tools=[...] API). Isolated method so the
+        # audit-hardened prose/marker loop below is untouched and stays
+        # the fallback for every other backend/model.
+        if (
+            getattr(self._llm_config, "native_tools", False)
+            and self._tool_registry
+            and isinstance(self._llm, SupportsNativeTools)
+        ):
+            async for token in self._process_text_stream_native(
+                session_id, text, input_mode, audio_duration_s,
+                on_tool_call, on_tool_result, on_tool_error, media_id,
+            ):
+                yield token
+            return
 
         # Store user message — multimodal turns pass media_id to encode
         # the content with the multimodal marker (#183 PR 3). Uses
@@ -683,5 +706,141 @@ class ConversationEngine:
 
         logger.info(
             "Conversation streamed (session=%s, latency=%.0fms, tools=%d): '%s' → '%s'",
+            session_id, latency_ms, tool_calls_made, text[:50], response_text[:50],
+        )
+
+    async def _process_text_stream_native(
+        self,
+        session_id: str,
+        text: str,
+        input_mode: str = "text",
+        audio_duration_s: Optional[float] = None,
+        on_tool_call=None,
+        on_tool_result=None,
+        on_tool_error=None,
+        media_id: Optional[str] = None,
+    ) -> AsyncIterator[str]:
+        """Native tool-calling turn via the OpenAI tools=[...] API.
+
+        Mirrors process_text_stream's contract but uses
+        `SupportsNativeTools.generate_with_tools` instead of prose-listed
+        tools + the marker parser. Each loop iteration asks the model for
+        a structured decision: a tool call (execute → feed result back →
+        loop) or final content (yield + stop). `tool_choice="auto"` means
+        the model returns no tool call for chit-chat / out-of-scope, so
+        the synthetic none() escape hatch isn't needed.
+
+        Non-streaming: the final answer is yielded in one chunk. The
+        WS keepalive (server.py) covers the silent inference window.
+        """
+        import json as _json
+
+        await self._messages.add_message(
+            session_id=session_id,
+            role="user",
+            content=text,
+            input_mode="text" if media_id else input_mode,
+            audio_duration_s=audio_duration_s,
+            media_id=media_id,
+        )
+        await self._db.touch_session(session_id)
+
+        tools = self._tool_registry.openai_tools()
+        t0 = time.monotonic()
+        tool_calls_made = 0
+        response_text = ""
+
+        while True:
+            context = await self._build_context(
+                session_id, text, inject_tool_prose=False
+            )
+            result = await self._llm.generate_with_tools(context, tools)
+            calls = result.get("tool_calls") or []
+            response_text = result.get("content") or ""
+
+            if calls and tool_calls_made < MAX_TOOL_CALLS:
+                call = calls[0]  # one at a time, same as the prose path
+                tool_calls_made += 1
+                tool_call = {"tool": call["name"], "args": call.get("args") or {}}
+                logger.info(
+                    "Native tool call: %s(%s)", tool_call["tool"], tool_call["args"]
+                )
+
+                if on_tool_call:
+                    try:
+                        await on_tool_call(tool_call)
+                    except Exception as e:
+                        logger.debug("on_tool_call callback error: %s", e)
+
+                if not self._tool_registry.get(tool_call["tool"]):
+                    # Model invented a tool name — surface it, don't loop.
+                    if on_tool_error:
+                        try:
+                            await on_tool_error({
+                                "name": tool_call["tool"],
+                                "code": "unknown_tool",
+                                "message": f"No such tool: {tool_call['tool']}",
+                            })
+                        except Exception as e:
+                            logger.debug("on_tool_error callback error: %s", e)
+                    break
+
+                _args = dict(tool_call["args"])
+                _args.setdefault("session_id", session_id)
+                tool_result = await self._tool_registry.execute(
+                    tool_call["tool"], _args
+                )
+
+                if on_tool_result:
+                    try:
+                        await on_tool_result(tool_result)
+                    except Exception as e:
+                        logger.debug("on_tool_result callback error: %s", e)
+
+                await self._messages.add_message(
+                    session_id=session_id, role="assistant",
+                    content=f"<tool>{tool_call['tool']}</tool>"
+                            f"<args>{_json.dumps(tool_call['args'])}</args>",
+                    input_mode="system", model=self._llm.name,
+                )
+                await self._messages.add_message(
+                    session_id=session_id, role="tool",
+                    content=f"<tool_result>"
+                            f"{_json.dumps(tool_result.get('result', tool_result))}"
+                            f"</tool_result>",
+                    input_mode="system",
+                )
+                continue  # re-query with the tool result in context
+
+            # No tool call (or limit hit) — final answer.
+            if calls and tool_calls_made >= MAX_TOOL_CALLS and on_tool_error:
+                try:
+                    await on_tool_error({
+                        "name": "(chain)",
+                        "code": "tool_call_limit_reached",
+                        "message": (
+                            f"Reached the {MAX_TOOL_CALLS}-tool limit for "
+                            "this turn — please ask again to continue."
+                        ),
+                        "limit": MAX_TOOL_CALLS,
+                    })
+                except Exception as e:
+                    logger.debug("on_tool_error (limit) callback error: %s", e)
+
+            if response_text:
+                yield response_text
+            break
+
+        latency_ms = (time.monotonic() - t0) * 1000
+        await self._messages.add_message(
+            session_id=session_id,
+            role="assistant",
+            content=response_text,
+            input_mode="system",
+            model=self._llm.name,
+            latency_ms=latency_ms,
+        )
+        logger.info(
+            "Native turn (session=%s, latency=%.0fms, tools=%d): '%s' → '%s'",
             session_id, latency_ms, tool_calls_made, text[:50], response_text[:50],
         )

--- a/dragon_voice/conversation.py
+++ b/dragon_voice/conversation.py
@@ -489,7 +489,8 @@ class ConversationEngine:
         return response_text
 
     async def _build_context(
-        self, session_id: str, user_text: str, inject_tool_prose: bool = True
+        self, session_id: str, user_text: str, inject_tool_prose: bool = True,
+        light_memory: bool = False,
     ) -> list[dict]:
         """Build LLM context with optional memory augmentation and tool descriptions.
 
@@ -499,6 +500,13 @@ class ConversationEngine:
         `inject_tool_prose=False` skips the prose [TOOLS] block — used by the
         native tool-calling path, which sends tool schemas via the API
         `tools=[...]` parameter instead of describing them in the prompt.
+
+        `light_memory=True` injects only a couple facts and NO document chunks.
+        Document chunks (up to 3×512 tokens) are the dominant uncached cold-
+        prefill cost on the 1B CPU (~80s at ~13 tok/s) and are pointless for
+        quick voice tool commands ("what's on my calendar", "unread email").
+        The fast native path passes this; long-form knowledge QA keeps the full
+        RAG.
         """
         # Mode-aware context depth: local models have tiny context windows,
         # cloud models (128K+) can use much more conversation history.
@@ -511,7 +519,14 @@ class ConversationEngine:
         # Inject memory context before the user's message
         if self._memory_service:
             try:
-                memory_ctx = await self._memory_service.get_relevant_context(user_text)
+                if light_memory:
+                    memory_ctx = await self._memory_service.get_relevant_context(
+                        user_text, max_facts=2, max_chunks=0,
+                    )
+                else:
+                    memory_ctx = await self._memory_service.get_relevant_context(
+                        user_text
+                    )
                 if memory_ctx:
                     # Augment system prompt with memory context
                     if context and context[0]["role"] == "system":
@@ -850,7 +865,7 @@ class ConversationEngine:
 
         while True:
             context = await self._build_context(
-                session_id, text, inject_tool_prose=False
+                session_id, text, inject_tool_prose=False, light_memory=True,
             )
             # Recipe parts 1+3: append tool-routing guidance to the system
             # prompt and splice the read-vs-action / no-chitchat few-shot in

--- a/dragon_voice/conversation.py
+++ b/dragon_voice/conversation.py
@@ -26,6 +26,12 @@ from dragon_voice.config import LLMConfig
 logger = logging.getLogger(__name__)
 
 MAX_TOOL_CALLS = 3  # Prevent infinite tool-call loops
+# Fast native path: prior-turn history depth. A voice tool command needs the
+# current turn plus a turn or two of context — not the full 10-message window
+# whose stale fat tool-result blobs dominate CPU prefill. The current turn's
+# tool round-trip is accumulated in-memory (not re-fetched), so this cap never
+# truncates the active chain.
+NATIVE_HISTORY_MSGS = 6
 
 # ── Native tool-calling recipe (TinkerBox spec 2026-05-27) ─────────────
 # Lifts the 27-tool gauntlet from ~12/19 to 19/20 on Granite-4.0-Nano-1B.
@@ -48,7 +54,11 @@ _NATIVE_TOOL_GUIDANCE = (
     "gmail_unread; mark a task done/complete = tasks_complete (NOT tasks_list); "
     "save/'remember that' a fact = remember; 'what do you know'/recall = recall. "
     "For jokes, opinions, greetings, thanks, or chit-chat, do NOT call any tool "
-    "— just reply briefly."
+    "— just reply briefly. "
+    "ANSWER STYLE: this is a spoken voice assistant. When you summarize a tool "
+    "result, reply in ONE short, natural spoken sentence. Never use markdown, "
+    "bullet lists, headers, or URLs/links — say the essentials only (e.g. 'You "
+    "have 3 events today: standup at 7:30, the DE standup at 1, and day-end at 3')."
 )
 # Curated fast-tier tool allowlist (~13). Keeps the common calendar/email/
 # tasks/weather/time/calc/memory verbs the user actually hits; the rarer tools
@@ -76,6 +86,54 @@ _NATIVE_TOOL_DESC = {
     "remember": "Store/save a NEW fact about the user for later.",
     "recall": "Retrieve previously stored facts about the user.",
 }
+
+
+# Result-wrap prefill guard. A list-returning tool (gmail_unread → 10 emails
+# with snippets, calendar_today → many events, *_search) can emit a multi-
+# thousand-token result blob. The model must prefill that whole blob on the
+# result-wrap call just to summarize it — on the 1B CPU that single fat result
+# dominates the turn (measured: a 10-email result pushed the wrap prompt to
+# 6438 tokens / ~400s under thermal throttle). The fast tier only needs enough
+# to give a spoken summary, so cap list length and per-string length before the
+# result re-enters context. The full result already reached the user (the
+# answer) and the agent_log; this only trims what the model re-reads.
+_TOOL_RESULT_LIST_CAP = 4
+_TOOL_RESULT_STR_CAP = 120
+_TOOL_RESULT_CHAR_BUDGET = 1400
+# Fields a spoken summary never needs — they're large and the model would
+# otherwise echo them as markdown links. Dropped before the result re-enters
+# context. Matched case-insensitively as a substring of the key.
+_TOOL_RESULT_DROP_KEYS = ("link", "url", "html", "eid", "snippet", "ical")
+
+
+def _compact_tool_result(result: object) -> str:
+    """Serialize a tool result for feeding back to the model, capping fat
+    list/string fields and dropping voice-useless link/url fields so the
+    result-wrap prefill stays small."""
+    import json as _j
+
+    def _shorten(o: object) -> object:
+        if isinstance(o, str):
+            return o if len(o) <= _TOOL_RESULT_STR_CAP else o[:_TOOL_RESULT_STR_CAP] + "…"
+        if isinstance(o, list):
+            head = [_shorten(x) for x in o[:_TOOL_RESULT_LIST_CAP]]
+            if len(o) > _TOOL_RESULT_LIST_CAP:
+                head.append(f"…(+{len(o) - _TOOL_RESULT_LIST_CAP} more)")
+            return head
+        if isinstance(o, dict):
+            return {
+                k: _shorten(v) for k, v in o.items()
+                if not any(d in k.lower() for d in _TOOL_RESULT_DROP_KEYS)
+            }
+        return o
+
+    try:
+        s = _j.dumps(_shorten(result), ensure_ascii=False)
+    except Exception:  # noqa: BLE001
+        s = str(result)
+    if len(s) > _TOOL_RESULT_CHAR_BUDGET:
+        s = s[:_TOOL_RESULT_CHAR_BUDGET] + "…"
+    return s
 
 
 def _native_fewshot() -> list[dict]:
@@ -490,7 +548,8 @@ class ConversationEngine:
 
     async def _build_context(
         self, session_id: str, user_text: str, inject_tool_prose: bool = True,
-        light_memory: bool = False,
+        light_memory: bool = False, max_msgs: Optional[int] = None,
+        inject_memory: bool = True, drop_tool_history: bool = False,
     ) -> list[dict]:
         """Build LLM context with optional memory augmentation and tool descriptions.
 
@@ -511,13 +570,38 @@ class ConversationEngine:
         # Mode-aware context depth: local models have tiny context windows,
         # cloud models (128K+) can use much more conversation history.
         is_local = self._llm_config.backend in ("ollama", "npu_genie", "lmstudio")
-        max_msgs = 10 if is_local else 30
+        if max_msgs is None:
+            max_msgs = 10 if is_local else 30
         context = await self._messages.get_context(
             session_id, max_messages=max_msgs, media_store=self._media_store
         )
 
-        # Inject memory context before the user's message
-        if self._memory_service:
+        # Drop PRIOR turns' tool-call / tool-result messages from the prefill
+        # history. The native path supplies the current turn's tool round-trip
+        # in-memory (proper OpenAI format), so re-fetching old turns' legacy
+        # <tool>…</tool> markers from the DB only adds fat, format-mismatched
+        # tokens that bust prompt-cache reuse on every decision call. The DB
+        # record is untouched (dashboard/audit still see the full exchange);
+        # this trims only what gets prefilled. A brief assistant answer already
+        # captures what each prior turn did.
+        if drop_tool_history and len(context) > 1:
+            context = [context[0]] + [
+                m for m in context[1:]
+                if m.get("role") != "tool"
+                and not (
+                    m.get("role") == "assistant"
+                    and isinstance(m.get("content"), str)
+                    and m["content"].lstrip().startswith("<tool>")
+                )
+            ]
+
+        # Inject memory context before the user's message.
+        # `inject_memory=False` keeps the system prompt byte-stable across turns
+        # so llama-server's prompt cache can reuse the whole static prefix. The
+        # fast native path uses this: query-keyed memory facts would otherwise
+        # change the system message every turn and bust the cache (tool commands
+        # fetch live data and don't need injected facts — recall is a tool).
+        if self._memory_service and inject_memory:
             try:
                 if light_memory:
                     memory_ctx = await self._memory_service.get_relevant_context(
@@ -863,22 +947,30 @@ class ConversationEngine:
         response_text = ""
         turn_calls: list[dict] = []  # for the empty-response wrap
 
-        while True:
-            context = await self._build_context(
-                session_id, text, inject_tool_prose=False, light_memory=True,
+        # Build the prompt prefix ONCE (small history — see NATIVE_HISTORY_MSGS).
+        # The current turn's tool round-trip is accumulated in-memory below as
+        # proper OpenAI tool_calls/tool messages, so the static prefix (system +
+        # guidance + few-shot + tool schemas) stays byte-identical across loop
+        # iterations for prompt-cache reuse, and multi-tool chains keep their
+        # own results regardless of the history cap.
+        context = await self._build_context(
+            session_id, text, inject_tool_prose=False, light_memory=True,
+            max_msgs=NATIVE_HISTORY_MSGS, inject_memory=False,
+            drop_tool_history=True,
+        )
+        # Recipe parts 1+3: append tool-routing guidance to the system prompt
+        # and splice the read-vs-action / no-chitchat few-shot right after it.
+        if context and context[0].get("role") == "system":
+            context[0] = {**context[0],
+                          "content": context[0]["content"] + _NATIVE_TOOL_GUIDANCE}
+            context = [context[0]] + fewshot + context[1:]
+        else:
+            context = (
+                [{"role": "system", "content": _NATIVE_TOOL_GUIDANCE.strip()}]
+                + fewshot + context
             )
-            # Recipe parts 1+3: append tool-routing guidance to the system
-            # prompt and splice the read-vs-action / no-chitchat few-shot in
-            # right after it (native path only).
-            if context and context[0].get("role") == "system":
-                context[0] = {**context[0],
-                              "content": context[0]["content"] + _NATIVE_TOOL_GUIDANCE}
-                context = [context[0]] + fewshot + context[1:]
-            else:
-                context = (
-                    [{"role": "system", "content": _NATIVE_TOOL_GUIDANCE.strip()}]
-                    + fewshot + context
-                )
+
+        while True:
             result = await self._llm.generate_with_tools(context, tools)
             calls = result.get("tool_calls") or []
             response_text = result.get("content") or ""
@@ -927,6 +1019,11 @@ class ConversationEngine:
                     "result": tool_result.get("result", tool_result),
                 })
 
+                # Compact the result ONCE — used for both the DB record (so it
+                # doesn't bloat future-turn history) and the in-memory wrap.
+                _compact = _compact_tool_result(
+                    tool_result.get("result", tool_result)
+                )
                 await self._messages.add_message(
                     session_id=session_id, role="assistant",
                     content=f"<tool>{tool_call['tool']}</tool>"
@@ -935,11 +1032,26 @@ class ConversationEngine:
                 )
                 await self._messages.add_message(
                     session_id=session_id, role="tool",
-                    content=f"<tool_result>"
-                            f"{_json.dumps(tool_result.get('result', tool_result))}"
-                            f"</tool_result>",
+                    content=f"<tool_result>{_compact}</tool_result>",
                     input_mode="system",
                 )
+                # Feed the result back IN-MEMORY as proper OpenAI tool messages
+                # (stronger signal than the legacy <tool_result> text, and keeps
+                # the current turn's chain intact independent of the history cap).
+                _cid = f"c{tool_calls_made}"
+                context.append({
+                    "role": "assistant", "content": None,
+                    "tool_calls": [{
+                        "id": _cid, "type": "function",
+                        "function": {
+                            "name": tool_call["tool"],
+                            "arguments": _json.dumps(tool_call["args"]),
+                        },
+                    }],
+                })
+                context.append({
+                    "role": "tool", "tool_call_id": _cid, "content": _compact,
+                })
                 continue  # re-query with the tool result in context
 
             # No tool call (or limit hit) — final answer.

--- a/dragon_voice/conversation.py
+++ b/dragon_voice/conversation.py
@@ -573,7 +573,7 @@ class ConversationEngine:
         # audit-hardened prose/marker loop below is untouched and stays
         # the fallback for every other backend/model.
         _nt = getattr(self._llm_config, "native_tools", False)
-        logger.info(
+        logger.debug(
             "TT-ROUTE native_tools=%s backend=%s llm=%s supports_native=%s reg=%s",
             _nt, getattr(self._llm_config, "backend", None),
             type(self._llm).__name__,
@@ -846,6 +846,7 @@ class ConversationEngine:
         t0 = time.monotonic()
         tool_calls_made = 0
         response_text = ""
+        turn_calls: list[dict] = []  # for the empty-response wrap
 
         while True:
             context = await self._build_context(
@@ -906,6 +907,11 @@ class ConversationEngine:
                     except Exception as e:
                         logger.debug("on_tool_result callback error: %s", e)
 
+                turn_calls.append({
+                    "tool": tool_call["tool"], "args": tool_call["args"],
+                    "result": tool_result.get("result", tool_result),
+                })
+
                 await self._messages.add_message(
                     session_id=session_id, role="assistant",
                     content=f"<tool>{tool_call['tool']}</tool>"
@@ -935,6 +941,17 @@ class ConversationEngine:
                     })
                 except Exception as e:
                     logger.debug("on_tool_error (limit) callback error: %s", e)
+
+            # Empty-response wrap (parity with the prose path): if a tool
+            # fired but the model produced no user-visible text, synthesize a
+            # one-line natural-language ack from the tool result instead of
+            # leaving the user with a blank turn.
+            if not response_text and turn_calls:
+                try:
+                    from dragon_voice.tools.response_wrap import synthesize_wrap
+                    response_text = synthesize_wrap(turn_calls)
+                except Exception as e:  # noqa: BLE001
+                    logger.debug("native empty-wrap failed: %s", e)
 
             if response_text:
                 yield response_text

--- a/dragon_voice/conversation.py
+++ b/dragon_voice/conversation.py
@@ -27,6 +27,70 @@ logger = logging.getLogger(__name__)
 
 MAX_TOOL_CALLS = 3  # Prevent infinite tool-call loops
 
+# ── Native tool-calling recipe (TinkerBox spec 2026-05-27) ─────────────
+# Lifts the 27-tool gauntlet from ~12/19 to 19/20 on Granite-4.0-Nano-1B.
+# Three parts, applied only on the native (tools=[...]) path:
+#   1) _NATIVE_TOOL_GUIDANCE — appended to the system prompt: when to call a
+#      tool + read-vs-action / remember-vs-recall disambiguation + no-fire on
+#      chit-chat.
+#   2) _NATIVE_TOOL_DESC — intent-keyed descriptions for confusable tools
+#      (the native router leans heavily on tool descriptions).
+#   3) _NATIVE_FEWSHOT — message-level few-shot exemplars (the decisive lever;
+#      rules alone didn't fix read-vs-action, real tool_call examples did).
+_NATIVE_TOOL_GUIDANCE = (
+    "\n\nTOOL USE: Always call the matching tool when the user asks about their "
+    "calendar, email, tasks, the weather, the time, a calculation, or to "
+    "remember/recall a fact — never answer those from your own knowledge. Match "
+    "intent precisely: schedule/book/set up a NEW event = calendar_create (NOT "
+    "calendar_today); cancel/delete an event = calendar_cancel; read/list "
+    "existing events = calendar_today or calendar_week; find/search email or "
+    "'did X email me' = gmail_search (NOT gmail_unread); new/unread email = "
+    "gmail_unread; mark a task done/complete = tasks_complete (NOT tasks_list); "
+    "save/'remember that' a fact = remember; 'what do you know'/recall = recall. "
+    "For jokes, opinions, greetings, thanks, or chit-chat, do NOT call any tool "
+    "— just reply briefly."
+)
+_NATIVE_TOOL_DESC = {
+    "calendar_today": "List/read EXISTING calendar events for today. Read-only; does NOT create events.",
+    "calendar_week": "List/read EXISTING calendar events for this week. Read-only.",
+    "calendar_create": "Create/schedule/book a NEW calendar event or appointment.",
+    "calendar_cancel": "Cancel, delete, or remove an existing calendar event.",
+    "gmail_unread": "List the user's UNREAD/new emails ('any new mail', 'unread').",
+    "gmail_search": "Search the inbox by keyword/sender/subject ('did X email me', 'find email about Y').",
+    "gmail_send": "Compose and SEND a new email; extract recipient, subject, body.",
+    "gmail_read": "Read the full body of one specific email.",
+    "tasks_list": "List the user's existing to-do tasks. Read-only.",
+    "tasks_add": "Add a NEW to-do task.",
+    "tasks_complete": "Mark an existing to-do task as done/complete/finished.",
+    "remember": "Store/save a NEW fact about the user for later.",
+    "recall": "Retrieve previously stored facts about the user.",
+}
+
+
+def _native_fewshot() -> list[dict]:
+    """Read-vs-action + no-tool-on-chitchat exemplars in OpenAI tool format."""
+    import json as _j
+
+    def _tc(name, args):
+        return {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "fs", "type": "function",
+             "function": {"name": name, "arguments": _j.dumps(args)}}]}
+
+    def _tr():
+        return {"role": "tool", "tool_call_id": "fs", "content": "{\"ok\":true}"}
+
+    return [
+        {"role": "user", "content": "book a haircut for Friday at 2pm"},
+        _tc("calendar_create", {"summary": "Haircut", "start_iso": "Friday 14:00"}), _tr(),
+        {"role": "user", "content": "cancel my 4pm meeting"},
+        _tc("calendar_cancel", {"query": "4pm meeting"}), _tr(),
+        {"role": "user", "content": "mark the dishes task as done"},
+        _tc("tasks_complete", {"title": "dishes"}), _tr(),
+        {"role": "user", "content": "tell me a joke"},
+        {"role": "assistant",
+         "content": "Why don't scientists trust atoms? Because they make up everything!"},
+    ]
+
 # Audit D5 fix: the ToolRegistry's tolerant parser accepts `<tool>`/`</tool>`
 # + `<args>`/`</args>` with minor whitespace + stray closing chars. When we
 # fall through to "no tool call (or max reached)" and yield the buffered
@@ -746,6 +810,11 @@ class ConversationEngine:
         await self._db.touch_session(session_id)
 
         tools = self._tool_registry.openai_tools()
+        for _t in tools:  # sharpen confusable tool descriptions (recipe part 2)
+            _nm = _t["function"]["name"]
+            if _nm in _NATIVE_TOOL_DESC:
+                _t["function"]["description"] = _NATIVE_TOOL_DESC[_nm]
+        fewshot = _native_fewshot()
         t0 = time.monotonic()
         tool_calls_made = 0
         response_text = ""
@@ -754,6 +823,18 @@ class ConversationEngine:
             context = await self._build_context(
                 session_id, text, inject_tool_prose=False
             )
+            # Recipe parts 1+3: append tool-routing guidance to the system
+            # prompt and splice the read-vs-action / no-chitchat few-shot in
+            # right after it (native path only).
+            if context and context[0].get("role") == "system":
+                context[0] = {**context[0],
+                              "content": context[0]["content"] + _NATIVE_TOOL_GUIDANCE}
+                context = [context[0]] + fewshot + context[1:]
+            else:
+                context = (
+                    [{"role": "system", "content": _NATIVE_TOOL_GUIDANCE.strip()}]
+                    + fewshot + context
+                )
             result = await self._llm.generate_with_tools(context, tools)
             calls = result.get("tool_calls") or []
             response_text = result.get("content") or ""

--- a/dragon_voice/conversation.py
+++ b/dragon_voice/conversation.py
@@ -561,8 +561,16 @@ class ConversationEngine:
         # supports the OpenAI tools=[...] API). Isolated method so the
         # audit-hardened prose/marker loop below is untouched and stays
         # the fallback for every other backend/model.
+        _nt = getattr(self._llm_config, "native_tools", False)
+        logger.info(
+            "TT-ROUTE native_tools=%s backend=%s llm=%s supports_native=%s reg=%s",
+            _nt, getattr(self._llm_config, "backend", None),
+            type(self._llm).__name__,
+            isinstance(self._llm, SupportsNativeTools),
+            bool(self._tool_registry),
+        )
         if (
-            getattr(self._llm_config, "native_tools", False)
+            _nt
             and self._tool_registry
             and isinstance(self._llm, SupportsNativeTools)
         ):

--- a/dragon_voice/conversation.py
+++ b/dragon_voice/conversation.py
@@ -50,6 +50,17 @@ _NATIVE_TOOL_GUIDANCE = (
     "For jokes, opinions, greetings, thanks, or chit-chat, do NOT call any tool "
     "— just reply briefly."
 )
+# Curated fast-tier tool allowlist (~13). Keeps the common calendar/email/
+# tasks/weather/time/calc/memory verbs the user actually hits; the rarer tools
+# (gmail_read/archive, calendar_week, tasks_delete, convert, stock_ticker,
+# system_info, web_search, timesense_timer, quick_poll, schedule_reminder, note,
+# forget_fact, recall) are handled by the smart/async tier. Cuts prefill tokens.
+_FAST_NATIVE_TOOLS = {
+    "calendar_today", "calendar_create", "calendar_cancel",
+    "gmail_unread", "gmail_search", "gmail_send",
+    "tasks_list", "tasks_add", "tasks_complete",
+    "weather", "datetime", "calculator", "remember",
+}
 _NATIVE_TOOL_DESC = {
     "calendar_today": "List/read EXISTING calendar events for today. Read-only; does NOT create events.",
     "calendar_week": "List/read EXISTING calendar events for this week. Read-only.",
@@ -817,7 +828,16 @@ class ConversationEngine:
         )
         await self._db.touch_session(session_id)
 
-        tools = self._tool_registry.openai_tools()
+        # Curate the fast-tier tool set: send only the ~13 highest-value tools,
+        # not all 27. The dominant local-turn latency is PREFILLING the tool
+        # schemas on a 1B CPU (~16 tok/s), so halving the schema count roughly
+        # halves prefill. The long tail of rarer tools is reached via the smart
+        # / async tier. If the registry has none of these (test harness), fall
+        # back to the full set so the prompt isn't empty.
+        tools = [
+            t for t in self._tool_registry.openai_tools()
+            if t["function"]["name"] in _FAST_NATIVE_TOOLS
+        ] or self._tool_registry.openai_tools()
         for _t in tools:  # sharpen confusable tool descriptions (recipe part 2)
             _nm = _t["function"]["name"]
             if _nm in _NATIVE_TOOL_DESC:

--- a/dragon_voice/llm/__init__.py
+++ b/dragon_voice/llm/__init__.py
@@ -72,9 +72,22 @@ def create_llm(config: LLMConfig) -> LLMBackend:
     # swap to Ollama so Dragon comes up serving SOMETHING instead of
     # blowing up at the first request.
     if backend_name == "lmstudio":
-        if not _quick_tcp_probe(config.lmstudio_url):
+        # Retry the probe with backoff before giving up. At boot, llama-server
+        # is often still loading the model when tinkerclaw-voice starts; a
+        # single failed 1.5 s probe used to strand the whole session on (often
+        # dead) Ollama. ~5×2 s grace catches a loading server without delaying
+        # boot meaningfully when it's truly down.
+        import time as _time
+
+        reachable = False
+        for _attempt in range(5):
+            if _quick_tcp_probe(config.lmstudio_url):
+                reachable = True
+                break
+            _time.sleep(2.0)
+        if not reachable:
             logger.warning(
-                "LM Studio backend selected but %s unreachable — "
+                "LM Studio backend selected but %s unreachable after retries — "
                 "falling back to Ollama for this session.  Run "
                 "`systemctl status tinkerclaw-llama-server` on Dragon "
                 "and `systemctl restart tinkerclaw-voice` to switch back.",

--- a/dragon_voice/llm/base.py
+++ b/dragon_voice/llm/base.py
@@ -171,6 +171,32 @@ class LLMBackend(ABC):
 
 
 @runtime_checkable
+class SupportsNativeTools(Protocol):
+    """Backends that support the OpenAI-native `tools=[...]` API.
+
+    Instead of prose-listing tools in the system prompt and parsing
+    `<tool>NAME</tool><args>{}</args>` markers out of the streamed text,
+    these backends accept structured tool schemas + `tool_choice="auto"`
+    and return structured tool calls. This gives the model a schema to
+    fill (clean arg extraction) and a native "don't call a tool" path
+    (no spurious fires on chit-chat).
+
+    `generate_with_tools` is non-streaming: the tool-decision turn emits
+    a tool call, not user-facing prose, so streaming buys nothing. The
+    final natural-language turn (after the tool result) is returned as
+    `content` in one block.
+
+    Returns a dict:
+        {"content": str, "tool_calls": [{"name": str, "args": dict}, ...]}
+    `tool_calls` is empty when the model chose to answer directly.
+    """
+
+    async def generate_with_tools(
+        self, messages: list[dict], tools: list[dict]
+    ) -> dict: ...
+
+
+@runtime_checkable
 class SupportsSessionKey(Protocol):
     """Backends that own their own conversation context per-session.
 

--- a/dragon_voice/llm/lmstudio_llm.py
+++ b/dragon_voice/llm/lmstudio_llm.py
@@ -218,7 +218,10 @@ class LMStudioBackend(LLMBackend):
                 yield f"[Connection error: {e}]"
 
     async def generate_with_tools(
-        self, messages: list[dict], tools: list[dict]
+        self, messages: list[dict], tools: list[dict],
+        max_tokens: int | None = None,
+        disable_thinking: bool = False,
+        timeout_s: int | None = None,
     ) -> dict:
         """Native OpenAI tool-calling pass (SupportsNativeTools).
 
@@ -247,27 +250,42 @@ class LMStudioBackend(LLMBackend):
             "model": self._model,
             "messages": messages,
             "stream": False,
-            "max_tokens": min(self._config.max_tokens, 256),
+            "max_tokens": max_tokens or min(self._config.max_tokens, 256),
             "temperature": 0.0,
             "tools": tools,
             "tool_choice": "auto",
         }
+        # Reasoning models (Qwen3.x) default to thinking, which burns the
+        # token budget before emitting a tool call. The smart tier passes
+        # disable_thinking=True; templates that don't accept the kwarg 400,
+        # so we retry once without it.
+        if disable_thinking:
+            payload["chat_template_kwargs"] = {"enable_thinking": False}
+
+        _post_kw: dict = {}
+        if timeout_s:
+            _post_kw["timeout"] = aiohttp.ClientTimeout(
+                total=timeout_s, sock_read=timeout_s
+            )
+
+        async def _do_post(pl):
+            async with self._session.post(
+                f"{self._base_url}/chat/completions", json=pl, **_post_kw,
+            ) as resp:
+                if resp.status != 200:
+                    body = await resp.text()
+                    return None, resp.status, body
+                return await resp.json(), 200, ""
 
         async with self._lock:
             try:
-                async with self._session.post(
-                    f"{self._base_url}/chat/completions",
-                    json=payload,
-                ) as resp:
-                    if resp.status != 200:
-                        error_text = await resp.text()
-                        logger.error(
-                            "LM Studio tools error %d: %s",
-                            resp.status,
-                            error_text[:300],
-                        )
-                        return {"content": "", "tool_calls": []}
-                    data = await resp.json()
+                data, status, body = await _do_post(payload)
+                if data is None and status in (400, 500) and disable_thinking:
+                    payload.pop("chat_template_kwargs", None)
+                    data, status, body = await _do_post(payload)
+                if data is None:
+                    logger.error("LM Studio tools error %d: %s", status, body[:300])
+                    return {"content": "", "tool_calls": []}
             except aiohttp.ClientError as e:
                 logger.error("LM Studio tools request failed: %s", e)
                 return {"content": "", "tool_calls": []}

--- a/dragon_voice/llm/lmstudio_llm.py
+++ b/dragon_voice/llm/lmstudio_llm.py
@@ -217,6 +217,75 @@ class LMStudioBackend(LLMBackend):
                 logger.error("LM Studio request failed: %s", e)
                 yield f"[Connection error: {e}]"
 
+    async def generate_with_tools(
+        self, messages: list[dict], tools: list[dict]
+    ) -> dict:
+        """Native OpenAI tool-calling pass (SupportsNativeTools).
+
+        Non-streaming. Sends `tools=[...]` + `tool_choice="auto"` at
+        temperature 0 (deterministic tool routing) and returns the
+        structured result. Requires llama-server started with `--jinja`
+        so the loaded GGUF's chat template renders + parses tool calls.
+
+        Returns {"content": str, "tool_calls": [{"name", "args"}, ...]}.
+        On transport error returns content with an error marker and no
+        tool calls so the caller degrades to a plain reply.
+        """
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=600, sock_read=300),
+                headers={"Content-Type": "application/json"},
+            )
+
+        payload = {
+            "model": self._model,
+            "messages": messages,
+            "stream": False,
+            "max_tokens": self._config.max_tokens,
+            "temperature": 0.0,
+            "tools": tools,
+            "tool_choice": "auto",
+        }
+
+        async with self._lock:
+            try:
+                async with self._session.post(
+                    f"{self._base_url}/chat/completions",
+                    json=payload,
+                ) as resp:
+                    if resp.status != 200:
+                        error_text = await resp.text()
+                        logger.error(
+                            "LM Studio tools error %d: %s",
+                            resp.status,
+                            error_text[:300],
+                        )
+                        return {"content": "", "tool_calls": []}
+                    data = await resp.json()
+            except aiohttp.ClientError as e:
+                logger.error("LM Studio tools request failed: %s", e)
+                return {"content": "", "tool_calls": []}
+
+        choices = data.get("choices") or [{}]
+        msg = choices[0].get("message", {}) or {}
+        calls: list[dict] = []
+        for tc in msg.get("tool_calls") or []:
+            fn = tc.get("function") or {}
+            name = fn.get("name")
+            if not name:
+                continue
+            raw_args = fn.get("arguments")
+            if isinstance(raw_args, dict):
+                args = raw_args
+            else:
+                try:
+                    args = json.loads(raw_args) if raw_args else {}
+                except (json.JSONDecodeError, TypeError):
+                    args = {}
+            calls.append({"name": name, "args": args})
+
+        return {"content": msg.get("content") or "", "tool_calls": calls}
+
     def clear_history(self) -> None:
         """Clear conversation history."""
         self._conversation.clear()

--- a/dragon_voice/llm/lmstudio_llm.py
+++ b/dragon_voice/llm/lmstudio_llm.py
@@ -237,11 +237,17 @@ class LMStudioBackend(LLMBackend):
                 headers={"Content-Type": "application/json"},
             )
 
+        # Cap the tool-decision generation hard. A tool call (or a 1-2
+        # sentence reply) is short; without this the model can run toward
+        # the 1024 MAX_TOOL_LOCAL ceiling and, non-streaming on a 1B CPU,
+        # blow past the 300 s sock_read timeout (~0.2-0.3 s/token) — which
+        # presented as "native turn fires no tool". 256 is plenty for a
+        # tool call + clean args.
         payload = {
             "model": self._model,
             "messages": messages,
             "stream": False,
-            "max_tokens": self._config.max_tokens,
+            "max_tokens": min(self._config.max_tokens, 256),
             "temperature": 0.0,
             "tools": tools,
             "tool_choice": "auto",

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -1146,7 +1146,7 @@ class VoiceServer:
         text: str, session_id: str, content: str,
     ) -> None:
         """Body of _handle_text, wrapped by the B1 turn-gate bracket above."""
-        logger.info("TT-HTB reached: content=%r", (content or "")[:80])
+        logger.debug("TT-HTB reached: content=%r", (content or "")[:80])
 
         # SOLID-audit follow-up: TinkerClaw bypass branch
         # extracted to tinkerclaw_text_path.handle_tinkerclaw_text_path.

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -1146,6 +1146,7 @@ class VoiceServer:
         text: str, session_id: str, content: str,
     ) -> None:
         """Body of _handle_text, wrapped by the B1 turn-gate bracket above."""
+        logger.info("TT-HTB reached: content=%r", (content or "")[:80])
 
         # SOLID-audit follow-up: TinkerClaw bypass branch
         # extracted to tinkerclaw_text_path.handle_tinkerclaw_text_path.
@@ -1170,6 +1171,55 @@ class VoiceServer:
             safe_send_json=self._safe_send_json,
             message_store=self._message_store,
         ):
+            return
+
+        # Wave 3: async background smart-agent tier. A heavy/deferred agentic
+        # ask ("research X and get back to me", "go through my unread and draft
+        # replies") is acked instantly here on the fast tier and run on the
+        # smart model (Qwen3.5-4B, :1235) in the background; the result is
+        # delivered as a channel_message the Tab5 notification surface renders.
+        from dragon_voice.async_agent import (
+            is_background_request, spawn_background_agent,
+        )
+        if self._tool_registry is not None and is_background_request(content):
+            ack = "On it — I'll work on that in the background and let you know."
+            if not ws.closed:
+                await self._safe_send_json(ws, {"type": "llm", "text": ack})
+                await self._safe_send_json(ws, {"type": "llm_done", "llm_ms": 0})
+
+            target_device = conn_state.get("device_id", "")
+
+            async def _deliver(summary: str) -> None:
+                import time as _t
+                frame = {
+                    "type": "channel_message",
+                    "channel": "tinker",
+                    "message_id": f"bg-{int(_t.time())}",
+                    "sender": {"display_name": "Tinker", "starred": True},
+                    "text": summary,
+                    "preview": summary[:80],
+                    "priority": "normal",
+                    "needs_reply": False,
+                }
+                # Deliver to the device's CURRENT connection — the bg task runs
+                # for minutes and the original ws will likely have reconnected,
+                # so the captured socket is stale. Scan active connections by
+                # device_id (same approach as debug_channel).
+                for conn in self._active_connections.values():
+                    if conn.get("device_id") == target_device:
+                        cur = conn.get("ws")
+                        if cur is not None and not cur.closed:
+                            try:
+                                await cur.send_json(frame)
+                            except Exception as e:  # noqa: BLE001
+                                logger.warning("bg deliver send failed: %s", e)
+                        return
+                logger.warning(
+                    "bg deliver: device %s not connected — result dropped: %s",
+                    target_device, summary[:60],
+                )
+
+            spawn_background_agent(content, self._tool_registry, _deliver)
             return
 
         try:

--- a/dragon_voice/tools/integrations/oauth.py
+++ b/dragon_voice/tools/integrations/oauth.py
@@ -227,10 +227,17 @@ class OAuthAuthCodeClient:
         if extra_params:
             params.update(extra_params)
         url = f"{self._auth_url}?{urllib.parse.urlencode(params)}"
+        # The waiter's future is created lazily in wait_for_callback() on the
+        # running loop that actually awaits it.  start() is a synchronous
+        # URL-builder that may be called with no event loop at all (py3.12
+        # made asyncio.get_event_loop() raise in that case), and a future
+        # must live on the loop that awaits it — so we defer creation.  If
+        # the provider callback beats the waiter, resolve_callback() buffers
+        # the outcome for wait_for_callback() to honor immediately.
         self._pending[state] = {
             "code_verifier": verifier,
             "expires_at": time.time() + 600,
-            "future": asyncio.get_event_loop().create_future(),
+            "future": None,
         }
         return AuthCodeChallenge(
             authorization_url=url,
@@ -245,7 +252,13 @@ class OAuthAuthCodeClient:
         if entry is None:
             logger.warning("OAuth callback for unknown state %r — ignoring", state[:12])
             return
-        future = entry["future"]
+        future = entry.get("future")
+        if future is None:
+            # Callback arrived before wait_for_callback() parked — buffer the
+            # outcome so the waiter can honor it as soon as it starts waiting.
+            entry["pending_code"] = code
+            entry["pending_error"] = error
+            return
         if future.done():
             return
         if error:
@@ -262,8 +275,17 @@ class OAuthAuthCodeClient:
         entry = self._pending.get(state)
         if entry is None:
             raise DeviceCodeError("unknown_state", "no pending flow for state")
+        # If the callback already resolved before we parked, honor it now.
+        if "pending_code" in entry or "pending_error" in entry:
+            self._pending.pop(state, None)
+            err = entry.get("pending_error")
+            if err:
+                raise DeviceCodeError(code=err, description=err)
+            return entry.get("pending_code")
+        future = asyncio.get_running_loop().create_future()
+        entry["future"] = future
         try:
-            code = await asyncio.wait_for(entry["future"], timeout=timeout_s)
+            code = await asyncio.wait_for(future, timeout=timeout_s)
             return code
         except asyncio.TimeoutError:
             raise DeviceCodeError(

--- a/dragon_voice/tools/registry.py
+++ b/dragon_voice/tools/registry.py
@@ -136,6 +136,32 @@ class ToolRegistry:
         """
         return _has_tool_call(text, registered_names=self._tools.keys())
 
+    def openai_tools(self) -> list[dict]:
+        """Render registered tools as OpenAI-format function schemas.
+
+        For the native tool-calling path (SupportsNativeTools): passed as
+        `tools=[...]` to the llama-server OpenAI API. Each tool's
+        `parameters_schema` is already a JSON-schema object, so this is a
+        thin wrap. The whole registry is sent (not just the compact
+        priority subset) — the native API gives the model a structured
+        signal that doesn't bloat the prose context the way the prompt
+        block does.
+        """
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": t.name,
+                    "description": t.description,
+                    "parameters": t.parameters_schema or {
+                        "type": "object",
+                        "properties": {},
+                    },
+                },
+            }
+            for t in self._tools.values()
+        ]
+
     def format_for_llm(self, compact: bool = False) -> str:
         """Format tool descriptions for injection into LLM system prompt.
 

--- a/tests/audit/test_d5_d6_ws.py
+++ b/tests/audit/test_d5_d6_ws.py
@@ -15,8 +15,22 @@ import secrets
 import sys
 
 import aiohttp
+import pytest
 
 DRAGON_URL = os.environ.get("DRAGON_URL", "ws://192.168.1.91:3502/ws/voice")
+
+# These two functions are live-Dragon integration probes (see the module
+# docstring), not self-contained unit tests — they open a real /ws/voice
+# socket and exercise the live LLM + media pipeline.  Skip them in the normal
+# suite; opt in with RUN_LIVE_AUDIT=1 against a reachable Dragon.  When opted
+# in, run them as asyncio tests (the repo uses strict pytest-asyncio mode).
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.skipif(
+        not os.environ.get("RUN_LIVE_AUDIT"),
+        reason="live-Dragon audit probe; set RUN_LIVE_AUDIT=1 to run (see module docstring)",
+    ),
+]
 
 
 async def _register_and_config(ws, model: str):

--- a/tests/test_config_swap.py
+++ b/tests/test_config_swap.py
@@ -44,8 +44,15 @@ class _StubLlmCfg:
 
 
 @dataclass
+class _StubTtsCfg:
+    """Minimal subset of TTSConfig used by select_backends_for_mode."""
+    backend: str = "kokoro"
+
+
+@dataclass
 class _StubVoiceCfg:
     llm: _StubLlmCfg = field(default_factory=_StubLlmCfg)
+    tts: _StubTtsCfg = field(default_factory=_StubTtsCfg)
 
 
 class SelectBackendsTests(unittest.TestCase):

--- a/tests/test_native_context_accumulation.py
+++ b/tests/test_native_context_accumulation.py
@@ -1,0 +1,212 @@
+"""Native tool-calling path: prompt-prefix + history discipline.
+
+The fast native path (llm.native_tools + a SupportsNativeTools backend)
+must, for each turn:
+
+  1. Build the prompt prefix EXACTLY ONCE — the static prefix (system +
+     guidance + few-shot + tool schemas) stays byte-identical across loop
+     iterations so llama-server's prompt cache can reuse it.
+  2. Cap the prior-turn history window to NATIVE_HISTORY_MSGS so stale fat
+     tool-result blobs don't dominate CPU prefill on the 1B model.
+  3. Accumulate the CURRENT turn's tool round-trip IN-MEMORY as proper
+     OpenAI `tool_calls` / `tool` messages — not by re-fetching the
+     fattened history from the DB — so a multi-tool chain keeps its own
+     results regardless of the history cap.
+
+These are the latency levers landed after the dotprod rebuild: the
+6431-token prompt was dominated by re-fetched history, and re-building the
+prefix every iteration busted the prompt cache.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from dragon_voice import conversation as convo_mod
+from dragon_voice.conversation import ConversationEngine
+
+
+class _NativeLLM:
+    """Implements the SupportsNativeTools contract. Returns a tool call for
+    the first `tool_rounds` invocations, then a final text answer. Records
+    the messages passed on every call so the test can inspect accumulation."""
+
+    name = "native-fake"
+
+    def __init__(self, tool_rounds: int = 2) -> None:
+        self.tool_rounds = tool_rounds
+        self.calls = 0
+        self.seen: list[list[dict]] = []
+
+    async def generate_with_tools(self, messages, tools, **kw) -> dict:
+        self.calls += 1
+        self.seen.append([dict(m) for m in messages])
+        if self.calls <= self.tool_rounds:
+            return {"tool_calls": [{"name": "echo", "args": {"n": self.calls}}],
+                    "content": ""}
+        return {"tool_calls": [], "content": "all done"}
+
+
+class _Registry:
+    def __init__(self) -> None:
+        self._tools = {"echo": object()}
+
+    def openai_tools(self) -> list[dict]:
+        return [{"type": "function",
+                 "function": {"name": "echo", "description": "echo",
+                              "parameters": {"type": "object", "properties": {}}}}]
+
+    def get(self, name: str):
+        return self._tools.get(name)
+
+    async def execute(self, name: str, args: dict[str, Any]) -> dict:
+        return {"tool": name, "result": {"echoed": args}, "execution_ms": 1}
+
+
+class _MsgStore:
+    def __init__(self) -> None:
+        self.added: list[dict] = []
+
+    async def add_message(self, **kw) -> None:
+        self.added.append(kw)
+
+
+class _DB:
+    async def touch_session(self, sid: str) -> None:
+        return None
+
+
+def _engine(llm: _NativeLLM) -> ConversationEngine:
+    eng = ConversationEngine.__new__(ConversationEngine)
+    eng._llm = llm
+    eng._tool_registry = _Registry()
+    eng._messages = _MsgStore()
+    eng._db = _DB()
+    eng._memory_service = None
+    eng._media_store = None
+    eng._llm_config = type(
+        "C", (), {"backend": "lmstudio", "native_tools": True}
+    )()
+    return eng
+
+
+def _run_native(eng: ConversationEngine, text: str = "what's on my calendar"):
+    build_calls = {"n": 0, "max_msgs": "unset"}
+
+    async def fake_build_context(session_id, user_text, inject_tool_prose=True,
+                                 light_memory=False, max_msgs=None,
+                                 inject_memory=True, drop_tool_history=False):
+        build_calls["n"] += 1
+        build_calls["max_msgs"] = max_msgs
+        return [{"role": "system", "content": "sys"},
+                {"role": "user", "content": user_text}]
+
+    eng._build_context = fake_build_context  # type: ignore[assignment]
+
+    async def go():
+        out: list[str] = []
+        async for tok in eng._process_text_stream_native(
+            "s1", text, "text", None, None, None, None, None,
+        ):
+            out.append(tok)
+        return out
+
+    return asyncio.run(go()), build_calls
+
+
+def test_compact_tool_result_caps_fat_list() -> None:
+    # Simulate gmail_unread returning 10 emails with long snippets + links.
+    big = {
+        "count": 10,
+        "messages": [
+            {"from": f"sender{i}@x.com", "subject": f"Subject {i}",
+             "snippet": "x" * 500, "htmlLink": "https://mail.google.com/" + "y" * 80,
+             "id": f"id{i}"}
+            for i in range(10)
+        ],
+    }
+    out = convo_mod._compact_tool_result(big)
+    # Stays within the prefill budget instead of ~6KB of raw JSON.
+    assert len(out) <= convo_mod._TOOL_RESULT_CHAR_BUDGET
+    # The summary-critical count + senders survive; the list is trimmed.
+    assert '"count": 10' in out
+    assert "more)" in out
+    assert "sender0@x.com" in out
+    # Voice-useless fields are dropped entirely, not just truncated.
+    assert "x" * 200 not in out  # snippet dropped
+    assert "https://" not in out  # htmlLink dropped
+
+
+def test_compact_tool_result_passthrough_small() -> None:
+    small = {"ok": True, "result": "done"}
+    out = convo_mod._compact_tool_result(small)
+    assert '"ok": true' in out
+    assert "done" in out
+
+
+def test_build_context_drops_prior_tool_history() -> None:
+    # _build_context(drop_tool_history=True) must strip prior turns' tool +
+    # <tool> marker messages from the prefill history (cache-stability), while
+    # keeping the system prompt + real user/assistant text.
+    eng = ConversationEngine.__new__(ConversationEngine)
+    eng._memory_service = None
+    eng._tool_registry = None
+    eng._media_store = None
+    eng._llm_config = type("C", (), {"backend": "lmstudio"})()
+
+    class _MS:
+        async def get_context(self, session_id, max_messages=10, media_store=None):
+            return [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "whats on my calendar"},
+                {"role": "assistant", "content": "<tool>calendar_today</tool><args>{}</args>"},
+                {"role": "tool", "content": "<tool_result>{...}</tool_result>"},
+                {"role": "assistant", "content": "You have 3 events"},
+                {"role": "user", "content": "any unread email?"},
+            ]
+
+    eng._messages = _MS()
+    ctx = asyncio.run(
+        eng._build_context("s1", "any unread email?", inject_tool_prose=False,
+                           inject_memory=False, drop_tool_history=True)
+    )
+    roles = [m["role"] for m in ctx]
+    assert "tool" not in roles
+    assert not any(
+        m["role"] == "assistant" and m["content"].lstrip().startswith("<tool>")
+        for m in ctx
+    )
+    # Real user + assistant-answer turns survive.
+    contents = [m["content"] for m in ctx]
+    assert "You have 3 events" in contents
+    assert "whats on my calendar" in contents
+
+
+def test_native_builds_prefix_once_with_capped_history() -> None:
+    llm = _NativeLLM(tool_rounds=2)
+    eng = _engine(llm)
+    out, build_calls = _run_native(eng)
+    # Prefix built exactly once despite two tool rounds + a final synth call.
+    assert build_calls["n"] == 1, f"expected 1 build, got {build_calls['n']}"
+    assert build_calls["max_msgs"] == convo_mod.NATIVE_HISTORY_MSGS
+    assert "".join(out) == "all done"
+
+
+def test_native_accumulates_tool_roundtrip_in_memory() -> None:
+    llm = _NativeLLM(tool_rounds=2)
+    eng = _engine(llm)
+    _run_native(eng)
+    # Three LLM calls: round 1, round 2, final synthesis.
+    assert llm.calls == 3, f"expected 3 LLM calls, got {llm.calls}"
+    n0, n1, n2 = (len(s) for s in llm.seen)
+    # Each tool round appends exactly two messages: the assistant tool_calls
+    # turn and the tool result. The history cap must NOT truncate them.
+    assert n1 - n0 == 2, f"round 1 should append 2 msgs, got {n1 - n0}"
+    assert n2 - n1 == 2, f"round 2 should append 2 msgs, got {n2 - n1}"
+    # The appended pair is proper OpenAI shape, correlated by tool_call_id.
+    pair = llm.seen[2][n1:]
+    assert pair[0]["role"] == "assistant" and pair[0]["tool_calls"]
+    assert pair[1]["role"] == "tool" and "tool_call_id" in pair[1]
+    assert pair[0]["tool_calls"][0]["id"] == pair[1]["tool_call_id"]
+    # The tool message carries the executed result, not the legacy XML text.
+    assert "echoed" in pair[1]["content"]

--- a/tests/test_oauth_auth_code.py
+++ b/tests/test_oauth_auth_code.py
@@ -120,7 +120,8 @@ def test_start_registers_pending_state_with_verifier(fake_session):
     chal = client.start()
     entry = client._pending[chal.state]
     assert entry["code_verifier"] == chal.code_verifier
-    assert entry["future"] is not None
+    # Future is created lazily in wait_for_callback() on the awaiting loop.
+    assert entry["future"] is None
 
 
 # ── resolve_callback + wait_for_callback ────────────────────────────
@@ -179,8 +180,9 @@ def test_resolve_callback_unknown_state_does_not_raise(fake_session):
 def test_wait_for_callback_unknown_state_raises_immediately(fake_session):
     client = _make_client(fake_session)
     with pytest.raises(DeviceCodeError) as excinfo:
-        # No coroutine awaited — the raise is synchronous.
-        asyncio.get_event_loop().run_until_complete(
+        # wait_for_callback raises synchronously for an unknown state; asyncio.run
+        # gives it a fresh loop (no reliance on a deprecated current-loop).
+        asyncio.run(
             client.wait_for_callback("never-issued", timeout_s=1),
         )
     assert excinfo.value.code == "unknown_state"

--- a/tests/test_tool_openai_schema.py
+++ b/tests/test_tool_openai_schema.py
@@ -1,0 +1,57 @@
+"""Unit tests for ToolRegistry.openai_tools() — the native tool-calling
+schema builder (SupportsNativeTools path). Pure, no network: CI-safe."""
+from dragon_voice.tools.base import Tool
+from dragon_voice.tools.registry import ToolRegistry
+
+
+class _Echo(Tool):
+    def __init__(self, name, desc, schema):
+        self._n, self._d, self._s = name, desc, schema
+
+    @property
+    def name(self):
+        return self._n
+
+    @property
+    def description(self):
+        return self._d
+
+    @property
+    def parameters_schema(self):
+        return self._s
+
+    async def execute(self, args):
+        return {"ok": True, "args": args}
+
+
+def test_openai_tools_shape():
+    reg = ToolRegistry()
+    reg.register(_Echo("gmail_search", "Search emails", {
+        "type": "object",
+        "properties": {"query": {"type": "string"}},
+        "required": ["query"],
+    }))
+    tools = reg.openai_tools()
+    assert len(tools) == 1
+    fn = tools[0]
+    assert fn["type"] == "function"
+    assert fn["function"]["name"] == "gmail_search"
+    assert fn["function"]["description"] == "Search emails"
+    assert fn["function"]["parameters"]["properties"]["query"]["type"] == "string"
+
+
+def test_openai_tools_empty_schema_defaults_to_object():
+    reg = ToolRegistry()
+    reg.register(_Echo("calendar_today", "Get today's events", {}))
+    tools = reg.openai_tools()
+    params = tools[0]["function"]["parameters"]
+    assert params["type"] == "object"
+    assert params["properties"] == {}
+
+
+def test_openai_tools_lists_every_registered_tool():
+    reg = ToolRegistry()
+    for n in ("a", "b", "c"):
+        reg.register(_Echo(n, n.upper(), {"type": "object", "properties": {}}))
+    names = {t["function"]["name"] for t in reg.openai_tools()}
+    assert names == {"a", "b", "c"}


### PR DESCRIPTION
## Local-mode capability rework — native tool-calling on llama-server

Capability-first rework of Dragon's Local mode: native OpenAI `tools=[…]` calling on llama-server, a fast/smart/async tiering, and a prefix-stable prompt-cache latency fix. **Winner: Granite 4.0 Nano-1B (19/20 on the hard gauntlet).**

Spec: `docs/superpowers/specs/2026-05-27-local-mode-capability-design.md` (602 lines).

### Capability arc (existing commits)
| Commit | What |
|---|---|
| `d199342` | native tool path: `SupportsNativeTools` protocol, `LMStudioBackend.generate_with_tools`, `ToolRegistry.openai_tools`, `LLMConfig.native_tools` flag |
| `ed51b20` | optimized recipe → **19/20** (`_NATIVE_TOOL_GUIDANCE`, sharpened descs, few-shot — the decisive lever) |
| `151827c` | curate fast-tier tool set 27→13 (halves schema prefill on a 1B CPU) |
| `0958561` | async background smart-agent tier (`async_agent.py`, Qwen3.5-4B on `:1235`) |
| `6b0510d` | **latency fix** — prefix-stable cache reuse: email turn **436s→29s**, warm follow-up ~7s |
| `a4dd9ed` | harden lmstudio probe (retry + IPv4) to stop dead-Ollama fallback |
| `b7e0940` | docs: dotprod rebuild + thermal-throttle findings — none a hardware floor ($5 fan = next ~2x) |

### Added in this PR (greens the suite + activates the capability)
- **`fix(oauth)`** — `start()` no longer creates the PKCE waiter future via deprecated `asyncio.get_event_loop()`; it's created lazily on the awaiting loop in `wait_for_callback()`, with early callbacks buffered. Fixes 4 suite-order-dependent failures under Python 3.12.
- **`test`** — `_StubVoiceCfg` gains the `.tts` attr `select_backends_for_mode` reads (14 failures); live-Dragon `d5/d6` WS probes now skip unless `RUN_LIVE_AUDIT=1` (2 failures).
- **`chore(config)`** — committed `config.yaml` defaults to `lmstudio` + `native_tools: true` (Granite) to match the live Dragon; previously the rework was dormant behind `backend: ollama`. Secrets stay in `.env`.

All three were **pre-existing failures on `main`** (0-diff vs main), surfaced during a full memory-validation + state-of-stack pass.

### Test status
`python -m pytest -q` → **1829 passed, 3 skipped, 0 failed** (was 1811/20/1). 2 remaining warnings are pre-existing harmless collection notices.

### Deploy note (not in repo)
The 2x latency win depends on Dragon-only infra that has **no in-repo artifact**: the DOTPROD llama.cpp rebuild, the CPU-governor service, core pinning, and both systemd units (`:1234` Granite + `:1235` Qwen smart-agent). A reflash silently reverts these and breaks `async_agent.py`'s hardcoded `:1235`. Follow-up: capture these as deploy artifacts + build the committed scored-gauntlet harness (no regression net exists yet).

Refs #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
