### PR TITLE
fix(dictation): Dragon-side W0/W2/W4 + WS connection-leak fixes + progress audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,8 @@ jobs:
             tests/test_media_pipeline.py \
             tests/test_mcp_bridge.py \
             tests/test_notes_db_async.py \
+            tests/test_notes_embed_retry.py \
+            tests/test_stop_handler.py \
             tests/test_paused_session_retention.py \
             tests/test_progress_bus_integration.py \
             tests/test_progress_emit.py \

--- a/dragon_voice/dictation_post.py
+++ b/dragon_voice/dictation_post.py
@@ -102,6 +102,14 @@ def _classify_safe(transcript: str) -> dict:
 OnEvent = Callable[[dict], Awaitable[None]]
 
 
+# Single source for "is this transcript substantial enough to keep?"
+# Shared by pipeline.finish_dictation (summary gate) and
+# stop_handler (note-auto-save gate) so the two can't disagree —
+# pre-fix a 11-20 char transcript saved a note while the pipeline
+# reported it EMPTY (dictation audit 2026-05-29, S3-3).
+MIN_DICTATION_CHARS = 20
+
+
 # Title + summary prompt template.  Module-level so the contract
 # is greppable; tweaks to the wording propagate to a single
 # place.  Transcript truncated to 2000 chars to keep the LLM
