### PR TITLE
docs: Wave 2 — TinkerBox content (Diátaxis, ~19 pages)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,10 +10,10 @@
 This is the documentation map for **TinkerBox** — the Dragon-side server (the
 brain). Docs follow [Diátaxis](https://diataxis.fr): four content types, each
 with one job, never mixed. The [`tutorials/`](tutorials/), [`how-to/`](how-to/),
-[`reference/`](reference/), and [`explanation/`](explanation/) directories are
-the target structure; **most deep content lands in
-[Wave 2](ROADMAP.md)** and the table below shows where each page lives today vs.
-where it is headed.
+[`reference/`](reference/), and [`explanation/`](explanation/) directories hold
+the [Wave 2](ROADMAP.md) content, indexed below by type and audience. A handful
+of older top-level pages (`getting-started-user.md`, `dev-setup.md`, …) remain
+in place and are linked from their type's section until they are folded in.
 
 ## Standards
 
@@ -24,37 +24,54 @@ where it is headed.
 
 ## By Diátaxis type
 
-### Tutorials (learning by doing — for tinkerers / end users)
+### Tutorials (learning by doing — for tinkerers / operators)
 
-| Page | Status |
-|---|---|
-| [`getting-started-user.md`](getting-started-user.md) | exists — to be reworked into `tutorials/getting-started.md` (Wave 2) |
+| Page | Audience | What it gets you |
+|---|---|---|
+| [`tutorials/get-dragon-running.md`](tutorials/get-dragon-running.md) | operator | A working Dragon server you can talk to — install, configure, first voice turn. |
+| [`getting-started-user.md`](getting-started-user.md) | tinkerer | Older end-user walkthrough; superseded by the tutorial above, kept until folded in. |
 
-### How-to guides (achieve a task — for developers / operators / integrators)
+### How-to guides (achieve a task — for operators / developers)
 
-| Page | Status |
-|---|---|
-| [`dev-setup.md`](dev-setup.md) | exists — dev environment + deployment (Wave 2: split into `how-to/dev-setup.md` + `how-to/deploy.md`) |
-| [`adding-a-tool.md`](adding-a-tool.md) | exists — author a new tool (Wave 2 → `how-to/`) |
-| [`SKILL_AUTHORING.md`](SKILL_AUTHORING.md) | exists — author a skill/widget (Wave 2 → `how-to/`) |
-| [`npu-setup.md`](npu-setup.md) | exists — Qualcomm NPU / QAIRT setup (Wave 2 → `how-to/`) |
-| [`telegram-bot.md`](telegram-bot.md) | exists — Telegram channel setup (Wave 2 → `how-to/`) |
+| Page | Audience | Task |
+|---|---|---|
+| [`how-to/deploy-on-a-dragon.md`](how-to/deploy-on-a-dragon.md) | operator | Push code to a Dragon and bring the services up under systemd. |
+| [`how-to/swap-the-llm-backend.md`](how-to/swap-the-llm-backend.md) | operator | Change the active LLM backend (Ollama / llama-server / OpenRouter / TinkerClaw). |
+| [`how-to/configure-the-multi-model-router.md`](how-to/configure-the-multi-model-router.md) | operator | Declare a backend fleet and route per-turn by modality + tier. |
+| [`how-to/connect-an-integration.md`](how-to/connect-an-integration.md) | operator | Connect a Google integration (Calendar / Gmail / Tasks) via the REST connect flow. |
+| [`how-to/run-the-tinkerclaw-sidecar.md`](how-to/run-the-tinkerclaw-sidecar.md) | operator | Run the TinkerClaw gateway and route voice mode 3 to it. |
+| [`how-to/add-a-tool.md`](how-to/add-a-tool.md) | developer | Author and register a new agentic tool. |
+| [`dev-setup.md`](dev-setup.md) | developer | Older dev-environment + deploy page; kept until split into `how-to/`. |
+| [`adding-a-tool.md`](adding-a-tool.md) | developer | Original worked tool example; companion to `how-to/add-a-tool.md`. |
+| [`SKILL_AUTHORING.md`](SKILL_AUTHORING.md) | developer | Author a skill/widget surface. |
+| [`npu-setup.md`](npu-setup.md) | operator | Qualcomm NPU / QAIRT SDK setup. |
+| [`telegram-bot.md`](telegram-bot.md) | operator | Telegram channel setup. |
 
 ### Reference (look up facts — for integrators / developers)
 
-| Page | Status |
-|---|---|
-| [`protocol.md`](protocol.md) | exists — the WebSocket protocol contract (Tab5 ↔ Dragon) |
-| [`router-cookbook.md`](router-cookbook.md) | exists — multi-model router fleet recipes |
-| REST API reference | planned (Wave 2 → `reference/`) — see CLAUDE.md "API-First Architecture" for the current surface |
+| Page | Audience | What it documents |
+|---|---|---|
+| [`reference/rest-api.md`](reference/rest-api.md) | integrator | The REST API surface (`/api/v1/*`) — endpoints, auth, payloads. |
+| [`reference/websocket-protocol.md`](reference/websocket-protocol.md) | integrator | The Dragon-side WebSocket message catalog (Tab5 ↔ Dragon). |
+| [`reference/config-reference.md`](reference/config-reference.md) | integrator | Every `config.yaml` field, scope, and default. |
+| [`reference/voice-modes.md`](reference/voice-modes.md) | integrator | The six voice modes and their STT/LLM/TTS backend mapping. |
+| [`reference/tools-catalog.md`](reference/tools-catalog.md) | integrator | The built-in tools, their args, and tool-call dialects. |
+| [`reference/package-file-map.md`](reference/package-file-map.md) | developer | The `dragon_voice` package layout — module → responsibility. |
+| [`protocol.md`](protocol.md) | integrator | The full canonical WebSocket protocol contract (source of truth). |
+| [`router-cookbook.md`](router-cookbook.md) | integrator | Multi-model router fleet recipes. |
 
 ### Explanation (understand why — for developers)
 
-| Page | Status |
-|---|---|
-| [`ARCHITECTURE.md`](ARCHITECTURE.md) | exists — system overview, components, data flows (the map) |
-| [`flows/voice-turn.md`](flows/voice-turn.md) · [`flows/vision-turn.md`](flows/vision-turn.md) · [`flows/video-call.md`](flows/video-call.md) | exist — per-flow traces |
-| `explanation/how-the-stack-fits-together.md` | planned (Wave 2) — how the four repos relate, linked from the peer block |
+| Page | Audience | The mental model |
+|---|---|---|
+| [`explanation/how-the-stack-fits-together.md`](explanation/how-the-stack-fits-together.md) | developer | How the four repos relate — Tab5 (face) ↔ Dragon (brain) ↔ gateway ↔ cloud. Linked from the peer block. |
+| [`explanation/architecture.md`](explanation/architecture.md) | developer | Inside the brain — sessions, the append-only ledger, the `#65` decomposition. |
+| [`explanation/the-voice-pipeline.md`](explanation/the-voice-pipeline.md) | developer | How one voice turn flows STT → ConvEngine → LLM → tools → TTS. |
+| [`explanation/the-multi-model-router.md`](explanation/the-multi-model-router.md) | developer | Why routing is capability- and tier-aware, and how `choose()` works. |
+| [`explanation/local-first-inference.md`](explanation/local-first-inference.md) | developer | Why Local mode is Dragon-only and how llama-server replaced Ollama. |
+| [`explanation/memory-and-rag.md`](explanation/memory-and-rag.md) | developer | How facts + documents are embedded and recalled into context. |
+| [`ARCHITECTURE.md`](ARCHITECTURE.md) | developer | The system map — components, network topology, data flows. |
+| [`flows/voice-turn.md`](flows/voice-turn.md) · [`flows/vision-turn.md`](flows/vision-turn.md) · [`flows/video-call.md`](flows/video-call.md) | developer | Per-flow code-level traces. |
 
 ## Not audience documentation
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,0 +1,289 @@
+---
+audience: developer
+type: explanation
+prerequisites: [docs/ARCHITECTURE.md](../ARCHITECTURE.md), [docs/explanation/how-the-stack-fits-together.md](how-the-stack-fits-together.md)
+last-verified: 2026-05-29
+---
+# TinkerBox architecture — how it works and why
+
+## The question
+
+Why does the Dragon server look the way it does? Why is a session a different
+thing from a WebSocket connection? Why can you never edit a message after it is
+written? Why is there a separate package for middleware, another for handlers,
+another for lifecycle? And why did a 2,747-line `server.py` get torn into four
+sibling packages in a single umbrella issue?
+
+This page builds the mental model. It is not a how-to — you will not flash
+anything or run a deploy here. It explains the load-bearing design decisions so
+that when you open `dragon_voice/`, the layout reads as deliberate rather than
+accidental, and so that when you add a feature you put it where the existing
+grain already runs.
+
+For the cross-repo picture — how Dragon relates to the Tab5 firmware, the
+TinkerClaw gateway, and the cloud — read
+[How the stack fits together](how-the-stack-fits-together.md) first. This page
+is the inside of the brain.
+
+## The model
+
+### Dragon is the brain; Tab5 is the face
+
+The first decision is also the one that shapes everything else: **all
+intelligence lives on Dragon.** The Tab5 device is a thin client. It captures
+microphone PCM, paints an LVGL UI, drives a speaker and camera, and stores its
+own WiFi and NVS settings — and nothing more. There is no AI logic on the Tab5.
+
+Dragon, a Radxa Dragon Q6A (Qualcomm QCS6490, ARM64), owns the entire pipeline:
+speech-to-text, the language model, text-to-speech, embeddings, session
+management, the conversation engine, the REST API, the dashboard, and the
+database. The two halves talk over a single WebSocket on port 3502, with the
+wire contract pinned in [`protocol.md`](../protocol.md).
+
+```
+Tab5 (ESP32-P4) — the face          Dragon Q6A — the brain (this repo)
++--------------------+              +----------------------------------+
+| LVGL UI            |   WS /ws/voice  | Voice server (:3502)           |
+| Mic / Speaker      | <============>  |   STT  -> ConvEngine -> LLM     |
+| Touch / Camera     |  PCM + JSON     |        -> tools/memory -> TTS   |
+| WiFi / NVS         |                 |   SessionManager + MessageStore |
++--------------------+                 |   REST API  +  event bus  +  DB |
+                                       +----------------------------------+
+```
+
+This split is not a layering preference. It is a deployment fact: the Tab5
+cross-compiles to ESP32-P4 and flashes over USB, while Dragon is a Python
+service that `scp`s into place and runs under systemd. Different toolchains,
+different release cadences, different contributor expertise — so they are
+different repos, and the protocol contract is what lets each evolve on its own
+schedule.
+
+### Eight decisions that hold the server together
+
+These are durable design rules, captured from the original scaffolding research
+and enforced ever since. They came from studying production voice stacks: the
+ChatContext item model from LiveKit, Vocode's transcript metadata, Pipecat's
+frame taxonomy, and StackFlow's `create/resume/pause/end` lifecycle verbs.
+
+#### 1. Session != Connection
+
+A WebSocket connection is ephemeral — it dies on every network blip, every Tab5
+reboot, every WiFi handoff. A [session](../../GLOSSARY.md#tinkerbox-specific-terms)
+is durable. It survives disconnects. When a device reconnects and presents its
+`session_id` in the `register` frame, Dragon resumes the same session with full
+message history intact, rather than starting a blank conversation.
+
+| Concept | Lifetime | Survives | Stored in |
+|---|---|---|---|
+| WebSocket connection | Until the next network blip | Reconnect resumes the session | in-memory only |
+| Session | Until aged-out (default 30 min idle) or explicitly ended | Reboot, reconnect, mode swap | `sessions` table |
+| Device | Forever (registered once) | Reboot, factory reset | `devices` table |
+
+The lifecycle is `active -> paused -> active -> ended`, mirroring StackFlow's
+verbs. A clean disconnect moves a session to `paused`; a matching reconnect
+flips it back to `active`. This is why a Tab5 can lose WiFi mid-conversation,
+reconnect, and pick up exactly where it left off — the connection was disposable
+but the session was not.
+
+#### 2. Conversation items are append-only
+
+Messages are **never mutated after creation.** The `messages` table is a
+write-once ledger: a row records `role`, `content`, `input_mode`, whether the
+turn was `interrupted`, the `model` that generated it, and `latency_ms`. Once
+written, it stays. There is no update path.
+
+This is the cheapest possible source of truth for a conversation. Context
+reconstruction is just "read the rows in order." There is no merge logic, no
+last-writer-wins race, no question of whether the in-memory transcript and the
+stored transcript agree — they cannot disagree, because the store only ever
+grows. `MessageStore` (`dragon_voice/messages.py`) owns both the append and the
+context builder that walks those rows into LLM input.
+
+#### 3. The device is first-class
+
+A device is not an anonymous socket. It registers once with a stable
+`device_id` (the Tab5 uses its hardware MAC), a `hardware_id`, a `firmware_ver`,
+a `platform`, and a `capabilities` map (`{mic, speaker, screen, camera, ...}`).
+Online and offline status is tracked in real time in the `devices` table.
+
+Making the device first-class is what lets Dragon answer "which Tab5s are live
+right now?", target a specific device for a channel-message push, scope config
+to one device, and check a capability flag before relying on a firmware feature.
+A new firmware feature ships behind a flag in the `register` frame; Dragon reads
+the flag before using it, so the two repos never have to release in lockstep.
+
+#### 4. OpenAI message format as the universal context representation
+
+Every backend — Ollama, OpenRouter, LM Studio, the NPU, the TinkerClaw gateway —
+speaks a different dialect. Rather than thread N representations through the
+conversation engine, Dragon uses **OpenAI chat-message format** as the one
+internal representation and converts to each provider's shape at the adapter
+boundary.
+
+The payoff shows up in multimodal continuity. A photo is persisted as a
+`__mm__:` JSON marker on a message row; `MessageStore.get_context(media_store=…)`
+hydrates that marker back into an OpenAI `image_url` content array on the next
+turn. The Ollama backend then translates the OpenAI array into Ollama's flat
+`content + images` shape. Because the canonical form is OpenAI-format, you can
+send a photo and ask "what color was the chair?" three turns later and the
+follow-up still sees the image — the conversion happens once, at the edge,
+per backend.
+
+#### 5. Notes are sessions, not a parallel system
+
+A note is a session tagged `type='recording'`. There is no second storage
+engine, no duplicate lifecycle, no parallel "notes vs. conversations" code path.
+Dictation produces a recording session whose transcript and LLM-generated title
+and summary live on the same tables as everything else. One data model, reused.
+
+#### 6. An event bus for decoupled real-time updates
+
+Real-time consumers — the dashboard, the notes view, the skills surface, the
+`agent_log` feed — all **subscribe** rather than reach into the pipeline.
+Producers emit events (`session.created`, `device.connected`, `message.added`,
+tool-call activity) and never know who is listening. The `events` table is the
+durable side of this: an append-only audit log that doubles as the dashboard's
+catch-up feed and as the data source behind `GET /api/v1/spend` (daily LLM cost
+rolled up over `events`).
+
+The bus is why adding a new observer is a local change — you subscribe, you do
+not edit the pipeline. The `progress` event family (issue #123) is the same idea
+on the wire: a single unified progress event the Tab5 subscribes to, instead of
+a bespoke message type per phase.
+
+#### 7. Scoped config: global -> device -> session
+
+Configuration resolves by specificity. A value can be set at **global**,
+**device**, or **session** scope, and the most specific scope wins. The `config`
+table is keyed on `(key, scope, scope_id)`; a `GET /api/v1/config/{key}?resolve=true`
+applies the cascade `session > device > global` and returns the effective value.
+
+This is what lets two Tab5s on the same Dragon run in different voice modes at
+once. Each WebSocket connection gets a `copy.deepcopy()` of the global config, so
+one device switching to Cloud mode cannot corrupt another device's pipeline
+config. Scope plus per-connection deep-copy is the whole isolation story —
+there is no shared mutable config object for two clients to fight over.
+
+#### 8. aiosqlite, and one db.py
+
+Async SQLite via [`aiosqlite`](../../GLOSSARY.md#tinkerbox-specific-terms), in
+WAL mode with foreign keys on, behind a **single** `dragon_voice/db.py` module.
+No raw SQL is scattered across the codebase. Every table touch goes through one
+async CRUD layer.
+
+SQLite is the right call for a single-box server: no separate database process
+to run or monitor, WAL mode gives concurrent readers alongside a writer, and
+FTS5 plus `sqlite-vec` cover keyword and vector search without a second
+datastore. Concentrating all of it in one module means the schema, the query
+patterns, and the connection lifecycle have exactly one place to live and one
+place to audit. The schema itself is `schema.sql` — 11 tables: 6 foundation
+(`devices`, `sessions`, `messages`, `notes`, `events`, `config`), 3 memory
+(`memory_facts`, `memory_documents`, `memory_chunks`), and 2 scheduler
+(`scheduled_notifications`, `notification_queue`).
+
+### A turn, from frame to speaker
+
+The decisions above describe state. Here is how they cooperate during one voice
+turn. The Tab5 sends `start`, streams binary PCM, and sends `stop`. Dragon then:
+
+```
+mic PCM (16 kHz int16)
+  -> STT (Moonshine / Whisper.cpp / Vosk / OpenRouter)
+  -> ConversationEngine.process_text_stream(session_id, text)
+       (reads append-only history, injects recalled memory facts,
+        runs the tool loop, picks a backend via the router)
+  -> LLM stream
+  -> sentence buffer (flush on sentence boundary for low-latency TTS)
+  -> TTS (Piper / Kokoro / Edge / OpenRouter)
+  -> resample to 16 kHz, pace at ~80% real-time, stream 4096-byte chunks
+  -> speaker PCM
+```
+
+Every turn — voice, text, or vision — converges on
+`ConversationEngine.process_text_stream`. The only exception is voice mode 3,
+where Dragon becomes an audio pipe and the TinkerClaw gateway runs the turn
+instead. The tool loop inside the engine parses one of three accepted XML
+dialects, executes a tool, injects the result, and lets the model continue —
+capped at three tool calls per turn to bound the loop. The trace for each turn
+type lives in [`flows/`](../flows/).
+
+### The #65 decomposition: why server.py became four packages
+
+`server.py` started as a 2,747-line monolith holding everything: request
+middleware, diagnostic endpoints, boot and shutdown logic, long-running
+monitors, and the WebSocket voice handler family — all in one file. Umbrella
+issue #65 (closed 2026-04-24) split it into four siblings:
+
+```
+dragon_voice/
+  server.py       — VoiceServer class + create_app wiring + WS-voice handlers
+  middleware/     — request-filter concerns (cors, security_headers, auth, rate_limit)
+  handlers/       — diagnostic + status + config endpoints (debug, status, config_api)
+  lifecycle/      — boot / shutdown / long-running monitors (startup, shutdown,
+                    monitors, purge)
+```
+
+The split followed one rule — the **file-split smell test**: a file is too big
+when it has more than one *reason to change*. Middleware changes for
+ops and security reasons. Diagnostic endpoints change for dev and diagnostics
+reasons. Lifecycle changes for ops and reliability reasons. Business endpoints
+change for product reasons. Four stakeholders, four packages. Each extracted
+module takes its dependencies explicitly — a server handle or specific args — so
+each can be unit-tested without standing up a full `VoiceServer`. That testability
+is the dividend: `lifecycle/monitors.py` has its own focused test suite because
+it no longer drags the whole server in behind it.
+
+The decomposition also followed **extract before decompose**: the first move was
+to relocate code to its new home with identical behavior, and only later refactor
+the internals. That keeps each diff reviewable in minutes. The `media_cleanup_loop`,
+for instance, was inline in `server.py` before #65 and now lives in
+`lifecycle/purge.py` — moved verbatim first, cleaned up after.
+
+`server.py` was 1,803 lines right after the split and has since regrown to
+~2,720 lines as UX-gap fixes, the multi-model router, and W7 agent handlers
+accreted to the core WS handler family. That regrowth is expected and managed:
+the package root now holds 60+ extracted sibling modules (the `*_handler.py`,
+`*_swap.py`, `config_*.py`, `*_path.py`, `*_emit.py` families), each owning one
+concern so tests can import it in isolation. When you add a slow path, a config
+guard, or a new endpoint, the question to ask is "whose reason-to-change is
+this?" — and the answer almost always points at an existing sibling rather than
+at `server.py` itself.
+
+## Why it's built this way
+
+The through-line is that **state is durable and conversation is a ledger.** Every
+one of the eight decisions exists to make a single-box, intermittently-connected
+voice assistant survivable:
+
+- Sessions outlive connections because the connection is the thing that fails.
+- Messages are append-only because a conversation has no legitimate reason to be
+  rewritten, and a write-once store has no race to lose.
+- Devices are first-class because the server has to reason about specific
+  hardware — capabilities, targeting, scoped config — not anonymous sockets.
+- One internal message format and one db.py exist because the alternative is N
+  representations and SQL scattered across the codebase, and both rot.
+
+**Trade-offs taken on purpose.** SQLite means no horizontal database scaling —
+acceptable, because Dragon is one box serving a household, not a fleet. The
+append-only ledger trades storage growth for the elimination of mutation races;
+a `periodic_purge_loop` in `lifecycle/purge.py` handles retention so the trade
+stays bounded. Local-mode inference is slow (60-90 s per turn on the Q6A CPU) —
+accepted as the cost of privacy, with Hybrid and Cloud modes as the explicit
+opt-out when latency matters more.
+
+**The constraint that drives the rest** is the hardware: 12 GB of LPDDR5, an
+~8 GB effective ceiling after the OS and services, and CPU-bound local
+inference. That budget is why the model representation is shared rather than
+duplicated, why the router evicts unused models via `keep_alive_s`, and why the
+voice mode picks how much of the work goes to the cloud. The architecture is the
+shape of "do as much as possible on one modest ARM box, and let the user decide
+when to spend money or trust on the cloud."
+
+## See also
+
+- [How the stack fits together](how-the-stack-fits-together.md) — the cross-repo view: Tab5 (face) ↔ Dragon (brain) ↔ gateway ↔ cloud.
+- [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) — the system map, network topology, and hardware reference.
+- [WebSocket protocol reference](../reference/websocket-protocol.md) · [`protocol.md`](../protocol.md) — the Tab5 ↔ Dragon wire contract.
+- [Voice-turn flow](../flows/voice-turn.md) · [Vision-turn flow](../flows/vision-turn.md) — code-level traces of one request through the engine.
+- [Router cookbook](../router-cookbook.md) · [Configure the multi-model router](../how-to/configure-the-multi-model-router.md) — the per-modality, per-tier LLM router.
+- [`GLOSSARY.md`](../../GLOSSARY.md) — canonical terms for the stack.

--- a/docs/explanation/how-the-stack-fits-together.md
+++ b/docs/explanation/how-the-stack-fits-together.md
@@ -1,0 +1,108 @@
+---
+audience: developer
+type: explanation
+prerequisites: none
+last-verified: 2026-05-29
+---
+# How the stack fits together — Tab5, Dragon, and TinkerON
+
+## The question
+
+You have heard of [TinkerTab](../../GLOSSARY.md), [TinkerBox](../../GLOSSARY.md),
+the [Dragon](../../GLOSSARY.md), and [TinkerON](../../GLOSSARY.md), and you want
+a mental model of **how they relate** before diving into any one repo. This page
+draws the map. It does not teach you how to do anything — for that, start with
+the [Get your Dragon running tutorial](../tutorials/get-dragon-running.md).
+
+## The model
+
+The live product is two devices talking over **one WebSocket**, with an optional
+on-device LLM module hanging off the Tab5:
+
+```
+        +-----------------------------+                 +-------------------------------+
+        |  Tab5  (TinkerTab firmware)  |   one WebSocket  |  Dragon Q6A  (TinkerBox)      |
+        |  "the face" — thin client    | <==============> |  "the brain" — all intelligence|
+        |                              |  ws://host:3502  |                               |
+        |  - LVGL v9 UI                |  /ws/voice       |  - STT (Moonshine)            |
+        |  - 4-mic array + ES8388 spkr |                  |  - LLM (llama-server / cloud) |
+        |  - SC202CS camera, touch     |   audio frames > |  - TTS (Piper / Kokoro)       |
+        |  - SD card, NVS settings     | < STT/LLM/TTS    |  - embeddings + memory + RAG  |
+        |  - ESP32-P4 + ESP32-C6 Wi-Fi |   config/events  |  - sessions, REST API, dashboard|
+        +--------------+---------------+                  +-------------------------------+
+                       |
+              M5-Bus UART / USB
+                       |
+        +--------------v---------------+
+        |  K144 / TinkerON module       |
+        |  (AX630C NPU) — optional      |
+        |  - on-device ASR (sherpa-ncnn)|
+        |  - on-device LLM + TTS        |
+        |  - always-on wakeword         |
+        +-------------------------------+
+```
+
+- **Tab5 (TinkerTab)** is a deliberately *thin client*. It owns hardware I/O and
+  the native UI but no intelligence. It captures microphone audio, streams it to
+  the Dragon, and plays back the audio that streams down.
+- **Dragon (TinkerBox)** is the *brain* — this repo. Speech-to-text, the LLM,
+  text-to-speech, embeddings, memory, sessions, the dashboard, and OTA all live
+  here. The wire contract between the two is documented in this repo's
+  [`docs/protocol.md`](../protocol.md) (and summarized in the
+  [WebSocket protocol reference](../reference/websocket-protocol.md)); the
+  cross-stack architecture is in [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) and
+  the inside-the-brain view is in [TinkerBox architecture](architecture.md).
+- **K144 / TinkerON** is an *optional* on-device module. When present it adds
+  always-on "Hey Tinker" wakeword and can run a whole voice turn — ASR, LLM, and
+  TTS — entirely on-device with no Dragon. The Tab5 must never *depend* on it
+  being present.
+- **[PingOS](../../GLOSSARY.md)** is a portable, BSP-abstracted layer derived
+  from the Tab5 UI so the interface can run on hardware beyond the M5Stack Tab5.
+  **[TinkerClaw](../../GLOSSARY.md)** is an optional agent sidecar (voice mode 3)
+  that runs its own LLM + tools + browser automation on the Dragon. See
+  [Run the TinkerClaw sidecar](../how-to/run-the-tinkerclaw-sidecar.md).
+
+### Where a voice turn can run — the six modes
+
+The same orb-tap or wakeword fires a turn, but *where the work happens* depends
+on the active [voice mode](../../GLOSSARY.md). The full backend mapping lives in
+the [voice modes reference](../reference/voice-modes.md):
+
+| Mode | STT | LLM | TTS | Needs Dragon? |
+|---|---|---|---|---|
+| 0 — Local | Moonshine (Dragon) | Dragon-local | Piper (Dragon) | Yes |
+| 1 — Hybrid | OpenRouter | Dragon-local | OpenRouter | Yes |
+| 2 — Cloud | OpenRouter | OpenRouter | OpenRouter | Yes (as audio pipe) |
+| 3 — TinkerClaw | Dragon | TinkerClaw gateway | Dragon | Yes (as audio pipe) |
+| 4 — Onboard (K144) | K144 | K144 | K144 | **No** |
+| 5 — Solo | OpenRouter | OpenRouter | OpenRouter | **No** |
+
+Modes 4 and 5 are Tab5-side-only: they downconvert to `0` on the wire so the
+Dragon never sees them as live state.
+
+## Why it's built this way
+
+- **Thin client, fat brain.** The ESP32-P4 has ~512 KB of tight internal SRAM;
+  it cannot host a useful LLM. Pushing all intelligence to the Dragon keeps the
+  firmware small, lets the brain upgrade independently (new models are a Dragon
+  deploy, not a reflash), and means a single Dragon can serve a fleet of faces.
+- **One WebSocket, many message types.** Multiplexing voice, text, vision,
+  video, config, and events over a single persistent connection avoids
+  connection churn on a memory-constrained device and keeps the protocol in one
+  place ([`docs/protocol.md`](../protocol.md)).
+- **Each repo stands alone.** Rather than a single umbrella front door, the four
+  repos cross-link as peers (the "Part of the Tinker stack" block). A reader who
+  learns one repo's layout can navigate any of them, but each repo is fully
+  documented on its own.
+- **Optional on-device fallback.** TinkerON exists so the Tab5 can keep working
+  when the Dragon is unreachable (and for hands-free wakeword), but it is strictly
+  additive — the Tab5 degrades gracefully when it is absent.
+
+## See also
+
+- [Get your Dragon running](../tutorials/get-dragon-running.md) · [Deploy on a Dragon](../how-to/deploy-on-a-dragon.md)
+- [TinkerBox architecture](architecture.md) — the inside-the-brain view of the Dragon server.
+- [How the voice pipeline works](the-voice-pipeline.md) · [Voice modes reference](../reference/voice-modes.md)
+- System architecture (cross-stack): [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) · Wire protocol: [`docs/protocol.md`](../protocol.md)
+- The Tab5-side companion to this page: [TinkerTab `docs/explanation/how-the-stack-fits-together.md`](https://github.com/lorcan35/TinkerTab/blob/main/docs/explanation/how-the-stack-fits-together.md)
+- [`GLOSSARY.md`](../../GLOSSARY.md) — canonical terms for the stack.

--- a/docs/explanation/local-first-inference.md
+++ b/docs/explanation/local-first-inference.md
@@ -1,0 +1,323 @@
+---
+audience: developer
+type: explanation
+prerequisites: [docs/explanation/architecture.md](architecture.md), [docs/explanation/how-the-stack-fits-together.md](how-the-stack-fits-together.md)
+last-verified: 2026-05-29
+---
+# Local-first inference on the Dragon — how it works and why
+
+## The question
+
+Voice mode 0 — Local — runs the entire LLM turn on the Dragon Q6A itself: no
+OpenRouter, no workstation, no cloud. This page explains the principle behind
+that choice, why the Local LLM path runs on
+[llama-server](../../GLOSSARY.md#runtime--inference-terms) instead of Ollama,
+how small models are made to call tools reliably, which models actually survived
+the selection process, and the two hard physical limits — thermal throttling and
+the Hexagon DSP's instruction set — that shape what "local" can be on this
+hardware.
+
+If you want to *change* the Local backend, read
+[Swap the LLM backend](../how-to/swap-the-llm-backend.md). This page is the
+*why* behind the defaults that guide does not re-explain.
+
+## The Dragon-only principle
+
+Local mode is Dragon-only. When a model is too big for the
+[Dragon's](../../GLOSSARY.md#the-four-repos--the-hardware) ARM64 CPU + Ollama,
+the answer is never "run it on a workstation on the LAN and point the Dragon at
+it." The answer is: wait for upstream support, or have the user explicitly opt
+into Cloud (voice mode 2) or Hybrid (voice mode 1).
+
+This is a product decision, not a technical one. Two things break the moment a
+workstation enters the Local path:
+
+- **Privacy.** Local mode's whole promise is that the audio, the transcript, and
+  the reply never leave the box in front of you. A LAN inference server is
+  another machine that sees your data.
+- **The product story.** The live product is "Tab5 + Dragon, nothing else." A
+  silent dependency on a third always-on machine turns a two-box appliance into
+  a homelab. That is a different product.
+
+The router's `lan` tier (LM Studio on a workstation, see the
+[router cookbook](../router-cookbook.md)) exists for Cloud-mode acceleration,
+where the user has already opted out of the privacy guarantee. It is never the
+answer to a Local-mode gap. (This is a captured user directive — see
+`feedback_dragon_only_local.md` in the project memory.)
+
+## Why llama-server, not Ollama
+
+The Dragon serves its Local LLM through
+[`llama-server`](../../GLOSSARY.md#runtime--inference-terms) — the
+OpenAI-compatible binary from llama.cpp, built ARM64-native on the box (master
+build `b8696` verified) — listening on `localhost:1234`. The Dragon backend that
+talks to it is `dragon_voice/llm/lmstudio_llm.py` (LM Studio and llama-server
+speak the same `/v1/chat/completions` dialect, so one backend covers both):
+
+```yaml
+llm:
+  backend: "lmstudio"          # was "ollama"
+  local_backend: "lmstudio"    # remembers the original for fallback
+  lmstudio_url: "http://localhost:1234/v1"
+  lmstudio_model: "default"    # llama-server reports its loaded GGUF
+```
+
+It runs persistently as `tinkerclaw-llama-server.service` (unit in
+`deploy/systemd/`): survives reboot, restarts on failure, swaps model via the
+unit's `--model` arg plus `systemctl restart`.
+
+We swapped away from Ollama because, on identical hardware and the identical
+`ministral-3:3b` model, the wrapper overhead was enormous:
+
+| Path | Direct tool-call probe | End-to-end through Dragon |
+|---|---|---|
+| Ollama | ~78 s | ~140 s |
+| llama-server | **~7.6 s** | **~191 s** |
+
+The ~10× speedup on the direct probe is the load + sampler overhead Ollama's Go
+wrapper adds on top of the same llama.cpp eval kernel. End-to-end the gap
+narrows because most of the wall-clock is the eval itself plus tool execution
+and the natural-language wrap — but the net product wins stack up: the MiniCPM-V
+vision family loads and serves cleanly via llama-server (Ollama 500'd on V-4.6
+projector blobs), the OpenAI-compatible API opens a richer ecosystem of tooling
+and clients, and we stop paying for the wrapper.
+
+### The fallback is one-shot, not per-request
+
+`create_llm()` in `dragon_voice/llm/__init__.py` does a synchronous TCP probe to
+`lmstudio_url` at process start when `backend="lmstudio"`. If the llama-server
+socket is not reachable then, it transparently falls back to Ollama for the rest
+of that process's life. Two consequences fall out of "one-shot at instance
+creation":
+
+- Restarting `tinkerclaw-llama-server` mid-session is **not** picked up
+  automatically. After fixing llama-server, also
+  `systemctl restart tinkerclaw-voice` so the next process re-runs the probe.
+- Warm-path latency is unaffected — there is no per-request probe tax.
+
+The order of preference in Local mode is: (1) `lmstudio` (llama-server) when
+reachable on `127.0.0.1:1234`, then (2) `ollama` as automatic fallback. To force
+pure Ollama without removing llama-server, set both `llm.backend: "ollama"` and
+`llm.local_backend: "ollama"`.
+
+Two timing knobs exist because Q6A Local turns are genuinely slow:
+
+- `MAX_TOKENS_LOCAL = 1024` (was 128). Thinking-mode models (MiniCPM-V-4.6,
+  qwen3-thinking) spend their budget inside `<think>…</think>` and emit zero
+  visible content if capped low. Non-thinking models like `ministral-3:3b` stop
+  naturally well under the cap, so the higher ceiling costs them nothing.
+- `ClientTimeout(total=600, sock_read=300)` in `lmstudio_llm.py` — bumped from
+  120/60 because Local turns on Q6A routinely hit 90–180 s.
+
+## Making a 1–4 B model call tools
+
+A frontier cloud model gets a structured `tools=[…]` array and a `tool_choice`
+field and reliably emits a function call. A 1–4 B model running locally does not
+have that much headroom, so the Dragon meets it where it is: it prose-lists the
+tools in the system prompt and **parses the tool call back out of free text**.
+
+The parser (`dragon_voice/tools/parser.py` and the registry in
+`dragon_voice/tools/registry.py`) accepts several *dialects* because different
+model families emit different markup regardless of what the system prompt asks
+for:
+
+1. **Legacy / Dragon-standard** — `<tool>NAME</tool><args>{json}</args>`. The
+   TinkerBox house format; ministral and gemma3 emit this.
+2. **Standard FC** — `<tool_call>{"name":"…","arguments":{…}}</tool_call>`.
+   Industry-typical function-calling fine-tunes (Qwen-FC, Gemma-FC) emit this no
+   matter the prompt.
+3. **Bracketed-name** — `[NAME]{json}</NAME>`, gated on `NAME` being a
+   registered tool so prose like `[note]` does not false-fire.
+4. **Gemma sentinel** — `<|tool_call>call:NAME{}<tool_call|>` (added 2026-05-17).
+5. **LFM sentinel** — `<|tool_call_start|>[name(arg="val")]<|tool_call_end|>`,
+   parsed via `ast.literal_eval` so nested quotes and embedded commas survive
+   (added 2026-05-17).
+
+The parser is deliberately tolerant of small-model quirks — stray `>` after
+`</args>`, missing closing tags, xLAM bracket noise — because that is the actual
+output distribution of these models under prose pressure.
+
+Two guards make this usable as a voice assistant rather than a demo:
+
+- **Empty-reply wrap** (`dragon_voice/tools/response_wrap.py`). Some FC-trained
+  models emit a tool call and stop, leaving the user-visible text empty once the
+  markup is stripped. When that happens and at least one tool fired, the Dragon
+  synthesizes a one-line natural-language acknowledgement from the tool result
+  using a per-tool template — no extra LLM round-trip.
+- **WS keepalive during inference** (`server.py: _ws_keepalive_during_inference`).
+  Local turns routinely take 60–90 s; the Tab5's WebSocket library times out
+  after ~30 s without a PONG and reconnects, which the server treats as a
+  duplicate connection and evicts the in-flight stream — an empty reply on every
+  slow turn. The keepalive fires `ws.ping()` every 5 s while the engine
+  generates.
+
+The deeper move — letting the inference server's own structured `tools=[…]` API
+do the work instead of prose-listing — is what the glossary calls
+[native tool-calling](../../GLOSSARY.md#runtime--inference-terms). That is the
+direction of the parked local-mode capability rework (see "Where this is going"
+below); it is not how the live Dragon Local path works today.
+
+## The model gauntlets
+
+Choosing the Local default is an empirical question, so it was settled by
+running candidate models through fixed gauntlets on the Q6A — same system
+prompt, same tool definitions, `temperature` pinned, no Dragon middleware in the
+way for the direct probes. Two gauntlets matter: an **easy** 10-scenario
+happy-path set, and a **hard** 20-scenario set that probes disambiguation,
+complex arg extraction, red herrings, out-of-scope rejection, multi-step intent,
+and chitchat. The hard gauntlet is the one that separates "looks like it works"
+from "works on messy prose."
+
+A model has to be good on **three independent axes**, and small models tend to
+trade them against each other:
+
+- **Latency** — sub-minute per turn is the floor for real-time voice.
+- **Tool-routing accuracy** — picks the right tool *and* extracts the right args
+  from prose, *and* knows when to call nothing.
+- **Reply quality** — specific and actionable, not vague.
+
+### LFM2.5-VL-1.6B — the real-time voice default
+
+LiquidAI's 1.6 B vision-language model (696 MB Q4_0 weights + 583 MB Q8_0
+mmproj) is the Local default for real-time voice (user decision, 2026-05-17). It
+**aced the easy gauntlet 10/10** on tool name, tool choice, and arg extraction —
+where ministral scored 7/10 — and it brings vision essentially for free (a
+300×400 sunflower image described accurately in ~40 s wall-clock). Text turns run
+~13–20 s.
+
+The catch is the hard gauntlet: **7/20**. At 1.6 B the model has the capacity for
+clean happy-path routing but not enough to robustly tell "use the word X" from
+"invoke tool X." The documented failure modes are worth internalizing because
+they are characteristic of *every* tiny tool-router, not a bug:
+
+1. **Red-herring trigger** — any word matching a tool name fires that tool, even
+   in chitchat ("calendar joke" → `calendar_today`). The model treats tool names
+   as keywords, not intent.
+2. **Verb confusion** — "ping the boss" became `timer_set`; "did Sarah email me"
+   became `gmail_reply`. Action verbs near a duration or subject get misread.
+3. **Few-shot contamination** — "buy bread" from a system-prompt exemplar leaked
+   verbatim into an unrelated answer. Tiny models echo the examples.
+4. **Arg-extraction brittleness** — `gmail_send(to, subject, body)` emitted the
+   *parameter names* as positional placeholders instead of extracting "mom",
+   "Happy Birthday", "love you…" from the prompt.
+
+A crucial operational note: LFM-VL only routes well under a **directive** system
+prompt ("you are a tool-router; you ALWAYS call exactly one tool; NEVER explain,
+NEVER ask permission, NEVER refuse"). With a softer prompt it falls into
+conversational refusals ("I can use `calendar_week()`. Would you like me to?")
+and drops to 1/10 on the *easy* gauntlet. The prompt is load-bearing.
+
+We accept the 7/20 hard-gauntlet brittleness as the cost of speed: sub-second
+time-to-first-byte matters more for voice than tool-routing perfection, and the
+easy gauntlet covers the common case. `ministral-3:3b` (7/10 easy, ~3–8 s/turn)
+is kept at `/home/radxa/llama.cpp/models/ministral/model-q4_k_m.gguf` as a
+one-line rollback.
+
+### Qwen3.5-4B — the accuracy leader, parked for agentic
+
+`lmstudio-community/Qwen3.5-4B-GGUF` Q4_K_M (2.7 GB) is the new accuracy leader:
+**18/20 strict on the hard gauntlet — effectively 20/20, both misses scoring
+artifacts**. It scored 4/4 on disambiguation, 3/3 on red herrings, 3/3 on
+out-of-scope, and 3/3 on chitchat, the exact axes where LFM-VL and Gemma broke.
+On "ping the boss I'll be late by 15 min" it drafted a complete, sane email body
+in one shot where LFM-VL had chosen `timer_set(900)`.
+
+Two non-obvious requirements: each request must pass
+`chat_template_kwargs: {"enable_thinking": false}` (otherwise Qwen burns the
+whole token budget inside `<think>` and emits empty content), and the recommended
+non-thinking sampling is `temp 0.7, top_p 0.8, top_k 20, presence_penalty 1.5`.
+
+It is **parked for real-time voice on latency**: ~96 s per turn (range 79–123 s)
+on the Q6A, roughly 5× slower than LFM-VL for ~3× the accuracy. That makes it the
+candidate for *agentic / background / browser-agent* workloads — where multiple
+tool calls chain and quality beats latency — not for live conversation.
+
+| Model | Hard-gauntlet score | Per-turn (mean) |
+|---|---|---|
+| ministral-3:3b | (easy: 7/10) | 3–8 s |
+| LFM2.5-VL-1.6B Q4 | 7/20 | ~14–20 s |
+| Gemma-4-E4B Q4 | (too slow to finish hard) | 30–75 s |
+| Gemma-4-E2B Q4 | 0/10 args emitted | 7–8 s warm |
+| **Qwen3.5-4B Q4_K_M** | **18/20 (≈20/20)** | **~96 s** |
+
+The Gemma-4 siblings illustrate the two ways a candidate fails: E4B is *accurate*
+but unusably slow (30–75 s per turn at 80-token headroom), and E2B is *fast*
+(ministral-class) but defaults to `calendar_today` on any ambiguity and never
+emits an `<args>` block (8/10 tool tokens, 0/10 args). Both are parked. Parser
+Dialect 4 was added for Gemma and stays — it is harmless for other models and
+earned its keep.
+
+### Granite — the K144 onboard winner
+
+[Granite](../../GLOSSARY.md#runtime--inference-terms) (IBM Granite 4.0 Nano-1B)
+is the winner of a *different* gauntlet: native tool-calling on the
+[K144 / TinkerON](../../GLOSSARY.md#the-four-repos--the-hardware) onboard module
+(voice mode 4), where the model runs on the Tab5-side AX630C NPU with no Dragon
+present. It scored **19/20** there. Do not confuse it with the Dragon's
+llama-server default — Granite is the candidate to become the live *onboard*
+Local default, and that work lives on the unpushed `feat/local-mode-capability`
+branch, not on the Dragon's Local LLM path described above. See "Where this is
+going."
+
+## Thermal reality
+
+The Q6A's Local latency is not a fixed hardware floor — a large part of it is
+**thermal throttling**. On the K144 onboard work the same turn that took 436 s
+dropped to 29 s after a prefix-stable cache-reuse fix, and the *residual*
+slowness was traced to the SoC sitting at ~90 °C with no fan and half-clocking
+itself. A $5 fan is the next 2× on that path, not a new chip.
+
+The lesson generalizes to the Dragon. When you see a Local turn take three
+minutes, the chain of suspects, in order, is:
+
+1. **Prompt-cache misses** — a turn that cannot reuse the warm KV-cache prefix
+   re-evaluates the full system + tools + memory + history prompt from scratch.
+   Keeping the prefix stable is the single biggest warm-path win.
+2. **Thermal half-clocking** — a hot, unfanned SoC runs at half its rated clock.
+   Cooling is cheaper than any software optimization.
+3. **The eval itself** — only after the first two are ruled out is the model
+   genuinely too big for the silicon.
+
+Treat a slow turn as a cache or thermal problem until proven otherwise. "The
+model is too slow" is the last conclusion, not the first.
+
+## Multimodal is parked, not skipped
+
+Mainline llama.cpp does not yet support MiniCPM-V-4.6's `minicpmv4_6` projector
+or MiniCPM-o's audio encoder, so the heaviest local multimodal paths are not
+available on the Dragon today. This is a *wait-for-upstream* state, consistent
+with the Dragon-only principle — not a "give up and add a workstation" state:
+
+- **Vision via the MiniCPM-V family** — wait for projector support to land
+  upstream, or rebuild llama.cpp from a feature branch that has it. (LFM2.5-VL
+  already gives the Local default working vision.)
+- **Audio via MiniCPM-o** — the realistic path is the openbmb maintainer's
+  `tc-mb/llama.cpp-omni` fork (clean ~15 min build on Q6A), GGUF-ifying
+  MiniCPM-o-4.5 from safetensors with the fork's converter. Tracked for a future
+  session.
+
+In the meantime, **Cloud mode (voice mode 2)** already handles audio and vision
+via OpenRouter — the right answer precisely *because* the user has explicitly
+opted in to cloud. Parking a local path is not the same as having no path.
+
+## Where this is going
+
+The native-tool-calling rework is the active investigation
+(`feat/local-mode-capability`, unpushed). It moves the onboard
+[K144 / TinkerON](../../GLOSSARY.md#the-four-repos--the-hardware) path off
+prose-parsed XML dialects and onto the inference server's structured
+[`native_tools`](../../GLOSSARY.md#runtime--inference-terms) API, with
+**Granite 4.0 Nano-1B (19/20)** as the winning model and the prefix-stable
+cache-reuse + cooling work as the latency story. The next steps are to make
+Granite the live onboard Local default and to land the branch. None of this
+changes the Dragon's llama-server Local path documented here — it is a parallel,
+Tab5-side capability.
+
+## See also
+
+- [Swap the LLM backend](../how-to/swap-the-llm-backend.md) — the procedure for changing the Local (or any) LLM backend.
+- [Configure the multi-model router](../how-to/configure-the-multi-model-router.md) · [Router cookbook](../router-cookbook.md) — the per-modality, per-tier fleet (and where the `lan` tier legitimately belongs).
+- [Voice modes reference](../reference/voice-modes.md) — what Local / Hybrid / Cloud / TinkerClaw actually swap.
+- [NPU setup](../npu-setup.md) — the QAIRT / Genie path and the HTP v68 size ceiling that blocks 3 B+ models on the Dragon.
+- [TinkerBox architecture](architecture.md) — the system map this inference path sits inside.
+- [`GLOSSARY.md`](../../GLOSSARY.md) — canonical terms for the stack.

--- a/docs/explanation/memory-and-rag.md
+++ b/docs/explanation/memory-and-rag.md
@@ -1,0 +1,213 @@
+---
+audience: developer
+type: explanation
+prerequisites: [How the voice pipeline works](the-voice-pipeline.md), [Tools catalog](../reference/tools-catalog.md)
+last-verified: 2026-05-29
+---
+# Memory and RAG — how it works and why
+
+## The question
+
+The Dragon runs small local models. A `ministral-3:3b` or an `LFM2.5-VL-1.6B`
+has no idea who you are, what you told it yesterday, or what is in the PDF you
+handed it last week — and it has neither the context window nor the recall to
+hold all of that in the prompt. So how does Tinker remember that your dog is
+named Biscuit, surface that fact unprompted three turns later, and answer a
+question by quoting a document you ingested days ago?
+
+The answer is two cooperating subsystems that live in
+[`dragon_voice/memory.py`](../../dragon_voice/memory.py): a **fact store** (the
+`remember` / `recall` tools) and a **document store** (chunked retrieval-augmented
+generation, "RAG"). Both run entirely on the Dragon, both use the same local
+embedding model, and both feed the same place: the system prompt that the
+[ConversationEngine](architecture.md) builds *before every single LLM call*.
+
+This page builds the mental model of how a fact or a document chunk becomes a
+vector, how that vector gets searched, and why retrieval happens automatically on
+every turn rather than only when the model asks for it.
+
+## The model
+
+### One embedding model, everywhere
+
+Every piece of text that enters or queries the system — a stored fact, a document
+chunk, and the user's current utterance — is turned into the *same shape* of
+number: a 768-dimensional vector produced by **Ollama `nomic-embed-text`**. It
+runs locally on the Dragon via Ollama on port 11434. No cloud API is involved,
+which keeps memory on the same privacy footing as Local-mode inference.
+
+Using one model for storage and for queries is the load-bearing decision. Cosine
+similarity between two vectors is only meaningful if both vectors live in the
+same embedding space. Embed the fact with `nomic-embed-text` and the query with
+something else and the distances are noise. So the rule is absolute: facts,
+chunks, and queries all go through `nomic-embed-text`, all come out 768-dim, and
+all distances are cosine similarity in that one space.
+
+### Two stores, three tables
+
+The two subsystems are backed by three of the eleven tables in
+[`schema.sql`](../../schema.sql):
+
+| Table | Holds | Embedding lives in |
+|-------|-------|--------------------|
+| `memory_facts` | one short fact per row (the `remember` store) | the row |
+| `memory_documents` | document metadata (title, source, ingest time) | — |
+| `memory_chunks` | the 512-token slices of each document | the row, indexed by `sqlite-vec` |
+
+Facts are atomic and self-contained — "the user's dog is named Biscuit" is one
+row. Documents are large, so they are split into chunks first (see *Chunking*
+below) and each chunk gets its own embedding and its own row in `memory_chunks`,
+linked back to its parent in `memory_documents`. The document store uses the
+[`sqlite-vec`](https://github.com/asg017/sqlite-vec) extension for vector search
+over chunks; vectors are stored alongside the relational data in the same SQLite
+file, so there is no separate vector database to operate.
+
+### Two ways in, two ways out
+
+A **fact** gets into `memory_facts` one of two ways:
+
+- The LLM calls the **`remember`** tool mid-conversation
+  (`<tool>remember</tool><args>{"fact":"..."}</args>`). This is the common path:
+  the model decides something is worth keeping and stores it itself.
+- A client `POST`s to **`/api/v1/memory`** with a fact body. This is the
+  programmatic path — the dashboard's Memory tab and any integration use it.
+
+A fact gets *out* the same two ways: the LLM calls **`recall`** to search facts
+explicitly, or a client hits **`POST /api/v1/memory/search`** with a query. Both
+embed the query, run cosine similarity against every stored fact, and return the
+top matches ranked by score. The fact tools live in
+[`dragon_voice/tools/memory_tools.py`](../../dragon_voice/tools/memory_tools.py)
+(`StoreFactTool`, `RecallFactsTool`, and the confirm-gated `ForgetFactTool`).
+
+A **document** gets in via **`POST /api/v1/documents`**, which chunks, embeds,
+and stores in one call, and is searched via **`POST /api/v1/documents/search`**,
+which returns ranked chunks. There is no LLM tool for ingesting a document — that
+is deliberately a REST-only operation. (The full endpoint surface is in the
+[REST API reference](../reference/rest-api.md).)
+
+### The flow: an utterance becomes an augmented prompt
+
+This is the piece that ties it all together. **Before every LLM call**, the
+ConversationEngine does retrieval and injects what it finds into the system
+prompt. The model never has to ask:
+
+```
+User utterance (text)
+  |
+  v
+[Embed query] -- nomic-embed-text -> 768-dim vector (Ollama :11434)
+  |
+  +---------------------------+
+  |                           |
+  v                           v
+[Cosine search           [Cosine search via sqlite-vec
+ over memory_facts]       over memory_chunks]
+  |                           |
+  v                           v
+top-k relevant facts     top-k relevant chunks
+  |                           |
+  +-------------+-------------+
+                |
+                v
+[Inject into system prompt] -- facts + chunks prepended as context
+                |
+                v
+[ConversationEngine builds full context]
+   system prompt (+ memory + chunks)
+   + session history (from MessageStore)
+   + tool definitions
+                |
+                v
+[LLM] -- generates the reply with your facts and documents in view
+```
+
+So when you ask "what should I get Biscuit for his birthday?", the query embeds,
+the "dog is named Biscuit" fact scores high on cosine similarity, it lands in the
+system prompt, and the model answers as if it always knew. The recall is
+*automatic and silent* — the model does not call `recall`; the engine did it for
+the model before the model ran.
+
+### Chunking
+
+Documents are too large to embed as one vector and too large to drop whole into a
+small model's context. So ingestion splits each document into **512-token chunks
+with a 50-token overlap** between consecutive chunks. Each chunk is embedded
+independently and stored as its own row.
+
+The overlap matters: a sentence that straddles a chunk boundary would otherwise
+be cut in half, and neither half would embed to anything close to the full
+thought. The 50-token overlap means any span of ≤50 tokens appears intact in at
+least one chunk, so a query that matches that span still finds a coherent result.
+Search returns whole chunks ranked by cosine similarity, and the top chunks — not
+the whole document — are what get injected. A 40-page manual contributes only the
+two or three paragraphs that actually answer the question, which is exactly what a
+small-context local model needs.
+
+## Why it's built this way
+
+### Why retrieve on *every* turn instead of only when the model asks
+
+The obvious alternative is tool-gated recall: give the model a `recall` tool and
+let it decide when to look things up. The Dragon keeps the `recall` tool — but it
+also does automatic retrieval on every turn, and that is the primary path. The
+reason is the models. A 1.6–4 B local model on a Q6A is not reliable at deciding
+*when* to recall; it forgets the tool exists, or fires it for the wrong query, or
+burns a tool call it can only afford three of (turns are capped at three tool
+calls to prevent loops). Automatic injection removes that decision from the model
+entirely: the relevant facts are simply *there*, in the prompt, every time. The
+model's job shrinks to "use what you can see," which even a small model does well.
+
+The cost is a pair of embed-and-search operations on the critical path of every
+turn. On the Q6A that is cheap relative to LLM generation — `nomic-embed-text` is
+a small encoder and the SQLite vector search is in-process — so it does not move
+the needle against the ~60–90 s a Local-mode turn already takes.
+
+### Why one local embedding model and not a cloud embedder
+
+Cloud embedding APIs are higher quality. They are also a network round-trip on
+every turn, a dependency that breaks Local mode's "Tab5 + Dragon, nothing else"
+guarantee, and a privacy leak — every fact and every query would cross the wire.
+`nomic-embed-text` runs on the same Ollama instance that already exists on the
+Dragon, costs nothing per call, and never sends your memory off the box. For a
+privacy-first local assistant that is the right trade, and it is why Ollama stays
+unmasked on the Dragon even when the LLM path moved to llama-server: embeddings
+still need it.
+
+### Why `sqlite-vec` and not a dedicated vector database
+
+A standalone vector store (FAISS server, Qdrant, pgvector) would be one more
+service to install, run, monitor, and keep alive across reboots on an ARM64 SBC.
+`sqlite-vec` is a loadable SQLite extension: the chunk vectors live in the same
+WAL-mode SQLite file as sessions, messages, and notes, searched with the same
+`aiosqlite` connection layer in [`db.py`](../../dragon_voice/db.py). One database
+file, one backup, one thing to operate. For the scale a single household device
+sees — facts in the hundreds, documents in the dozens — the in-process search is
+fast enough that a dedicated vector DB would be pure operational overhead with no
+payoff.
+
+### Why facts and documents are separate stores
+
+They have different shapes and different lifecycles. A fact is small, atomic, and
+written by the model in the middle of a conversation; it is cheap to embed inline
+and store as a single row. A document is large, externally supplied, and must be
+chunked before it can be embedded at all. Forcing both through one table would
+mean either chunking facts (pointless — they are already one thought) or storing
+documents un-chunked (impossible — they would not fit a small context and would
+embed to mush). Two stores let each keep the representation that fits it, while
+both share the one thing that has to be shared: the embedding space.
+
+### What memory is *not* available for
+
+Memory and RAG are part of the [ConversationEngine](architecture.md), and the
+ConversationEngine is bypassed in **voice mode 3 (TinkerClaw)** — in that mode
+Dragon is an audio pipe and the gateway owns intelligence, tools, and its own
+memory. The Tab5-side-only **voice mode 5 (Solo)** does its own on-device RAG
+against `/sdcard/rag.bin` and never touches the Dragon's stores at all. Memory as
+described on this page is the Local / Hybrid / Cloud (modes 0/1/2) story, where
+the Dragon's ConversationEngine runs the turn.
+
+## See also
+
+- [How the voice pipeline works](the-voice-pipeline.md) · [TinkerBox architecture](architecture.md)
+- [REST API reference](../reference/rest-api.md) — the `/api/v1/memory` and `/api/v1/documents` endpoints · [Tools catalog](../reference/tools-catalog.md) — the `remember` / `recall` tools
+- [Add a tool](../how-to/add-a-tool.md) · [Config reference](../reference/config-reference.md) — `MemoryConfig`

--- a/docs/explanation/the-multi-model-router.md
+++ b/docs/explanation/the-multi-model-router.md
@@ -1,0 +1,345 @@
+---
+audience: developer
+type: explanation
+prerequisites: [architecture.md](architecture.md), [the-voice-pipeline.md](the-voice-pipeline.md)
+last-verified: 2026-05-29
+---
+# The capability-aware multi-model router — how it works and why
+
+## The question
+
+This page answers: *when Dragon has a whole fleet of language models
+to choose from, how does it decide which one runs your turn — and why
+is that decision shaped the way it is?*
+
+For most of TinkerBox's life the rule was simple: one voice_mode picked
+one LLM backend. Local mode meant ollama; Cloud mode meant whatever
+single model OpenRouter was pointed at. That rule could not survive
+contact with reality. A photo turn needs a vision model; a plain "what's
+on my calendar?" turn does not, and paying frontier-vision prices to
+answer it is waste. A video frame from a call needs a model that
+actually ingests video. The model that is best at extracting email
+arguments from messy prose is not the model that answers fastest.
+
+The multi-model router (PRs #183–#188) replaces "voice_mode picks a
+backend" with "voice_mode picks a *tier*, the message's modalities pick
+the *requirements*, and the cheapest model that satisfies both wins."
+This page is the mental model behind that sentence. If you want to
+*configure* a fleet, read the
+[configure the multi-model router how-to](../how-to/configure-the-multi-model-router.md)
+or the [router cookbook](../router-cookbook.md). If you want to *look
+up* what a voice mode does, read the
+[voice modes reference](../reference/voice-modes.md). This page exists
+to explain the design, not to give you a recipe.
+
+## The model
+
+The router is opt-in. Set `llm.backend: "router"` in
+`dragon_voice/config.yaml` and populate `llm.fleet`, and the
+`CapabilityAwareRouter` in `dragon_voice/llm/router.py` takes over model
+selection. Leave `backend` set to any single value (`ollama`,
+`lmstudio`, `openrouter`, …) and the router code never runs — behavior
+is byte-identical to the pre-router days. There is no flag day; the
+fleet is dormant until you ask for it.
+
+When it is active, every turn flows through four decisions.
+
+```
+Incoming message (OpenAI-format content array)
+        |
+        v
+[1] infer_required_caps(messages)  ──►  required_caps : frozenset(Modality)
+        |                                e.g. {TEXT}  or  {TEXT, VISION}
+        v
+[2] TIER_FOR_MODE[voice_mode]      ──►  tier_filter   : {"local"} / {"cloud","lan"} / None
+        |
+        v
+[3] candidates = [ m in fleet
+                   if required_caps  <=  m.capabilities    # m can do everything the turn needs
+                   and m.tier in tier_filter ]             # m is allowed in this mode
+        |
+        v
+[4] winner = min(candidates, key=lambda m: m.priority)     # lowest priority number wins
+        |
+        v
+   chosen backend generates the turn
+```
+
+### Modality capabilities
+
+Every model in the fleet declares what it can *do* as a frozenset of
+`Modality` values. The enum lives in `dragon_voice/llm/base.py`, and
+each `LLMBackend` subclass exposes its set through a `capabilities`
+property.
+
+| Modality | The turn requires it when |
+|----------|---------------------------|
+| `TEXT` | Always — every turn requires `TEXT` |
+| `VISION` | The message content contains `{"type":"image_url"}` (a photo) |
+| `VIDEO` | The message content contains `{"type":"video_url"}` (a call frame) |
+| `AUDIO_IN` | The message content contains `{"type":"input_audio"}` |
+| `AUDIO_OUT` | The backend can emit audio responses |
+| `TOOL_CALLING` | The backend is trained for function-calling |
+
+Backends declare their capabilities differently because they know
+different things about themselves:
+
+- **ollama** scans the model id as a substring. Vision is implied by
+  `llava`, `minicpm-v`, `minicpm-o`, `moondream`, `qwen2-vl`, `pixtral`,
+  or `internvl`; audio by `minicpm-o`; tools by the known
+  function-calling families.
+- **openrouter** uses a static registry, `_OPENROUTER_CAPS` in
+  `openrouter_llm.py` (35 models tracked as of the 2026-04-27 sync in
+  #187). An unknown model id defaults to `{TEXT, TOOL_CALLING}`.
+- **lmstudio** uses the same name-substring heuristic as ollama, because
+  LM Studio serves arbitrary GGUFs and the file name is all it has.
+- **npu_genie** is text-only — QAIRT has no vision path on the QCS6490
+  Hexagon DSP.
+- **tinkerclaw** declares `TEXT + TOOL_CALLING`, plus `VISION` when the
+  gateway's configured model is `anthropic/`, `openai/gpt-4o`,
+  `google/gemini`, or `minimax/`.
+- **dual** forwards to its responder's capabilities — the responder is
+  the sub-backend whose tokens actually reach the user.
+
+### `infer_required_caps` — reading the message, not the prompt
+
+Step [1] is `infer_required_caps(messages)`. It walks the OpenAI-format
+content arrays of the incoming messages and accumulates requirements
+from what is *present in the payload*:
+
+- an `image_url` part adds `VISION`
+- a `video_url` part adds `VIDEO`
+- an `input_audio` part adds `AUDIO_IN`
+- `TEXT` is always in the set
+
+The function is deliberately mechanical. It looks at structured content
+parts, not at the words the user said. A turn that carries a JPEG
+requires `VISION` whether the user said "look at this" or said nothing
+at all. This is what makes routing predictable: the requirement set is a
+function of the wire payload, and you can reproduce any routing decision
+by hand from the message and the fleet.
+
+### `TIER_FOR_MODE` — voice_mode chooses the lane, not the model
+
+The router never reads `voice_mode` to pick a model. It reads it to pick
+a *tier filter* — the set of tiers a candidate is allowed to live in.
+
+```python
+TIER_FOR_MODE = {
+    0: {"local"},          # Local
+    1: {"local"},          # Hybrid — LLM stays local; only STT/TTS go cloud
+    2: {"cloud", "lan"},   # Full Cloud — LAN tier eligible (e.g. LM Studio on a workstation)
+    3: None,               # TinkerClaw — bypass the router, the gateway picks
+}
+```
+
+Three things fall out of this table:
+
+- **Hybrid mode (1) keeps the LLM local.** Hybrid sends STT and TTS to
+  the cloud for speed and quality, but the language model stays on
+  Dragon. So Hybrid's tier filter is `{"local"}`, exactly like Local
+  mode. The cloud part of Hybrid lives entirely in the pipeline's STT/TTS
+  swap, never in the router.
+- **Cloud mode (2) admits the LAN tier.** When you run a heavy
+  multimodal model on a workstation via LM Studio's OpenAI-compatible
+  API, you declare it `tier: lan`, and Cloud mode can route to it. That
+  is the one sanctioned use of off-Dragon inference, and it is opt-in per
+  fleet entry. (Note the project's standing rule: *Local mode is
+  Dragon-only*. The LAN tier is a Cloud-mode affordance, never a
+  Local-first path.)
+- **TinkerClaw mode (3) returns `None`.** When the tier filter is `None`,
+  `choose()` returns `None` immediately and the router gets out of the
+  way — the TinkerClaw gateway runs its own agent loop and picks its own
+  model. See [run the TinkerClaw sidecar](../how-to/run-the-tinkerclaw-sidecar.md).
+
+### Lowest-priority-wins
+
+Step [3] filters the fleet down to candidates that can satisfy the turn
+*and* are allowed in the active tier. Step [4] breaks the tie by
+`priority`, an integer you assign per fleet entry. **Lower wins.**
+
+```python
+def choose(required_caps, voice_mode):
+    tier_filter = TIER_FOR_MODE[voice_mode]
+    if tier_filter is None:
+        return None  # tinkerclaw mode — router not used
+    candidates = [m for m in fleet
+                  if required_caps <= m.capabilities
+                  and m.tier in tier_filter]
+    return min(candidates, key=lambda m: m.priority) if candidates else None
+```
+
+Priority is "default preference within the set of models that can do the
+job," not "quality rank." You give your cheapest acceptable model
+priority 0 and reserve the higher numbers for models you only want to
+reach when the cheaper ones are filtered out by a capability they lack.
+Because filtering happens *before* the priority sort, a vision turn never
+even considers a text-only model no matter how low its priority — it is
+simply not a candidate.
+
+Walk the canonical fleet through this:
+
+| Mode | Turn carries | Candidates after filter | Winner (min priority) |
+|------|--------------|--------------------------|-----------------------|
+| Local (0) | text only | all local-tier models | `ministral-3:3b` (priority 0) |
+| Local (0) | a photo | only `minicpm_v4` (the one local vision model) | `minicpm_v4` |
+| Cloud (2) | text only | all cloud-tier models | `deepseek-v4-flash` (priority 0) |
+| Cloud (2) | a photo | cloud models with `VISION` | `qwen3.6-flash` (priority 5) |
+| Cloud (2) | a video frame | cloud models with `VIDEO` | `gemini-3-flash-preview` (priority 8) |
+
+The full fleet that produces this table is in
+[CLAUDE.md](../../CLAUDE.md)'s Multi-Model Router section and in the
+[router cookbook](../router-cookbook.md). A voice_mode swap — say Local
+→ Cloud — calls `set_voice_mode(2)` on the router; it only flips the
+tier filter. The instantiated sub-backends survive the switch, so there
+is no model reload cost to changing modes.
+
+### Why `TOOL_CALLING` is declared but never gates
+
+`TOOL_CALLING` appears in the capability registry, and most fleet entries
+list it. But `infer_required_caps` *never* adds it to the required set,
+so it never narrows the candidate list. It is informational — a label,
+not a gate.
+
+This is a deliberate, load-bearing decision, and it is the most
+counterintuitive part of the design. Here is the trap it avoids:
+
+> Imagine a vision turn. The local vision model is MiniCPM-V, which is
+> excellent at describing a photo but is *not* a tool-calling model. If
+> `infer_required_caps` added `TOOL_CALLING` to the requirements of
+> every turn — reasoning "Dragon is agentic, so every turn might need a
+> tool" — then MiniCPM-V would be filtered out of its own vision turn,
+> and the router would have *no* local candidate that can see. The photo
+> turn would fail or fall through to a worse model.
+
+So tool capability is excluded from inference on purpose. Tool detection
+is a *runtime* event, not a routing input: the chosen model generates,
+and if it emits a tool marker (`<tool>name</tool><args>{…}</args>` or one
+of the other accepted dialects), the `ToolRegistry` parses and executes
+it then. A model that lacks tool training simply never emits a marker,
+and you get a plain answer. Routing on a capability the turn doesn't
+strictly *require* would amputate models that are the only option for the
+capability the turn *does* require. The
+[router cookbook troubleshooting](../router-cookbook.md) makes the same
+point from the operator's chair: "TOOL_CALLING is intentionally NOT
+inferred from system-prompt content; it's a bonus, not a gate."
+
+### Cross-modal continuity
+
+A router that picks the right model for *this* turn is only half the
+problem. The other half is making a *later* text turn remember an
+*earlier* image turn. Before the router landed, the multimodal handler
+(`_handle_user_media`) bypassed the conversation engine entirely, so a
+photo never entered conversation history. Send a photo, then ask "what
+color was the chair?" — and the text follow-up routed to a text-only
+model that had never seen the chair.
+
+The router fixes this end to end:
+
+- `_handle_user_media` no longer bypasses `ConversationEngine`.
+  Multimodal user messages persist through
+  `MessageStore.add_message(media_id=…)` using a `__mm__:` JSON marker in
+  the message content — a compact pointer, not the raw image bytes, in
+  the row.
+- On context build, `get_context(media_store=…)` *hydrates* those markers
+  back into OpenAI `image_url` content arrays, pulling the image from the
+  media store. So the follow-up turn's message array carries the photo
+  again, `infer_required_caps` re-derives `VISION`, and the router again
+  picks a vision-capable model — which now answers "the chair was blue"
+  because it can see the original photo in context.
+- `OllamaBackend.generate_stream_with_messages` translates the OpenAI
+  multimodal content array into Ollama's flat `content + images` shape.
+  Without that translation step, router-fed vision turns failed with
+  `json: cannot unmarshal array into Go struct field`.
+
+The result is the property you actually want from a "smart" assistant:
+modality is sticky across the conversation, not just within one turn.
+
+### `fleet_summary` — telling Tab5 what it can do
+
+When the router is active, `session_start.config` and every
+`config_update` ACK carry a `fleet_summary` object — a per-modality map
+of which model would handle each kind of turn:
+
+```json
+{
+  "type": "session_start",
+  "config": {
+    "fleet_summary": {
+      "text":         "ministral-3:3b",
+      "vision":       "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M",
+      "video":        "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M",
+      "audio_in":     null,
+      "audio_out":    null,
+      "tool_calling": "ministral-3:3b"
+    }
+  }
+}
+```
+
+This lets Tab5 light up its vision/video/audio capability chips
+dynamically from the *actual* fleet, rather than guessing. A `null` entry
+means no model in the active tier can serve that modality, so Tab5 knows
+to grey out the camera affordance. Tab5 firmware is free to ignore
+`fleet_summary` — the legacy `vision_capability` event keeps firing for
+backward compatibility — but a fleet-aware client gets a precise picture
+of what the current mode can handle. The summary is produced by the
+router's `summarize()`; the wire shape is in the
+[WebSocket protocol reference](../reference/websocket-protocol.md).
+
+## Why it's built this way
+
+**Why separate "what the turn needs" from "what the mode allows"?**
+Because they answer to different stakeholders. The required-caps set is a
+fact about the *message* — the user sent a photo, or they didn't. The
+tier filter is a *policy* about privacy and cost — the user chose Local
+to keep data on the box, or Cloud to get frontier quality. Folding them
+together is what created the original one-mode-one-model rigidity. Keeping
+them orthogonal means you can change the privacy policy (swap modes)
+without re-deciding modality, and you can change modality (send a photo)
+without re-deciding privacy. The intersection is computed fresh each turn,
+so the two axes never fight.
+
+**Why lowest-priority-wins instead of a scoring function?** A scoring
+function (weigh cost, latency, quality, …) would be more "intelligent"
+and far less predictable. With a single integer per model and a hard
+capability filter, every routing decision is reproducible by hand from
+the fleet config — which is exactly what you want when you are debugging
+"why did *that* model fire?" at 2 a.m. The cost of the simplicity is that
+you, the fleet author, encode your preferences as priority numbers
+up front. That is a feature: the policy lives in `config.yaml` where you
+can read it, not in a weighting heuristic you have to reverse-engineer.
+Use gaps (0, 5, 10, 15, …) so you can slot a new model in without
+renumbering.
+
+**Why is the router opt-in?** Because the single-backend path is simpler,
+and most installs don't need a fleet. A factory `router` with one model
+would be a one-model fleet pretending to be a router — exactly the kind of
+speculative abstraction the project's anti-slop rules forbid. So the
+router only exists when you have a reason to declare more than one model,
+and the dormant fleet costs nothing.
+
+**Why does TinkerClaw mode bypass the router entirely?** Because in mode
+3 the language-model decision belongs to the gateway's agent loop, not to
+Dragon. Dragon is an audio pipe in that mode — `ConversationEngine`,
+`ToolRegistry`, and the router are all out of the path. Returning `None`
+from `TIER_FOR_MODE[3]` is how the router declines to have an opinion.
+
+**The trade-off we accepted.** A capability filter is a *hard* filter: if
+no model in the active tier can satisfy the required modalities, `choose`
+returns `None` and the turn has nowhere to go (you'll see `router: no
+fleet model satisfies …` in the logs). The cookbook's "Local with Cloud
+Vision Fallback" pattern — let Local mode borrow a cloud vision model when
+the local one isn't loaded — is *not* supported, precisely because the
+tier filter is hard by design. Softening it would reintroduce the
+cross-tier surprises the tier split was meant to eliminate. The workaround
+is the honest one: stay in Local mode for text, flip to Cloud when you tap
+the camera. If you want the soft-fallback behavior, that is a feature
+request, not a bug.
+
+## See also
+
+- [Configure the multi-model router](../how-to/configure-the-multi-model-router.md) · [Swap the LLM backend](../how-to/swap-the-llm-backend.md) · [Run the TinkerClaw sidecar](../how-to/run-the-tinkerclaw-sidecar.md)
+- [Voice modes reference](../reference/voice-modes.md) · [Config reference](../reference/config-reference.md) · [WebSocket protocol](../reference/websocket-protocol.md) · [Package & file map](../reference/package-file-map.md)
+- [Router cookbook](../router-cookbook.md) — copy-paste fleets for common patterns
+- [Architecture](architecture.md) · [The voice pipeline](the-voice-pipeline.md)

--- a/docs/explanation/the-voice-pipeline.md
+++ b/docs/explanation/the-voice-pipeline.md
@@ -1,0 +1,271 @@
+---
+audience: developer
+type: explanation
+prerequisites: [How the stack fits together](how-the-stack-fits-together.md), [Voice modes reference](../reference/voice-modes.md)
+last-verified: 2026-05-29
+---
+# How the voice pipeline works
+
+## The question
+
+You speak to a Tab5. A few seconds later it speaks back. In between, a single
+object on the Dragon — `VoicePipeline` in
+[`dragon_voice/pipeline.py`](../../dragon_voice/pipeline.py) — takes your raw
+microphone PCM, turns it into text, runs that text through a multi-turn LLM that
+can call tools, synthesizes the reply, and streams audio back. This page builds
+the mental model of that orchestration: what each stage does, why the stages are
+ordered the way they are, and why several non-obvious mechanisms exist
+(sentence-buffered TTS, the WebSocket keepalive that fires during inference,
+auto-fallback, and the sample-rate conversions on both ends).
+
+This is the *why*. For the *what* — the exact wire frames — read the
+[WebSocket protocol reference](../reference/websocket-protocol.md); for the
+backend mapping per mode, read the [voice modes reference](../reference/voice-modes.md);
+for the canonical full spec, read [`docs/protocol.md`](../protocol.md).
+
+## The model
+
+A voice turn is a one-directional flow with two re-rate steps bracketing it. The
+[Tab5](../../GLOSSARY.md) captures audio, the [Dragon](../../GLOSSARY.md) does
+all the thinking, and audio comes back. Everything between the two re-rate steps
+runs on the Dragon inside `pipeline.py`.
+
+```text
+Mic audio (PCM int16, 16 kHz mono)              ← Tab5 downsamples 48k → 16k (3:1 box filter)
+  │
+  ▼
+[VAD]  energy-based silence detection           ← optional, server-side
+  │
+  ▼
+[STT]  Moonshine / Whisper.cpp / Vosk / OpenRouter
+  │      → emits `stt` frame: {"text": "...", "stt_ms": N}
+  ▼
+[ConversationEngine]  builds context from message history + memory facts
+  │                    + document chunks, then calls the LLM
+  ▼
+[LLM]  streaming tokens (lmstudio / ollama / npu_genie / openrouter / router)
+  │      → tool-call markers parsed + executed mid-stream, result re-injected
+  │      → emits `llm` token frames, then `llm_done`
+  ▼
+[Sentence buffer]  flush at sentence boundaries, not at end of generation
+  │
+  ▼
+[TTS]  per-sentence synthesis (Piper / Kokoro / Edge TTS / OpenRouter)
+  │
+  ▼
+[Resample]  TTS engine rate (e.g. 22 050 Hz) → 16 kHz
+  │
+  ▼
+[Pace & stream]  4096-byte chunks, paced at ~80% real-time
+  │      → `tts_start`, [binary PCM frames], `tts_end`
+  ▼
+Speaker audio (PCM int16, 16 kHz mono)          → Tab5 upsamples 16k → 48k (linear interp)
+```
+
+### Stage 1 — VAD and capture
+
+The Tab5 streams raw 16 kHz mono int16 PCM as untagged binary WebSocket frames.
+The pipeline appends them to a per-connection buffer. Whether a turn ends is
+decided in one of two places:
+
+- **Explicit endpointing.** The Tab5 sends `{"type":"start"}`, streams PCM, then
+  sends `{"type":"stop"}`. This is the push-to-talk path and the default.
+- **Server-side VAD.** When `audio.vad_enabled` is true, the pipeline watches
+  input energy and triggers STT after `audio.vad_silence_ms` (default 600 ms) of
+  silence — useful when the client cannot detect end-of-speech itself.
+
+The two are not exclusive: VAD is energy-based silence detection layered under
+the explicit `start`/`stop` markers. Turn it off (`vad_enabled: false`) when the
+client owns endpointing and you do not want the server second-guessing it.
+
+### Stage 2 — STT
+
+The buffered PCM goes to the active STT backend, selected by the
+[voice mode](../reference/voice-modes.md): Moonshine on the Q6A CPU for Local
+mode, OpenRouter `gpt-audio-mini` for Hybrid/Cloud. The transcript is emitted as
+an `stt` frame so the Tab5 can show what it heard before the answer arrives. In
+**dictate mode** the flow stops here — see *Dictation* below.
+
+### Stage 3 — the ConversationEngine and the LLM
+
+Voice, text, and vision turns all converge on `ConversationEngine`
+(`dragon_voice/conversation.py`). It is not a thin LLM wrapper. Before each call
+it builds context from the append-only message history, then injects relevant
+memory facts and document chunks found by cosine-similarity search against the
+turn's embedding. The result is a memory-augmented prompt, sent to whichever LLM
+backend the mode binds.
+
+The LLM streams tokens. Two things happen to that stream:
+
+- **Tool-calling, inline.** When the model emits a tool marker —
+  `<tool>name</tool><args>{...}</args>` is the Dragon-standard dialect, with two
+  other dialects accepted — the engine parses it, executes the tool, injects the
+  result back into the context, and lets the model continue. A turn is capped at
+  **three tool calls** so a confused small model cannot loop forever. The token
+  stream the client sees never contains the raw `<tool>` markup; it is stripped
+  before the `llm` frames go out.
+- **The empty-reply guard.** Some function-calling-tuned models fire a tool and
+  then stop, leaving no user-visible prose. When that happens *and* at least one
+  tool fired, Dragon synthesizes a one-line natural-language acknowledgement from
+  the tool result using a per-tool template library — no extra LLM round-trip.
+  See `dragon_voice/tools/response_wrap.py`.
+
+When the model finishes, the engine emits `llm_done`.
+
+### Stage 4 — sentence-buffered TTS
+
+The pipeline does **not** wait for the full reply before synthesizing speech. As
+LLM tokens arrive, a buffer accumulates them and flushes at sentence boundaries.
+Each completed sentence is synthesized and streamed while the LLM is still
+generating the next one. This is the single biggest perceived-latency win in the
+whole flow: the user hears the first sentence seconds before the model has
+finished thinking the last one.
+
+TTS runs on the backend the mode binds — Piper for Local (the default Dragon
+engine, `en_US-lessac-medium`), OpenRouter `gpt-audio-mini` for Cloud. Kokoro
+and Edge TTS are alternatives.
+
+### Stage 5 — resample, pace, and stream
+
+The TTS engine does not emit at the Tab5's rate, so the pipeline always
+resamples to 16 kHz before sending (see *Audio rates* below). Then it streams the
+PCM back in **4096-byte chunks paced at roughly 80% of real-time playback
+speed**. Pacing matters: if the Dragon dumped audio as fast as TCP allowed, the
+Tab5's fixed-size ring buffer would overflow and playback would stutter. By
+delivering slightly *slower* than the speaker consumes, the buffer stays
+comfortably fed without overrunning. The first few chunks go out immediately so
+playback starts fast; the rest are paced. The stream is bracketed by `tts_start`
+and `tts_end` frames.
+
+### Dictation: STT without the LLM
+
+Dictation is a different shape of the same machine. The Tab5 sends
+`{"type":"start","mode":"dictate"}`, performs **client-side VAD** with adaptive
+thresholds, and sends a `segment` marker on each detected pause. Dragon
+transcribes each segment independently and returns an `stt_partial` frame per
+segment, which the Tab5 appends space-separated into a growing transcript.
+Server-side VAD, the LLM, and TTS are all bypassed during the recording —
+recording length is unbounded.
+
+When the user stops, the **post-processing** step runs:
+`pipeline._post_process_dictation()` sends the assembled transcript to the LLM
+*once* to generate a title and summary, then emits a `dictation_summary` frame.
+This is the only place dictation touches the LLM, and it happens after the
+recording is already saved — so a post-processing failure never costs you the
+transcript.
+
+### The keepalive that fires during inference
+
+Local-mode 4B-class models on the Q6A routinely take **60–90 seconds** to finish
+a turn. That collides with a hard constraint: the Tab5's WebSocket library
+treats a long silence as a dead connection and reconnects — and a reconnect trips
+`server.py`'s "device already has connection" guard, which **evicts the in-flight
+LLM stream**. Without intervention, every slow Local turn returned an empty
+reply.
+
+The fix is a keepalive context manager,
+`server.py: _ws_keepalive_during_inference` (issue #76). While the
+ConversationEngine is generating, it fires a WebSocket ping every **5 seconds** —
+far under any client's connection-watch window — so the socket never looks idle.
+It wraps the three slow paths: the TinkerClaw text bypass, the Local text path
+through the ConversationEngine, and the vision/multimodal path.
+
+There is a deliberate subtlety on the Tab5 side, documented in
+[`docs/protocol.md`](../protocol.md): a keepalive ping does **not** reset the
+Tab5's response-timeout timer. Only real data — `stt`, `llm`, or `tts` frames —
+resets it. So the keepalive keeps the *transport* alive without disabling the
+*application*-level timeout that lets the Tab5 give up on a genuinely wedged
+turn. The two timers serve different jobs and are intentionally decoupled.
+
+### Auto-fallback: degrade, never dead-air
+
+Cloud and gateway backends can fail mid-turn. The pipeline never leaves the user
+in silence; it degrades and tells the Tab5 what happened.
+
+- **Cloud STT/TTS fails (timeout or API error):** the pipeline falls back to
+  local Moonshine/Piper for *that request*, then sends a `config_update` carrying
+  an `error` field, which pushes the Tab5 back to Local mode for subsequent
+  turns. `LLMConfig.local_backend` remembers the original local backend so the
+  swap target is always known.
+- **TinkerClaw gateway down (connection refused on `localhost:18789`):** Dragon
+  sends an `error` to the Tab5 — the same auto-revert-to-Local pattern.
+- **`lmstudio` socket unreachable at process start:** `create_llm()`
+  transparently falls back to Ollama for the whole session. This one is
+  **one-shot at backend creation, not per-request**, so warm-path latency is
+  unaffected — but it also means restarting `tinkerclaw-llama-server`
+  mid-session is not picked up until you `systemctl restart tinkerclaw-voice`.
+
+The full fallback table is in the [voice modes reference](../reference/voice-modes.md#auto-fallback).
+
+### Audio rates: why two re-rate steps bracket the flow
+
+The whole pipeline standardizes on **16 kHz mono int16 PCM on the wire**, but
+neither the microphone nor the TTS engines run at 16 kHz natively. So there are
+re-rate steps at both ends:
+
+| Where | Conversion | Done by |
+|---|---|---|
+| Tab5 mic capture | 48 kHz → 16 kHz (3:1 box filter, average of 3 samples) | Tab5 firmware |
+| Piper TTS output | 22 050 Hz → 16 kHz (linear interpolation) | Dragon `pipeline.py` |
+| OpenRouter TTS output | 24 kHz → 16 kHz | Dragon `pipeline.py` |
+| Tab5 speaker playback | 16 kHz → 48 kHz (linear interpolation) | Tab5 firmware |
+
+The 16 kHz wire rate is chosen because it is the rate the STT models expect and
+it halves the bytes on the wire versus 24 kHz, which matters for a battery client
+over WiFi. The Dragon always resamples *down* to 16 kHz before sending; the Tab5
+always upsamples *up* to its 48 kHz codec rate for playback. Sending TTS at its
+native 22 050/24 kHz rate would force the Tab5 to resample a rate it does not
+expect and would inflate the wire payload — so the Dragon eats the resample cost
+once, server-side, where there is CPU to spare.
+
+## Why it's built this way
+
+**One pipeline object, three turn shapes.** Ask, dictate, and text turns are not
+separate code paths bolted together; they are configurations of one
+`VoicePipeline`. Dictate is "stop after STT, post-process later"; text is "skip
+STT"; ask is the full flow. Keeping them in one object means VAD, cancellation,
+session bookkeeping, and the keepalive are written once and shared. The cost is
+that `pipeline.py` carries conditionals for the mode — an acceptable trade for
+not maintaining three near-identical orchestrators.
+
+**Sentence buffering over whole-reply synthesis.** Synthesizing the full reply
+before speaking would be simpler and would let the TTS engine make better
+prosody decisions across the whole utterance. We pay that small quality cost to
+buy seconds of perceived latency, because on a voice assistant the gap between
+"stop talking" and "start hearing a reply" is the experience. A user forgives a
+slightly clipped sentence boundary; they do not forgive ten seconds of silence.
+
+**Keepalive instead of a longer client timeout.** We could have told the Tab5 to
+wait longer before reconnecting. We did not, because a long fixed timeout makes
+*genuinely* dead connections take a long time to recover, and it does nothing for
+a turn that exceeds the timeout anyway. Pinging every 5 s keeps the transport
+alive for arbitrarily long turns while leaving the Tab5's *data*-driven response
+timeout free to fire on a real hang. The keepalive and the response timeout are
+deliberately on different clocks — see the protocol note above.
+
+**Fallback that reverts the mode, not just the request.** When cloud STT fails,
+the per-request local fallback alone would let the next turn fail the same way.
+Pushing the Tab5 back to Local mode means the failure is sticky until the user
+re-opts into cloud — the system assumes a cloud outage persists rather than
+optimistically retrying every turn. That is the safe default for a thing held in
+your hand: degrade once, stay degraded, let the human decide when to climb back.
+
+**16 kHz on the wire, resample at the edges.** The alternative — carrying each
+engine's native rate end-to-end — would push resampling onto the battery-powered
+Tab5 and vary the wire format by backend. Standardizing the wire on 16 kHz makes
+the Tab5's audio path identical regardless of which TTS engine the Dragon used,
+and concentrates the resampling cost on the side with a real CPU. The product
+constraint ("Tab5 + Dragon, nothing else") makes the Dragon the right place to
+spend cycles.
+
+**Pacing at 80% real-time.** Streaming audio faster than the speaker consumes it
+is the classic way to overrun a small embedded ring buffer. Pacing slightly under
+real-time keeps the buffer fed without overflowing, and front-loading the first
+few chunks hides the pacing from the listener at the start of playback. It is a
+flow-control decision dressed as an audio decision.
+
+## See also
+
+- [Voice modes reference](../reference/voice-modes.md) · [WebSocket protocol reference](../reference/websocket-protocol.md) · [Tools catalog](../reference/tools-catalog.md)
+- [Swap the LLM backend](../how-to/swap-the-llm-backend.md) · [Configure the multi-model router](../how-to/configure-the-multi-model-router.md)
+- [`docs/protocol.md`](../protocol.md) — the canonical full wire specification · [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) — the system map

--- a/docs/how-to/add-a-tool.md
+++ b/docs/how-to/add-a-tool.md
@@ -1,0 +1,265 @@
+---
+audience: developer
+type: how-to
+prerequisites: [Agentic Pipeline in CLAUDE.md](../../CLAUDE.md#agentic-pipeline), [Adding a Tool — worked example](../adding-a-tool.md)
+last-verified: 2026-05-29
+est-time: 30 min
+---
+# Add a tool
+
+Use this when you need to give the Dragon LLM a new capability it can invoke
+mid-conversation — fetch data, do a calculation, change some state. A **tool**
+is a Python class the model calls by emitting a marker like
+`<tool>name</tool><args>{...}</args>`; Dragon parses the marker, runs your code,
+and feeds the result back into the model's context so it can keep going. Assumes
+you have a checkout of TinkerBox, can run `pytest` locally, and have read the
+[Agentic Pipeline section in CLAUDE.md](../../CLAUDE.md#agentic-pipeline).
+
+This page is the task checklist. For a full end-to-end worked example (a
+`dice_roll` tool from issue to merge), follow the
+[Adding a Tool worked example](../adding-a-tool.md).
+
+## Steps
+
+### 1. Subclass `Tool`
+
+Every tool subclasses `dragon_voice.tools.base.Tool` and implements four members.
+Create your file under [`dragon_voice/tools/`](../../dragon_voice/tools/), named
+`<name>_tool.py`:
+
+```python
+from dragon_voice.tools.base import Tool
+
+
+class WeatherTool(Tool):
+    """Look up current weather for a city."""
+
+    @property
+    def name(self) -> str:
+        return "weather"
+
+    @property
+    def description(self) -> str:
+        # Injected into the LLM system prompt — this is what the model
+        # reads to decide when to call you. Keep it under ~100 chars.
+        return "Get the current weather for a city. Use when the user asks about weather."
+
+    @property
+    def parameters_schema(self) -> dict:
+        # JSON Schema, same shape as OpenAI function-calling.
+        return {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string", "description": "City name, e.g. 'Paris'"},
+            },
+            "required": ["city"],
+        }
+
+    async def execute(self, args: dict) -> dict:
+        # Coerce + validate args — the model may pass strings, omit
+        # fields, or send junk. Return a clean error dict, never raise.
+        city = args.get("city")
+        if not isinstance(city, str) or not city.strip():
+            return {"error": "city is required"}
+        # ... do the work ...
+        return {"city": city, "temp_c": 18, "conditions": "clear"}
+```
+
+The four members and their jobs:
+
+| Member | Purpose |
+|--------|---------|
+| `name` | Snake_case identifier the model emits in `<tool>name</tool>`. Must be unique in the registry. |
+| `description` | One line injected into the system prompt. The model uses it to decide *when* to call you. System-prompt context is precious — keep it under ~100 characters. |
+| `parameters_schema` | JSON Schema for the args, OpenAI function-calling shape. |
+| `execute` | Async. Receives the parsed args dict, returns a result dict that gets serialised to JSON and shown to the model as the tool result. |
+
+`Tool.to_dict()` is provided by the base class and feeds the
+`GET /api/v1/tools` listing — you do not implement it.
+
+### 2. Register in the `ToolRegistry`
+
+Tools are registered once at startup in
+[`dragon_voice/lifecycle/startup.py`](../../dragon_voice/lifecycle/startup.py).
+Find where the registry is populated (search for `tool_registry.register` or
+`_tool_registry.register`) and add your tool alongside the existing ones:
+
+```python
+from dragon_voice.tools.weather_tool import WeatherTool
+
+# ... existing registrations ...
+server._tool_registry.register(WeatherTool())
+logger.info("WeatherTool registered")
+```
+
+`ToolRegistry.register()` lives in
+[`dragon_voice/tools/registry.py`](../../dragon_voice/tools/registry.py). The
+registry owns parsing the model's markers, dispatching to your `execute`, and
+catching exceptions — there is no separate tool-runner or scheduler to wire up.
+
+> Register order matters in exactly one case: the **compact tool format** for
+> local models hard-codes a top-priority list, `_PRIORITY_TOOLS`, in
+> `registry.py`. See step 4.
+
+### 3. Know the XML dialects the parser accepts
+
+You write the tool; the registry's parser handles however the model phrases the
+call. Three dialects are accepted (see the `registry.py` module docstring and
+`LEARNINGS.md` #79):
+
+1. **Legacy** — `<tool>NAME</tool><args>{json}</args>`. The TinkerBox
+   system-prompt format; `ministral-3:3b` and `gemma3` emit this. The parser
+   tolerates xLAM bracket quirks (`[tool>`, `<tool]`, `[tool]`).
+2. **Standard** — `<tool_call>{"name": "...", "arguments": {...}}</tool_call>`.
+   The industry-typical function-calling fine-tune format; Qwen-FC, Gemma-FC,
+   and `distil-*` emit this regardless of system prompt.
+3. **Bracketed-name** — `[NAME]{json}</NAME>` or `[NAME]UPPERCASE_IDENT()`. An
+   xLAM quirk (issue #82). Gated on `NAME` being a registered tool name, so prose
+   like `[note]` in chat does not false-fire.
+
+The parser is also lenient about small-model noise — stray `>` after `</args>`,
+missing closing tags, and similar formatting slips common with models like
+`qwen3:1.7b`. You do not need to handle any of this in your tool; your `execute`
+only ever sees a parsed args dict.
+
+### 4. (Optional) Add to the compact format for local models
+
+Local models run on a tight context budget, so Dragon sends them a **compact XML
+tool format** to save tokens (`format_for_llm(compact=True)` in `registry.py`).
+That compact view only includes a top-priority subset, `_PRIORITY_TOOLS`, in
+`registry.py`. Cloud-mode models always get the full tool list.
+
+- If your tool is high-traffic and you want local models to see it, add its
+  `name` to `_PRIORITY_TOOLS`.
+- If it is an opt-in or niche tool, leave it out — cloud-mode LLMs still see it
+  and will call it.
+
+### 5. Mind the runtime budget and the agent log
+
+Two pipeline behaviors your tool runs inside:
+
+- **Max 3 tool calls per turn.** `MAX_TOOL_CALLS = 3` caps the
+  ConversationEngine's tool loop to prevent infinite chains. A single turn fires
+  at most three tools before the model must produce a final reply. Do not write a
+  tool that assumes it can be re-invoked many times in one turn.
+- **`agent_log`.** Every `ToolRegistry.execute` call is recorded in a
+  cross-session ring buffer (last 64 entries) exposed at
+  `GET /api/v1/agent_log`. Your tool shows up there automatically — no
+  instrumentation needed — which is the fastest way to confirm it actually fired
+  during a live turn. Tool names observed here also surface in the merged
+  `GET /api/v1/agent_skills` catalog the Tab5 Agents overlay displays.
+
+Also relevant for tools that talk to the network: per-tool timeouts. `asyncio.timeout`
+inside `execute` keeps one slow tool from eating the whole turn budget. See the
+[long-running tools pattern](../adding-a-tool.md#long-running-tools).
+
+### 6. Write a unit test
+
+Mirror any existing `tests/test_*_tool.py`. Cover the happy path, default/missing
+args, and the error branches:
+
+```python
+import pytest
+
+from dragon_voice.tools.weather_tool import WeatherTool
+
+
+@pytest.fixture
+def tool():
+    return WeatherTool()
+
+
+@pytest.mark.asyncio
+async def test_missing_city_errors(tool):
+    result = await tool.execute({})
+    assert "error" in result
+
+
+def test_metadata(tool):
+    assert tool.name == "weather"
+    assert tool.parameters_schema["type"] == "object"
+```
+
+Add the new test file to the named test set in
+[`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) so CI runs it — CI
+runs only the named unit tests, not the E2E suite.
+
+### 7. Lint and test locally
+
+```bash
+ruff check --select F821,F722,F811,F823,B006,B904,E722,B007,RUF006 dragon_voice/ tests/
+pytest -q tests/test_weather_tool.py
+```
+
+## Verify it worked
+
+Start the server locally and check the tool surfaces, then exercise it directly:
+
+```bash
+python3 -m dragon_voice
+```
+
+```bash
+# Tool is registered and listed
+curl -s -H "Authorization: Bearer $DRAGON_API_TOKEN" \
+    http://localhost:3502/api/v1/tools | jq '.tools[] | select(.name == "weather")'
+# → {"name": "weather", "description": "...", "parameters": {...}}
+
+# Execute it directly
+curl -s -X POST -H "Authorization: Bearer $DRAGON_API_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"city": "Paris"}' \
+    http://localhost:3502/api/v1/tools/weather/execute
+# → {"city": "Paris", "temp_c": 18, "conditions": "clear"}
+```
+
+For the full path, deploy to the Dragon (see
+[Deploy on a Dragon](deploy-on-a-dragon.md)) and ask the question that should
+trigger your tool. Confirm the model fired the marker and got a result by reading
+the agent log:
+
+```bash
+curl -s -H "Authorization: Bearer $DRAGON_API_TOKEN" \
+    http://localhost:3502/api/v1/agent_log | jq '.[0]'
+# → most recent ToolRegistry.execute entry — should name your tool
+```
+
+## Troubleshooting
+
+- **Tool never appears in `GET /api/v1/tools`** → it was not registered. Confirm
+  your `register(WeatherTool())` line runs in
+  [`startup.py`](../../dragon_voice/lifecycle/startup.py) and you restarted
+  `tinkerclaw-voice`. After an `scp` deploy, clear stale bytecode first:
+  `find /home/radxa/dragon_voice -name '__pycache__' -exec rm -rf {} +`.
+- **Local model never calls the tool, but cloud mode does** → the tool is not in
+  the compact format. Add its `name` to `_PRIORITY_TOOLS` in
+  [`registry.py`](../../dragon_voice/tools/registry.py) (step 4). Local models only
+  see the compact subset.
+- **Model emits a marker but the reply comes back empty** → some
+  function-calling models emit a tool call and stop, leaving no visible text after
+  the parser strips the markup. The empty-reply guard in
+  [`tools/response_wrap.py`](../../dragon_voice/tools/response_wrap.py) synthesizes a
+  one-line acknowledgement from your tool result. If your tool returns an unusual
+  shape and the ack reads wrong, add a per-tool wrap function there.
+- **`execute` raises and the user sees "Tool execution failed"** → the registry
+  caught your exception. Return `{"error": "message"}` instead of raising — a clean
+  error dict surfaces to the user far better than a generic failure.
+- **Tool fires twice on the same args (sends two emails, charges twice)** → the
+  model can re-call within the 3-call budget. Make side-effecting tools idempotent,
+  or use the confirmation gate from
+  [`memory_tools.py: ForgetFactTool`](../../dragon_voice/tools/memory_tools.py): the
+  first call returns `{"requires_confirmation": true, "preview": "..."}` and only a
+  follow-up `{"confirmed": true}` executes.
+- **Long network call stalls the whole turn** → wrap the network I/O in
+  `asyncio.timeout` and return `{"error": "timeout after Ns"}` on expiry. The
+  per-turn `MAX_TOOL_CALLS = 3` cap bounds total tool time, but one runaway can
+  still consume the entire turn.
+
+## Related
+
+- [Adding a Tool — worked example](../adding-a-tool.md) — the full `dice_roll`
+  walkthrough with patterns to follow and patterns to avoid.
+- [Swap the LLM backend](swap-the-llm-backend.md) — choose which model runs the
+  turn that calls your tool.
+- [Deploy on a Dragon](deploy-on-a-dragon.md) — get your change onto the device.
+- [Architecture](../ARCHITECTURE.md) — where the ToolRegistry sits in the pipeline.

--- a/docs/how-to/configure-the-multi-model-router.md
+++ b/docs/how-to/configure-the-multi-model-router.md
@@ -1,0 +1,276 @@
+---
+audience: operator
+type: how-to
+prerequisites: [Swap the LLM backend](swap-the-llm-backend.md), [Multi-Model Router Cookbook](../router-cookbook.md)
+last-verified: 2026-05-29
+est-time: 20 min
+---
+# Configure the multi-model router
+
+Use this when you want the Dragon to pick a different LLM per turn instead of
+running every turn on one fixed backend — a cheap cloud model for plain text, a
+vision-capable model when a photo arrives, a video-capable model for a clip,
+and a premium model on standby for the hard turns. You opt in by setting
+`llm.backend: "router"` and listing the models in `llm.fleet`. Assumes you can
+SSH to the Dragon and have already decided which [backend](../../GLOSSARY.md#core--llm-serving--models)
+keys you want in the fleet (see [Swap the LLM backend](swap-the-llm-backend.md)).
+
+The router is the [`CapabilityAwareRouter`](../../GLOSSARY.md#multi-model-router)
+in `dragon_voice/llm/router.py`. It implements `LLMBackend` so the
+ConversationEngine treats it like any single model, but internally it holds the
+whole fleet and chooses one per turn from two inputs:
+
+- **the modalities the message needs** — text, vision, video, or audio-in,
+  inferred from the message content by `infer_required_caps()`.
+- **the [tier](../../GLOSSARY.md#core--llm-serving--models) allowed by the
+  active voice mode** — Local mode picks only `local` models, Cloud mode picks
+  `cloud` and `lan` models.
+
+Among the models that satisfy both, the lowest `priority` integer wins.
+
+The router is fully opt-in. With any single backend and `fleet: []` the router
+code never runs and behavior is identical to a fixed backend — so there is no
+risk in editing the fleet on a Dragon that is currently on `lmstudio` or
+`ollama`.
+
+## How the pick works
+
+The choice is a one-line filter-then-minimize. Pseudocode from
+`dragon_voice/llm/router.py`:
+
+```python
+def choose(required_caps, voice_mode):
+    tier_filter = TIER_FOR_MODE[voice_mode]
+    if tier_filter is None:
+        return None  # tinkerclaw mode (voice_mode 3) — router not used
+    candidates = [m for m in fleet
+                  if required_caps <= m.capabilities   # model covers every needed modality
+                  and m.tier in tier_filter]            # model is in an allowed tier
+    return min(candidates, key=lambda m: m.priority) if candidates else None
+```
+
+`TIER_FOR_MODE` maps each voice mode to the tiers the router may pick from:
+
+| `voice_mode` | Mode | Tiers the router considers |
+|--------------|------|----------------------------|
+| 0 | Local | `{"local"}` |
+| 1 | Hybrid | `{"local"}` (LLM stays local; only STT/TTS go cloud) |
+| 2 | Full Cloud | `{"cloud", "lan"}` |
+| 3 | TinkerClaw | `None` — router bypassed, the gateway picks |
+
+The required capabilities are inferred from the message content, never from the
+system prompt. `image_url` content adds `VISION`, `video_url` adds `VIDEO`,
+`input_audio` adds `AUDIO_IN`. `TOOL_CALLING` is deliberately **not** a routing
+gate — gating on it would stop a vision turn from picking a vision model that
+lacks tool training (MiniCPM-V). Tool detection happens at runtime when the
+model emits a tool marker.
+
+## Tiers, capabilities, and priority
+
+A fleet entry is a `ModelSpec`. Three fields drive routing:
+
+- **`tier`** — one of `local`, `cloud`, `lan`. `local` runs on the Dragon
+  (Ollama or llama-server); `cloud` is OpenRouter; `lan` is an
+  OpenAI-compatible server elsewhere on the network (for example LM Studio on a
+  workstation). The active voice mode decides which tiers are eligible.
+- **`caps`** — the modalities the model can serve. A model is a candidate only
+  if its caps are a superset of what the turn needs. Valid values: `text`,
+  `vision`, `video`, `audio_in`, `audio_out`, `tool_calling`.
+- **`priority`** — a plain integer; **lowest wins**. Leave gaps (0, 5, 10, 15,
+  …) so you can slot a new model in without renumbering the rest.
+
+Two more fields tune resource use rather than routing:
+
+- **`keep_alive_s`** — passed straight to Ollama as its `keep_alive`. Set it
+  high (600+ s) for the always-resident text model so it never has to reload,
+  and low (60–120 s) for a heavy multimodal model so it evicts from RAM
+  promptly between bursts.
+- **`model_id`** — the provider-specific model string (Ollama tag, OpenRouter
+  slug, or the loaded GGUF for an LM Studio server).
+
+How each backend declares its own capabilities:
+
+| Backend | Capability source |
+|---------|-------------------|
+| `ollama` | substring scan of the model id (vision on `llava`, `minicpm-v`, `minicpm-o`, `moondream`, `qwen2-vl`, `pixtral`, `internvl`; audio on `minicpm-o`; tools on known FC families) |
+| `openrouter` | static registry `_OPENROUTER_CAPS` in `openrouter_llm.py` (35 models tracked, last synced 2026-04-27); unknown models default to `{TEXT, TOOL_CALLING}` |
+| `lmstudio` | same name-substring heuristic as Ollama |
+| `npu_genie` | text-only (QAIRT has no vision) |
+| `tinkerclaw` | text + tool-calling, plus vision when the gateway model is `anthropic/`, `openai/gpt-4o`, `google/gemini`, or `minimax/` |
+
+The `caps` you write in the fleet entry are what the router uses — keep them
+honest with what the model actually supports, or you will route a vision turn
+to a model that returns a 400.
+
+## Steps
+
+### 1. SSH to the Dragon
+
+The LAN rotates between the `192.168.1.x` and `192.168.70.x` subnets, so verify
+the IP first.
+
+```bash
+ping radxa-dragon-q6a
+ssh radxa@192.168.70.242   # or whatever the current LAN IP resolves to
+```
+
+### 2. Set `backend: "router"` and add a fleet
+
+Edit the `llm` block in `/home/radxa/dragon_voice/config.yaml`. This is the
+canonical example fleet — cheap defaults for both text and multimodal, premium
+models on standby. Model ids are verified live against OpenRouter (2026-04-27);
+the trailing comments are dollars-per-million input/output tokens.
+
+```yaml
+llm:
+  backend: "router"
+  fleet:
+    # ── Local tier ──
+    - {id: ministral,    backend: ollama,     model_id: "ministral-3:3b",
+       caps: [text, tool_calling],          tier: local, priority: 0,  keep_alive_s: 600}
+    - {id: minicpm_v4,   backend: ollama,
+       model_id: "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M",
+       caps: [text, vision, video],         tier: local, priority: 10, keep_alive_s: 120}
+    # ── Cloud tier ──
+    - {id: ds_v4_flash,  backend: openrouter, model_id: "deepseek/deepseek-v4-flash",
+       caps: [text, tool_calling],          tier: cloud, priority: 0}      # $0.14/$0.28
+    - {id: qwen36_flash, backend: openrouter, model_id: "qwen/qwen3.6-flash",
+       caps: [text, vision, tool_calling],  tier: cloud, priority: 5}      # $0.25/$1.50
+    - {id: gemini_flash, backend: openrouter, model_id: "google/gemini-3-flash-preview",
+       caps: [text, vision, video, audio_in, tool_calling],
+                                            tier: cloud, priority: 8}      # $0.50/$3
+    - {id: sonnet_46,    backend: openrouter, model_id: "anthropic/claude-sonnet-4.6",
+       caps: [text, vision, tool_calling],  tier: cloud, priority: 12}     # $3/$15
+    - {id: gemini_pro,   backend: openrouter, model_id: "google/gemini-3.1-pro-preview",
+       caps: [text, vision, video, audio_in, tool_calling],
+                                            tier: cloud, priority: 18}     # $2/$12
+    - {id: opus_47,      backend: openrouter, model_id: "anthropic/claude-opus-4.7",
+       caps: [text, vision, tool_calling],  tier: cloud, priority: 25}     # $5/$25
+    - {id: gpt_55,       backend: openrouter, model_id: "openai/gpt-5.5",
+       caps: [text, vision, tool_calling],  tier: cloud, priority: 30}     # $5/$30
+```
+
+This fleet routes like so:
+
+- **Local mode, text turn** → `ministral` (priority 0, always resident).
+- **Local mode, vision turn** → `minicpm_v4` (the only local-tier model with
+  `vision`; loads on the first photo, evicts after 2 min idle).
+- **Cloud mode, text turn** → `ds_v4_flash` (cheapest text + tools).
+- **Cloud mode, vision turn** → `qwen36_flash` (cheapest multimodal, 1M context).
+- **Cloud mode, video turn** → `gemini_flash` (the lowest-priority cloud entry
+  carrying `video`).
+
+The OpenRouter API key is **not** in `config.yaml`. It lives in
+`/home/radxa/.env` (loaded by the systemd `EnvironmentFile=`) and survives
+`scp` deploys. Keep `llm.openrouter_api_key` empty in the file.
+
+For more fleet patterns — sub-$0.50/M "cheapskate", frontier-on-every-turn, and
+a `lan`-tier DGX/workstation acceleration fleet — see the
+[Multi-Model Router Cookbook](../router-cookbook.md).
+
+### 3. Restart the voice service
+
+The router reads the fleet at process start and picks it up on the next
+`session_start`.
+
+```bash
+# clear stale bytecode first if you also scp'd new code
+find /home/radxa/dragon_voice -name '__pycache__' -exec rm -rf {} +
+sudo systemctl restart tinkerclaw-voice
+```
+
+## Verify it worked
+
+When the router is active, both `session_start.config` and the `config_update`
+ACK carry a `fleet_summary` — a per-modality map of which model would serve each
+modality. Tab5 uses it to light up its vision/video/audio capability chips. If
+`fleet_summary` is present, the router is live.
+
+```json
+{
+  "type": "session_start",
+  "config": {
+    "fleet_summary": {
+      "text":     "ministral-3:3b",
+      "vision":   "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M",
+      "video":    "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M",
+      "audio_in": null,
+      "audio_out": null,
+      "tool_calling": "ministral-3:3b"
+    }
+  }
+}
+```
+
+The fast confirmation is to read back the live config (secrets redacted) and
+check the backend flipped:
+
+```bash
+curl -s http://192.168.70.242:3502/api/config | python3 -m json.tool
+# → "llm": { "backend": "router", "fleet": [ ... ], ... }
+```
+
+Then connect a client (or open the dashboard Chat tab on port 3500) and confirm
+the per-modality model names in `fleet_summary` match the fleet you wrote. Watch
+which model actually fires:
+
+```bash
+journalctl -u tinkerclaw-voice -f
+# send a text turn → expect the local/cloud text model
+# send a photo (vision turn) → expect the vision model
+```
+
+## Troubleshooting
+
+- **`fleet_summary` is missing from `session_start.config`** → the router is not
+  active. Confirm `backend: "router"` is actually set in `config.yaml` and that
+  the service restarted cleanly.
+
+- **`router: no fleet model satisfies …`** → no model in the active tier covers
+  the modality combination the turn needs (for example a vision turn in Local
+  mode with no `vision` model in the `local` tier). Either add a model that
+  covers it, or switch voice mode so a tier that does is eligible.
+
+- **The router is active but the wrong model fires** → check
+  `infer_required_caps(messages)`. `TOOL_CALLING` is intentionally not inferred,
+  so it never gates the pick — it is a bonus, not a requirement. The pick is
+  driven only by `VISION`/`VIDEO`/`AUDIO_IN` present in the message content plus
+  the tier filter. See `tests/test_router_routing.py`.
+
+- **An OpenRouter model returns a 400** → OpenRouter may have brokered the
+  request to a route that does not support the modality your `caps` claimed.
+  Conservatively declare that entry text-only in the fleet and revisit once the
+  route situation clarifies.
+
+- **A new OpenRouter model is rejected or has no price** → add it to
+  `_OPENROUTER_CAPS` in `dragon_voice/llm/openrouter_llm.py` with the right
+  `frozenset` of modalities, add the matching row to `_PRICING_MILS_PER_M` (the
+  registry-completeness test catches drift), then add the fleet entry and
+  restart.
+
+- **A heavy multimodal model hogs RAM between turns** → lower its `keep_alive_s`
+  (60–120 s) so Ollama evicts it promptly; keep the always-on text model high
+  (600+ s) so it never reloads. The Dragon's effective fleet ceiling is ~8 GB
+  after the OS and services.
+
+- **Cloud turns auto-revert to Local unexpectedly** → cost cap. Spend is
+  enforced device-side via the Tab5 NVS `cap_mils` value (default $1/day); the
+  router asks `price_for_model()` after each turn and sums into the daily
+  counter, and auto-downgrade flips `voice_mode` to 0 when the cap is exceeded.
+  Raise `cap_mils` before running a frontier-only fleet.
+
+- **You want to turn the router off** → set `backend` back to a single backend
+  (`lmstudio`, `ollama`, …) and `local_backend` to match. An empty `fleet: []`
+  is fine in that mode — the router code never runs. See
+  [Swap the LLM backend](swap-the-llm-backend.md).
+
+## Related
+
+- [Swap the LLM backend](swap-the-llm-backend.md) — choosing a single backend, or
+  pointing Local mode at the router from the backend side.
+- [Multi-Model Router Cookbook](../router-cookbook.md) — copy-paste fleets and
+  tuning notes.
+- [`docs/protocol.md`](../protocol.md) — the `session_start` / `config_update`
+  wire format that carries `fleet_summary`.
+- [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) — where the router sits in the
+  voice pipeline and how it relates to the four voice modes.

--- a/docs/how-to/connect-an-integration.md
+++ b/docs/how-to/connect-an-integration.md
@@ -1,0 +1,244 @@
+---
+audience: operator
+type: how-to
+prerequisites: [Deploy on a Dragon](deploy-on-a-dragon.md), [API-First Architecture in CLAUDE.md](../../CLAUDE.md#api-first-architecture-62-rest-endpoints--1-websocket)
+last-verified: 2026-05-29
+est-time: 15 min
+---
+# Connect a Google integration
+
+Use this when you need to connect a Google account — Calendar, Gmail, or
+Tasks — to the [Dragon](../../GLOSSARY.md) so that the assistant's
+`calendar_*`, `gmail_*`, and `tasks_*` tools start returning real data. These
+tools are Dragon-native: once a provider is connected they work in every voice
+mode that runs through Dragon's `ConversationEngine` (Local, Hybrid, Full
+Cloud), not just the TinkerClaw sidecar. Assumes you can reach the Dragon's
+REST API on port 3502 and have its bearer token.
+
+The connect flow is **PKCE with a loopback redirect**. The original plan called
+for the OAuth device-code grant (RFC 8628), but Google's verification wall
+rejected device-code for the production Calendar / Gmail / Tasks scope
+combination, so all three Google integrations ship on public-client PKCE
+instead. Credentials are **keyed by email address**, so you can connect both a
+work and a personal Google account to the same provider.
+
+## The endpoint family
+
+All four routes live under `/api/v1/integrations/` on port 3502. They sit
+behind the Wave 13 bearer-token gate, so every call needs an
+`Authorization: Bearer <token>` header (the `DRAGON_API_TOKEN` value from
+`/home/radxa/.env`).
+
+| Method | Path | Does |
+|--------|------|------|
+| `GET` | `/api/v1/integrations/list` | Lists available integrations + per-email connection state |
+| `POST` | `/api/v1/integrations/connect` | Starts a connect flow; returns an `authorization_url` (PKCE) |
+| `POST` | `/api/v1/integrations/disconnect` | Revokes tokens + deletes the credentials file for a `provider, email` |
+| `GET` | `/api/v1/integrations/test/{provider}` | Smoke-tests the active connection; returns `{ok, detail}` |
+
+The valid `provider` values are `google-calendar`, `google-gmail`, and
+`google-tasks`. The three share one Google OAuth client, so the consent screen
+covers whichever scopes the provider you are connecting needs.
+
+## Before you start
+
+Resolve the Dragon's current address — the LAN flips between the `192.168.1.x`
+and `192.168.70.x` subnets and the host is DHCP-managed, so never assume a
+hardcoded IP:
+
+```bash
+ping radxa-dragon-q6a
+# → 64 bytes from 192.168.70.242: icmp_seq=1 ttl=64 time=1.2 ms
+```
+
+The examples below use `192.168.70.242` (verified 2026-05-04) and read the
+bearer token into a shell variable so you do not paste it on every line:
+
+```bash
+DRAGON=192.168.70.242
+TOKEN=$(ssh radxa@$DRAGON "grep -oP 'DRAGON_API_TOKEN=\K.*' /home/radxa/.env")
+```
+
+## Steps
+
+### 1. See what is available and what is already connected
+
+```bash
+curl -s http://$DRAGON:3502/api/v1/integrations/list \
+  -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
+```
+
+```json
+{
+  "integrations": [
+    {"provider": "google-calendar", "display_name": "Google Calendar",
+     "connected": false, "accounts": []},
+    {"provider": "google-gmail", "display_name": "Gmail",
+     "connected": true, "accounts": ["emilesawayame@gmail.com"]},
+    {"provider": "google-tasks", "display_name": "Google Tasks",
+     "connected": false, "accounts": []}
+  ]
+}
+```
+
+`accounts` is per-email — a multi-account provider lists every Google address
+you have connected to it.
+
+### 2. Start the connect flow
+
+`POST /api/v1/integrations/connect` with the provider you want. The Dragon
+generates a PKCE `code_verifier`, retains it server-side, binds an ephemeral
+loopback listener on `http://127.0.0.1:<port>/oauth/callback`, and returns the
+Google consent URL with the matching `code_challenge` and a `state` nonce:
+
+```bash
+curl -s -X POST http://$DRAGON:3502/api/v1/integrations/connect \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"provider": "google-calendar"}' | python3 -m json.tool
+```
+
+```json
+{
+  "provider": "google-calendar",
+  "authorization_url": "https://accounts.google.com/o/oauth2/v2/auth?client_id=...&code_challenge=...&state=...&redirect_uri=http%3A%2F%2F127.0.0.1%3A<port>%2Foauth%2Fcallback",
+  "expires_in": 600
+}
+```
+
+On a Tab5 this is the moment the **Settings → Integrations** screen renders the
+URL as a QR code so you can scan it with a phone. From the command line, open
+`authorization_url` in any browser.
+
+### 3. Complete consent in the browser
+
+Sign in to the Google account you want, grant the requested scopes, and let
+Google redirect back to the Dragon's loopback listener with the authorization
+code. The Dragon exchanges the code plus its retained `code_verifier` for
+tokens, then writes them to disk keyed by the account's email address:
+
+```
+~/.tinkerclaw/integrations/<provider>/<email>.json   # mode 0o600, atomic write
+```
+
+A token-refresh writes back through the same path, so a connection survives
+restarts and refreshes silently on a 401.
+
+> **The unverified-app warning is expected.** If the OAuth client is still in
+> Google's testing/unverified state you will see an "Google hasn't verified
+> this app" interstitial. Click **Advanced → Go to (unsafe)** to proceed, and
+> make sure the Google account is on the OAuth client's test-user allowlist —
+> otherwise consent fails with `access_denied`. This verification wall is the
+> reason the flow is PKCE and not device-code (issue #103).
+
+### 4. Confirm the tokens landed
+
+```bash
+ssh radxa@$DRAGON "ls -l ~/.tinkerclaw/integrations/google-calendar/"
+# → -rw------- 1 radxa radxa 1834 May 29 14:02 emilesawayame@gmail.com.json
+```
+
+The file is `0o600` — owner-only — so it is never world-readable. If you see a
+`_legacy.json` alongside the email-keyed file, that is the single-account
+migration shim from the Phase 1 storage layout; the loader promotes it to the
+email-keyed name on the first successful refresh.
+
+## Verify it worked
+
+Smoke-test the live connection. `GET /api/v1/integrations/test/{provider}`
+makes one real read against Google (list today's calendar, count unread mail,
+or list tasks, depending on the provider) and returns whether it succeeded:
+
+```bash
+curl -s http://$DRAGON:3502/api/v1/integrations/test/google-calendar \
+  -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
+# → {"ok": true, "detail": "3 events today"}
+```
+
+Then confirm `list` now shows the provider connected with your email under
+`accounts`:
+
+```bash
+curl -s http://$DRAGON:3502/api/v1/integrations/list \
+  -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
+# → "provider": "google-calendar", "connected": true, "accounts": ["emilesawayame@gmail.com"]
+```
+
+Finally, prove the tool is wired into the assistant. Run a stateless turn that
+should trigger the calendar tool and watch it fire in the logs:
+
+```bash
+curl -s -X POST http://$DRAGON:3502/api/v1/completions \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "What is on my calendar today?"}'
+
+ssh radxa@$DRAGON "journalctl -u tinkerclaw-voice -n 40 --no-pager | grep -i tool"
+# → ToolRegistry.execute calendar_today ... ok
+```
+
+You can also watch tool activity on the dashboard's agent feed or via
+`GET /api/v1/agent_log` — the calendar/gmail/tasks call lands there with a
+`source: dragon` tag.
+
+## Disconnecting
+
+`POST /api/v1/integrations/disconnect` revokes the tokens with Google and
+deletes the email-keyed credentials file. For a multi-account provider you must
+name the email, otherwise the Dragon does not know which account to drop:
+
+```bash
+curl -s -X POST http://$DRAGON:3502/api/v1/integrations/disconnect \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"provider": "google-gmail", "email": "emilesawayame@gmail.com"}'
+# → {"ok": true}
+```
+
+## Troubleshooting
+
+- **Every call returns `401 Unauthorized`** → the `/api/v1/*` surface is behind
+  the bearer-token gate. Send `Authorization: Bearer <DRAGON_API_TOKEN>` (the
+  value lives in `/home/radxa/.env`, loaded by the systemd `EnvironmentFile=`).
+  A blank `$TOKEN` is the usual cause — re-read it from `.env`.
+
+- **Consent fails with `access_denied` on an unverified app** → the Google
+  account is not on the OAuth client's test-user allowlist. Add it in the Google
+  Cloud Console OAuth consent screen, or push the client through verification.
+  This is the verification wall that forced PKCE over device-code (issue #103).
+
+- **`authorization_url` works but the redirect never completes** → the loopback
+  listener is bound only for the life of the flow (`expires_in` seconds, 600 by
+  default) on `127.0.0.1`. If you opened the URL on a different machine, the
+  browser's redirect to `http://127.0.0.1:<port>/oauth/callback` hits *that*
+  machine's loopback, not the Dragon's. Complete consent in a browser on the
+  Dragon, or use the Tab5 QR flow which round-trips through Dragon.
+
+- **`test/{provider}` returns `{"ok": false, ...}` after a working connect** →
+  the refresh token was revoked (you removed the app's access in your Google
+  account, or the token expired while unused). Re-run the connect flow; the new
+  tokens overwrite the email-keyed file in place.
+
+- **Tools fire but return stale or empty data on a small Local model** → the
+  connection is fine; this is the model, not the integration. On the
+  hard-prose gauntlet small Local models confuse tool selection and arg
+  extraction. Confirm with `test/{provider}` (which bypasses the LLM) before
+  blaming the integration, and see the Local-model notes in
+  [Swap the LLM backend](swap-the-llm-backend.md).
+
+- **Connected the wrong Google account** → disconnect that specific email (see
+  [Disconnecting](#disconnecting)), then connect again and sign in with the
+  account you want. Credentials are email-keyed, so connecting a second account
+  does not evict the first.
+
+## Related
+
+- [Deploy on a Dragon](deploy-on-a-dragon.md) — get a working tree onto the
+  Dragon and confirm `tinkerclaw-voice` is healthy before connecting anything.
+- [Swap the LLM backend](swap-the-llm-backend.md) — which model actually decides
+  to call the `calendar_*` / `gmail_*` / `tasks_*` tools, and how tool-calling
+  is wired per backend.
+- [WebSocket protocol](../protocol.md) — the Tab5 ↔ Dragon contract the Tab5
+  Settings → Integrations screen rides on.
+- [`CLAUDE.md`](../../CLAUDE.md) — the full operator runbook, including the
+  complete REST endpoint table.

--- a/docs/how-to/deploy-on-a-dragon.md
+++ b/docs/how-to/deploy-on-a-dragon.md
@@ -1,0 +1,218 @@
+---
+audience: operator
+type: how-to
+prerequisites: ../dev-setup.md, ../ARCHITECTURE.md
+last-verified: 2026-05-29
+est-time: 15 min
+---
+# Deploy on a Dragon
+
+Use this when you have a working tree on your workstation and need to push it to
+a live [Dragon](../../GLOSSARY.md) running the `dragon_voice` service. This guide
+covers the `scp` of code + dashboard + schema, restarting the systemd services,
+and the post-deploy checklist that keeps you from chasing ghosts (stale
+`__pycache__`, a clobbered `.env`, a missing token, dead ngrok tunnels).
+
+Assumes you already have SSH access to the Dragon and the `tinkerclaw-*` systemd
+units installed. If the units do not exist yet, install them first — see
+[Developer Environment Setup](../dev-setup.md) for the one-time service install,
+or [`systemd/`](https://github.com/lorcan35/TinkerBox/blob/main/systemd) in the
+repo root for the canonical unit files.
+
+## Before you start
+
+Confirm the Dragon's current address. The LAN flips between `192.168.1.x` and
+`192.168.70.x` and the host is DHCP-managed, so the IP rotates — never assume a
+hardcoded value:
+
+```bash
+# Resolve by hostname, or scan the subnet for the open ports
+ping radxa-dragon-q6a
+# → 64 bytes from 192.168.70.242: icmp_seq=1 ttl=64 time=1.2 ms
+
+nmap -p 22,3502,18789 --open 192.168.70.0/24
+```
+
+The examples below use `192.168.70.242` (verified 2026-05-04). Substitute the
+address you just resolved. The SSH user is `radxa`; sudo on the Dragon is
+passwordless after login.
+
+## Steps
+
+### 1. Sync code, dashboard, and schema to the Dragon
+
+`scp` the three things that change on a code push: the `dragon_voice/` package,
+`dashboard.py`, and `schema.sql`. Run this from the repo root on your
+workstation:
+
+```bash
+scp -r dragon_voice/ radxa@192.168.70.242:/home/radxa/
+scp dashboard.py radxa@192.168.70.242:/home/radxa/
+scp schema.sql radxa@192.168.70.242:/home/radxa/
+```
+
+The target user is `radxa` and everything lives under `/home/radxa/` — never
+`/home/rock`. The voice service runs as `python3 -m dragon_voice` with
+`PYTHONPATH=/home/radxa`, so the package must land at `/home/radxa/dragon_voice`.
+
+### 2. Clear stale `__pycache__` on the Dragon
+
+After any `scp -r`, leftover `.pyc` files can shadow your new source and cause
+import errors that look like the deploy never happened. Wipe them before
+restarting:
+
+```bash
+ssh radxa@192.168.70.242 "find /home/radxa/dragon_voice -name '__pycache__' -exec rm -rf {} +"
+```
+
+### 3. Restart the voice service
+
+```bash
+ssh radxa@192.168.70.242 "sudo systemctl restart tinkerclaw-voice"
+```
+
+`tinkerclaw-voice` (port 3502) is the unit that carries the STT/LLM/TTS pipeline,
+the REST API, and the Notes API — it is the one that picks up your code change.
+Restart `tinkerclaw-dashboard` (port 3500) too only if you changed `dashboard.py`:
+
+```bash
+ssh radxa@192.168.70.242 "sudo systemctl restart tinkerclaw-dashboard"
+```
+
+You can chain the cache-clear and the restart into one SSH call:
+
+```bash
+ssh radxa@192.168.70.242 \
+  "find /home/radxa/dragon_voice -name '__pycache__' -exec rm -rf {} +; sudo systemctl restart tinkerclaw-voice"
+```
+
+## Post-deploy checklist
+
+Walk these four after every deploy. They are the difference between "it restarted"
+and "it actually works."
+
+- **`__pycache__` cleared.** Covered in step 2. If you skipped it and see
+  `ImportError` or behavior that doesn't match your diff, that's the cause — clear
+  it and restart again.
+
+- **`.env` survives the push.** The OpenRouter API key and `DRAGON_API_TOKEN`
+  live in `/home/radxa/.env`, loaded by systemd via `EnvironmentFile=`. A
+  `scp -r dragon_voice/` does **not** touch `/home/radxa/.env`, so secrets
+  survive code pushes. Never put real API keys in `config.yaml` in the repo —
+  keep them in `.env` so they aren't overwritten and aren't committed. Confirm
+  the file is still present and populated:
+
+  ```bash
+  ssh radxa@192.168.70.242 "grep -c '=' /home/radxa/.env"
+  # → a small positive number (one per VAR=value line)
+  ```
+
+- **`tinkerclaw_token` matches the gateway.** If you use the optional TinkerClaw
+  sidecar (voice mode 3), the `tinkerclaw_token` in `dragon_voice/config.yaml`
+  must match the gateway auth token in `~/.tinkerclaw/tinkerclaw.json`. A
+  `config.yaml` overwrite from your deploy can reset it — restore it if so.
+
+- **ngrok tunnels are up.** The `tinkerclaw-ngrok` unit serves three public
+  domains that map 1:1 to the local ports:
+
+  | Domain | → Local port | Service |
+  |--------|--------------|---------|
+  | `tinkerclaw-voice.ngrok.dev` | 3502 | Voice WS + REST API |
+  | `tinkerclaw-dashboard.ngrok.dev` | 3500 | Web dashboard |
+  | `tinkerclaw-gateway.ngrok.dev` | 18789 | TinkerClaw gateway (localhost-bound) |
+
+  ngrok survives a `tinkerclaw-voice` restart on its own, but confirm it after a
+  full reboot — Tab5 falls back to `wss://tinkerclaw-voice.ngrok.dev` when off the
+  LAN.
+
+## Verify it worked
+
+Check the service is active and not crash-looping:
+
+```bash
+ssh radxa@192.168.70.242 "sudo systemctl status tinkerclaw-voice --no-pager"
+# → Active: active (running) since ...
+```
+
+Hit the health endpoint over the LAN:
+
+```bash
+curl -s http://192.168.70.242:3502/health
+# → {"status": "ok", ...}
+```
+
+Tail the logs for a clean startup — no tracebacks, backends initialized:
+
+```bash
+ssh radxa@192.168.70.242 "journalctl -u tinkerclaw-voice -n 40 --no-pager"
+```
+
+Confirm the ngrok path resolves from outside the LAN:
+
+```bash
+curl -s https://tinkerclaw-voice.ngrok.dev/health
+# → {"status": "ok", ...}
+```
+
+For a deeper smoke test against the running server, run the live e2e suite from
+your workstation (it expects the Dragon reachable on `:3502`):
+
+```bash
+python3 tests/test_api_e2e.py
+```
+
+## Service map reference
+
+The units you interact with on a deploy:
+
+| Service | Port | systemd unit | Restart when… |
+|---------|------|--------------|---------------|
+| Voice + API | 3502 | `tinkerclaw-voice` | you changed `dragon_voice/` or `schema.sql` |
+| Dashboard | 3500 | `tinkerclaw-dashboard` | you changed `dashboard.py` |
+| mDNS | — | `tinkerclaw-mdns` | rarely — advertises `_tinkerclaw._tcp` |
+| ngrok | 443 (ext) | `tinkerclaw-ngrok` | after a full reboot, to confirm tunnels |
+| TinkerClaw gateway | 18789 | `tinkerclaw-gateway` | only if running voice mode 3 |
+
+## Troubleshooting
+
+- **`ImportError` or stale behavior after deploy** → leftover `.pyc` files.
+  Re-run the `__pycache__` clear from step 2, then restart.
+
+- **LLM calls fail with auth errors** → `/home/radxa/.env` is missing or empty.
+  The `OPENROUTER_API_KEY` and `DRAGON_API_TOKEN` are loaded from there via the
+  unit's `EnvironmentFile=`. Restore the file (it is not pushed by `scp`) and
+  restart `tinkerclaw-voice`.
+
+- **`scp` lands code under the wrong path / `python3 -m dragon_voice` can't find
+  the package** → the user is `radxa` and everything lives under `/home/radxa/`,
+  with `PYTHONPATH=/home/radxa`. Verify `/home/radxa/dragon_voice/__main__.py`
+  exists on the Dragon.
+
+- **Connection refused / wrong IP** → the Dragon is DHCP and the LAN rotates
+  between `192.168.1.x` and `192.168.70.x`. Re-resolve with
+  `ping radxa-dragon-q6a` or `nmap -p 22,3502,18789 --open <subnet>/24` and reuse
+  that address for every command.
+
+- **`Address already in use` on port 3502** → a stale process is holding the
+  port. Find and kill it, or let systemd own it:
+  `ssh radxa@192.168.70.242 "sudo lsof -i :3502"` then
+  `sudo systemctl restart tinkerclaw-voice`.
+
+- **Voice mode 3 (TinkerClaw) returns errors after deploy** → the
+  `tinkerclaw_token` in `config.yaml` no longer matches
+  `~/.tinkerclaw/tinkerclaw.json`. Restore the matching token and restart.
+
+- **Tab5 can't reach the Dragon off-LAN** → an ngrok tunnel is down. Check
+  `sudo systemctl status tinkerclaw-ngrok` and confirm the three domains in the
+  post-deploy checklist resolve.
+
+## Related
+
+- [Developer Environment Setup](../dev-setup.md) — first-time clone, `.env`,
+  service install, and the workstation deploy workflow.
+- [Architecture](../ARCHITECTURE.md) — the map of what runs where on the Dragon.
+- [WebSocket protocol](../protocol.md) — the Tab5 ↔ Dragon contract your deploy
+  has to keep honoring.
+- [NPU setup](../npu-setup.md) — the Qualcomm Genie/HTP LLM path on the Dragon.
+- [`CLAUDE.md`](../../CLAUDE.md) — the full operator runbook (debug, monitor,
+  restart, service internals).

--- a/docs/how-to/run-the-tinkerclaw-sidecar.md
+++ b/docs/how-to/run-the-tinkerclaw-sidecar.md
@@ -1,0 +1,117 @@
+---
+audience: operator
+type: how-to
+prerequisites: [Architecture overview](../ARCHITECTURE.md), [Swap the LLM backend](swap-the-llm-backend.md)
+last-verified: 2026-05-29
+est-time: 20 min
+---
+# Run the TinkerClaw sidecar (vmode 3)
+
+Use this when you want a voice turn handled by the agentic [TinkerClaw](../../GLOSSARY.md) gateway instead of by the Dragon's own conversation engine — for long-running autonomous work like code review or browser automation. Assumes you can SSH to the Dragon and have already read the [backend options](../../README.md#backend-options).
+
+In voice mode 3, the Dragon stops being the brain and becomes an audio pipe. STT still runs locally to turn speech into a transcript, that transcript is forwarded to the TinkerClaw gateway on `localhost:18789`, and the gateway's reply is spoken back through local TTS. The `ConversationEngine`, `ToolRegistry`, and `MemoryService` are all bypassed — TinkerClaw runs its own LLM choice, tool execution, and browser automation. The LLM-backend adapter that forwards the call is [`dragon_voice/llm/tinkerclaw_llm.py`](../../dragon_voice/llm/tinkerclaw_llm.py).
+
+## Steps
+
+### 1. Confirm the gateway is running and listening on 18789
+
+The gateway runs as its own systemd unit, `tinkerclaw-gateway.service`, bound to localhost only. SSH to the Dragon first — the LAN rotates between the `192.168.1.x` and `192.168.70.x` subnets, so verify the IP:
+
+```bash
+ping radxa-dragon-q6a
+ssh radxa@192.168.70.242   # or whatever the current LAN IP resolves to
+```
+
+Then check the unit and the port:
+
+```bash
+sudo systemctl status tinkerclaw-gateway
+ss -ltnp | grep 18789
+# → LISTEN 0 ... 127.0.0.1:18789 ...
+```
+
+If the unit is dead, start it and watch the logs:
+
+```bash
+sudo systemctl start tinkerclaw-gateway
+journalctl -u tinkerclaw-gateway -f
+```
+
+### 2. Match the gateway auth token in `config.yaml`
+
+The voice server authenticates to the gateway with a shared token. The `tinkerclaw_token` value in [`dragon_voice/config.yaml`](../../dragon_voice/config.yaml) must match the gateway auth token in `~/.tinkerclaw/tinkerclaw.json`. This is one of the items that an `scp -r dragon_voice/` deploy can clobber, so re-check it after every code push.
+
+```bash
+# The gateway's configured token
+grep -i token /home/radxa/.tinkerclaw/tinkerclaw.json
+
+# The voice server's copy — these two must agree
+grep -i tinkerclaw_token /home/radxa/dragon_voice/config.yaml
+```
+
+If they differ, edit `config.yaml` so its `tinkerclaw_token` matches `~/.tinkerclaw/tinkerclaw.json`, then restart the voice service:
+
+```bash
+sudo systemctl restart tinkerclaw-voice
+```
+
+### 3. Enter voice mode 3 from the Tab5
+
+Mode selection is device-driven, not operator-driven. The Tab5 sends a `config_update` frame to switch the whole pipeline to TinkerClaw:
+
+```json
+{"type": "config_update", "voice_mode": 3}
+```
+
+On receiving `voice_mode: 3`, the Dragon keeps STT (Moonshine, or OpenRouter if the device is in a cloud STT/TTS configuration) and TTS (Piper, or OpenRouter) local, but routes the LLM call to the gateway. The multi-model router is bypassed entirely in this mode — `TIER_FOR_MODE[3]` is `None`, so the gateway picks the model, not the Dragon.
+
+To exercise the path without a Tab5 in hand, drive the WebSocket directly. Send a `register` frame first, then `config_update`, then a `text` frame — text input in mode 3 bypasses the `ConversationEngine` and routes straight through `tinkerclaw_llm.py`:
+
+```bash
+ssh radxa@192.168.70.242
+```
+
+```python
+# On the Dragon: a minimal mode-3 probe over /ws/voice
+import asyncio, json, aiohttp
+
+async def main():
+    async with aiohttp.ClientSession() as s:
+        async with s.ws_connect("ws://localhost:3502/ws/voice") as ws:
+            await ws.send_json({"type": "register", "device_id": "probe",
+                                "hardware_id": "00:00:00:00:00:01",
+                                "firmware_ver": "0.0.0", "platform": "probe"})
+            await ws.receive_json()                                  # session_start
+            await ws.send_json({"type": "config_update", "voice_mode": 3})
+            await ws.send_json({"type": "text", "content": "review the open PRs"})
+            async for msg in ws:
+                print(msg.data)
+
+asyncio.run(main())
+```
+
+## Verify it worked
+
+Watch the voice-server log while you send a mode-3 turn:
+
+```bash
+journalctl -u tinkerclaw-voice -f
+```
+
+A successful turn shows the LLM call going to the gateway (not to `lmstudio`/`ollama`/`openrouter`) and streams `llm` tokens back. Over the WebSocket you should see the standard turn shape — `llm` tokens, then `llm_done`, then `tts_start` / binary audio / `tts_end` — with no `tool_call` events originating from the Dragon's own `ToolRegistry` (the gateway runs its tools internally). Rich-media rendering (code blocks, tables) still works in mode 3: media detection runs in the TinkerClaw code path too, emitting `text_update` before any `media` frame.
+
+You can also confirm session continuity. The Dragon passes its `session_id` as the `user` field on every TinkerClaw request, so the gateway maintains per-session context across turns. A second turn in the same session reaches the gateway with the same `user` value.
+
+## Troubleshooting
+
+- **Turn fails immediately, Tab5 drops back to Local mode** → the gateway is down. When `tinkerclaw_llm.py` gets connection-refused on `localhost:18789`, the Dragon sends an `error` frame to the Tab5 — the same auto-revert-to-Local pattern as a cloud STT/TTS failure. Start the unit (`sudo systemctl start tinkerclaw-gateway`) and re-send `config_update` with `voice_mode: 3`.
+- **Gateway is up but every turn is rejected with an auth error** → `tinkerclaw_token` in `config.yaml` no longer matches `~/.tinkerclaw/tinkerclaw.json`. This is the classic post-deploy regression because `scp -r dragon_voice/` overwrites `config.yaml`. Re-sync the token (step 2) and restart `tinkerclaw-voice`.
+- **Mode 3 turns hang for a long time before responding** → expected. The TinkerClaw pipeline timeout is 180 s (3 min), set per voice mode in `pipeline.py`, because agentic tool-execution chains leave long gaps with no token output. The Tab5's own response timeout is 35 s, but keepalive `ping` frames during `PROCESSING` keep the connection alive across the gap.
+- **`config_update` to mode 3 seems ignored after a reconnect** → on reconnect the pipeline re-initializes with Local defaults (voice_mode 0) regardless of the prior session's mode. The client must re-send `config_update` to restore mode 3.
+- **Channel messages from Telegram/WhatsApp do not arrive** → that is a different path. Inbound third-party messages flow through `GatewayConnector` (`dragon_voice/channels/gateway.py`) over the same `localhost:18789` gateway, not through `tinkerclaw_llm.py`. See [`docs/protocol.md`](../protocol.md) §20 for the `channel_message` / `channel_reply` / `channel_reply_ack` frames.
+
+## Related
+
+- [Swap the LLM backend](swap-the-llm-backend.md) — flip `llm.backend` to `tinkerclaw` persistently or at runtime, and the rest of the backend keys.
+- [Architecture overview](../ARCHITECTURE.md) — where the gateway sits among the three pieces and the four voice modes.
+- [WebSocket protocol](../protocol.md) — the full `config_update` and channel-frame contracts.

--- a/docs/how-to/swap-the-llm-backend.md
+++ b/docs/how-to/swap-the-llm-backend.md
@@ -1,0 +1,304 @@
+---
+audience: operator
+type: how-to
+prerequisites: [Backend Options in the README](../../README.md#backend-options), [Multi-Model Router Cookbook](../router-cookbook.md)
+last-verified: 2026-05-29
+est-time: 15 min
+---
+# Swap the LLM backend
+
+Use this when you need to change which language model the Dragon runs a turn
+on — flipping the Local path between `lmstudio` (llama-server) and `ollama`,
+pointing Local mode at the multi-model `router`, sending Cloud turns to a
+different OpenRouter model, or handing turns to the `npu_genie`, `tinkerclaw`,
+or `dual` backends. Assumes you can SSH to the Dragon and have already read the
+[backend options table](../../README.md#backend-options) so you know which key
+names which engine.
+
+The LLM backend is one field: `llm.backend` in
+[`dragon_voice/config.yaml`](../../dragon_voice/config.yaml). You change it in
+one of two places:
+
+- **At rest, in `config.yaml`** — edit the file on the Dragon and restart
+  `tinkerclaw-voice`. This is the persistent, survives-reboot path.
+- **At runtime, over the config API** — `POST /api/config` hot-swaps the
+  backend on every active pipeline without dropping the WebSocket. The change
+  lasts until the next restart, which reloads `config.yaml`.
+
+There is also a third, Tab5-driven path: a `config_update` WebSocket frame
+flips the whole voice mode (Local / Hybrid / Cloud / TinkerClaw) for one
+connection. That belongs to the device, not the operator — see
+[Three-Tier Voice Mode](#how-voice-mode-relates-to-the-backend) below.
+
+## The valid backend keys
+
+| Key | Engine | Where it runs |
+|-----|--------|---------------|
+| `lmstudio` | llama-server (OpenAI-compatible) on `localhost:1234` | Local — **primary** Local path |
+| `ollama` | Ollama on `localhost:11434` | Local — automatic fallback for `lmstudio` |
+| `npu_genie` | Llama 3.2 1B on the QCS6490 Hexagon DSP (~8 tok/s) | Local (NPU) |
+| `openrouter` | Any cloud model via OpenRouter | Cloud |
+| `tinkerclaw` | TinkerClaw agent gateway on `localhost:18789` | Local sidecar (voice mode 3) |
+| `dual` | Fast tool-picker + warm responder pair | Local |
+| `router` | `CapabilityAwareRouter` picks per-turn from a fleet | Mixed (local / cloud / lan) |
+
+`lmstudio` and `ollama` are the two Local-mode options that matter day to day.
+The Dragon ships with `backend: "lmstudio"` and `local_backend: "lmstudio"` —
+llama-server is the Local default because it is roughly 10× faster on a direct
+tool-call probe than Ollama on the same Q6A hardware and serves the
+[Granite](../../GLOSSARY.md) and MiniCPM-V GGUFs that Ollama 500'd on.
+
+## Steps
+
+### Option A — swap persistently in `config.yaml`
+
+1. SSH to the Dragon (verify the current IP first — the LAN rotates between the
+   `192.168.1.x` and `192.168.70.x` subnets):
+
+   ```bash
+   ping radxa-dragon-q6a
+   ssh radxa@192.168.70.242   # or whatever the current LAN IP resolves to
+   ```
+
+2. Edit the `llm` block in `/home/radxa/dragon_voice/config.yaml`. To switch the
+   Local path from llama-server to plain Ollama, set both `backend` and
+   `local_backend`:
+
+   ```yaml
+   llm:
+     backend: "ollama"          # was "lmstudio"
+     local_backend: "ollama"    # was "lmstudio" — used for cloud→local fallback
+     ollama_url: "http://localhost:11434"
+     ollama_model: "qwen3.5:4b"
+   ```
+
+   To go the other way — Ollama back to the llama-server Local default with
+   native tool-calling on:
+
+   ```yaml
+   llm:
+     backend: "lmstudio"
+     local_backend: "lmstudio"
+     lmstudio_url: "http://localhost:1234/v1"
+     lmstudio_model: "default"  # llama-server reports its loaded GGUF
+     native_tools: true
+   ```
+
+3. Restart the voice service so the new config loads:
+
+   ```bash
+   sudo systemctl restart tinkerclaw-voice
+   ```
+
+> **Always set `local_backend` too, not just `backend`.** `local_backend` is
+> the backend the pipeline reverts to when a Cloud turn fails or when a device
+> reconnects (reconnect resets to Local defaults). If you leave it stale, a
+> cloud-failure fallback or a reconnect will quietly land on the wrong engine.
+
+### Option B — hot-swap at runtime over the config API
+
+`POST /api/config` re-initializes every active pipeline in place. The
+WebSocket stays up; the next turn uses the new backend.
+
+```bash
+curl -X POST http://192.168.70.242:3502/api/config \
+  -H "Content-Type: application/json" \
+  -d '{"llm": {"backend": "ollama", "ollama_model": "qwen3.5:4b"}}'
+# → {"status": "ok", "message": "Config updated, 1 pipelines reloaded", ...}
+```
+
+The response reports how many pipelines reloaded. This change is **not**
+written to `config.yaml` — the next `tinkerclaw-voice` restart reloads the file
+and reverts it. Use Option A for anything you want to persist.
+
+### Local path: pick the GGUF llama-server serves
+
+The `lmstudio` backend does not pick the model — it points at whatever GGUF
+llama-server already has loaded on `localhost:1234`, which is why
+`lmstudio_model: "default"` is fine. The model is chosen by the
+`--model` argument in the `tinkerclaw-llama-server.service` systemd unit. To
+swap the served model, edit the unit's `--model` path and restart it:
+
+```bash
+sudo systemctl restart tinkerclaw-llama-server   # picks up the new --model
+sudo systemctl restart tinkerclaw-voice          # re-probe + re-evaluate fallback
+```
+
+> **Restarting llama-server mid-session is not picked up automatically.**
+> `create_llm()` does a one-shot TCP probe of `lmstudio_url` at process start.
+> If llama-server was down at boot the session falls back to Ollama and stays
+> there. After you fix or restart llama-server, restart `tinkerclaw-voice` too
+> so the probe re-runs.
+
+The winning Local model is IBM Granite 4.0 Nano-1B (10/10 → 19/20 on the tool
+gauntlet at ~13 s/turn) served at
+`/home/radxa/llama.cpp/models/`. Ministral-3:3b remains the one-line rollback at
+`/home/radxa/llama.cpp/models/ministral/model-q4_k_m.gguf`.
+
+### Turn on native tool-calling
+
+`native_tools` controls *how* the Local model is asked to call tools. With it
+on, the Dragon passes the OpenAI `tools=[...]` array plus `tool_choice="auto"`
+to llama-server (which must run with `--jinja`) and consumes the structured
+`tool_calls` response. With it off, the Dragon prose-lists the tools in the
+system prompt and parses `<tool>NAME</tool><args>{}</args>` markers from the
+model's free text (the five-dialect parser).
+
+```yaml
+llm:
+  backend: "lmstudio"
+  native_tools: true   # structured tools=[...] path; falls back to prose if unsupported
+```
+
+Native tool-calling is shipped on (`native_tools: true`) and is essential for
+Granite — it scores 19/20 native versus 4/10 on the prose path. It only applies
+to the `lmstudio` Local path; other backends ignore it. See
+[native tool-calling in the glossary](../../GLOSSARY.md#core--llm-serving--models)
+for the concept.
+
+### Point Local mode at the multi-model router
+
+To let Dragon pick a model per turn from a fleet instead of one fixed backend,
+set `backend: "router"` and populate `llm.fleet`. The router is opt-in — an
+empty `fleet: []` with any single backend behaves exactly as today.
+
+```yaml
+llm:
+  backend: "router"
+  fleet:
+    - {id: ministral,  backend: ollama, model_id: "ministral-3:3b",
+       caps: [text, tool_calling],         tier: local, priority: 0,  keep_alive_s: 600}
+    - {id: ds_v4_flash, backend: openrouter, model_id: "deepseek/deepseek-v4-flash",
+       caps: [text, tool_calling],         tier: cloud, priority: 0}
+```
+
+Restart `tinkerclaw-voice`; the router picks up the fleet on the next
+`session_start`. Copy-paste fleets for common patterns (cheapskate, top-tier,
+DGX-accelerated) live in the
+[Multi-Model Router Cookbook](../router-cookbook.md).
+
+### Hand turns to the TinkerClaw gateway
+
+`backend: "tinkerclaw"` (voice mode 3) makes Dragon an audio pipe — STT and TTS
+still run locally, but the LLM call, tools, and memory all go to the TinkerClaw
+gateway on `localhost:18789`. The gateway token must come from the environment,
+never `config.yaml`:
+
+```yaml
+llm:
+  backend: "tinkerclaw"
+  tinkerclaw_url: "http://localhost:18789"
+  tinkerclaw_token: ""          # injected via TINKERCLAW_TOKEN env (in /home/radxa/.env)
+  tinkerclaw_model: "minimax/MiniMax-M2.5"
+```
+
+`TinkerClawBackend` raises at construction if the token resolves to blank, so a
+misconfigured gateway fails loudly rather than silently no-opping.
+
+## How voice mode relates to the backend
+
+The Tab5 swaps the *voice mode tier* (Local / Hybrid / Cloud / TinkerClaw) per
+connection with a `config_update` frame; the operator config above sets the
+*default backend* the server boots with. They interact:
+
+| Voice mode | `voice_mode` | LLM source |
+|------------|--------------|------------|
+| Local | 0 | The configured Local backend (`lmstudio` → `ollama` fallback, or `router` local tier) |
+| Hybrid | 1 | Same Local LLM (only STT/TTS go cloud) |
+| Full Cloud | 2 | OpenRouter, user-selected model (or `router` cloud/lan tier) |
+| TinkerClaw | 3 | The TinkerClaw gateway (router bypassed entirely) |
+
+Two consequences for an operator:
+
+- **Reconnect resets to Local defaults.** When a device reconnects, the
+  pipeline re-initializes at `voice_mode 0` regardless of the previous mode.
+  The client must re-send `config_update` to restore Cloud. Your `config.yaml`
+  Local backend is what it lands on.
+- **Per-connection config is deep-copied.** Each WebSocket gets a
+  `copy.deepcopy()` of the global config, so one Tab5 switching to Cloud does
+  not corrupt another device's pipeline.
+
+The full mode contract lives in
+[`docs/protocol.md`](../protocol.md); the four-repo picture is in
+[`docs/explanation/how-the-stack-fits-together.md`](../explanation/how-the-stack-fits-together.md).
+
+## Verify it worked
+
+Read back the live config (secrets are redacted in the response):
+
+```bash
+curl -s http://192.168.70.242:3502/api/config | python3 -m json.tool
+# → "llm": { "backend": "lmstudio", "local_backend": "lmstudio", "native_tools": true, ... }
+```
+
+Confirm the backend is actually reachable and serving:
+
+```bash
+# llama-server (lmstudio path)
+curl -s http://localhost:1234/v1/models
+# → {"data": [{"id": "...granite...", ...}]}
+
+# Ollama (ollama path)
+curl -s http://localhost:11434/api/tags
+# → {"models": [{"name": "qwen3.5:4b", ...}]}
+```
+
+Then run one stateless completion through the new backend and watch the logs:
+
+```bash
+curl -s -X POST http://192.168.70.242:3502/api/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Say hi in three words."}'
+
+journalctl -u tinkerclaw-voice -f   # confirm the turn ran on the expected backend
+```
+
+If you swapped to `router`, the new model lands in `fleet_summary` inside the
+`session_start.config` frame — connect a client (or the dashboard Chat tab) and
+confirm the per-modality model names match your fleet.
+
+## Troubleshooting
+
+- **`POST /api/config` returns "0 pipelines reloaded"** → no WebSocket is
+  currently connected, so there is no active pipeline to swap. The new config
+  still applies to the next connection. To make it persistent, edit
+  `config.yaml` and restart.
+
+- **Swapped to `lmstudio` but turns still run on Ollama** → llama-server was not
+  reachable on `127.0.0.1:1234` at process start, so `create_llm()` fell back to
+  Ollama for the whole session. The fallback is one-shot at instance creation,
+  not per-request. Fix llama-server, then `sudo systemctl restart
+  tinkerclaw-voice` to re-probe.
+
+- **Granite (or any thinking model) emits an empty reply** → the token cap is
+  too low; thinking-mode models spend budget inside `<think>...</think>`. Local
+  mode uses `MAX_TOKENS_LOCAL = 1024`. Non-thinking models stop naturally well
+  under the cap, so this is a no-op cost for them.
+
+- **Local turns crawl to the 300 s timeout** → concurrent Local turns thrash the
+  8-core CPU. Local mode's pipeline timeout is 300 s by design (5 min) for slow
+  tool-calling chains; the CPU backend must be serialized (one inference at a
+  time) so two turns don't compete. Cloud mode's timeout is 60 s; TinkerClaw is
+  180 s.
+
+- **Tools don't fire after switching to native** → llama-server must be started
+  with `--jinja` for the `tools=[...]` path to work, and `native_tools` only
+  affects the `lmstudio` backend. If you are on `ollama`, tool-calling uses the
+  prose five-dialect parser instead — that is expected.
+
+- **Ollama is very slow (~0.24 tok/s)** → expected on the QCS6490 ARM64 CPU.
+  Ollama runs CPU-only. Use `lmstudio` (llama-server) for the Local path, or
+  `npu_genie` (~8 tok/s on the Hexagon DSP — see
+  [`docs/npu-setup.md`](../npu-setup.md)), or switch to Cloud.
+
+- **`tinkerclaw` backend raises at startup** → the gateway token is blank.
+  `tinkerclaw_token` must stay empty in `config.yaml`; inject the real value via
+  the `TINKERCLAW_TOKEN` env var in `/home/radxa/.env` (loaded by the systemd
+  `EnvironmentFile=`).
+
+- **`router` is set but the wrong model fires** → `TOOL_CALLING` is intentionally
+  not inferred as a routing gate; only `VISION`/`VIDEO`/`AUDIO_IN` from the
+  message content drive the pick. If no fleet model covers the required modality
+  in the active tier you get `router: no fleet model satisfies …` — expand the
+  fleet or change voice mode. See the
+  [router cookbook troubleshooting section](../router-cookbook.md#troubleshooting).

--- a/docs/reference/config-reference.md
+++ b/docs/reference/config-reference.md
@@ -1,0 +1,370 @@
+---
+audience: integrator
+type: reference
+prerequisites: [router cookbook](../router-cookbook.md), [REST API reference](rest-api.md)
+last-verified: 2026-05-29
+---
+# config.yaml reference
+
+Every Dragon-side setting lives in one file: `dragon_voice/config.yaml`. It is
+loaded at startup by `dragon_voice/config.py` into a tree of dataclasses, so the
+authoritative list of fields, types, and defaults is the dataclass definitions —
+this page mirrors them field-by-field.
+
+`config.yaml` is the lowest-priority layer. Three layers stack on top of it:
+
+| Layer | Wins over | How |
+|---|---|---|
+| `config.yaml` | — | YAML file next to `config.py`, or the path in `DRAGON_VOICE_CONFIG` |
+| Environment variables | the file | `DRAGON_VOICE_{SECTION}_{KEY}` (type-coerced), plus the special vars below |
+| CLI flags | env + file | `--port`, `--host`, `--stt`, `--tts`, `--llm`, `--log-level`, `--config` |
+| REST hot-reload | runtime config | `POST /api/config` swaps backends on live pipelines without a reconnect |
+
+Sections that exist in the dataclass tree but are not in this list (`server`,
+`stt`, `tts`, `llm`, `audio`, `tools`, `memory`, `database`, `billing`,
+`channel_gateway`, `coredump_scraper`) are all created with their defaults even
+when absent from the YAML — you only declare what you want to change.
+
+Unknown keys in any section are silently dropped (`_dict_to_dataclass` filters
+to known fields), so a stale field name fails quietly rather than crashing. A
+bad **value** (e.g. an invalid backend name) fails fast: `load_config` runs
+`VoiceConfig.validate()` at the end and raises `ValueError` so the
+`tinkerclaw-voice` unit restart-loops with an actionable cause.
+
+## `server`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `host` | str | `"0.0.0.0"` | Bind address for the voice server (WS + REST). |
+| `port` | int | `3502` | Listen port. Overridable with `--port`. |
+| `api_token` | str | `""` | Bearer token protecting every REST route except the public prefixes. Blank in the committed file — populated at load time from `DRAGON_API_TOKEN`. |
+
+`api_token` is never written to the repo. Set it through the `DRAGON_API_TOKEN`
+env var (shorter than `DRAGON_VOICE_SERVER_API_TOKEN`, and explicit env wins
+over YAML). `GET /api/config` redacts it.
+
+## `stt`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `backend` | str | `"whisper_cpp"` | STT engine. One of `moonshine`, `whisper_cpp`, `vosk`, `openrouter`. |
+| `model` | str | `"tiny"` | Engine model id (e.g. Whisper `tiny`/`medium`). |
+| `language` | str | `"en"` | Transcription language code. |
+| `moonshine_model_path` | str | `""` | Custom Moonshine model dir. Empty = auto-download on first use. |
+| `whisper_model_path` | str | `""` | Custom whisper.cpp model path. |
+| `vosk_model_path` | str | `""` | Custom Vosk model path. |
+| `openrouter_api_key` | str | `""` | Cloud STT key. Auto-populated from `llm.openrouter_api_key` when `backend: openrouter` and left blank. |
+| `openrouter_url` | str | `"https://openrouter.ai/api/v1"` | OpenRouter base URL for cloud STT. |
+| `transcribe_backend` | str | `""` | Dedicated backend for the `POST /api/v1/transcribe` REST endpoint (long-form dictation). When set, batched WAV uploads use this while the WS pipeline keeps its low-latency `backend`. |
+| `transcribe_model` | str | `""` | Model for `transcribe_backend`. |
+| `transcribe_audio_dir` | str | `""` | Where `/api/v1/transcribe` preserves raw WAV uploads for later re-transcription. Empty = `/home/radxa/tinkerclaw/dictation_audio`. |
+
+Valid `backend` (and `transcribe_backend`) values are validated at load:
+`moonshine`, `whisper_cpp`, `vosk`, `openrouter`. The cloud OpenRouter STT
+backend uses the `openai/gpt-audio-mini` model and sends base64-encoded WAV.
+
+## `tts`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `backend` | str | `"piper"` | TTS engine. One of `piper`, `kokoro`, `edge_tts`, `openrouter`, `neutts_air`, `supertonic`, `kitten`. |
+| `piper_model` | str | `"en_US-lessac-medium"` | Piper voice model id. |
+| `piper_data_dir` | str | `""` | Piper model data dir. Empty = default. |
+| `kokoro_model_path` | str | `""` | Kokoro ONNX model path. |
+| `kokoro_voices_path` | str | `""` | Kokoro voices `.bin` (kokoro-onnx 0.5.0+ needs it separately). |
+| `kokoro_voice` | str | `"af_bella"` | Kokoro voice id. |
+| `text_cleaner_enabled` | bool | `true` | Strip markdown / bullets / code fences / emojis / bare URLs before synthesis so TTS doesn't read punctuation aloud. |
+| `edge_voice` | str | `"en-US-AriaNeural"` | Microsoft Edge TTS voice. |
+| `sample_rate` | int | `22050` | TTS engine output rate (Hz). Dragon resamples to 16 kHz before sending to Tab5. |
+| `neutts_ref_audio` | str | `""` | NeuTTS Air voice-clone reference audio path. |
+| `neutts_ref_text` | str | `""` | NeuTTS Air reference transcript. |
+| `supertonic_voice` | str | `"F1"` | Supertonic-3 voice (`F1`–`F5` / `M1`–`M5`). 44.1 kHz output. |
+| `supertonic_lang` | str | `"en"` | Supertonic-3 language. |
+| `supertonic_speed` | float | `1.0` | Supertonic-3 speaking rate. |
+| `supertonic_steps` | int | `8` | Supertonic-3 diffusion steps. |
+| `kitten_voice` | str | `"expr-voice-2-f"` | KittenTTS voice (8 expression voices, 24 kHz, English-only). |
+| `kitten_speed` | float | `1.0` | KittenTTS speaking rate. |
+| `openrouter_api_key` | str | `""` | Cloud TTS key. Auto-populated from `llm.openrouter_api_key` when `backend: openrouter` and blank. |
+| `openrouter_url` | str | `"https://openrouter.ai/api/v1"` | OpenRouter base URL for cloud TTS. |
+| `openrouter_voice` | str | `"alloy"` | OpenRouter TTS voice. |
+
+The cloud OpenRouter TTS backend uses `openai/gpt-audio-mini` and streams pcm16
+over SSE at 24 kHz (resampled to 16 kHz before sending to Tab5).
+
+## `llm`
+
+The largest section. Selects the language-model backend and carries
+per-backend settings for all of `ollama`, `openrouter`, `lmstudio`,
+`npu_genie`, `tinkerclaw`, the `dual` picker/responder pipeline, and the
+`router` fleet.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `backend` | str | `"ollama"` | Active LLM backend. One of `ollama`, `openrouter`, `lmstudio`, `npu_genie`, `tinkerclaw`, `dual`, `router`. |
+| `local_backend` | str | `""` | Remembers the original local backend so cloud-mode fallback can revert. Set at load time to `backend` if left blank. |
+| `ollama_url` | str | `"http://localhost:11434"` | Ollama base URL. |
+| `ollama_model` | str | `"gemma3:4b"` | Ollama model id. See [model selection](#llm-model-selection) below. |
+| `ollama_keep_alive` | str | `"30s"` | How long Ollama keeps a model resident after the last request. `dual` setups override to `"5m"` so picker + responder stay warm. |
+| `openrouter_api_key` | str | `""` | OpenRouter key. Reads from `OPENROUTER_API_KEY` env when blank. Required when `backend: openrouter`. |
+| `openrouter_model` | str | `"anthropic/claude-3-haiku"` | Cloud model id (user-selectable via the `llm_model` field in `config_update`). |
+| `openrouter_url` | str | `"https://openrouter.ai/api/v1"` | OpenRouter base URL. |
+| `lmstudio_url` | str | `"http://localhost:1234/v1"` | LM Studio / llama-server OpenAI-compatible endpoint. |
+| `lmstudio_model` | str | `"default"` | LM Studio model id (`"default"` = whatever GGUF llama-server reports loaded). |
+| `native_tools` | bool | `false` | Pass `tools=[...]` + `tool_choice="auto"` to the llama-server OpenAI API (requires `--jinja`) and consume structured `tool_calls`, instead of prose-listing tools and parsing XML markers. Off by default; the prose path is the fallback for models without native tool support. |
+| `genie_model_dir` | str | `"/home/radxa/qairt/models/llama32-1b"` | NPU Genie (QAIRT) model directory. |
+| `genie_config` | str | `"htp-model-config-llama32-1b-gqa.json"` | NPU Genie HTP model config file. |
+| `system_prompt` | str | (Tinker base prompt) | Default system prompt. Overridden per voice mode by the mode-aware prompts. |
+| `max_tokens` | int | `128` | Default generation cap. Overridden per voice mode (`MAX_TOKENS_LOCAL=1024`, `HYBRID=256`, `CLOUD=512`). Validated `1 ≤ n ≤ 4096`. |
+| `temperature` | float | `0.7` | Sampling temperature. Validated `0 ≤ t ≤ 2`. |
+| `tinkerclaw_url` | str | `"http://localhost:18789"` | TinkerClaw gateway URL (voice mode 3). |
+| `tinkerclaw_token` | str | `""` | Gateway auth token. Blank in the committed file — injected from `TINKERCLAW_TOKEN` env. |
+| `tinkerclaw_model` | str | `"minimax/MiniMax-M2.5"` | Model the TinkerClaw gateway uses. |
+| `dual_picker_backend` | str | `""` | `backend: dual` — tool-picker backend. Empty = `ollama`. |
+| `dual_picker_model` | str | `"hf.co/Salesforce/xLAM-2-1b-fc-r-gguf:Q4_K_M"` | Fast tool-picker model. |
+| `dual_responder_backend` | str | `""` | `backend: dual` — responder backend. Empty = `ollama`. |
+| `dual_responder_model` | str | `"ministral-3:3b"` | Warm responder model. |
+| `fleet` | list[dict] | `[]` | `backend: router` — the per-turn model pool. Empty list = legacy single-backend dispatch. See [fleet](#fleet). |
+
+### LLM model selection
+
+For Local mode, the live default is **LFM2.5-VL-1.6B** served by llama-server
+(`backend: lmstudio`, `lmstudio_url: http://localhost:1234/v1`), with
+`ministral-3:3b` kept as a one-line Ollama rollback. The Ollama default in the
+committed dataclass is `gemma3:4b`. Latency, accuracy gauntlets, and the
+"when to use what" matrix live in [`docs/CHANGELOG.md`](../CHANGELOG.md).
+
+To force pure Ollama (no llama-server probe):
+
+```yaml
+llm:
+  backend: "ollama"
+  local_backend: "ollama"
+  ollama_model: "ministral-3:3b"
+```
+
+To run Local via llama-server (LM Studio-compatible):
+
+```yaml
+llm:
+  backend: "lmstudio"
+  local_backend: "lmstudio"
+  lmstudio_url: "http://localhost:1234/v1"
+  lmstudio_model: "default"
+```
+
+### `native_tools`
+
+When `true`, Dragon uses the model's structured function-calling API instead of
+the prose-list-and-parse path. It requires a llama-server started with
+`--jinja`. A live A/B on LFM2.5-VL-1.6B lifted the hard-gauntlet score from
+7/10 to 9/10. Leave it `false` for backends or models without native tool
+support — the marker-parsing fallback handles those.
+
+### `fleet`
+
+Activate the multi-model router by setting `backend: "router"` and populating
+`fleet`. Each entry mirrors a `ModelSpec`:
+
+| Key | Type | Required | Description |
+|---|---|---|---|
+| `id` | str | yes | Stable identifier for logs / `fleet_summary`. |
+| `backend` | str | yes | `ollama`, `openrouter`, `lmstudio`, `npu_genie`, or `tinkerclaw`. |
+| `model_id` | str | yes | Backend-specific model id. |
+| `caps` | list[str] | yes | Modalities: `text`, `vision`, `video`, `audio_in`, `audio_out`, `tool_calling`. |
+| `tier` | str | yes | `local`, `cloud`, or `lan`. The active voice mode picks eligible tiers. |
+| `priority` | int | yes | Lower wins among candidates that satisfy the required caps. |
+| `keep_alive_s` | int | no | Ollama keep-alive seconds for this model. |
+| `lmstudio_url` | str | no | Per-entry LM Studio URL (LAN-tier workstation). |
+
+The router picks per-turn from the modalities present in the message and the
+tier allowed by the voice mode. Copy-paste fleets and the full routing rule are
+in the [router cookbook](../router-cookbook.md).
+
+```yaml
+llm:
+  backend: "router"
+  fleet:
+    - {id: ministral,   backend: ollama, model_id: "ministral-3:3b",
+       caps: [text, tool_calling],         tier: local, priority: 0,  keep_alive_s: 600}
+    - {id: minicpm_v4,  backend: ollama,
+       model_id: "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M",
+       caps: [text, vision, video],        tier: local, priority: 10, keep_alive_s: 120}
+    - {id: ds_v4_flash, backend: openrouter, model_id: "deepseek/deepseek-v4-flash",
+       caps: [text, tool_calling],         tier: cloud, priority: 0}
+    - {id: qwen36_flash, backend: openrouter, model_id: "qwen/qwen3.6-flash",
+       caps: [text, vision, tool_calling], tier: cloud, priority: 5}
+```
+
+## `audio`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `input_sample_rate` | int | `16000` | Tab5 mic PCM rate (Hz). |
+| `input_channels` | int | `1` | Mic channels (mono). |
+| `output_sample_rate` | int | `22050` | TTS engine native rate; resampled to 16 kHz before sending to Tab5. |
+| `vad_enabled` | bool | `true` | Server-side energy-based silence detection. Set `false` when Tab5 sends explicit `start`/`stop`. |
+| `vad_silence_ms` | int | `1500` | Milliseconds of silence before STT triggers. Raise for slower speakers. |
+
+## `tools`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `true` | Master switch for the agentic tool-calling pipeline. |
+| `max_tool_calls` | int | `3` | Maximum tool invocations per turn (loop guard). |
+| `web_search_engine` | str | `"duckduckgo"` | Web-search backend for the `web_search` tool. |
+| `searxng_url` | str | `""` | Set to `http://your-searxng:8888` to use the self-hosted SearXNG metasearch (falls back to DuckDuckGo when blank or down). |
+
+## `memory`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `true` | Master switch for the memory + document RAG service. |
+| `embed_model` | str | `"nomic-embed-text"` | Ollama embedding model (768-dim vectors). |
+| `auto_extract_facts` | bool | `true` | Auto-extract facts from conversation for later recall. |
+| `max_context_facts` | int | `3` | Facts injected into the system prompt per turn. |
+| `max_context_chunks` | int | `3` | Document chunks injected per turn. |
+| `max_document_bytes` | int | `10485760` | Cap on a single ingested document (10 MB). `0` = disable the cap. |
+
+## `database`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `message_retention_days` | int | `30` | Purge messages older than this. `0` = never purge. |
+| `paused_session_retention_days` | int | `30` | Auto-end `paused` sessions idle longer than this, then purge their messages. `0` = disable. |
+
+## `channel_gateway`
+
+OpenClaw gateway connector for third-party messaging channels (Telegram,
+WhatsApp, Discord, …). Off by default — startup uses an in-process
+`MockConnector` until you enable it.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `false` | When `true`, swap `MockConnector` for the real `GatewayConnector` so `channel_reply` frames forward to the platform. |
+| `url` | str | `"ws://127.0.0.1:18789"` | Gateway WS-RPC endpoint (loopback-only). |
+| `token` | str | `""` | Auth token. Blank = reuse `llm.tinkerclaw_token` (same gateway process). |
+| `client_id` | str | `"gateway-client"` | Must match OpenClaw's `GATEWAY_CLIENT_IDS` enum. |
+
+## `coredump_scraper`
+
+Dragon-side poller that pulls Tab5 coredumps off flash and archives them. Off
+by default.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `false` | Set `true` plus a non-empty `targets` to opt in. |
+| `poll_interval_s` | float | `60.0` | Seconds between full target sweeps. |
+| `request_timeout_s` | float | `10.0` | Per-request HTTP timeout. |
+| `save_dir` | str | `"/home/radxa/tinkerclaw/tab5-coredumps"` | Archive root. Default is inside the systemd `ReadWritePaths` whitelist. |
+| `firmware_elf` | str | `""` | Path to the deployed firmware ELF for auto-symbolicate. Empty = archive raw bin only. |
+| `targets` | list | `[]` | Tab5s to poll. Each entry: `device_id`, `host`, `port` (default `8080`), `token`. |
+
+## `billing`
+
+The `billing` section is built with defaults even though it is not in the
+`load_config` section list — it is created from the `BillingConfig` default.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `daily_cap_cents` | int | `0` | Server-side daily LLM budget cap. When `> 0` and today's `api_usage` total exceeds it, Dragon emits a `cap_downgrade` frame to Tab5. `0` = disabled. Set via `BUDGET_DAILY_CENTS` env (overrides the file). |
+
+## Top-level flags
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `progress_bus_emit_legacy` | bool | `true` | Double-write migrated emitters (legacy ad-hoc event + new `progress` event) so unmodified Tab5 firmware keeps working. Not hot-reloaded; a flip needs a restart. |
+
+## Environment variable overrides
+
+Any section field is overridable with `DRAGON_VOICE_{SECTION}_{KEY}`. Type is
+coerced from the existing value (bool / int / float / str):
+
+```bash
+export DRAGON_VOICE_STT_BACKEND=moonshine
+export DRAGON_VOICE_LLM_BACKEND=lmstudio
+export DRAGON_VOICE_TTS_BACKEND=piper
+export DRAGON_VOICE_LLM_OPENROUTER_API_KEY=sk-or-v1-...
+export DRAGON_VOICE_AUDIO_VAD_SILENCE_MS=800
+export DRAGON_VOICE_LLM_MAX_TOKENS=512
+```
+
+Four special env vars bypass the `DRAGON_VOICE_*` prefix and take precedence:
+
+| Env var | Sets | Notes |
+|---|---|---|
+| `DRAGON_VOICE_CONFIG` | the config file path | Point at a non-default `config.yaml`. |
+| `DRAGON_API_TOKEN` | `server.api_token` | The REST bearer. Explicit env wins over YAML. |
+| `TINKERCLAW_TOKEN` | `llm.tinkerclaw_token` | Keeps the gateway token out of the repo. |
+| `BUDGET_DAILY_CENTS` | `billing.daily_cap_cents` | Lets oncall flip the cap without redeploying. |
+
+Secrets (any field whose name contains `api_key`, `token`, `password`, or
+`secret`) are redacted by `config_to_dict(redact_secrets=True)`, which backs
+`GET /api/config`.
+
+## Hot-reload at runtime
+
+`POST /api/config` merges a partial config and re-initializes active pipeline
+instances in place — no WebSocket reconnect:
+
+```bash
+curl -X POST http://192.168.70.242:3502/api/config \
+  -H "Content-Type: application/json" \
+  -d '{"llm": {"backend": "ollama", "ollama_model": "ministral-3:3b"}}'
+# → {"status": "ok", "message": "Config updated, 1 pipelines reloaded", ...}
+```
+
+The three-tier voice-mode swap (`config_update` over the WebSocket) hot-swaps
+STT/TTS/LLM backends per voice mode without touching `config.yaml`; see the
+[WebSocket protocol reference](websocket-protocol.md).
+
+## Examples
+
+### Minimal Local-mode `config.yaml`
+
+```yaml
+server:
+  host: "0.0.0.0"
+  port: 3502
+
+stt:
+  backend: "moonshine"
+
+tts:
+  backend: "piper"
+  piper_model: "en_US-lessac-medium"
+
+llm:
+  backend: "lmstudio"
+  local_backend: "lmstudio"
+  lmstudio_url: "http://localhost:1234/v1"
+  lmstudio_model: "default"
+
+audio:
+  vad_enabled: true
+  vad_silence_ms: 1500
+```
+
+### Cloud-mode `config.yaml`
+
+```yaml
+stt:
+  backend: "openrouter"      # gpt-audio-mini; key auto-propagated from llm
+
+tts:
+  backend: "openrouter"
+  openrouter_voice: "alloy"
+
+llm:
+  backend: "openrouter"
+  openrouter_model: "anthropic/claude-sonnet-4.6"
+  # openrouter_api_key left blank — supplied via OPENROUTER_API_KEY env
+```
+
+### Production secrets via env (do NOT put keys in the repo file)
+
+```bash
+export OPENROUTER_API_KEY="sk-or-v1-..."   # → llm.openrouter_api_key
+export DRAGON_API_TOKEN="..."              # → server.api_token (REST bearer)
+export TINKERCLAW_TOKEN="..."              # → llm.tinkerclaw_token
+python3 -m dragon_voice
+```

--- a/docs/reference/package-file-map.md
+++ b/docs/reference/package-file-map.md
@@ -1,0 +1,287 @@
+---
+audience: developer
+type: reference
+prerequisites: none
+last-verified: 2026-05-29
+---
+# dragon_voice package map
+
+This is the lookup table for the `dragon_voice/` Python package — the
+[Dragon](../../GLOSSARY.md) voice server that runs on port 3502 and holds all of
+TinkerBox's intelligence. Use it to answer "which file owns this concern?"
+before you add code or chase a bug. Each row names a module and the single
+responsibility it owns.
+
+The package was decomposed from a 2,747-LOC monolithic `server.py` under umbrella
+issue [#65](https://github.com/lorcan35/TinkerBox/issues/65) (closed 2026-04-24)
+into four sibling sub-packages (`middleware/`, `handlers/`, `lifecycle/`, plus the
+slimmed `server.py`), then grew a wide layer of single-concern modules directly
+under the package root as later UX-gap fixes, the [multi-model router](../router-cookbook.md),
+and the W7 channel/agent work landed. Every extracted module takes its
+dependencies explicitly (a server handle or specific args), so each can be
+imported and unit-tested without instantiating `VoiceServer`.
+
+## How to read this map
+
+- **Top-level modules** (`dragon_voice/*.py`) split into two groups: a handful of
+  *core* modules (server, pipeline, conversation, sessions, messages, db, memory,
+  config) and ~60 *single-concern* sibling modules whose name describes the one
+  thing they own (`config_swap.py`, `vision_turn.py`, `channel_reply_handler.py`, …).
+- **Sub-packages** (`dragon_voice/<name>/`) group a family: `stt/`, `tts/`, `llm/`,
+  `api/`, `tools/`, and so on.
+- Anything not under `dragon_voice/` (the repo-root files, `tests/`, `docs/`) is in
+  the [Repo-root companions](#repo-root-companions) table at the end.
+
+To re-derive the live counts on a checkout:
+
+```bash
+ls dragon_voice/*.py | wc -l          # top-level modules (73 as of 2026-05-29)
+ls dragon_voice/                      # sub-packages + modules
+grep -c 'app.router.add_' dragon_voice/api/*.py dragon_voice/notes/api.py \
+  | awk -F: '{s+=$2} END {print s}'   # REST endpoint count
+```
+
+## Core modules
+
+The eight modules that define the server's spine. These are the ones you read
+first to understand a request's path through Dragon.
+
+| File | Owns | Key types |
+|---|---|---|
+| `dragon_voice/__main__.py` | Entry point for `python3 -m dragon_voice` | — |
+| `dragon_voice/__init__.py` | Package init | — |
+| `dragon_voice/server.py` | `VoiceServer` class + `create_app` wiring + the WS-voice handler family (register / text / user_media / disconnect / audio + event hooks). ~2,720 LOC | `VoiceServer` |
+| `dragon_voice/pipeline.py` | STT → LLM → TTS orchestration with VAD, dictation, and post-processing. Mode-aware timeouts live here (Local 300 s, Cloud 60 s, TinkerClaw 180 s) | `VoicePipeline` |
+| `dragon_voice/conversation.py` | Multi-turn `ConversationEngine`: tool-calling loop + memory-augmented context build | `ConversationEngine` |
+| `dragon_voice/sessions.py` | `SessionManager` — create / resume / pause / end lifecycle; sessions survive disconnect | `SessionManager` |
+| `dragon_voice/messages.py` | `MessageStore` — append-only message log, LLM context builder, multimodal `__mm__:` content marker encode/decode | `MessageStore` |
+| `dragon_voice/db.py` | Async SQLite layer (aiosqlite, WAL mode, full CRUD) | `Database` |
+| `dragon_voice/memory.py` | `MemoryService` — facts + documents + RAG via `nomic-embed-text` (768-dim) Ollama embeddings | `MemoryService` |
+| `dragon_voice/config.py` | Config dataclasses (`STTConfig`, `TTSConfig`, `LLMConfig`, `ToolsConfig`, `MemoryConfig`, fleet) + YAML/env loading | dataclasses |
+| `dragon_voice/config.yaml` | Default configuration (see the [config reference](config-reference.md)) | — |
+| `dragon_voice/requirements.txt` | Voice-pipeline Python dependencies | — |
+| `dragon_voice/errors.py` | Shared error types + WS error-code constants | — |
+| `dragon_voice/progress.py` | β-arch unified progress event model (issue #123) | — |
+
+The DB is further sliced into per-table helper modules so a single `db.py` no
+longer holds every query: `db_config.py`, `db_devices.py`, `db_events.py`,
+`db_messages.py`, `db_notes.py`, `db_sessions.py`, plus `db_corruption_recovery.py`
+(boot-time integrity check + rebuild) and `device_upsert.py`.
+
+## WS-voice handler family (top-level siblings)
+
+These modules each own one branch of the WebSocket voice handler or one stage of a
+turn. `server.py` dispatches into them; they take an explicit server/connection
+handle so they unit-test in isolation. Find the full live list with
+`ls dragon_voice/*.py`.
+
+| File | Owns |
+|---|---|
+| `ws_voice_admission.py` | Admission control for a new `/ws/voice` connection (the P13 "device already has connection" guard) |
+| `session_handshake.py` | `register` frame → device upsert → session create/resume → `session_start` reply |
+| `conn_state.py` | Per-connection state object shared across the handler family |
+| `start_handler.py` | `start` frame — begins a voice turn, clears the audio buffer |
+| `stop_handler.py` | `stop` frame — finalizes the turn (ask mode → STT→LLM→TTS; dictate mode → transcript) |
+| `cancel_handler.py` | `cancel` frame — aborts in-flight LLM/TTS generation |
+| `clear_handler.py` | `clear` frame — ends the session and starts a fresh one |
+| `disconnect_handler.py` | WS close → session → `paused`, cleanup |
+| `stale_conn_eviction.py` | Evicts a stale prior connection when a device reconnects |
+| `binary_frame_dispatch.py` | Routes binary frames: untagged → mic PCM for STT; `AUD0`/`VID0` → call relay |
+| `local_text_stream.py` | Local-mode text turn through `ConversationEngine` |
+| `tinkerclaw_text_path.py` | voice_mode=3 text bypass straight to the TinkerClaw gateway adapter |
+| `text_turn_gate.py` / `text_path_receipt.py` / `text_path_tts.py` | Text-turn gating, receipt emission, and optional TTS of a text reply |
+| `voice_path_receipt.py` | Receipt emission for the voice path |
+| `vision_turn.py` | Multimodal (image) turn — routes to a vision-capable backend |
+| `vision_capability.py` | Emits the `vision_capability` event (camera-screen capability chip) |
+| `cap_downgrade.py` | Capability downgrade when the active backend cannot serve a requested modality |
+| `token_flush.py` | Sentence-boundary token buffering for low-latency TTS |
+| `speak_system.py` | Speaks a system-generated utterance (e.g. notifications) |
+| `dictation_audio.py` / `dictation_classifier.py` / `dictation_post.py` | Dictation segment buffering, intent classification, and post-process (LLM title + summary → `dictation_summary`) |
+| `empty_response_wrap.py` | Synthesizes a one-line ack when a model fires a tool then emits no visible text (see `tools/response_wrap.py`, #77/#79) |
+| `tool_event_emitter.py` | Emits `tool_call` / `tool_result` WS events during agentic turns |
+| `widget_action_handler.py` / `widget_capabilities_init.py` | Tab5 widget-surface action handling + capability init |
+| `channel_reply_handler.py` | `channel_reply` frame → forward to `ChannelConnector` → emit `channel_reply_ack` (W7-F) |
+| `gateway_memory_mirror.py` | Mirrors memory facts to the gateway for voice_mode=3 continuity |
+| `codec_negotiation.py` / `audio_codec.py` | Codec capability negotiation (OPUS gated off pending TinkerTab #264) |
+| `progress_emit.py` / `rich_media_emit.py` | Progress-event and rich-media (`media`/`card`/`text_update`) emission |
+| `video_upstream.py` | `VID0`/`AUD0` fan-out relay for two-way calls — verbatim broadcast, no transcode |
+| `ws_keepalive.py` | Fires `ws.ping()` every 5 s during inference so slow local turns don't trigger a client reconnect (#76) |
+| `handler_task_spawn.py` / `pipeline_callbacks.py` / `pipeline_init.py` | Async task spawning, pipeline callback wiring, per-connection pipeline init (resets to Local defaults on reconnect) |
+| `config_swap.py` / `config_swap_guards.py` / `pool_aware_swap.py` / `backend_swap.py` | Hot backend swap on `config_update`, with validation guards + backend-pool awareness |
+| `config_update_ack.py` / `config_update_rate_limit.py` / `config_finalize.py` | `config_update` ACK, server-side coalescing/rate-limit, and finalization |
+| `fallback_stt_cache.py` / `fallback_tts_cache.py` | Cached local STT/TTS instances for cloud auto-fallback |
+| `async_agent.py` | Async agent-runner glue |
+| `coredump_scraper.py` | Scrapes Tab5 coredumps surfaced over the protocol |
+
+> The exact set of siblings moves as concerns are extracted. When in doubt, the
+> live tree is authoritative — run `ls dragon_voice/*.py`. The map above is
+> verified against the tree on the `last-verified` date.
+
+## `api/` — REST API package
+
+Modular REST route classes wired by `setup_all_routes()`. Endpoint reference:
+[REST API](rest-api.md). Re-count endpoints with the `grep` above.
+
+| File | Routes |
+|---|---|
+| `__init__.py` | `setup_all_routes()` — wires every route class |
+| `utils.py` | Shared helpers (`json_error`, pagination) |
+| `sessions.py` | Session CRUD + lifecycle (`/api/v1/sessions*`) |
+| `messages.py` | Message listing + SSE chat (`/api/v1/sessions/{id}/{messages,chat}`) |
+| `devices.py` | Device CRUD (`/api/v1/devices*`) |
+| `config_routes.py` | Config CRUD + delete (`/api/v1/config*`) |
+| `events.py` | Event listing with device filter (`/api/v1/events`) |
+| `agent_log.py` | Cross-session tool-call ring buffer (`/api/v1/agent_log`) — `source` field buckets dragon/gateway/channel_push/user_reply (W7-A.3) |
+| `agent_skills.py` | W7-B merged catalog of OpenClaw core tools + observed tool names (`/api/v1/agent_skills`) |
+| `synthesize.py` | TTS synthesis + STT transcription + OTA routes |
+| `completions.py` | Stateless direct-LLM completion (`/api/v1/completions`) |
+| `system.py` | System metrics + backend listing |
+| `tools.py` | Tool listing + direct execution (`/api/v1/tools*`) |
+| `memory_routes.py` | Memory-fact CRUD + semantic search |
+| `documents.py` | Document ingest + listing + chunk search |
+| `media_routes.py` | `GET /api/media/{id}` (serve), `POST /api/media/upload` (Tab5 camera) |
+| `scheduler.py` | 5 endpoints for the notification scheduler (`/api/v1/scheduler/notifications*`) |
+| `spend.py` | W5-A daily LLM spend roll-up (`/api/v1/spend`) — backed by `billing/spend_tracker.py` |
+| `integrations.py` | Calendar / Gmail / Tasks connect/disconnect/list/test (`/api/v1/integrations/*`) |
+| `video_inject.py` | Debug-only `POST /api/video/inject` — push a JPEG as if from a paired Tab5 (#178) |
+| `debug_channel.py` | W7-F stub `POST /api/v1/debug/channel_message` — fan a synthetic frame to a Tab5 |
+| `logs_tail.py` | Tail server logs over REST for diagnostics |
+| `coredumps.py` | Coredump listing/retrieval endpoints |
+
+## `handlers/` — extracted HTTP endpoint handlers
+
+Stateless HTTP handlers pulled out of `VoiceServer` in #65. Each takes explicit deps.
+
+| File | Owns |
+|---|---|
+| `__init__.py` | Re-exports submodules |
+| `status.py` | `handle_status` (HTML status page) + `handle_health` (JSON liveness) |
+| `config_api.py` | `handle_get_config` (redacted dump) + `handle_set_config` (hot-reload + lock-guarded backend swap) |
+| `debug.py` | `handle_debug_mem` (tracemalloc/RSS/gc probe) + `handle_debug_widget_{chart,prompt,card,media}` audit emitters |
+
+## `lifecycle/` — boot, shutdown, monitors
+
+| File | Owns |
+|---|---|
+| `__init__.py` | Re-exports submodules |
+| `startup.py` | `run_startup(server, app)`: DB → sessions → memory + tools → surfaces → conversation → REST routes → notes → MCP → periodic tasks |
+| `shutdown.py` | `run_shutdown(server, app)`: cancel+await monitors → drain pipelines → release backend pool → close HTTP clients |
+| `monitors.py` | `get_rss_mb`, `get_cpu_temp`, `memory_monitor_loop` (5-min RSS/temp/FD sample + pipeline drain on critical) |
+| `purge.py` | `periodic_purge_loop` (message retention) + `media_cleanup_loop` (24 h media auto-cleanup) |
+| `agentic_init.py` | Tool registry + memory + document service init |
+| `notes_init.py` | Notes service init (wires `NoteTool` after the service exists) |
+| `integrations_init.py` | Calendar / Gmail / Tasks integration init |
+| `mcp_init.py` | MCP client/bridge init |
+| `surfaces_scheduler_init.py` | SurfaceManager + scheduler init (`timesense_tool` registers after SurfaceManager) |
+| `background_tasks_init.py` | Spawns the periodic background tasks |
+
+## `middleware/` — aiohttp request middleware
+
+Each is stateless with explicit deps. See the [config reference](config-reference.md)
+for the security-related knobs.
+
+| File | Owns |
+|---|---|
+| `__init__.py` | Re-exports submodules |
+| `cors.py` | `handle_cors` + `DEFAULT_ALLOWED_ORIGINS` (SEC12) |
+| `security_headers.py` | `handle_security_headers` + `SECURITY_HEADERS` (W14-M06) |
+| `auth.py` | `handle_auth` + `PUBLIC_PREFIXES` (Wave 13 bearer-token gate) |
+| `rate_limit.py` | `handle_rate_limit` + `DEFAULT_RATE_LIMIT_RULES` (W15-H01/H06) |
+
+## `llm/` — LLM backends + multi-model router
+
+The router is opt-in (`backend: "router"` + a populated `fleet`). Full recipes:
+[router cookbook](../router-cookbook.md). To swap the active backend, see
+[Swap the LLM backend](../how-to/swap-the-llm-backend.md); to build a fleet, see
+[Configure the multi-model router](../how-to/configure-the-multi-model-router.md).
+
+| File | Owns |
+|---|---|
+| `base.py` | `LLMBackend` ABC + `Modality` enum + `capabilities` default |
+| `router.py` | `CapabilityAwareRouter`, `ModelSpec`, `TIER_FOR_MODE`, `infer_required_caps`, `summarize` |
+| `capability_registry.py` | Per-backend modality declarations |
+| `ollama_llm.py` | Ollama backend (OpenAI → Ollama multimodal content translator added in #186) |
+| `openrouter_llm.py` | OpenRouter backend + `_OPENROUTER_CAPS` + `_PRICING_MILS_PER_M` (35 models, sync 2026-04-27) |
+| `lmstudio_llm.py` | LM Studio / llama-server OpenAI-compatible backend (LAN tier; the live Local default path) |
+| `npu_genie.py` | Qualcomm QAIRT/Genie backend — text-only, ~8 tok/s on the QCS6490 HTP |
+| `tinkerclaw_llm.py` | TinkerClaw gateway adapter (voice_mode=3) |
+| `dual.py` | Two-backend picker+responder (predates the router) |
+
+## `stt/` and `tts/` — speech backends
+
+| `stt/` file | Backend key | | `tts/` file | Backend key |
+|---|---|---|---|---|
+| `base.py` | `STTBackend` ABC | | `base.py` | `TTSBackend` ABC |
+| `moonshine_stt.py` | `moonshine` | | `piper_tts.py` | `piper` (22050 Hz) |
+| `whisper_cpp.py` | `whisper_cpp` | | `kokoro_tts.py` | `kokoro` |
+| `vosk_stt.py` | `vosk` | | `edge_tts_backend.py` | `edge_tts` |
+| `openrouter_stt.py` | `openrouter` | | `openrouter_tts.py` | `openrouter` |
+| | | | `registry.py` | TTS backend factory |
+| | | | `text_cleaner.py` | Pre-synthesis text normalization |
+
+`tts/` also carries experimental backends `kitten_tts.py`, `neutts_air_tts.py`, and
+`supertonic_tts.py`. The mode-to-backend mapping is in the
+[voice-modes reference](voice-modes.md).
+
+## `tools/` — tool-calling infrastructure
+
+The tool parser accepts multiple dialects; the canonical catalog of tools and their
+schemas is in the [tools catalog](tools-catalog.md), and the authoring workflow is
+[Add a tool](../how-to/add-a-tool.md).
+
+| File | Owns |
+|---|---|
+| `__init__.py` | Exports `ToolRegistry`, `Tool` |
+| `base.py` | `Tool` abstract base class |
+| `registry.py` | `ToolRegistry`: register, parse XML markers, execute. `execute()` feeds the `agent_log` ring buffer (single canonical instrumentation site) |
+| `parser.py` | Tool-marker parser — 5 accepted dialects (legacy / standard / bracketed-name / Gemma `<\|tool_call>` / LFM `<\|tool_call_start\|>`) |
+| `formatter.py` | Renders tool defs into the compact system-prompt format for local models |
+| `response_wrap.py` | `synthesize_wrap` — per-tool natural-language ack templates (empty-reply guard, #77/#79) |
+| `web_search.py` | SearXNG-backed search (DuckDuckGo fallback), port 8888 |
+| `memory_tools.py` | `StoreFactTool` + `RecallFactsTool` + `ForgetFactTool` (confirm-gated) |
+| `datetime_tool.py`, `calculator_tool.py`, `unit_converter_tool.py`, `weather_tool.py`, `system_tool.py`, `stock_ticker_tool.py`, `timer_tool.py` | Individual built-in tools |
+| `timesense_tool.py` | Pomodoro + `widget_live` emitter (registered after SurfaceManager) |
+| `quick_poll_tool.py` | Declarative widget-skill reference (Wave 12) |
+| `note_tool.py` | `NoteTool` (registered after `NotesService`) |
+| `google_calendar_tool.py`, `gmail_tool.py`, `schedule_reminder_tool.py` | Integration-backed tools (Calendar / Gmail / scheduler) |
+
+## Other sub-packages
+
+| Package | Owns | Key files |
+|---|---|---|
+| `notes/` | Notes CRUD + search + audio ingestion | `db.py`, `service.py`, `api.py` (`/api/notes/*`) |
+| `media/` | Rich-media rendering | `store.py` (MediaStore, 24 h cleanup, 500 MB cap), `pipeline.py` (Pygments/Pillow render), `url_signer.py` (HMAC-signed `/api/media/{id}`) |
+| `surfaces/` | Tab5 widget abstraction (`live`/`card`/`list`/`chart`/`media`/`prompt`) | `base.py`, `manager.py` (`SurfaceManager`) |
+| `scheduler/` | In-process notification scheduler + sqlite-backed store | `manager.py`, `models.py`, `parser.py` (`parse_when`), `store.py` (in-memory + sqlite replay/queue/snooze) |
+| `channels/` | W7-F third-party messaging connectors | `base.py` (`ChannelConnector`), `gateway.py` (`GatewayConnector`, ed25519 signed-connect, `_TAB5_CHANNEL_ALIASES`), `device_identity.py` (`~/.dragon/identity/device.json`), `mock.py` |
+| `billing/` | LLM spend tracking | `spend_tracker.py` (backs `/api/v1/spend`) |
+| `mcp/` | Model Context Protocol client + bridge | `client.py`, `bridge.py` |
+
+## Repo-root companions
+
+Files outside `dragon_voice/` that the server depends on or ships beside.
+
+| Path | Owns |
+|---|---|
+| `schema.sql` | Database schema — 11 tables (6 foundation + 3 memory + 2 scheduler) |
+| `dashboard.py` | Web dashboard (port 3500, 11-tab SPA, proxies `/api/proxy/*` to the voice server) |
+| `tests/` | Test suite — CI named-set runs without a live server; `test_api_e2e.py` (29 live scenarios) + `test_e2e_dragon.py` are local-only |
+| `docs/` | Audience-facing Diátaxis docs (see [the docs index](../README.md)) |
+| `systemd/` | Canonical `tinkerclaw-*.service` unit files |
+| `CLAUDE.md` | The runbook — deploy / debug / restart / monitor, and the source-of-truth File Structure section |
+| `LEARNINGS.md` | Institutional knowledge (bugs / fixes / gotchas) |
+
+> **Legacy files:** `dragon_server.py` (CDP browser streaming, port 3501) and
+> `udp_streamer.py` (UDP JPEG streaming) were retired Tab5-side in #155
+> ("voice-first is the product"). If copies linger on a deployed Dragon they are
+> no longer wired up by systemd.
+
+## Where to go next
+
+| Goal | Read |
+|---|---|
+| Look up a REST endpoint | [REST API reference](rest-api.md) |
+| Look up a WebSocket frame | [WebSocket protocol reference](websocket-protocol.md) · [`docs/protocol.md`](../protocol.md) |
+| Look up a config key | [Config reference](config-reference.md) |
+| Look up a tool | [Tools catalog](tools-catalog.md) |
+| See the system map | [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) |

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,0 +1,362 @@
+---
+audience: integrator
+type: reference
+prerequisites: [protocol.md](../protocol.md), [SECURITY.md](../../SECURITY.md)
+last-verified: 2026-05-29
+---
+# REST API reference
+
+Dragon is API-first: every capability the voice pipeline uses is also reachable
+over HTTP, so any client — not just a Tab5 — can drive it. This page is the
+authoritative list of the `/api` surface (62+ endpoints) served by
+`tinkerclaw-voice` on **port 3502**, grouped by domain. The single WebSocket
+endpoint (`/ws/voice`) is documented separately in the
+[WebSocket protocol reference](../protocol.md).
+
+Every endpoint below is served by the voice server. The
+[dashboard](../../README.md#web-dashboard) on port 3500 does not own any of
+these — it proxies them through `/api/proxy/` to port 3502.
+
+## Base URL and conventions
+
+| Property | Value |
+|---|---|
+| Host | `http://<dragon-ip>:3502` (LAN) or `https://tinkerclaw-voice.ngrok.dev` (tunnel) |
+| Versioned prefix | `/api/v1/*` — sessions, messages, devices, config, events, agent log, media, system, tools, memory, documents, scheduler, spend, integrations, channels |
+| Unversioned prefix | `/api/*` — notes (`/api/notes`), OTA (`/api/ota`), rich media (`/api/media`), video debug (`/api/video`), top-level config (`/api/config`) |
+| Request body | JSON (`Content-Type: application/json`) unless noted (audio/media uploads use `application/octet-stream` or `image/*`) |
+| Response body | JSON unless noted (SSE for `/chat` and `/completions`; binary for `/synthesize`, `/api/media/{id}`, `/api/ota/firmware.bin`) |
+| ID format | Session IDs are 12-char hex; message/note IDs are short UUIDs; device IDs are the device's MAC/hardware ID |
+
+## Authentication
+
+The `/api/*` surface is gated by a bearer token (`DRAGON_API_TOKEN`) enforced in
+[`dragon_voice/middleware/auth.py`](../../dragon_voice/middleware/auth.py). The
+token lives in `/home/radxa/.env` on the Dragon and survives `scp -r dragon_voice/`
+deploys. Send it on every authenticated request:
+
+```bash
+curl -s http://192.168.1.91:3502/api/v1/sessions \
+  -H "Authorization: Bearer $DRAGON_API_TOKEN" | python3 -m json.tool
+```
+
+A few prefixes are intentionally **public (no bearer)** — they carry no secrets
+or use their own access control:
+
+| Public route | Why it is public |
+|---|---|
+| `/health` | Liveness probe — no privacy concern |
+| `/ws/voice` | The bearer is checked *during* the WS upgrade, not bypassed |
+| `/dashboard` | Static dashboard shell; the data calls it proxies are bearer-gated |
+| `/api/media/{id}` | Access controlled by HMAC-signed, time-bounded URLs (`MediaUrlSigner`, W14-H04) instead of a bearer |
+| `/call`, `/static/*` | Browser call client assets; sensitive routes stay under `/api/v1/*` |
+
+Per-IP throttling runs in
+[`dragon_voice/middleware/rate_limit.py`](../../dragon_voice/middleware/rate_limit.py)
+(`DEFAULT_RATE_LIMIT_RULES`, W15-H01/W15-H06). On the wire, `config_update`
+pushes from Tab5 are coalesced server-side; expect 500–1000 ms ACK latency under
+back-pressure. See [`SECURITY.md`](../../SECURITY.md) for the full token
+lifecycle, rotation, and network-exposure model.
+
+## Sessions (`/api/v1/sessions`)
+
+A session is the conversation container. Sessions survive WebSocket disconnects:
+a device that reconnects resumes the same session with its full message history.
+Sessions move through `active → paused → active → ended`.
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| GET | `/api/v1/sessions` | List sessions | Query: `device_id`, `status`, `limit`, `offset` |
+| POST | `/api/v1/sessions` | Create a session | Body: `device_id`, `type`, `system_prompt`, `config` |
+| GET | `/api/v1/sessions/{id}` | Get one session | — |
+| POST | `/api/v1/sessions/{id}/end` | End a session permanently | Sets `status=ended`, `ended_at` |
+| POST | `/api/v1/sessions/{id}/resume` | Resume a paused session | `paused → active` |
+| POST | `/api/v1/sessions/{id}/pause` | Pause an active session | `active → paused` |
+| PATCH | `/api/v1/sessions/{id}` | Update metadata | Body: `title`, `system_prompt`, `metadata` |
+| GET | `/api/v1/sessions/{id}/context` | Get the formatted LLM context | OpenAI message-array shape built from history |
+
+## Messages (`/api/v1/sessions/{id}/messages`)
+
+Messages are append-only and never mutated after creation. The conversation
+engine builds LLM context from this history automatically.
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| GET | `/api/v1/sessions/{id}/messages` | List messages in a session | Query: `limit`, `offset` |
+| POST | `/api/v1/sessions/{id}/chat` | Send text, stream the LLM reply | **SSE stream** (see Examples) |
+| GET | `/api/v1/messages/{id}` | Get a single message by ID | — |
+| DELETE | `/api/v1/sessions/{id}/messages` | Purge all messages in a session | Clears history; keeps the session |
+
+## Devices (`/api/v1/devices`)
+
+Every connecting client registers as a device with its hardware ID, firmware
+version, platform, and capability set. Online/offline state is tracked live.
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| GET | `/api/v1/devices` | List devices | Query: `online=true` to filter |
+| GET | `/api/v1/devices/{id}` | Get one device | — |
+| PATCH | `/api/v1/devices/{id}` | Update device | Body: `name`, `config` |
+| DELETE | `/api/v1/devices/{id}` | Remove a device | — |
+
+## Config store (`/api/v1/config`)
+
+A scoped key-value store, distinct from the process `config.yaml`. Resolution
+order is `session → device → global` — the most specific scope wins.
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| GET | `/api/v1/config` | List config entries | Query: `scope`, `scope_id` |
+| GET | `/api/v1/config/{key}` | Get a value | Query: `scope`, `scope_id`, `resolve=true` |
+| PUT | `/api/v1/config/{key}` | Set a value | Body: `value`, `scope`, `scope_id` |
+| DELETE | `/api/v1/config/{key}` | Delete a key | — |
+
+The unversioned `/api/config` endpoints are a separate concern — they hot-reload
+the running pipeline's `config.yaml` (backend swap), not the scoped store. See
+[Top-level config and health](#top-level-config-and-health) below.
+
+## Events (`/api/v1/events`)
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| GET | `/api/v1/events` | List system events | Query: filter by `type`, `session`, `device` |
+
+Event types include `session.created`, `device.connected`, and `message.added`.
+The events table also backs the [spend roll-up](#spend-apiv1spend).
+
+## Agent log (`/api/v1/agent_log`)
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| GET | `/api/v1/agent_log` | Cross-session tool-call activity feed | Last 64 entries; populated at the `ToolRegistry.execute` chokepoint (TT #328 Wave 12) |
+
+Each entry is source-flagged (`tool_call`, `user_reply`, `channel_push`) so the
+Tab5 Agents overlay can break out per-source counts.
+
+## Media (`/api/v1/transcribe`, `/synthesize`, `/completions`)
+
+Stateless single-shot pipeline primitives — no session needed.
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| POST | `/api/v1/transcribe` | STT: audio bytes → text | Body: raw PCM (`application/octet-stream`) or `audio/wav`. Optional `X-Sample-Rate` header (default 16000). Returns `{text, duration_s, stt_ms}` |
+| POST | `/api/v1/synthesize` | TTS: text → audio bytes | Returns binary audio (PCM int16, resampled to 16 kHz) |
+| POST | `/api/v1/completions` | Direct LLM completion | **SSE stream**; stateless, no session context — the dashboard Chat tab's "stateless mode" |
+
+## System (`/api/v1/system`, `/backends`)
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| GET | `/api/v1/system` | System metrics | CPU, RAM, active connection count |
+| GET | `/api/v1/backends` | List available backends | Installed STT / TTS / LLM backend keys |
+
+## Tools (`/api/v1/tools`)
+
+Direct access to the agentic tool layer. The tool catalog (`web_search`,
+`remember`, `recall`, `datetime`, plus 6 more — 10 total) is the same set the
+LLM invokes during a turn.
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| GET | `/api/v1/tools` | List available tools | Each carries a JSON schema for its arguments |
+| POST | `/api/v1/tools/{name}/execute` | Execute a tool directly | Body = the tool's argument object; bypasses the LLM |
+
+To add a tool to this surface, follow the
+[add-a-tool how-to](../how-to/add-a-tool.md).
+
+## Memory (`/api/v1/memory`)
+
+Semantic fact store. Facts are embedded with Ollama `nomic-embed-text`
+(768-dim) and auto-recalled into the system prompt before every LLM call.
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| GET | `/api/v1/memory` | List stored facts | — |
+| POST | `/api/v1/memory` | Store a fact | Same store the LLM's `remember` tool writes to |
+| DELETE | `/api/v1/memory/{id}` | Delete a fact | — |
+| POST | `/api/v1/memory/search` | Semantic search facts | Body: `query`, `limit`; ranks by cosine similarity |
+
+## Documents (`/api/v1/documents`)
+
+Long-term knowledge ingest. Text is chunked (512 tokens / chunk, 50-token
+overlap), embedded with `nomic-embed-text`, and stored in SQLite with
+`sqlite-vec` for vector search.
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| POST | `/api/v1/documents` | Ingest a document | Chunks + embeds the text |
+| GET | `/api/v1/documents` | List documents | — |
+| DELETE | `/api/v1/documents/{id}` | Delete a document | Removes the document and all its chunks |
+| POST | `/api/v1/documents/search` | Semantic search across chunks | Returns ranked chunks by cosine similarity |
+
+## Notes (`/api/notes`)
+
+Notes are session artifacts (`type='recording'`) — created from text or from a
+raw audio upload, optionally enriched with an LLM-generated title and summary.
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| POST | `/api/notes` | Create a note from text | Body: `text`, `title` |
+| GET | `/api/notes` | List notes | Query: `limit`, `offset` |
+| GET | `/api/notes/{id}` | Get one note | — |
+| PUT | `/api/notes/{id}` | Update a note | Body: `title`, `transcript`, `summary`, `tags` |
+| DELETE | `/api/notes/{id}` | Delete a note | — |
+| POST | `/api/notes/search` | Semantic search notes | Body: `query`, `limit` |
+| POST | `/api/notes/from-audio` | Create a note from raw PCM audio | Transcribes then stores |
+
+## Top-level config and health
+
+Served at the root, outside `/api/v1`.
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| GET | `/` | HTML status page | Backend info + uptime |
+| GET | `/health` | JSON health check | **Public** (no bearer) |
+| GET | `/api/config` | Current process config | Secrets redacted |
+| POST | `/api/config` | Hot-reload config / swap backends | Re-inits active pipelines in place — see [swap-the-llm-backend](../how-to/swap-the-llm-backend.md) |
+
+## OTA (`/api/ota`)
+
+Firmware delivery for Tab5. Deploy a build by copying `tinkertab.bin` to
+`/home/radxa/ota/` and updating `version.json`.
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| GET | `/api/ota/check?current=VERSION` | Check for a firmware update | Compares against `/home/radxa/ota/version.json`; returns `{update, version, url, sha256}` |
+| GET | `/api/ota/firmware.bin` | Download the firmware image | Streams `/home/radxa/ota/tinkertab.bin` in 8 KB chunks |
+
+## Rich media (`/api/media`)
+
+Dragon renders code blocks, markdown tables, and image URLs from LLM responses
+into JPEGs for inline display on Tab5, and accepts camera uploads.
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| GET | `/api/media/{id}` | Serve a rendered media file | JPEG / PNG / WAV; `Cache-Control: max-age=3600`. **Public** via HMAC-signed URL |
+| POST | `/api/media/upload` | Accept a BMP/JPEG from the Tab5 camera | Converts + resizes via Pillow; returns `media_id` for `user_media` WS reference |
+
+## Video (debug) (`/api/video`)
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| POST | `/api/video/inject?device_id=X` | Push a JPEG as if from a paired Tab5 | Body = raw JPEG; wrapped with the `VID0` magic + 4-byte BE length. Exercises the Tab5 downlink decode path without a second device (#178) |
+
+## Scheduler (`/api/v1/scheduler/notifications`)
+
+Time-deferred reminders. A scheduled notification is delivered to a device over
+the voice WS at fire time and is replayable from the SQLite-backed queue across
+reboots.
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| POST | `/api/v1/scheduler/notifications` | Schedule a notification | Body: `when`, `message`, `device_id` |
+| GET | `/api/v1/scheduler/notifications` | List notifications | Query: `device_id`, `status` |
+| GET | `/api/v1/scheduler/notifications/{id}` | Get one notification | — |
+| PATCH | `/api/v1/scheduler/notifications/{id}` | Reschedule | Body: new `when` |
+| DELETE | `/api/v1/scheduler/notifications/{id}` | Cancel a pending notification | — |
+
+## Spend (`/api/v1/spend`)
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| GET | `/api/v1/spend?day=YYYY-MM-DD` | Daily LLM-spend roll-up | Aggregated over the `events` table; empty `day` = today UTC. Backed by `dragon_voice/billing/spend_tracker.py` (W5-A) |
+
+## Agent skills (`/api/v1/agent_skills`)
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| GET | `/api/v1/agent_skills` | Catalog of available agentic skills | Merges 8 static OpenClaw core tools with the tool names observed in `agent_log`. Tab5 fetches it on Agents-overlay open and on voice-mode change (W7-B) |
+
+## Integrations (`/api/v1/integrations`)
+
+Third-party OAuth-backed providers (Google Calendar, Gmail, Tasks). Connect
+flows are OAuth/PKCE or device-code; credentials are stored per-email so a
+provider can hold multiple accounts.
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| POST | `/api/v1/integrations/connect` | Start a connect flow | Body: `provider` (+ `email` for multi-account). Returns `authorization_url` or the device-code triple |
+| POST | `/api/v1/integrations/disconnect` | Revoke and forget a connection | Body: `provider`, `email`. Revokes tokens + deletes the email-keyed credentials file |
+| GET | `/api/v1/integrations/list` | List integrations + connection state | Per-email state for multi-account providers |
+| GET | `/api/v1/integrations/test/{provider}` | Smoke-test the active connection | Reads calendar / unread mail / tasks. Returns `{ok, detail}` |
+
+Walkthrough: [connect-an-integration how-to](../how-to/connect-an-integration.md).
+
+## Channels (`/api/v1/debug/channel_message`)
+
+Lets a messaging platform (Telegram, WhatsApp, Discord, Slack, Signal,
+iMessage, Matrix, Email) push a message to Tab5 through Dragon. The debug
+endpoint fans a synthetic frame; the real round-trip runs through the
+`GatewayConnector` to OpenClaw.
+
+| Method | Path | Purpose | Notes |
+|---|---|---|---|
+| POST | `/api/v1/debug/channel_message?device_id=X` | Push a synthetic `channel_message` to a connected Tab5 | Fans a JSON frame over the existing voice WS; mirrors the `video_inject` shape. Records a `channel_push` entry in `agent_log` (W7-F) |
+
+The user's reply path is not REST — it returns over the WebSocket as a
+`channel_reply` frame (`channel_reply_handler` → `GatewayConnector.send_reply` →
+OpenClaw → platform API → `channel_reply_ack`). See the
+[WebSocket protocol reference](../protocol.md) §20.
+
+## Examples
+
+### List active sessions for a device
+
+```bash
+curl -s "http://192.168.1.91:3502/api/v1/sessions?device_id=AA:BB:CC:DD:EE:FF&status=active" \
+  -H "Authorization: Bearer $DRAGON_API_TOKEN" | python3 -m json.tool
+```
+
+### Stream a chat reply (SSE)
+
+```bash
+curl -N -X POST http://192.168.1.91:3502/api/v1/sessions/3f9a1c0b7e22/chat \
+  -H "Authorization: Bearer $DRAGON_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "What is the weather?"}'
+# → data: {"token": "It's"}
+# → data: {"token": " sunny"}
+# → data: [DONE]
+```
+
+### Transcribe a raw-PCM clip
+
+```bash
+curl -s -X POST http://192.168.1.91:3502/api/v1/transcribe \
+  -H "Authorization: Bearer $DRAGON_API_TOKEN" \
+  -H "Content-Type: application/octet-stream" \
+  -H "X-Sample-Rate: 16000" \
+  --data-binary @clip.pcm
+# → {"text": "hello there", "duration_s": 1.2, "stt_ms": 340}
+```
+
+### Store and search a memory fact
+
+```bash
+curl -s -X POST http://192.168.1.91:3502/api/v1/memory \
+  -H "Authorization: Bearer $DRAGON_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Emile prefers metric units"}'
+
+curl -s -X POST http://192.168.1.91:3502/api/v1/memory/search \
+  -H "Authorization: Bearer $DRAGON_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "units", "limit": 3}' | python3 -m json.tool
+```
+
+### Execute a tool directly (no LLM)
+
+```bash
+curl -s -X POST http://192.168.1.91:3502/api/v1/tools/web_search/execute \
+  -H "Authorization: Bearer $DRAGON_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "QCS6490 datasheet"}' | python3 -m json.tool
+```
+
+## Related
+
+- [WebSocket protocol reference](../protocol.md) — the `/ws/voice` contract (frames, channel messages, video/audio relay)
+- [Architecture](../ARCHITECTURE.md) — what runs where and how the pieces talk
+- [SECURITY.md](../../SECURITY.md) — token lifecycle, public-prefix list, network exposure
+- [Multi-model router cookbook](../router-cookbook.md) — fleet config behind the `router` backend
+- [Swap the LLM backend](../how-to/swap-the-llm-backend.md) · [Add a tool](../how-to/add-a-tool.md) · [Connect an integration](../how-to/connect-an-integration.md)

--- a/docs/reference/tools-catalog.md
+++ b/docs/reference/tools-catalog.md
@@ -1,0 +1,212 @@
+---
+audience: integrator
+type: reference
+prerequisites: [WebSocket protocol](../protocol.md), [REST API reference](rest-api.md)
+last-verified: 2026-05-29
+---
+# Built-in tools catalog
+
+This is the authoritative list of the tools Dragon's LLM can call during a turn,
+their argument schemas, and the empty-reply wrap that keeps a turn from going
+silent when a function-calling model fires a tool and then stops talking.
+
+A tool is a Python class in `dragon_voice/tools/` that subclasses `Tool`
+(`dragon_voice/tools/base.py`) and declares four things: a `name` (the string the
+model emits), a `description` (injected into the system prompt), a
+`parameters_schema` (JSON Schema for its args), and an async `execute(args)`.
+All tools register on the single `ToolRegistry`
+(`dragon_voice/tools/registry.py`), and every invocation — voice, REST, or
+dashboard — funnels through `ToolRegistry.execute`, which is also where the
+`agent_log` activity feed is populated.
+
+For how a tool call travels over the wire, see the
+[`tool_call` / `tool_result` protocol messages](../protocol.md#121-tool_call-dragon---tab5).
+To add your own tool, follow the [adding-a-tool how-to](../adding-a-tool.md). To
+list the live registry on a running Dragon, call `GET /api/v1/tools` (see the
+[REST API reference](rest-api.md)).
+
+## How tools are invoked
+
+The LLM emits an XML marker; Dragon parses it, executes the named tool, injects
+the result back into the context, and lets the model continue. The parser
+(`dragon_voice/tools/parser.py`) accepts three dialects so models trained on
+different conventions all work:
+
+| Dialect | Shape | Emitted by |
+|---|---|---|
+| Legacy (TinkerBox standard) | `<tool>NAME</tool><args>{json}</args>` | ministral, gemma3 — the prompt format Dragon ships. Tolerates xLAM bracket quirks (`[tool>`, `<tool]`, `[tool]`) |
+| Standard | `<tool_call>{"name": "...", "arguments": {...}}</tool_call>` | industry FC fine-tunes (Qwen-FC, Gemma-FC, distil-*) regardless of system prompt |
+| Bracketed-name | `[NAME]{json}</NAME>` or `[NAME]IDENT()` | xLAM quirk (#82). Gated on `NAME` being a registered tool so prose like `[note]` in chat does not false-fire |
+
+The native `tools=[...]` API path (used by llama-server backends that support it)
+renders the whole registry as OpenAI-format function schemas via
+`ToolRegistry.openai_tools()` instead of prose-listing them. Either way the
+limits below apply.
+
+| Constraint | Value | Where |
+|---|---|---|
+| Max tool calls per turn | 3 (loop guard) | ConversationEngine |
+| System-prompt format for small models | compact XML (priority tools only) | `formatter.format_for_llm(compact=True)` |
+| Compact-prompt priority threshold | `Tool.priority < 50` opts in | `dragon_voice/tools/base.py` |
+
+## Always-on tools
+
+These register at startup and are available in every turn (voice mode 0/1/2 — in
+mode 3 the TinkerClaw gateway owns tool execution and Dragon's registry is
+bypassed). They depend only on Dragon-local services (SearXNG, Ollama
+embeddings, the surface manager, the scheduler), never on an external account.
+Registration lives in `dragon_voice/lifecycle/agentic_init.py` (the 10 core
+tools), `notes_init.py` (`note`), `surfaces_scheduler_init.py`
+(`timesense_timer`, `quick_poll`, `schedule_reminder`).
+
+| Tool name | Description | Required args | Optional args | Source file |
+|---|---|---|---|---|
+| `web_search` | Search the web for current information, news, facts, or answers | `query` (string) | `max_results` (integer, default 3) | `web_search.py` |
+| `datetime` | Get the current date, time, and day of the week | — | — | `datetime_tool.py` |
+| `remember` | Save a fact or preference about the user for future conversations | `fact` (string) | — | `memory_tools.py` |
+| `recall` | Search your memory for relevant information about the user or past conversations | `query` (string) | `limit` (integer, default 5) | `memory_tools.py` |
+| `forget_fact` | Forget a remembered fact. Two-step: search first, then confirm | — | `query` (string), `fact_id` (string), `confirm` (boolean) | `memory_tools.py` |
+| `calculator` | Calculate mathematical expressions accurately | `expression` (string) | — | `calculator_tool.py` |
+| `convert` | Convert between units (temperature, length, weight, volume, speed) | `value` (number), `from` (string), `to` (string) | — | `unit_converter_tool.py` |
+| `weather` | Get current weather for a location | — | `location` (string), `latitude` (number), `longitude` (number) | `weather_tool.py` |
+| `system_info` | Get info about the Dragon server (memory, CPU, uptime, connections) | — | — | `system_tool.py` |
+| `stock_ticker` | Current price + daily change for a US stock or ETF ticker | `symbol` (string) | `currency` (string, default `USD`) | `stock_ticker_tool.py` |
+| `note` | Take a quick note or create a reminder | `text` (string) | — | `note_tool.py` |
+| `timesense_timer` | Start an AI-first focus timer; the orb becomes the timer | — | `minutes` (number, default 25, 1–120), `session_id` (string, internal) | `timesense_tool.py` |
+| `quick_poll` | Ask a 2–3 button poll on the Tab5 screen and wait for the tap | `question` (string), `choices` (array, 2–3 items) | `timeout_s` (number, default 60, max 120) | `quick_poll_tool.py` |
+| `schedule_reminder` | Schedule a reminder to fire later as a card in the user's chat | `when` (string), `message` (string) | `title` (string, default `Reminder`), `priority` (`normal` \| `important`) | `schedule_reminder_tool.py` |
+
+Notes on the always-on set:
+
+- **`web_search`** queries SearXNG (self-hosted on port 8888,
+  google/bing/duckduckgo engines, up to 44 results, 10 s timeout). If SearXNG is
+  down it falls back to DuckDuckGo. Snippets are truncated to 300 chars.
+- **`remember` / `recall` / `forget_fact`** are backed by the
+  `MemoryService` with Ollama `nomic-embed-text` embeddings (768-dim). `forget_fact`
+  is a deliberate two-step: call with `query` to get a match plus
+  `requires_confirm: true`, read it back to the user, then call again with
+  `fact_id` + `confirm=true` to delete. It refuses to delete on a `fact_id`
+  without `confirm=true`.
+- **`timesense_timer`** is the agentic-path timer. The plain `timer` tool
+  (`timer_tool.py`) is intentionally **not** registered in the agentic loop
+  (D8/K7 dedup, 2026-04-20): the LLM kept picking `timer` on short phrases, which
+  made the live-widget flow unreachable. `timer_tool.py` is retained for
+  REST-only callers.
+- **`quick_poll`, `timesense_timer`, `schedule_reminder`** emit UI over the voice
+  WebSocket (`widget_prompt`, `widget_live`, `widget_card`). See the
+  [widget protocol section](../protocol.md#17-live-widgets).
+- **`schedule_reminder` `when`** accepts a relative duration (`5m`, `2h30m`,
+  `1d`), an ISO 8601 timestamp (`2026-04-26T15:00:00-04:00`), or a natural phrase
+  (`tomorrow at 3pm`). Bare times resolve in the server's local timezone.
+
+## Integration tools (registered when the account is connected)
+
+These register only when their integration package imports cleanly
+(`dragon_voice/lifecycle/integrations_init.py`); each block is wrapped
+independently so a broken Google import does not block the rest of the registry.
+The tool *backend* connects lazily — the credentials come from the
+[integrations connect flow](rest-api.md) (`POST /api/v1/integrations/connect`).
+Every integration tool accepts an optional `account` arg (string) so a user with
+multiple connected Google accounts can disambiguate.
+
+### Google Calendar
+
+| Tool name | Description | Required args | Optional args |
+|---|---|---|---|
+| `calendar_today` | List today's events from the primary calendar | — | `max_results` (integer, default 10), `account` |
+| `calendar_week` | List events for the next 7 days | — | `max_results` (integer, default 20), `account` |
+| `calendar_create` | Create an event (confirm details first — not undoable by voice) | `summary` (string), `start_iso` (string, ISO 8601 with tz), `end_iso` (string, ISO 8601 with tz) | `location` (string), `description` (string), `account` |
+| `calendar_cancel` | Delete an event by its id | `event_id` (string) | `account` |
+
+### Gmail
+
+| Tool name | Description | Required args | Optional args |
+|---|---|---|---|
+| `gmail_unread` | List unread messages (from, subject, snippet, id) | — | `max_results` (integer, default 10, max 25), `account` |
+| `gmail_search` | Search Gmail with Gmail's query syntax (`from:`, `subject:`, `has:attachment`, `newer_than:Nd`) | `query` (string) | `max_results` (integer, default 10, max 25), `account` |
+| `gmail_read` | Fetch the full body of a message by id | `message_id` (string) | `account` |
+| `gmail_send` | Send an email (confirm content first — not undoable) | `to` (string), `subject` (string), `body` (string) | `in_reply_to` (string), `cc` (string), `account` |
+| `gmail_archive` | Archive a message (removes INBOX label; not deleted) | `message_id` (string) | `account` |
+
+## The empty-reply wrap
+
+Some function-calling-trained models (xLAM, distil-functiongemma, LFM2.5-FC)
+emit a tool call and then stop, producing no conversational text. After
+ConversationEngine strips the tool markup, the user-visible reply is empty even
+though the tool fired and did real work. The empty-reply wrap
+(`dragon_voice/tools/response_wrap.py`, #77) fills that gap with a templated
+one-liner — **no extra LLM call**.
+
+The wrap runs only when **both** are true:
+
+1. At least one tool fired during the turn, **and**
+2. The model's own final text was empty or stripped to empty.
+
+"Stripped to empty" is judged by `looks_like_useful_text()` (#79 widened the
+trigger from strict-empty to "no useful text"): any closing-tag remnant like
+`</tool>` is treated as junk, and after stripping well-formed `<…>`/`[…]`/`{…}`
+blocks the text must still carry at least 3 meaningful characters to count as a
+real reply. A happy-path turn where the model wrote a real reply gets **no**
+wrap — the model's text is always preferred.
+
+`synthesize_wrap(calls)` is the entrypoint. It picks a per-tool template, dedups
+repeated snippets (xLAM sometimes fires the same tool twice in a loop), caps the
+output at 3 snippets, and falls back to a generic ack for any tool without a
+template. It never raises and always returns a non-empty string.
+
+### Per-tool wrap templates
+
+| Tool name(s) | Example wrap output |
+|---|---|
+| `datetime` | `It's 14:30:00 (UTC).` |
+| `calculator` | `15% of 230 = 34.5.` |
+| `unit_converter` | `That's 100 celsius.` |
+| `weather` | `In Dubai: sunny, 34°.` |
+| `remember`, `store_fact` | `Got it — User is allergic to peanuts.` |
+| `recall`, `recall_facts` | `<first fact>. (+2 more.)` |
+| `forget`, `forget_fact` | `OK — forgotten.` |
+| `web_search` | `Top hit: <title>.` |
+| `system_info` | `Dragon: ram: 41%, cpu: 12%.` |
+| `stock_ticker` | `AAPL is at 231.40.` |
+| `timer` | `Timer running for 300 seconds.` |
+| `timesense` | `Timer set for 1500 seconds.` |
+| `quick_poll` | `Tap one.` |
+| `note` | `Saved note: Buy groceries.` |
+| any unlisted tool | `OK — ran <name>.` |
+
+> The wrap table is keyed by tool name and ships its own aliases (e.g. both
+> `remember` and `store_fact` route to the same template). A tool name that has
+> no template falls through to `generic_wrap`, which lists the tools that ran.
+
+## Examples
+
+A full tool turn on the voice WebSocket — the model calls `web_search`, Dragon
+runs it, and the model finishes with a real reply (no wrap needed):
+
+```text
+Client → Dragon: {"type":"text","content":"what's the weather in Tokyo?"}
+Dragon → Tab5:   {"type":"tool_call","tool":"web_search","args":{"query":"weather Tokyo"}}
+Dragon → Tab5:   {"type":"tool_result","tool":"web_search","result":{"results":[...]},"execution_ms":234}
+Dragon → Tab5:   {"type":"llm","text":"It's "}
+Dragon → Tab5:   {"type":"llm","text":"18°C and clear in Tokyo."}
+Dragon → Tab5:   {"type":"llm_done","llm_ms":1200}
+```
+
+Execute a tool directly over REST, bypassing the LLM:
+
+```bash
+curl -s -X POST http://192.168.70.242:3502/api/v1/tools/datetime/execute \
+  -H "Authorization: Bearer $DRAGON_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+# → {"tool":"datetime","result":{"date":"2026-05-29","time":"14:30:00","day":"Friday",...},"execution_ms":1}
+```
+
+List the live registry to see exactly which tools (including connected
+integrations) are registered on a running Dragon:
+
+```bash
+curl -s http://192.168.70.242:3502/api/v1/tools \
+  -H "Authorization: Bearer $DRAGON_API_TOKEN" | python3 -m json.tool
+# → [{"name":"web_search","description":"...","parameters":{...}}, ...]
+```

--- a/docs/reference/voice-modes.md
+++ b/docs/reference/voice-modes.md
@@ -1,0 +1,142 @@
+---
+audience: integrator
+type: reference
+prerequisites: none
+last-verified: 2026-05-29
+---
+# Voice modes reference (backend mapping)
+
+[Tab5](../../GLOSSARY.md) selects how a turn is processed by sending one `config_update` frame over the [WebSocket](../../GLOSSARY.md); [Dragon](../../GLOSSARY.md) reads the `voice_mode` integer and hot-swaps its STT, LLM, and TTS backends in place — no reconnection, no dropped session. This page is the lookup table for that mapping: which backend each mode binds for each pipeline stage, the per-mode system-prompt budget and pipeline timeout, the auto-fallback rules, and the per-connection config isolation that lets two Tab5s run different modes against one Dragon.
+
+The wire shape of the `config_update` frame itself (both accepted forms, ACK latency, the Tab5-side-only modes) is in the [WebSocket protocol reference](websocket-protocol.md#config_update-inbound). What each mode *changes on Dragon* in operational terms is in [Swap the LLM backend](../how-to/swap-the-llm-backend.md). This page is the authoritative field index for the mapping.
+
+## The four wire tiers
+
+`config_update.voice_mode` is one of four integers Dragon accepts as live state. Each binds a fixed STT/TTS pairing; the LLM column is the per-mode default before the [router](../../GLOSSARY.md) (if active) and any `llm_model` override apply.
+
+| `voice_mode` | Mode | STT | LLM | TTS |
+|---|---|---|---|---|
+| `0` | **Local** | Moonshine | Local (`lmstudio`/`ollama`/`npu_genie`) | Piper (22050 Hz) |
+| `1` | **Hybrid** | OpenRouter `gpt-audio-mini` | Local (unchanged) | OpenRouter `gpt-audio-mini` (24 kHz) |
+| `2` | **Full Cloud** | OpenRouter `gpt-audio-mini` | OpenRouter (user-selected `llm_model`) | OpenRouter `gpt-audio-mini` (24 kHz) |
+| `3` | **TinkerClaw** | Moonshine (or OpenRouter) | TinkerClaw gateway (agent runner) | Piper (or OpenRouter) |
+
+Notes on the mapping:
+
+- **Hybrid (1)** moves only STT and TTS to the cloud; the LLM stays Dragon-local. It is the cheapest path to a snappy assistant because the round-trip cost is audio I/O, not generation.
+- **Full Cloud (2)** is the only mode that reads `llm_model`. Accepted values include `anthropic/claude-3-haiku`, `anthropic/claude-sonnet-4-20250514`, and `openai/gpt-4o-mini`; the value is stored in `LLMConfig.openrouter_model`.
+- **TinkerClaw (3)** bypasses Dragon's `ConversationEngine`, `ToolRegistry`, and `MemoryService` entirely — Dragon is an audio pipe (STT in, TTS out) and the LLM call goes to the [TinkerClaw](../../GLOSSARY.md) gateway at `localhost:18789`. See [Run the TinkerClaw sidecar](../how-to/run-the-tinkerclaw-sidecar.md).
+
+### Modes 4 and 5 (Tab5-side-only)
+
+Modes 4 (TinkerON) and 5 (Solo) run the turn without Dragon. Tab5 **downconverts them to `voice_mode=0` on the wire**, so Dragon never sees them as live state — treat this as a protocol feature, not a bug. Dragon's mapping table therefore stops at mode 3.
+
+### Backward compatibility: `cloud_mode`
+
+Older firmware sends a boolean instead of an integer. Dragon still accepts it: `cloud_mode: true` maps to `voice_mode=2`, `cloud_mode: false` maps to `voice_mode=0`. The boolean form cannot express Hybrid (mode 1); new clients should send the integer form.
+
+## Valid backend keys per stage
+
+The mode table above picks from these registered backend keys. A backend is selected by its key string in `config.yaml` (`stt.backend`, `tts.backend`, `llm.backend`) or hot-swapped at runtime.
+
+| Stage | Valid keys |
+|---|---|
+| STT | `moonshine`, `whisper_cpp`, `vosk`, `openrouter` |
+| TTS | `piper`, `kokoro`, `edge_tts`, `openrouter` |
+| LLM | `ollama`, `npu_genie`, `openrouter`, `lmstudio`, `tinkerclaw`, `dual`, `router` |
+
+The `router` LLM key activates the [`CapabilityAwareRouter`](../../GLOSSARY.md), which holds a fleet of sub-backends and picks one per turn from the active mode's tier policy. See [Configure the multi-model router](../how-to/configure-the-multi-model-router.md) and the [router cookbook](../router-cookbook.md).
+
+## Mode-aware system prompts
+
+Each voice mode sets a different system-prompt budget so the local model's context stays tight while cloud models get room for nuance.
+
+| Mode | System-prompt budget |
+|---|---|
+| Local (0) | Concise — 128 tokens |
+| Hybrid (1) | Medium — 256 tokens |
+| Cloud (2) | Rich — 512 tokens |
+
+When `voice_mode` changes, the session's `system_prompt` is updated in the database immediately, so the `ConversationEngine` picks up the new prompt on the next turn rather than the next reconnect.
+
+## Mode-aware pipeline timeouts
+
+The pipeline applies a per-mode wall-clock timeout to a turn, configured in `pipeline.py`. Local models on the Q6A are slow, and tool-calling chains compound that, so Local gets the longest budget.
+
+| Mode | Pipeline timeout | Why |
+|---|---|---|
+| Local (0) | 300 s (5 min) | Tool-calling chains on slow local models |
+| Cloud (2) | 60 s (1 min) | Cloud generation is fast |
+| TinkerClaw (3) | 180 s (3 min) | Gaps between gateway tool executions |
+
+These are the pipeline-level turn timeouts. They are distinct from the local LLM backend's HTTP timeouts: `lmstudio_llm.py` uses `ClientTimeout(total=600, sock_read=300)` because individual Local-mode turns on the Q6A routinely hit 90–180 s, and `MAX_TOKENS_LOCAL = 1024` so thinking-mode models that spend budget inside `<think>...</think>` still emit visible content.
+
+## Auto-fallback
+
+Cloud STT/TTS failures degrade gracefully to local for the failed request, then push Tab5 back to Local mode for subsequent turns.
+
+| Trigger | Per-request behavior | Mode-level behavior |
+|---|---|---|
+| Cloud STT/TTS fails (timeout, API error) | Falls back to local `moonshine`/`piper` for that request | Sends a `config_update` with an `error` field → Tab5 auto-reverts to Local (mode 0) |
+| TinkerClaw gateway down (connection refused on `localhost:18789`) | Sends `error` to Tab5 | Same auto-revert-to-Local pattern as cloud fallback |
+| `lmstudio` socket unreachable at process start | `create_llm()` transparently falls back to Ollama for the session | One-shot at backend creation, **not per-request** — warm-path latency is unaffected |
+
+The API key needed for cloud fallback is auto-propagated: `llm.openrouter_api_key` is copied to `stt.openrouter_api_key` and `tts.openrouter_api_key`, and is validated before a swap — a cloud swap with an empty key is rejected with an error rather than silently failing mid-turn.
+
+The `lmstudio`→Ollama fallback is evaluated only once, when the backend instance is created. Restarting `tinkerclaw-llama-server` mid-session is **not** picked up automatically — after fixing llama-server, also run `systemctl restart tinkerclaw-voice` so the backend is re-evaluated.
+
+## Per-connection config isolation (deep copy)
+
+Each WebSocket connection gets its own deep copy of the global config via `copy.deepcopy()`. A `config_update` from one device — say, switching to Cloud — mutates only that connection's pipeline config, never the shared global object or another device's pipeline.
+
+Without the deep copy, two Tab5s connected at once would share one mutable config object and one device's mode switch would corrupt the other's pipeline. With it, two devices can hold different modes against the same Dragon simultaneously.
+
+## Reconnect behavior
+
+When a device reconnects, the pipeline is re-initialized with **Local defaults (`voice_mode=0`)** regardless of the previous session's mode. The session history is preserved (the session resumes), but the mode is not. A client that wants to stay in Cloud or Hybrid must re-send its `config_update` after the `session_start` frame arrives.
+
+## Config fields
+
+| Field | Type | Role |
+|---|---|---|
+| `LLMConfig.backend` | str | Active LLM backend key for the current mode |
+| `LLMConfig.local_backend` | str | Remembers the original local backend for fallback |
+| `LLMConfig.openrouter_model` | str | User-selectable cloud model (`llm_model` from `config_update`) |
+
+## Examples
+
+### Switch to Full Cloud with a specific model
+
+```json
+{"type": "config_update", "voice_mode": 2, "llm_model": "anthropic/claude-sonnet-4-20250514"}
+```
+
+Dragon swaps STT and TTS to OpenRouter `gpt-audio-mini`, sets the LLM to OpenRouter with the named model, raises the system-prompt budget to 512 tokens, and applies the 60 s pipeline timeout. It replies with a `config_update` ACK reporting the applied backends.
+
+### Switch back to Local (legacy boolean form)
+
+```json
+{"type": "config_update", "cloud_mode": false}
+```
+
+Maps to `voice_mode=0`: STT → Moonshine, TTS → Piper (22050 Hz), LLM → the local backend, system prompt back to 128 tokens, pipeline timeout back to 300 s.
+
+### Hot-reload the LLM backend over REST (no Tab5)
+
+```bash
+curl -X POST http://192.168.70.242:3502/api/config \
+  -H "Content-Type: application/json" \
+  -d '{"llm": {"backend": "ollama", "ollama_model": "ministral-3:3b"}}'
+# → {"status": "ok", "message": "Config updated, 1 pipelines reloaded", ...}
+```
+
+This swaps the backend on every active pipeline in place, the same hot-swap path a `config_update` frame triggers.
+
+## See also
+
+- [WebSocket protocol reference](websocket-protocol.md) — the `config_update` frame shape, ACK latency, and the full inbound/outbound frame index.
+- [Swap the LLM backend](../how-to/swap-the-llm-backend.md) — operational walkthrough of what each mode changes on Dragon.
+- [Configure the multi-model router](../how-to/configure-the-multi-model-router.md) — populating `fleet` and reading `fleet_summary` when `llm == "router"`.
+- [Run the TinkerClaw sidecar](../how-to/run-the-tinkerclaw-sidecar.md) — enabling voice mode 3.
+- [Router cookbook](../router-cookbook.md) — copy-paste fleets for common routing patterns.
+- [`docs/protocol.md`](../protocol.md) — the canonical full wire specification.

--- a/docs/reference/websocket-protocol.md
+++ b/docs/reference/websocket-protocol.md
@@ -1,0 +1,242 @@
+---
+audience: integrator
+type: reference
+prerequisites: none
+last-verified: 2026-05-29
+---
+# WebSocket protocol (Dragon side)
+
+The single WebSocket between [Tab5](../../GLOSSARY.md) (the face) and [Dragon](../../GLOSSARY.md) (the brain) carries every voice turn, text turn, control command, tool event, rich-media push, and call frame. This page is the lookup table for that wire from Dragon's side: every frame type, its direction, its fields, and when it fires.
+
+The full narrative specification — sequence diagrams, state machine, audio-pipeline internals, OTA, widget platform, channel messaging, the progress event bus — is [`docs/protocol.md`](../protocol.md). That document is canonical; this reference is the condensed field index. When the two disagree, `docs/protocol.md` wins.
+
+## Endpoint
+
+| Property | Value |
+|---|---|
+| URL | `ws://<dragon-ip>:3502/ws/voice` |
+| Transport | WebSocket (RFC 6455) |
+| Port | `3502` (`tinkerclaw-voice` service) |
+| Path | `/ws/voice` |
+| Max message size | 10 MB (server limit) |
+| Server heartbeat | 600 s (aiohttp) |
+| First frame | `register` (JSON text) — Dragon rejects all other commands until registration is processed |
+
+Frames are either **JSON text frames** (every control and event message; each carries a `type` field) or **binary frames** (PCM audio, plus the `VID0`/`AUD0`-tagged call frames). Dragon disambiguates binary frames by their leading 4-byte magic tag — an untagged binary frame is mic PCM bound for STT.
+
+## Inbound frames (Tab5 → Dragon)
+
+| Type | Frame | Key fields | Fires when | Dragon does |
+|---|---|---|---|---|
+| `register` | JSON | `device_id` (req), `hardware_id` (req), `firmware_ver` (req), `platform` (req), `name`, `session_id`, `capabilities` | First frame after connect; once per connection | Upserts device, creates/resumes session, inits pipeline, replies `session_start` |
+| `start` | JSON | `mode` (`"ask"` default, or `"dictate"`) | Push-to-talk / dictation begins | Clears audio buffer, sets mode, awaits binary PCM |
+| (binary PCM) | Binary | 640-byte chunks (20 ms, 16 kHz mono int16) | Continuously during `LISTENING` | Appends to audio buffer; server VAD may auto-trigger |
+| `segment` | JSON | — | Tab5 detects a 500 ms pause in dictation mode | Transcribes the segment, replies `stt_partial` |
+| `stop` | JSON | — | Push-to-talk released / 30 s ask cap / 5 s dictation silence | Ask: STT → LLM → TTS. Dictate: finalize combined transcript |
+| `cancel` | JSON | — | User cancels, or Tab5's 35 s response timeout fires | Sets cancel flag, kills in-flight STT/LLM/TTS task, clears buffers |
+| `text` | JSON | `content` (req, non-empty) | User types or sends text via API | Skips STT, streams `llm` tokens; TTS per `response_mode` |
+| `clear` | JSON | — | User clears history | Ends current session, creates a fresh one, replies `session_start` |
+| `config_update` | JSON | `cloud_mode` (bool) **or** `voice_mode` (int) + `llm_model` | User toggles mode in Settings | Hot-swaps STT/TTS/LLM backends in place, replies `config_update` ACK |
+| `config_ack` | JSON | `applied` | Tab5 confirms receipt of a Dragon `config_update` | Logs at debug level only |
+| `ready_ack` | JSON | `mode` (int) | Tab5's playback ring drained and the orb returned to `READY` | Logs the event; no state change |
+| `ping` | JSON | — | Every 15 s during `PROCESSING`/`SPEAKING` | Replies `pong` immediately |
+| `user_media` | JSON | `media_id` (req), `media_type` (`"image"`), `text` | Camera photo uploaded via `POST /api/media/upload` | Loads image from MediaStore, runs multimodal LLM, streams reply |
+| `widget_action` | JSON | `card_id` (req), `event` (req), `payload` | User taps a widget action or answers a prompt | `widget_action_router` dispatches to the owning skill's `on_action` |
+| `channel_reply` | JSON | `channel`, `thread_id`, `text`, `in_reply_to` | User replies to a `channel_message` | Forwards via `GatewayConnector` to OpenClaw, replies `channel_reply_ack` |
+
+### `register`
+
+The mandatory first frame. Sent once per connection.
+
+```json
+{
+  "type": "register",
+  "device_id": "aabbccddeeff",
+  "hardware_id": "AA:BB:CC:DD:EE:FF",
+  "name": "Tab5",
+  "firmware_ver": "0.5.0",
+  "platform": "esp32p4-tab5",
+  "session_id": null,
+  "capabilities": {
+    "mic": true, "speaker": true, "screen": true,
+    "camera": true, "sd_card": true, "touch": true,
+    "widgets": {
+      "types": ["live", "card", "list", "chart", "media", "prompt"],
+      "list_max_items": 5, "chart_max_points": 12, "prompt_max_choices": 3,
+      "screen_w": 720, "screen_h": 1280,
+      "media_max_w": 660, "media_max_h": 440, "action_rate_per_sec": 4
+    }
+  }
+}
+```
+
+Pass a non-null `session_id` to request resume of a previously paused session. Widget renderer limits are nested under `capabilities.widgets` — there is no separate `widget_capability` frame.
+
+### `config_update` (inbound)
+
+Two accepted shapes. New clients should use the integer form; the boolean form cannot express Hybrid (`voice_mode=1`) and is kept only for older firmware.
+
+```json
+{"type": "config_update", "cloud_mode": true}
+```
+
+```json
+{"type": "config_update", "voice_mode": 0, "llm_model": "anthropic/claude-3-haiku"}
+```
+
+| `voice_mode` | Mode | STT | LLM | TTS |
+|---|---|---|---|---|
+| `0` | Local | Moonshine | Local (lmstudio/ollama) | Piper (22050 Hz) |
+| `1` | Hybrid | OpenRouter gpt-audio-mini | Local (unchanged) | OpenRouter gpt-audio-mini (24 kHz) |
+| `2` | Full Cloud | OpenRouter gpt-audio-mini | OpenRouter (`llm_model`) | OpenRouter gpt-audio-mini (24 kHz) |
+| `3` | TinkerClaw | Moonshine / OpenRouter | TinkerClaw gateway | Piper / OpenRouter |
+
+`cloud_mode: true` maps to `voice_mode=2`, `false` to `voice_mode=0`. Modes 4 (TinkerON) and 5 (Solo) are Tab5-side-only — Tab5 downconverts them to `voice_mode=0` on the wire, so Dragon never sees them as live state. Rapid `config_update` sends are coalesced server-side; expect 500–1000 ms ACK latency under back-pressure. See [Swap the LLM backend](../how-to/swap-the-llm-backend.md) for what each mode changes on Dragon.
+
+### `text`
+
+```json
+{"type": "text", "content": "What time is it?"}
+```
+
+No `stt` frame follows text input — the flow starts directly at `llm` tokens. Whether TTS audio follows depends on the session's `response_mode` (`"always_speak"` synthesizes audio; `"match_input"` returns text-only for a text turn).
+
+### `user_media`
+
+```json
+{"type": "user_media", "media_id": "m3n4o5p6", "media_type": "image", "text": "What is this plant?"}
+```
+
+`media_id` comes from a prior `POST /api/media/upload`. The reply streams as a normal turn (`llm` → `llm_done` → optional TTS).
+
+### `channel_reply`
+
+```json
+{"type": "channel_reply", "channel": "tg", "thread_id": "tg:8675309",
+ "text": "yes lunch thurs works, 12:30 ok?", "in_reply_to": "tg:8675309:42"}
+```
+
+Mirrors `channel` and `thread_id` from the inbound `channel_message`. Dragon forwards through the OpenClaw gateway and returns `channel_reply_ack`.
+
+## Outbound frames (Dragon → Tab5)
+
+| Type | Frame | Key fields | Fires when | Tab5 does |
+|---|---|---|---|---|
+| `session_start` | JSON | `session_id`, `device_id`, `resumed`, `message_count`, `config` | After `register`/`clear` once pipeline is ready | Stores `session_id` in NVS, transitions to `READY` |
+| `stt` | JSON | `text`, `stt_ms` | After STT of the full utterance | Stores transcript; stays `PROCESSING` (ask) or → `READY` (dictate) |
+| `stt_partial` | JSON | `text`, `stt_ms` | After each dictation segment | Appends to running transcript, stays `LISTENING` |
+| `llm` | JSON | `text` | Per token as the LLM streams | Appends to LLM buffer, updates UI |
+| `llm_done` | JSON | `llm_ms` | LLM finished all tokens | Logs timing |
+| `tts_start` | JSON | — | Before the first binary TTS chunk | Enables speaker, → `SPEAKING` |
+| (binary TTS) | Binary | 4096-byte chunks (16 kHz mono int16) | Between `tts_start` and `tts_end` | Upsamples 16k→48k, writes ring buffer |
+| `tts_end` | JSON | `tts_ms` | After all TTS audio sent | Drains buffer, disables speaker, → `READY` |
+| `dictation_summary` | JSON | `title`, `summary` | Async after dictation (transcript > 20 chars) | Stores title/summary, updates UI |
+| `tool_call` | JSON | `tool`, `args` | LLM emitted tool markers, before execution | Shows tool activity indicator, stays `PROCESSING` |
+| `tool_result` | JSON | `tool`, `result`, `execution_ms` | After tool execution, before LLM resumes | Updates indicator, stays `PROCESSING` |
+| `media` | JSON | `media_type`, `url`, `width`, `height`, `alt` | After `llm_done`, code/table/image rendered | Fetches and displays inline |
+| `card` | JSON | `title`, `subtitle`, `image_url`, `description` | Structured content in the response | Renders a styled card |
+| `audio_clip` | JSON | `url`, `duration_s`, `label` | Non-TTS audio in the response | Shows a tap-to-play audio widget |
+| `text_update` | JSON | `text` | After media render, code stripped (before `media`) | Replaces (or removes, if `""`) the last AI bubble |
+| `config_update` | JSON | `config` (`cloud_mode`, `stt`, `tts`, `llm`) | After a config change, or pushed unprompted | Persists `cloud_mode` to NVS |
+| `error` | JSON | `code`, `message` | On any pipeline error | Stops playback, → `READY` (connected) or `IDLE` |
+| `pong` | JSON | — | In response to `ping` | No action (debug log) |
+| `channel_message` | JSON | `channel`, `message_id`, `thread_id`, `sender`, `text`, `preview`, `priority`, `needs_reply` | Third-party platform message via OpenClaw | Routes to toast or now-card; fires audio cue |
+| `channel_reply_ack` | JSON | `channel`, `thread_id`, `ok`, `platform_message_id`, `error` | After a `channel_reply` is processed | Toast "Replied via {channel}" or error toast |
+
+There is also a family of `widget_*` push frames (`widget_live`, `widget_live_update`, `widget_live_dismiss`, `widget_card`, `widget_list`, `widget_chart`, `widget_media`, `widget_prompt`, `widget_dismiss`) and a unified `progress` frame. They are catalogued in [`docs/protocol.md`](../protocol.md) §17 and §19; this page covers the core voice/text/media surface the task lists.
+
+### `session_start`
+
+```json
+{
+  "type": "session_start",
+  "session_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "device_id": "aabbccddeeff",
+  "resumed": false,
+  "message_count": 0,
+  "config": {
+    "stt": "moonshine",
+    "tts": "piper",
+    "llm": "router",
+    "tts_sample_rate": 22050,
+    "response_mode": "match_input",
+    "system_prompt": "You are Tinker...",
+    "fleet_summary": {
+      "text":         "ministral-3:3b",
+      "vision":       "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M",
+      "video":        "hf.co/openbmb/MiniCPM-V-4-gguf:Q4_K_M",
+      "audio_in":     null,
+      "audio_out":    null,
+      "tool_calling": "ministral-3:3b"
+    }
+  }
+}
+```
+
+`resumed` is `true` with `message_count > 0` when a paused session was rejoined. `config.fleet_summary` is present only when `llm == "router"`; it reports the per-modality `model_id` the router would currently pick at the active tier, and is re-sent on every `config_update` ACK after a `voice_mode` change. Firmware that does not understand it can ignore it. See [Configure the multi-model router](../how-to/configure-the-multi-model-router.md).
+
+### `error`
+
+```json
+{"type": "error", "code": "stt_failed", "message": "Transcription failed: model not loaded"}
+```
+
+| `code` | Meaning |
+|---|---|
+| `session_invalid` | Device not registered, or session not found |
+| `internal` | Pipeline init or internal server error |
+| `stt_failed` | STT transcription failed |
+| `llm_failed` | LLM text processing failed |
+| `tts_failed` | TTS synthesis failed |
+
+When STT returns empty text, Dragon sends an `error` and stops — no `llm`/`tts` follows. On any `error`, Tab5 transitions to `READY` if the socket is still up (transient), or `IDLE` if it disconnected.
+
+### `tool_call` / `tool_result`
+
+These interleave with `llm` tokens during the response. The LLM generates twice — once to emit the tool markers, then again with the tool result injected — so a tool turn produces tokens, the call/result pair, then the final token stream.
+
+```json
+{"type": "tool_call", "tool": "web_search", "args": {"query": "weather in Dublin today"}}
+```
+
+```json
+{"type": "tool_result", "tool": "web_search", "result": {"snippets": ["Dublin: 14°C, partly cloudy..."]}, "execution_ms": 234}
+```
+
+Dragon caps tool calls at **3 per turn** to prevent infinite loops; each call produces its own `tool_call` + `tool_result` pair before the final answer. See [Add a tool](../how-to/add-a-tool.md) for the registry and dialect parser.
+
+### `text_update`
+
+```json
+{"type": "text_update", "text": "Here is the solution:\n\n(see image above)\n\nLet me know if you need changes."}
+```
+
+**Ordering is load-bearing.** `text_update` is emitted *before* any `media` frame for the same turn, because Tab5 targets the tail of the chat store when replacing a bubble and the `media` event appends a new bubble to that tail. An empty `text` (`""`) means the whole response was a code block that moved into media — Tab5 removes the most recent AI bubble entirely. The contract is enforced by `tests/audit/test_d5_d6_ws.py`, which asserts `text_update.index < media.index` against a live Dragon.
+
+## Binary call frames (VID0 / AUD0)
+
+Two-way video calls (Tab5 ↔ Dragon ↔ Tab5 or browser) use tagged binary frames. Dragon is a verbatim broadcast relay — a frame from one connection is forwarded byte-for-byte to all *other* connections, with no transcode and no buffering beyond the WS write queue (`dragon_voice/video_upstream.py`).
+
+| Magic (4 bytes ASCII) | Length (4 bytes BE u32) | Payload |
+|---|---|---|
+| `VID0` | `len` | JPEG frame (Tab5 HW encoder, browser `getUserMedia`, or `POST /api/video/inject`) |
+| `AUD0` | `len` | Raw 16 kHz mono int16 PCM (Tab5 mic in call mode, or browser Web Audio capture) |
+
+An untagged binary frame is not a call frame — it is mic PCM bound for STT (the standard voice path). The magic tag is the only thing that disambiguates the two binary uses on the same socket.
+
+## Audio format
+
+| Direction | Encoding | Rate | Channels | Chunk |
+|---|---|---|---|---|
+| Tab5 → Dragon (mic) | PCM int16 LE | 16000 Hz | 1 (mono) | 640 bytes (20 ms) |
+| Dragon → Tab5 (TTS) | PCM int16 LE | 16000 Hz | 1 (mono) | 4096 bytes |
+
+Dragon resamples TTS from the engine's native rate (Piper 22050 Hz, OpenRouter 24 kHz) down to 16 kHz before sending. The first 4 TTS chunks ship immediately to pre-fill Tab5's ring buffer; the rest are paced at ~80% of real-time playback to keep the buffer from overflowing.
+
+## See also
+
+- [`docs/protocol.md`](../protocol.md) — the canonical full specification (sequence diagrams, state machine, OTA, widgets, progress bus, channel messaging).
+- [How the stack fits together](../explanation/how-the-stack-fits-together.md) — why Tab5 is thin and Dragon holds all intelligence.
+- [Swap the LLM backend](../how-to/swap-the-llm-backend.md) — what each `voice_mode` changes on Dragon.
+- [Configure the multi-model router](../how-to/configure-the-multi-model-router.md) — populating `fleet` and reading `fleet_summary`.
+- [Add a tool](../how-to/add-a-tool.md) — the tool registry behind `tool_call` / `tool_result`.

--- a/docs/tutorials/get-dragon-running.md
+++ b/docs/tutorials/get-dragon-running.md
@@ -1,0 +1,180 @@
+---
+audience: operator
+type: tutorial
+prerequisites: A Dragon Q6A (or any Linux box) with Python 3.12+, network access, and an OpenRouter API key for cloud backends
+last-verified: 2026-05-29
+est-time: 20 min
+---
+# Get your Dragon running
+
+By the end you will have the Dragon voice server live on port **3502**, answering
+a health check over the network. This is the brain of the stack — once it
+responds, a [Tab5](../../GLOSSARY.md) can connect to it and hold a voice
+conversation. Every step below has a visible result so you know it worked before
+you move on.
+
+This is a learning-by-doing walkthrough. You run the commands *on the Dragon
+itself* (SSH in first, or sit at its keyboard). If you only want to push code
+changes from a workstation to an already-running Dragon, that is the
+[deploy how-to](../../CLAUDE.md#deploy) instead — this page is about the first
+cold start.
+
+## Before you start
+
+- **A Dragon Q6A** (Radxa, Qualcomm QCS6490, ARM64, Ubuntu) — or any Linux box
+  with **Python 3.12+**. The Dragon is recommended because the NPU path only
+  exists there, but the server runs anywhere Python does.
+- **Network access** from the machine you will test from (a workstation on the
+  same LAN, or the Dragon's own shell).
+- **An OpenRouter API key** (`sk-or-v1-...`) if you want Hybrid or Cloud voice
+  modes. Pure Local mode (Moonshine STT + a local LLM + Piper TTS) needs no key,
+  but most first runs use Cloud for a quick, high-quality reply.
+- **SQLite 3.35+** (ships with Python 3.12+) and **git**.
+
+If your Dragon is across the room, SSH in first:
+
+```bash
+ssh radxa@192.168.70.242   # the LAN IP rotates — see note below
+```
+
+> The Dragon's IP flips between the `192.168.1.x` and `192.168.70.x` LANs over
+> time. If `192.168.70.242` does not answer, find it with
+> `ping radxa-dragon-q6a` or `nmap -p 22,3502 --open 192.168.70.0/24`. The
+> user is `radxa`, not `rock`.
+
+## Steps
+
+1. **Clone the repo.** SSH'd into the Dragon (or on your Linux box), clone
+   TinkerBox and enter it.
+
+   ```bash
+   git clone https://github.com/lorcan35/TinkerBox.git
+   cd TinkerBox
+   ```
+
+   _You should see:_ a `TinkerBox/` directory containing `dragon_voice/`,
+   `dashboard.py`, `schema.sql`, and `setup.sh`. Confirm with `ls`.
+
+2. **Run setup.** This installs the base Python packages and checks for Chromium.
+
+   ```bash
+   ./setup.sh
+   ```
+
+   _You should see:_ pip installing dependencies, then a line confirming setup
+   finished. On the Dragon (Debian/Radxa OS), pip needs `--break-system-packages`
+   because of PEP 668; `setup.sh` handles that for you.
+
+3. **Install the voice-pipeline dependencies.** These are the packages the
+   STT → LLM → TTS pipeline imports at startup.
+
+   ```bash
+   pip3 install --break-system-packages -r dragon_voice/requirements.txt
+   ```
+
+   _You should see:_ pip resolving and installing the voice pipeline
+   requirements with no `ERROR` lines. If you plan to run **Local** mode, also
+   install the backends you want — Moonshine STT and Piper TTS are the local
+   defaults:
+
+   ```bash
+   pip3 install --break-system-packages sherpa-onnx    # Moonshine STT
+   pip3 install --break-system-packages piper-tts       # Piper TTS
+   ```
+
+4. **Set your OpenRouter API key.** Export it into the shell that will launch the
+   server. The server reads `OPENROUTER_API_KEY` when
+   `llm.openrouter_api_key` is empty in the config.
+
+   ```bash
+   export OPENROUTER_API_KEY="sk-or-v1-..."
+   ```
+
+   _You should see:_ nothing printed — that is correct. Verify it stuck with
+   `echo "${OPENROUTER_API_KEY:0:10}..."`, which prints the first 10 characters.
+
+   > For a permanent install, the key lives in `/home/radxa/.env` and is loaded
+   > by the systemd unit's `EnvironmentFile=`. That file survives code deploys —
+   > never put a real key in `config.yaml` in the repo.
+
+5. **Start the voice server.** Launch the `dragon_voice` package as a module.
+
+   ```bash
+   python3 -m dragon_voice
+   ```
+
+   _You should see:_ startup logs ending with the server binding to
+   `0.0.0.0:3502`. The startup sequence brings up the database, sessions, memory
+   and tools, then the conversation engine and REST routes. Leave this terminal
+   running — closing it stops the server.
+
+   > If you get `OSError: [Errno 98] Address already in use`, port 3502 is taken.
+   > Find the owner with `lsof -i :3502` and `kill <PID>`, or start on another
+   > port with `python3 -m dragon_voice --port 3503`.
+
+6. **Confirm health on 3502.** From a second terminal (on the Dragon, or from a
+   workstation on the same LAN), hit the health endpoint.
+
+   ```bash
+   curl -s http://localhost:3502/health | python3 -m json.tool
+   # → {"status": "ok", ...}
+   ```
+
+   From a workstation, swap `localhost` for the Dragon's IP:
+
+   ```bash
+   curl -s http://192.168.70.242:3502/health | python3 -m json.tool
+   # → {"status": "ok", ...}
+   ```
+
+   _You should see:_ a JSON object with `"status": "ok"`. That is the Dragon
+   telling you the voice server is alive and reachable. You can also open
+   `http://192.168.70.242:3502/` in a browser for the HTML status page with
+   backend info and uptime.
+
+7. **Check the configured backends.** Confirm which STT/LLM/TTS backends are
+   active. Secrets are redacted in this response.
+
+   ```bash
+   curl -s http://localhost:3502/api/config | python3 -m json.tool
+   ```
+
+   _You should see:_ the resolved config showing `stt.backend` (e.g.
+   `moonshine`), `llm.backend` (e.g. `openrouter` or `ollama`), and `tts.backend`
+   (e.g. `piper`). This is the live configuration the next voice turn will use.
+
+## What you built
+
+You have a running Dragon voice server: `python3 -m dragon_voice` is bound to
+port 3502, `GET /health` returns `{"status": "ok"}`, and `GET /api/config` shows
+your active backends. The Dragon is now ready to accept a WebSocket connection
+from a Tab5 (or any client) at `ws://<dragon-ip>:3502/ws/voice`.
+
+That health line is your proof of success:
+
+```bash
+$ curl -s http://192.168.70.242:3502/health | python3 -m json.tool
+{
+    "status": "ok"
+}
+```
+
+This was a foreground run — it dies when you close the terminal. To make the
+Dragon start on boot and restart on failure, install it as the
+`tinkerclaw-voice` systemd unit (and its siblings for the dashboard, mDNS, and
+ngrok). The full service map — Dashboard on 3500, CDP on 3501, Voice on 3502 —
+and the systemd install commands live in the runbook.
+
+## Next
+
+- [Run it as a service and deploy code changes](../../CLAUDE.md#deploy) — install
+  the `tinkerclaw-voice` systemd unit, then `scp` + `systemctl restart` for every
+  later update.
+- [Switch voice modes (Local / Hybrid / Cloud / TinkerClaw)](../../CLAUDE.md#three-tier-voice-mode)
+  — how Dragon hot-swaps STT/LLM/TTS backends from a single `config_update`.
+- [The WebSocket protocol](../protocol.md) — the contract a Tab5 (or your own
+  client) uses to talk to the server you just started.
+- [How the stack fits together](../ARCHITECTURE.md) — where the Dragon sits
+  relative to the Tab5 and the optional TinkerClaw gateway.
+- [Set up the NPU LLM path](../npu-setup.md) — get Llama 3.2 1B running on the
+  Qualcomm Hexagon DSP at ~8 tok/s for faster Local mode.


### PR DESCRIPTION
## docs: Wave 2 — TinkerBox content (Diátaxis, 4 audiences)

Builds on the merged Wave 0 foundation (#375). TinkerBox (Dragon server) documentation across all four audiences, mined from CLAUDE.md / README / protocol.md / ARCHITECTURE.md / router-cookbook.md.

**19 pages** (18 planned + the cross-stack `how-the-stack-fits-together`):
- **Tutorials:** get-dragon-running
- **How-to (×6):** deploy-on-a-dragon · swap-the-llm-backend · configure-the-multi-model-router · connect-an-integration · add-a-tool · run-the-tinkerclaw-sidecar
- **Reference (×6):** rest-api (the full /api/v1 surface) · websocket-protocol · config-reference · voice-modes · tools-catalog · package-file-map
- **Explanation (×6):** architecture · the-voice-pipeline · the-multi-model-router · local-first-inference · memory-and-rag · how-the-stack-fits-together

`docs/README.md` indexed by type + audience. Standard `last-verified` headers throughout. **markdown-link-check: PASS** (fixed one GitHub-unsupported heading-anchor in rest-api).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