@@ -205,12 +213,15 @@ async def run_dictation_post_process(
         return
 
 
-    # PR 2 polish: short-circuit for Local mode (OllamaBackend).
-    # Synthesize title/summary from the transcript instead of calling
-    # the slow CPU LLM — fires dictation_summary immediately so the
-    # pipeline reaches SAVED before the ngrok WS idle-close window.
-    backend_name = type(llm).__name__
-    if backend_name == 'OllamaBackend':
+    # Short-circuit for slow CPU-local backends (Ollama / llama-server /
+    # NPU Genie): synthesize title/summary from the transcript instead of
+    # calling the slow LLM — fires dictation_summary immediately so the
+    # pipeline reaches SAVED before Tab5's 45 s grace timer / the ngrok WS
+    # idle-close window.  Gated on the backend *capability*, not its class
+    # name — the old `type(llm).__name__ == 'OllamaBackend'` check silently
+    # broke when Local moved Ollama → llama-server (LMStudioBackend),
+    # reintroducing the very hang it was meant to kill.
+    if getattr(llm, "synthesize_summary_locally", False):
         title, summary = _synthesize_local_title_summary(transcript)
         # PR 4: heuristic classifier → optional proposed_action chip.
         proposed = _classify_safe(transcript)

--- a/dragon_voice/llm/base.py
+++ b/dragon_voice/llm/base.py
@@ -130,6 +130,34 @@ class LLMBackend(ABC):
         """
         return frozenset({Modality.TEXT})
 
+    @property
+    def synthesize_summary_locally(self) -> bool:
+        """True for slow CPU-local backends where the dictation
+        title+summary should be synthesized from the transcript
+        directly instead of paying a 60-90 s `generate_stream` round
+        trip.
+
+        This is a *capability*, not an identity check.  It replaces the
+        old `type(llm).__name__ == 'OllamaBackend'` gate in
+        `dictation_post.run_dictation_post_process`, which silently
+        broke when the live Local backend moved from Ollama to
+        llama-server (`LMStudioBackend`) — reintroducing the very hang
+        the gate was written to kill (the slow summary races Tab5's 45 s
+        grace timer / the ngrok idle-close window).
+
+        Slow CPU-local backends (Ollama, llama-server, NPU Genie)
+        override to True.  Fast remote backends (OpenRouter, TinkerClaw)
+        keep the default False so they go through the LLM, which gives a
+        nicer title+summary and is fast enough not to race any timeout.
+
+        Wrapper backends (router/dual) inherit the default False today;
+        forwarding the property to the chosen sub-backend is a tracked
+        follow-up (dictation redesign W3/W4).  The live default
+        deployment is a direct backend, so the property resolves
+        correctly there.
+        """
+        return False
+
     async def health_check(self, timeout_s: float = 2.0) -> tuple[bool, str]:
         """W4-B: cheap reachability probe surfaced by `GET /health`.
 

--- a/dragon_voice/llm/lmstudio_llm.py
+++ b/dragon_voice/llm/lmstudio_llm.py
@@ -20,6 +20,12 @@ logger = logging.getLogger(__name__)
 class LMStudioBackend(LLMBackend):
     """LLM backend using LM Studio's local OpenAI-compatible API."""
 
+    # Slow CPU-local path (llama-server on Dragon, 60-90 s per summary):
+    # synthesize the dictation title+summary from the transcript instead
+    # of round-tripping the LLM, so the pipeline reaches SAVED before
+    # Tab5's 45 s grace timer / the ngrok idle-close window.
+    synthesize_summary_locally = True
+
     def __init__(self, config: LLMConfig) -> None:
         self._config = config
         self._base_url = config.lmstudio_url.rstrip("/")

--- a/dragon_voice/llm/npu_genie.py
+++ b/dragon_voice/llm/npu_genie.py
@@ -28,6 +28,11 @@ _MAX_RESPONSE_CHARS = 300  # Hard limit — kill genie process after this many c
 class NPUGenieBackend(LLMBackend):
     """LLM backend using Qualcomm Genie runtime on the NPU (HTP)."""
 
+    # Slow CPU/NPU-local path: synthesize the dictation title+summary
+    # from the transcript instead of paying a slow LLM round-trip (see
+    # LLMBackend.synthesize_summary_locally).
+    synthesize_summary_locally = True
+
     def __init__(self, config: LLMConfig) -> None:
         self._config = config
         self._model_dir = Path(config.genie_model_dir)

--- a/dragon_voice/llm/ollama_llm.py
+++ b/dragon_voice/llm/ollama_llm.py
@@ -81,6 +81,11 @@ def _is_reasoning_model(model_id: str) -> bool:
 class OllamaBackend(LLMBackend):
     """LLM backend using Ollama's REST API."""
 
+    # Slow CPU-local path: synthesize the dictation title+summary from
+    # the transcript instead of paying a 60-90 s LLM round-trip (see
+    # LLMBackend.synthesize_summary_locally).
+    synthesize_summary_locally = True
+
     # How long Ollama keeps a model loaded in memory after the last request.
     # Default is 5 minutes which causes OOM on 8GB Dragon when switching
     # between models (e.g. qwen3:1.7b -> qwen3:4b).  30s is enough to

--- a/dragon_voice/notes/service.py
+++ b/dragon_voice/notes/service.py
@@ -17,6 +17,12 @@ from dragon_voice.notes.db import Note, NotesDB
 
 logger = logging.getLogger(__name__)
 
+# W4: bounded background retry for note embeddings.  An embedding failure (e.g.
+# "Server disconnected") must never block or fail the note insert — the note is
+# saved + usable the moment the transcript exists; only the semantic index of
+# that note is deferred until a retry succeeds.  Delays in seconds (backoff).
+_EMBED_RETRY_DELAYS = [2, 10, 30]
+
 
 def _placeholder_title(text: str, max_words: int = 8) -> str:
     """First N non-empty words from the transcript as a placeholder title.
@@ -321,11 +327,27 @@ class NotesService:
     # ── Internal: Embeddings ────────────────────────────────────────────
 
     async def _embed_note(self, note_id: str, text: str) -> None:
-        """Generate and store embedding for a note."""
-        embedding = await self._get_embedding(text[:8000])
-        if embedding:
-            await self._db.update(note_id, {"embedding": embedding})
-            logger.info("Embedded note %s (%d dims)", note_id, len(embedding))
+        """Generate + store the note embedding, retrying transient failures.
+
+        Never raises — embedding is best-effort background work (W4).  On every
+        attempt failure we wait a backoff and retry; after the last delay we give
+        up quietly (the note stays usable, just unindexed until a later edit
+        re-embeds it).  This makes a transient "Server disconnected" self-heal
+        instead of leaving the note permanently unsearchable.
+        """
+        for delay in [0, *_EMBED_RETRY_DELAYS]:
+            if delay:
+                await asyncio.sleep(delay)
+            try:
+                embedding = await self._get_embedding(text[:8000])
+            except Exception:
+                logger.warning("Embedding attempt failed for %s", note_id, exc_info=True)
+                continue
+            if embedding:
+                await self._db.update(note_id, {"embedding": embedding})
+                logger.info("Embedded note %s (%d dims)", note_id, len(embedding))
+                return
+        logger.warning("Embedding gave up for %s after %d retries", note_id, len(_EMBED_RETRY_DELAYS))
 
     async def _get_embedding(self, text: str) -> list[float]:
         """Get embedding vector from Ollama."""

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -824,8 +824,13 @@ class VoicePipeline:
             stage=Stage.START,
             emit_legacy=self._config.progress_bus_emit_legacy,
         )
+        # W2: capture THIS turn's id NOW — a later `start` overwrites
+        # conn_state["turn_id"], and the async post-process emits its summary
+        # seconds later, so it must stamp the turn it belongs to rather than
+        # whatever turn has since started (the server root cause of S2-8).
+        post_turn_id = getattr(self, "_dictation_turn_id", "-")
         self._post_process_task = asyncio.ensure_future(
-            self._post_process_dictation(full_text)
+            self._post_process_dictation(full_text, turn_id=post_turn_id)
         )
         # Prevent "Task exception was never retrieved" warnings
         self._post_process_task.add_done_callback(self._on_post_process_done)
@@ -841,7 +846,7 @@ class VoicePipeline:
         if exc:
             logger.warning("Dictation post-processing task failed: %s", exc)
 
-    async def _post_process_dictation(self, transcript: str) -> None:
+    async def _post_process_dictation(self, transcript: str, turn_id: str = "-") -> None:
         """Generate title + summary for completed dictation via LLM.
 
         SOLID-audit follow-up: implementation extracted to
@@ -849,6 +854,10 @@ class VoicePipeline:
         resolves the active LLM (ConvEngine first, then
         pipeline._llm fallback) and forwards to the free
         function with the on_event callback + emit_legacy flag.
+
+        W2: ``turn_id`` is captured at finish_dictation time and stamped on
+        every emit from here, so a late summary stamps ITS OWN turn rather
+        than whatever turn conn_state has since moved on to (S2-8).
         """
         from dragon_voice.dictation_post import run_dictation_post_process
 
@@ -858,10 +867,17 @@ class VoicePipeline:
         elif self._llm:
             llm = self._llm
 
+        async def _on_event_stamped(event: dict) -> None:
+            # Stamp the CAPTURED turn_id (not conn_state's live one).  The
+            # downstream callback's "if turn_id not in event" guard then
+            # leaves it intact, so the late summary carries this turn's id.
+            event.setdefault("turn_id", turn_id)
+            await self._on_event(event)
+
         await run_dictation_post_process(
             transcript,
             llm=llm,
-            on_event=self._on_event,
+            on_event=_on_event_stamped,
             emit_legacy=self._config.progress_bus_emit_legacy,
         )
 

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -764,65 +764,71 @@ class VoicePipeline:
         # PR 2 polish: when transcript is empty/short, emit a final
         # dictation_summary with empty fields so Tab5's pipeline resolves
         # (DICT_FAILED/EMPTY) instead of stalling at TRANSCRIBING forever.
-        if not (full_text.strip() and len(full_text) > 20):
+        # MIN_DICTATION_CHARS is the single source shared with the
+        # note-auto-save gate in stop_handler (dictation audit S3-3) so a
+        # short utterance can't save a note while reporting EMPTY here.
+        from dragon_voice.dictation_post import MIN_DICTATION_CHARS
+
+        if not (full_text.strip() and len(full_text) > MIN_DICTATION_CHARS):
             await self._on_event({
                 "type": "dictation_summary",
                 "title": "",
                 "summary": "",
             })
             return full_text
-        if full_text.strip() and len(full_text) > 20:
-            # v4·D audit P1 fix: cancel any prior post-process task before
-            # overwriting the handle.  Two rapid finish_dictation calls
-            # previously leaked the first task -- it kept running while
-            # the second task raced it to write title/summary.
-            prev = self._post_process_task
-            if prev and not prev.done():
-                # Audit B5 (#152): await the cancellation so the prior
-                # task can't race-emit a stale dictation_summary
-                # between the LLM call returning and CancelledError
-                # firing at the next await.
-                self._post_process_task = None
-                prev.cancel()
-                try:
-                    await prev
-                except (asyncio.CancelledError, Exception):
-                    pass
-                # Phase 2 H4 (issue #94): tell Tab5 the prior post-process
-                # was abandoned for the new one.  Without this, a user who
-                # rapidly stops + restarts dictation could see a stale
-                # summary land on top of their new transcript a few seconds
-                # later.
-                # β-arch (issue #123): double-write — legacy frame for
-                # unmodified Tab5 firmware + new progress frame for the
-                # unified bus.
-                await emit_progress_pair(
-                    self._on_event,
-                    legacy={"type": "dictation_postprocessing_cancelled"},
-                    phase=Phase.DICTATION_POST,
-                    stage=Stage.CANCELLED,
-                    code="dictation_post_cancelled",
-                    message="Prior summary abandoned for new dictation.",
-                    emit_legacy=self._config.progress_bus_emit_legacy,
-                )
-            # Phase 2 H4 (issue #94): emit a "still working" event so Tab5
-            # can show "Generating summary..." instead of leaving the user
-            # staring at the bare transcript for 10-20 s while the LLM
-            # writes the title + summary.  Pre-fix, the only events between
-            # `stt` (line 490) and `dictation_summary` were silence —
-            # users assumed the device had hung.
+
+        # Transcript is substantial — spawn the async title+summary task.
+        # v4·D audit P1 fix: cancel any prior post-process task before
+        # overwriting the handle.  Two rapid finish_dictation calls
+        # previously leaked the first task -- it kept running while
+        # the second task raced it to write title/summary.
+        prev = self._post_process_task
+        if prev and not prev.done():
+            # Audit B5 (#152): await the cancellation so the prior
+            # task can't race-emit a stale dictation_summary
+            # between the LLM call returning and CancelledError
+            # firing at the next await.
+            self._post_process_task = None
+            prev.cancel()
+            try:
+                await prev
+            except (asyncio.CancelledError, Exception):
+                pass
+            # Phase 2 H4 (issue #94): tell Tab5 the prior post-process
+            # was abandoned for the new one.  Without this, a user who
+            # rapidly stops + restarts dictation could see a stale
+            # summary land on top of their new transcript a few seconds
+            # later.
+            # β-arch (issue #123): double-write — legacy frame for
+            # unmodified Tab5 firmware + new progress frame for the
+            # unified bus.
             await emit_progress_pair(
                 self._on_event,
-                legacy={"type": "dictation_postprocessing"},
+                legacy={"type": "dictation_postprocessing_cancelled"},
                 phase=Phase.DICTATION_POST,
-                stage=Stage.START,
+                stage=Stage.CANCELLED,
+                code="dictation_post_cancelled",
+                message="Prior summary abandoned for new dictation.",
                 emit_legacy=self._config.progress_bus_emit_legacy,
             )
-            self._post_process_task = asyncio.ensure_future(
-                self._post_process_dictation(full_text)
-            )
-            # Prevent "Task exception was never retrieved" warnings
-            self._post_process_task.add_done_callback(self._on_post_process_done)
+        # Phase 2 H4 (issue #94): emit a "still working" event so Tab5
+        # can show "Generating summary..." instead of leaving the user
+        # staring at the bare transcript for 10-20 s while the LLM
+        # writes the title + summary.  Pre-fix, the only events between
+        # `stt` (line 490) and `dictation_summary` were silence —
+        # users assumed the device had hung.
+        await emit_progress_pair(
+            self._on_event,
+            legacy={"type": "dictation_postprocessing"},
+            phase=Phase.DICTATION_POST,
+            stage=Stage.START,
+            emit_legacy=self._config.progress_bus_emit_legacy,
+        )
+        self._post_process_task = asyncio.ensure_future(
+            self._post_process_dictation(full_text)
+        )
+        # Prevent "Task exception was never retrieved" warnings
+        self._post_process_task.add_done_callback(self._on_post_process_done)
 
         return full_text
 

--- a/dragon_voice/pipeline.py
+++ b/dragon_voice/pipeline.py
@@ -804,7 +804,15 @@ class VoicePipeline:
             # unified bus.
             await emit_progress_pair(
                 self._on_event,
-                legacy={"type": "dictation_postprocessing_cancelled"},
+                # W2 (review F2): stamp the cancelled frame with the ABANDONED
+                # prior turn's id (the task we just cancelled), NOT conn_state's
+                # live turn_id — which a back-to-back `start` has overwritten
+                # with the SUCCESSOR turn.  Without this, Tab5 would cancel the
+                # live successor + discard its WAV.
+                legacy={
+                    "type": "dictation_postprocessing_cancelled",
+                    "turn_id": getattr(self, "_post_process_turn_id", "-"),
+                },
                 phase=Phase.DICTATION_POST,
                 stage=Stage.CANCELLED,
                 code="dictation_post_cancelled",
@@ -832,6 +840,10 @@ class VoicePipeline:
         self._post_process_task = asyncio.ensure_future(
             self._post_process_dictation(full_text, turn_id=post_turn_id)
         )
+        # W2 (review F2): remember which turn THIS post-process belongs to, so a
+        # later finish_dictation that cancels it stamps the cancelled frame with
+        # this (abandoned) turn's id rather than the successor's.
+        self._post_process_turn_id = post_turn_id
         # Prevent "Task exception was never retrieved" warnings
         self._post_process_task.add_done_callback(self._on_post_process_done)
 

--- a/dragon_voice/progress_emit.py
+++ b/dragon_voice/progress_emit.py
@@ -14,6 +14,19 @@ The swallow pattern matches the existing convention at
 take down the calling task.  Worst case: Tab5 sees only the legacy
 frame (status quo) or only the progress frame (consistent with the
 ``progress_bus_emit_legacy=False`` mode).  Both states are valid.
+
+W5 S3-8 audit (2026-05-30): the ``progress`` half of the dual-write
+has NO consumers fleet-wide at present — Tab5 firmware logs it as
+"Unknown message type: progress" (voice_ws_proto.c) and the dashboard
+(dashboard.py + dragon_voice/static/) never reads it.  It is NOT dead
+code to delete, though: it is the *intentional forward-compat* frame
+the β-arch added so a future progress-bus consumer (dashboard live
+view, a new client) gets a structured event without re-touching every
+emit site.  The legacy half is load-bearing for Tab5 today and is kept
+unconditionally.  Removal of the progress half is deferred until either
+a real consumer ships (then it's load-bearing too) or the progress-bus
+is abandoned (then drop the half + flip emit_legacy semantics).  Do NOT
+collapse the dual-write on the strength of "no consumers" alone.
 """
 from __future__ import annotations
 

--- a/dragon_voice/server.py
+++ b/dragon_voice/server.py
@@ -574,12 +574,22 @@ class VoiceServer:
         # Tab5 side (10 s idle + 5 s × 3 probes ≈ 25 s).
         ws = web.WebSocketResponse(
             max_msg_size=10 * 1024 * 1024,
-            heartbeat=180.0,
+            # 2026-05-30: 180 → 60 s.  The heartbeat is also the dead-socket
+            # reaper: when a client disconnects WHILE the handler is blocked
+            # mid-request (e.g. a dictation summary / inference), aiohttp can't
+            # see the close until the next heartbeat PING fails — so the socket
+            # sits in CLOSE-WAIT for up to `heartbeat` seconds.  Under reconnect
+            # churn (or repeated device reboots) those piled up and exhausted
+            # the WS handler (live: 27-59 CLOSE-WAIT wedged :3502, new upgrades
+            # failed, Tab5 stuck CONNECTING).  60 s reaps 3x faster.  Safe: a
+            # healthy client auto-PONGs the PING at the WS protocol level
+            # (autoping), independent of what its turn is doing; the long-turn
+            # protection is receive_timeout below, untouched.
+            heartbeat=60.0,
             # 2026-04-23 (#58): 120 → 600 s.  Previously Tab5 WS got dropped
-            # mid-turn when TC was running a long agent task — heartbeat
-            # PING goes out every 60 s but if the TC response hasn't started
-            # streaming within 120 s (normal for MiniMax-M2.5 + tools), the
-            # aiohttp server-side receive_timeout would yank the connection
+            # mid-turn when TC was running a long agent task — if the TC response
+            # hasn't started streaming within 120 s (normal for MiniMax + tools),
+            # the aiohttp server-side receive_timeout would yank the connection
             # and Tab5 would see the flap as "Dragon unreachable".
             receive_timeout=600.0,
             autoping=True,

--- a/dragon_voice/stale_conn_eviction.py
+++ b/dragon_voice/stale_conn_eviction.py
@@ -46,6 +46,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Optional
 
+from aiohttp import WSCloseCode
+
 from dragon_voice.errors import Scope, Severity, error_event
 
 logger = logging.getLogger(__name__)
@@ -139,6 +141,25 @@ async def evict_stale_connections_for_device(
         old_sid = old_conn.get("session_id")
         if old_sid and session_mgr is not None:
             await session_mgr.pause_session(old_sid)
+
+        # Force-close the old WebSocket so its socket fd is released NOW.
+        # Pre-fix, eviction tore down the pipeline + session + registry entry
+        # but left the old `ws` open, relying on aiohttp's 180 s heartbeat (or
+        # the old handler's receive loop) to eventually reap it.  Under rapid
+        # reconnect churn — or abrupt Tab5 reboots that half-close the TCP
+        # without the blocked handler noticing — evicted sockets pile up in
+        # CLOSE-WAIT and exhaust the WS handler.  Observed live 2026-05-30: 59
+        # CLOSE-WAIT sockets wedged :3502 so no new WS upgrade could complete
+        # ("Error read response for Upgrade header" on the client) and the Tab5
+        # could not reconnect at all until the service was restarted.  Closing
+        # here releases each evicted socket immediately.  Best-effort: a close
+        # failure (already-dead transport) must not block the eviction.
+        old_ws = old_conn.get("ws")
+        if old_ws is not None and not getattr(old_ws, "closed", False):
+            try:
+                await old_ws.close(code=WSCloseCode.GOING_AWAY, message=b"device_evicted")
+            except Exception as e:
+                logger.debug("P13: old ws close failed for %s: %s", old_ws_id, e)
 
         # Mark as unregistered so _handle_disconnect won't mark
         # device offline.

--- a/dragon_voice/start_handler.py
+++ b/dragon_voice/start_handler.py
@@ -74,6 +74,11 @@ async def handle_start_command(
     if mode == "dictate":
         pipeline._segment_buffer.clear()
         pipeline._dictation_segments.clear()
+        # W2: stash this dictation turn's id on the pipeline so finish_dictation
+        # can capture it for the async post-process — a later `start` overwrites
+        # conn_state["turn_id"], so the post-process must stamp the turn it
+        # belongs to, not the next one (back-to-back mis-stamp, S2-8).
+        pipeline._dictation_turn_id = turn_id
 
     logger.info(
         "Connection %s: start (mode=%s, turn_id=%s, audio buffer cleared)",

--- a/dragon_voice/stop_handler.py
+++ b/dragon_voice/stop_handler.py
@@ -9,7 +9,7 @@ dictation finished), the server has to:
 
   1. **Dictate mode** — call `pipeline.finish_dictation()` which
      runs STT + post-processing.  When the transcript is
-     non-trivial (>10 chars), auto-save it as a Dragon note via
+     non-trivial (> MIN_DICTATION_CHARS), auto-save it as a Dragon note via
      `notes_svc.create_from_text()` and emit a `note_created`
      frame so Tab5 can show the freshly-saved note.
   2. **Ask / other modes** — call `pipeline.start_processing()`
@@ -38,16 +38,17 @@ await handle_stop_command(
 
 `conn_lock` is the per-connection `asyncio.Lock` (US-P10).
 `notes_svc` is the NotesService singleton — when missing or
-when the dictation transcript is too short to be useful (≤10
-chars), the note auto-create silently skips.
+when the dictation transcript is too short to be useful
+(≤ MIN_DICTATION_CHARS), the note auto-create silently skips.
 
-## Why >10 char transcript gate
+## Why the MIN_DICTATION_CHARS transcript gate
 
 Dictation post-processing on a near-empty buffer can produce
 filler like " " or "Uh." or " uhh." after Whisper's silence
 trim.  Persisting these as notes would clutter the notes view
-without value.  The 10-char floor is a proxy for "the user
-actually said something dictatable".
+without value.  The MIN_DICTATION_CHARS floor is a proxy for
+"the user actually said something dictatable" and is shared
+with the pipeline summary gate so the two never disagree.
 
 ## Why try/except around create_from_text
 
@@ -65,12 +66,16 @@ from typing import Any, Optional
 
 from aiohttp import web
 
+from dragon_voice.dictation_post import MIN_DICTATION_CHARS
+
 logger = logging.getLogger(__name__)
 
 
-# Dictation transcripts shorter than this are filler (silence
-# trim residue); skip the note auto-save.
-_MIN_DICTATION_CHARS_FOR_NOTE = 10
+# The note-auto-save gate shares MIN_DICTATION_CHARS with the
+# pipeline's summary gate (dictation audit S3-3) — a transcript that is
+# too short to summarize is also too short to save as a note, so the two
+# can't disagree (pre-fix an 11-20 char transcript saved a note while
+# the pipeline reported it EMPTY).
 
 
 async def handle_stop_command(
@@ -87,7 +92,7 @@ async def handle_stop_command(
 
     Mode dispatch:
       * ``dictate`` → `pipeline.finish_dictation()` + auto-note
-        when transcript is >10 chars and notes_svc is available.
+        when transcript is > MIN_DICTATION_CHARS and notes_svc is available.
       * ``ask`` (or anything else) → `pipeline.start_processing()`
         — runs the STT → LLM → TTS chain on the buffered audio.
 
@@ -143,7 +148,7 @@ async def _maybe_auto_create_note(
     if not transcript:
         return
     stripped = transcript.strip()
-    if len(stripped) <= _MIN_DICTATION_CHARS_FOR_NOTE:
+    if len(stripped) <= MIN_DICTATION_CHARS:
         return
     if notes_svc is None:
         return

--- a/dragon_voice/stop_handler.py
+++ b/dragon_voice/stop_handler.py
@@ -121,6 +121,7 @@ async def handle_stop_command(
                 ws,
                 transcript=transcript,
                 notes_svc=notes_svc,
+                turn_id=conn_state.get("turn_id", "-"),
             )
         else:
             await pipeline.start_processing()
@@ -131,6 +132,7 @@ async def _maybe_auto_create_note(
     *,
     transcript: Optional[str],
     notes_svc: Optional[Any],
+    turn_id: str = "-",
 ) -> None:
     """Auto-save the dictation transcript as a Dragon note +
     emit `note_created`.  Silently skips on:
@@ -165,6 +167,9 @@ async def _maybe_auto_create_note(
                 "note_id": note.id,
                 "title": note.title,
                 "transcript": transcript[:200],
+                # W2: stamp the turn_id (note_created bypasses the pipeline
+                # callback's auto-stamp) so W4 can dedup the note by turn_id.
+                "turn_id": turn_id,
             })
     except Exception as e:
         logger.error("Failed to auto-create dictation note: %s", e)

--- a/tests/test_device_evicted.py
+++ b/tests/test_device_evicted.py
@@ -244,3 +244,82 @@ async def _drive_register(server: VoiceServer, ws, conn_state: dict, cmd: dict) 
         # Post-eviction setup uses real config attributes the stubs
         # don't provide; that's outside the scope of this test.
         pass
+
+
+# ───────────────────────── CLOSE-WAIT leak fix (2026-05-30)
+
+
+def test_eviction_closes_old_websocket() -> None:
+    """The evicted connection's WebSocket MUST be explicitly closed so its
+    socket fd is released immediately.  Pre-fix, eviction tore down the
+    pipeline/session/registry but left the old ws open, relying on aiohttp's
+    180 s heartbeat to reap it — under reconnect churn evicted sockets piled up
+    in CLOSE-WAIT and exhausted the WS handler (observed live: 59 CLOSE-WAIT
+    sockets wedged :3502, "Error read response for Upgrade header", Tab5 could
+    not reconnect until the service was restarted)."""
+    from aiohttp import WSCloseCode
+
+    from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
+
+    old_ws = MagicMock()
+    old_ws.closed = False
+    old_ws.close = AsyncMock()
+    active = {
+        "ws_old": {
+            "ws_id": "ws_old",
+            "device_id": "dev-Z",
+            "registered": True,
+            "session_id": "old-session",
+            "pipeline": MagicMock(shutdown=AsyncMock()),
+            "_on_event": AsyncMock(),
+            "ws": old_ws,
+        }
+    }
+
+    evicted = asyncio.run(
+        evict_stale_connections_for_device(
+            active_connections=active,
+            session_mgr=None,
+            device_id="dev-Z",
+            new_ws_id="ws_new",
+        )
+    )
+
+    assert evicted == 1
+    old_ws.close.assert_awaited_once()
+    assert old_ws.close.await_args.kwargs.get("code") == WSCloseCode.GOING_AWAY
+    assert "ws_old" not in active
+
+
+def test_eviction_skips_close_on_already_closed_ws() -> None:
+    """If the old ws is already closed, eviction skips the close (no
+    double-close) and still completes the teardown."""
+    from dragon_voice.stale_conn_eviction import evict_stale_connections_for_device
+
+    old_ws = MagicMock()
+    old_ws.closed = True
+    old_ws.close = AsyncMock()
+    active = {
+        "ws_old": {
+            "ws_id": "ws_old",
+            "device_id": "dev-Z",
+            "registered": True,
+            "session_id": None,
+            "pipeline": None,
+            "_on_event": None,
+            "ws": old_ws,
+        }
+    }
+
+    evicted = asyncio.run(
+        evict_stale_connections_for_device(
+            active_connections=active,
+            session_mgr=None,
+            device_id="dev-Z",
+            new_ws_id="ws_new",
+        )
+    )
+
+    assert evicted == 1
+    old_ws.close.assert_not_awaited()
+    assert "ws_old" not in active

--- a/tests/test_dictation_post.py
+++ b/tests/test_dictation_post.py
@@ -24,6 +24,11 @@ def _make_llm(*, response_tokens: list[str] | None = None) -> MagicMock:
             yield tok
 
     llm.generate_stream = _stream
+    # Default mock = a fast remote backend (OpenRouter/TinkerClaw): it
+    # goes through the LLM.  Without pinning this False the MagicMock
+    # auto-vivifies a truthy child attr and every happy-path test would
+    # wrongly take the local-synthesize short-circuit.
+    llm.synthesize_summary_locally = False
     return llm
 
 
@@ -132,6 +137,7 @@ class TestFailure:
     async def test_llm_exception_emits_error_event(self):
         on_event = _make_on_event()
         llm = MagicMock()
+        llm.synthesize_summary_locally = False  # exercise the LLM path
 
         async def _broken(prompt, system_prompt):
             raise RuntimeError("LLM crashed mid-summary")
@@ -162,6 +168,7 @@ class TestFailure:
         spawning this task — no double-emit)."""
         on_event = _make_on_event()
         llm = MagicMock()
+        llm.synthesize_summary_locally = False  # exercise the LLM path
 
         async def _cancel(prompt, system_prompt):
             raise asyncio.CancelledError()
@@ -320,20 +327,21 @@ def test_synthesize_local_word_boundary_in_title():
 
 
 @pytest.mark.asyncio
-async def test_ollama_backend_bypasses_llm_for_synthesis():
-    """When the LLM backend is OllamaBackend, dictation_post should
-    skip the LLM call entirely and emit a dictation_summary built from
-    the transcript directly (no slow CPU LLM round-trip)."""
+async def test_local_backend_bypasses_llm_for_synthesis():
+    """A backend that declares `synthesize_summary_locally` (slow
+    CPU-local: Ollama / llama-server / NPU Genie) must skip the LLM
+    call and emit a dictation_summary built from the transcript
+    directly (no slow CPU LLM round-trip)."""
     events: list[dict] = []
 
     async def on_event(e: dict) -> None:
         events.append(e)
 
-    # Mock that *looks* like OllamaBackend by name — that's the gate
-    # we use to distinguish Local mode from Solo/Cloud (which use
-    # OpenRouter and are fast enough to call directly).
+    # Capability gate — NOT a class-name check.  The old gate
+    # (`type(llm).__name__ == 'OllamaBackend'`) silently broke when
+    # Local moved Ollama → llama-server.
     llm = MagicMock()
-    llm.__class__.__name__ = "OllamaBackend"
+    llm.synthesize_summary_locally = True
 
     await run_dictation_post_process(
         "hello world testing cross-network dictation",
@@ -352,3 +360,38 @@ async def test_ollama_backend_bypasses_llm_for_synthesis():
     final = summaries[-1]
     assert final["title"].startswith("Hello world")
     assert "cross-network dictation" in final["summary"]
+
+
+@pytest.mark.parametrize(
+    "module_path,class_name",
+    [
+        ("dragon_voice.llm.lmstudio_llm", "LMStudioBackend"),
+        ("dragon_voice.llm.ollama_llm", "OllamaBackend"),
+        ("dragon_voice.llm.npu_genie", "NPUGenieBackend"),
+    ],
+)
+def test_slow_local_backends_declare_synthesize_capability(module_path, class_name):
+    """Regression guard for S1-1 (dictation audit 2026-05-29): the live
+    Local backend MUST take the synthesize path.  This is the test that
+    would have caught the silent Ollama → llama-server regression — if a
+    future rename/swap drops the capability, this fails here instead of
+    reintroducing the 60-90 s summary hang in production."""
+    import importlib
+
+    cls = getattr(importlib.import_module(module_path), class_name)
+    assert cls.synthesize_summary_locally is True
+
+
+def test_fast_remote_backends_do_not_synthesize_locally():
+    """Fast remote backends (OpenRouter / TinkerClaw) keep the LLM path
+    (nicer title+summary, no timeout risk) — they must NOT shadow the
+    capability and so inherit the ABC default of False."""
+    from dragon_voice.llm.base import LLMBackend
+    from dragon_voice.llm.openrouter_llm import OpenRouterBackend
+    from dragon_voice.llm.tinkerclaw_llm import TinkerClawBackend
+
+    # ABC default is False.
+    assert LLMBackend.synthesize_summary_locally.fget(object()) is False
+    # Neither fast backend overrides it with a class-level True.
+    assert "synthesize_summary_locally" not in OpenRouterBackend.__dict__
+    assert "synthesize_summary_locally" not in TinkerClawBackend.__dict__

--- a/tests/test_dictation_post_process_race.py
+++ b/tests/test_dictation_post_process_race.py
@@ -66,6 +66,33 @@ def _make_pipeline(llm: _FakeLLM) -> tuple[VoicePipeline, list[dict]]:
     return p, events
 
 
+@pytest.mark.asyncio
+async def test_late_postprocess_stamps_its_own_turn_id():
+    """W2 (S2-8): the async post-process stamps the turn_id captured at
+    finish_dictation time — NOT whatever turn _dictation_turn_id / conn_state
+    has moved on to by the time the (seconds-later) summary emits.  Pre-fix,
+    a back-to-back dictation B that started while A's summary was still
+    generating would see A's summary stamped with B's turn_id."""
+    llm = _FakeLLM(delay_s=0.02)
+    p, events = _make_pipeline(llm)
+    p._dictation_mode = True
+    p._dictation_turn_id = "turnAAAA"
+    p._dictation_segments = [
+        "this is a sufficiently long dictation transcript to summarize"
+    ]
+
+    await p.finish_dictation()        # spawns the post-process task, capturing turnAAAA
+    p._dictation_turn_id = "turnBBBB"  # a new dictation turn starts mid-post-process
+    if p._post_process_task:
+        await p._post_process_task     # let the late summary emit
+
+    summaries = [e for e in events if e.get("type") == "dictation_summary"]
+    assert summaries, "expected a dictation_summary frame"
+    # The late summary must carry the turn it BELONGS to (AAAA), not the
+    # turn that started after it (BBBB).
+    assert summaries[-1].get("turn_id") == "turnAAAA"
+
+
 # ─────────────────────────── cancel() awaits the task
 
 

--- a/tests/test_notes_embed_retry.py
+++ b/tests/test_notes_embed_retry.py
@@ -1,0 +1,56 @@
+"""W4: embedding must never fail/roll back the note insert, and a transient
+embedding error must retry in the background until it succeeds."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dragon_voice.notes.service import NotesService
+
+
+def _make_service() -> NotesService:
+    svc = NotesService.__new__(NotesService)  # bypass __init__ / config
+    svc._db = MagicMock()
+    svc._db.update = AsyncMock()
+    svc._bg_tasks = set()
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_embed_retries_then_succeeds(monkeypatch):
+    """First two _get_embedding calls fail (return []), the third succeeds.
+    _embed_note must keep retrying until it stores a non-empty vector, and must
+    NOT raise (so the note insert is never affected)."""
+    svc = _make_service()
+    calls = {"n": 0}
+
+    async def fake_get_embedding(text):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return []  # simulate "Server disconnected"
+        return [0.1, 0.2, 0.3]
+
+    monkeypatch.setattr(svc, "_get_embedding", fake_get_embedding)
+    monkeypatch.setattr("dragon_voice.notes.service._EMBED_RETRY_DELAYS", [0, 0, 0])
+
+    await svc._embed_note("note-1", "transcript")
+
+    assert calls["n"] == 3
+    svc._db.update.assert_awaited_once_with("note-1", {"embedding": [0.1, 0.2, 0.3]})
+
+
+@pytest.mark.asyncio
+async def test_embed_gives_up_without_raising(monkeypatch):
+    """If every attempt fails, _embed_note gives up quietly — never raises (so
+    the note insert is unaffected) and never stores an empty vector."""
+    svc = _make_service()
+
+    async def always_fail(text):
+        return []
+
+    monkeypatch.setattr(svc, "_get_embedding", always_fail)
+    monkeypatch.setattr("dragon_voice.notes.service._EMBED_RETRY_DELAYS", [0, 0, 0])
+
+    await svc._embed_note("note-2", "transcript")  # must not raise
+    svc._db.update.assert_not_awaited()

--- a/tests/test_stop_handler.py
+++ b/tests/test_stop_handler.py
@@ -279,6 +279,47 @@ class TestDictateMode:
         frame = ws.send_json.await_args.args[0]
         assert len(frame["transcript"]) == 200
 
+    @pytest.mark.asyncio
+    async def test_dictate_note_created_carries_turn_id(self):
+        """W4: Tab5 reconciles the optimistic note row by turn_id, so the
+        note_created frame MUST echo the turn's id (from conn_state, stashed
+        there by start_handler).  Pin it so a refactor can't drop it."""
+        ws = _make_ws()
+        pipeline = _make_pipeline(transcript="A long enough transcript")
+        notes_svc = _make_notes_svc(note_id="note-77")
+
+        await handle_stop_command(
+            ws,
+            ws_id="ws-tid",
+            conn_state={"pipeline": pipeline, "mode": "dictate", "turn_id": "abc123def456"},
+            conn_lock=asyncio.Lock(),
+            notes_svc=notes_svc,
+        )
+
+        frame = ws.send_json.await_args.args[0]
+        assert frame["type"] == "note_created"
+        assert frame["turn_id"] == "abc123def456"
+
+    @pytest.mark.asyncio
+    async def test_dictate_note_created_turn_id_defaults_to_dash(self):
+        """When conn_state has no turn_id (legacy / boot race), the frame still
+        carries a turn_id field ('-') so the Tab5 lookup is well-defined
+        (treated as 'no match' → fresh note)."""
+        ws = _make_ws()
+        pipeline = _make_pipeline(transcript="A long enough transcript")
+        notes_svc = _make_notes_svc()
+
+        await handle_stop_command(
+            ws,
+            ws_id="ws-tid2",
+            conn_state={"pipeline": pipeline, "mode": "dictate"},  # no turn_id
+            conn_lock=asyncio.Lock(),
+            notes_svc=notes_svc,
+        )
+
+        frame = ws.send_json.await_args.args[0]
+        assert frame["turn_id"] == "-"
+
 
 # ─── conn_lock serialisation ──────────────────────────────────
 


### PR DESCRIPTION
## Dictation redesign — Dragon side + WS connection-leak fixes

The Dragon half of the dictation structural redesign (pairs with TinkerTab #747), plus two WebSocket connection-leak fixes found while live-testing.

### W0 — backend-capability gate
The Local hang-fix was dead code (gated on `OllamaBackend` by class name, but the live Local backend is `LMStudioBackend`). Replaced with a `LLMBackend.synthesize_summary_locally` capability so slow local backends declare the cap and the 60-90s CPU-summary hang stays fixed. Single-source `MIN_DICTATION_CHARS`; removed an always-true dead branch in `finish_dictation`.

### W2 — turn_id identity end-to-end
Capture `turn_id` at dictation finish so a late async post-process stamps *its own* turn (not a successor's) — the real root cause of cross-turn summary bleed (S2-8). `dictation_postprocessing_cancelled` stamped with the abandoned turn's id (W2 review F2) so a rapid stop+restart can't cancel the live successor.

### WS connection-leak fixes (found live)
- **`close_evicted_websocket`**: `evict_stale_connections_for_device` tore down the old connection's pipeline/session/registry on device re-register but never closed the old `ws` — under reconnect churn these piled up in **CLOSE-WAIT** and exhausted the WS handler (live: 59 CLOSE-WAIT sockets wedged :3502, "Error read response for Upgrade header", Tab5 couldn't reconnect). Now `await old_ws.close()`; 2 unit tests pin it.
- **heartbeat 180→60s**: a client that drops *while the handler is blocked mid-request* leaves the socket in CLOSE-WAIT until the next heartbeat ping. 60s reaps 3× faster; the long-turn protection (`receive_timeout=600`) is untouched.

### W4 — optimistic-save Dragon side
`note_created` already carries `turn_id` (pinned by a regression test so the Tab5 reconcile contract can't silently break). **Embedding now retries in the background** (`_EMBED_RETRY_DELAYS`) so a transient "Server disconnected" self-heals instead of leaving a note permanently unsearchable — and it still never blocks/fails the note insert.

### W5 — progress-frame audit (S3-8)
Audited fleet-wide: the `progress` half of `emit_progress_pair`'s dual-write has no consumer today (Tab5 logs it Unknown; the dashboard never reads it), but it's the *intentional forward-compat* frame the β-arch added — documented, removal deferred, do not collapse on "no consumers" alone.

### Validation
46+ dictation pytest green; the new eviction-close + embed-retry + turn_id tests added to the CI named set; ruff clean. Deployed + live-verified on the Dragon: CLOSE-WAIT no longer accumulates under reconnect churn; offline dictation transcribes + syncs end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
